### PR TITLE
Retags: refactor extension

### DIFF
--- a/Extensions/retags.css
+++ b/Extensions/retags.css
@@ -1,0 +1,87 @@
+.ui_notes .date_header .part_full_date.stuck {
+	margin-left: 400px;
+	width: 165px;
+}
+
+label.retags {
+	margin-left: 15px;
+	top: -1px;
+}
+label.retags .binary_switch_label {
+	position: absolute;
+	top: 0; left: 24px;
+	padding: 0 8px;
+	line-height: 14px;
+	white-space: nowrap;
+}
+
+div.retags {
+	white-space: normal;
+	margin-top: 10px;
+}
+
+div.retags.error {
+	color: #c00000;
+}
+
+div.retags + div.retags:before {
+	color: #c00000;
+	content: "Warning: You are running multiple copies of Retags.";
+}
+
+div.retags + div.retags a {
+	display: none;
+}
+
+div.retags a {
+	color: #a7a7a7 !important;
+	position: relative;
+	margin-right: 11px;
+	text-decoration: none;
+}
+
+div.retags a:hover {
+	color: #969696 !important;
+}
+
+.note div.retags {
+	font-size: 12px;
+	line-height: 1.3;
+}
+
+.note div.retags a {
+	margin-right: 9px;
+}
+
+.post_notes .notes_outer_container.popover .note.with_commentary span.action {
+	min-height: 0;
+}
+
+.notification div.retags a {
+	color: rgba(255,255,255,0.3) !important;
+}
+
+.notification div.retags a:hover {
+	color: rgba(255,255,255,0.4) !important;
+}
+
+.ui_note div.retags {
+	margin-top: 0;
+	padding: 40px 50px 13px;
+}
+
+.ui_note div.retags + div.retags {
+	margin-top: -5px;
+	padding-top: 0;
+}
+
+.ui_note .part_response + div.retags {
+	margin-top: -7px;
+	padding-top: 0;
+}
+
+div.retags a:after {
+	content: "\\00a0  ";
+	font-size: 0;
+	line-height: 0;
+}

--- a/Extensions/retags.js
+++ b/Extensions/retags.js
@@ -1,6 +1,6 @@
 //* TITLE       Retags **//
 //* DEVELOPER   alexhong **//
-//* VERSION     0.6.6 **//
+//* VERSION     0.6.7 **//
 //* DESCRIPTION Adds tags to reblog notes **//
 //* FRAME       false **//
 //* SLOW        false **//
@@ -16,7 +16,6 @@ var retags = {
 		});
 	}),
 	run: function(){
-		retags.css.appendTo('head');
 		try {
 			retags.blog_name = $('body').data('new-root').split('/').pop();
 		} catch(e) {
@@ -25,9 +24,6 @@ var retags = {
 		retags.add_toggle();
 		retags.observer.observe($('body')[0],{childList:true,subtree:true});
 		retags.tag(retags.selectors);
-		/*$('body').on('mouseover.retags','.post_tags_inner',function(){
-			$(this).attr('class','DISABLED_post_tags_inner');
-		});*/
 	},
 	destroy: function(){
 		retags.css.detach();
@@ -36,7 +32,6 @@ var retags = {
 		retags.observer.disconnect();
 		$('.retags').remove();
 		$('body').off('.retags');
-		// $('.DISABLED_post_tags_inner').attr('class','post_tags_inner');
 	},
 	add_toggle: function(){
 		var toggle = 'retags_toggle_'+retags.blog_name;
@@ -131,28 +126,6 @@ var retags = {
 			$c.append($retags);
 		}
 	},
-	css:
-	$('<style class="retags">\
-		.ui_notes .date_header .part_full_date.stuck { width: 165px; margin-left:400px; }\
-		label.retags { top: -1px; margin-left: 15px; }\
-		label.retags .binary_switch_label { position: absolute; top: 0; left: 24px; padding: 0 8px; line-height: 14px; white-space: nowrap; }\
-		div.retags { white-space: normal; margin-top: 10px; }\
-		div.retags.error { color: #c00000; }\
-		div.retags + div.retags:before { color: #c00000; content: "Warning: You are running multiple copies of Retags."; }\
-		div.retags + div.retags a { display: none; }\
-		div.retags a { color: #a7a7a7 !important; position: relative; margin-right: 11px; text-decoration: none; }\
-		div.retags a:hover { color: #969696 !important; }\
-		.note div.retags { font-size: 12px; line-height: 1.3; }\
-		.note div.retags a { margin-right: 9px; }\
-		.post_notes .notes_outer_container.popover .note.with_commentary span.action { min-height: 0; }\
-		.notification div.retags a { color: rgba(255,255,255,0.3) !important; }\
-		.notification div.retags a:hover { color: rgba(255,255,255,0.4) !important; }\
-		.ui_note div.retags { margin-top: 0; padding: 40px 50px 13px; }\
-		.ui_note div.retags + div.retags { margin-top: -5px; padding-top: 0; }\
-		.ui_note .part_response + div.retags { margin-top: -7px; padding-top: 0; }\
-		div.retags a:after { content: "\\00a0  "; font-size: 0; line-height: 0; }\
-	</style>')
-	,
 	css_toggle:
 	$('<style class="retags">\
 		.ui_note { display: none; }\
@@ -172,10 +145,12 @@ XKit.extensions.retags = {
  	running: false,
 	run: function(){
 		this.running = true;
+		XKit.tools.init_css("retags");
 		retags.run();
 	},
 	destroy: function(){
 		this.running = false;
+		XKit.tools.remove_css("retags");
 		retags.destroy();
 	}
 };

--- a/Extensions/retags.js
+++ b/Extensions/retags.js
@@ -1,54 +1,51 @@
 //* TITLE       Retags **//
 //* DEVELOPER   alexhong **//
-//* VERSION     0.6.7 **//
+//* VERSION     0.6.8 **//
 //* DESCRIPTION Adds tags to reblog notes **//
 //* FRAME       false **//
 //* SLOW        false **//
 //* BETA        false **//
 
-var retags = {
+XKit.extensions.retags = {
+	running: false,
 	api_key: '3DFxEZm0tGISOmdvWe9Fl1QsQMo1LFqEatnc8GQ68wgF1YTZ4w',
 	selectors: '.reblog,.is_reblog,.notification_reblog',
 	blog_name: "",
+
+	run: function(){
+		this.running = true;
+		XKit.tools.init_css("retags");
+		try {
+			this.blog_name = $('body').data('new-root').split('/').pop();
+		} catch(e) {}
+		this.add_toggle();
+		this.observer.observe($('body')[0],{childList:true,subtree:true});
+		this.tag(this.selectors);
+	},
+
 	observer: new MutationObserver(function(ms){
 		ms.forEach(function(m){
-			retags.tag($(m.addedNodes).filter(retags.selectors));
+			XKit.extensions.retags.tag($(m.addedNodes).filter(XKit.extensions.retags.selectors));
 		});
 	}),
-	run: function(){
-		try {
-			retags.blog_name = $('body').data('new-root').split('/').pop();
-		} catch(e) {
 
-		}
-		retags.add_toggle();
-		retags.observer.observe($('body')[0],{childList:true,subtree:true});
-		retags.tag(retags.selectors);
-	},
-	destroy: function(){
-		retags.css.detach();
-		retags.css_toggle.detach();
-		retags.html_toggle.detach();
-		retags.observer.disconnect();
-		$('.retags').remove();
-		$('body').off('.retags');
-	},
 	add_toggle: function(){
-		var toggle = 'retags_toggle_'+retags.blog_name;
-		retags.html_toggle.appendTo('.ui_notes_switcher .part-toggle');
+		var toggle = 'retags_toggle_'+this.blog_name;
+		this.html_toggle.appendTo('.ui_notes_switcher .part-toggle');
 		$('#retags-toggle').change(function(){
 			if ($(this).prop('checked')) {
 				localStorage.setItem(toggle,'true');
-				retags.css_toggle.appendTo('head');
+				XKit.extensions.retags.css_toggle.appendTo('head');
 			} else {
 				localStorage.setItem(toggle,'false');
-				retags.css_toggle.detach();
+				XKit.extensions.retags.css_toggle.detach();
 			}
 		});
 		if (localStorage.getItem(toggle) === 'true') {
 			$('#retags-toggle').click();
 		}
 	},
+
 	tag: function(el){
 		$(el).each(function(){
 			var $t = $(this), cls, $c, url;
@@ -77,13 +74,14 @@ var retags = {
 				url = url.split('/');
 				var host = url[2], id = url[4], cache = 'retags_'+id;
 				if (localStorage.getItem(cache) !== null) {
-					retags.append($t,cls,$c,JSON.parse(localStorage.getItem(cache)));
+					XKit.extensions.retags.append($t,cls,$c,JSON.parse(localStorage.getItem(cache)));
 				} else {
-					retags.request($t,cls,$c,cache,'https://api.tumblr.com/v2/blog/'+host+'/posts/info?id='+id+'&api_key='+retags.api_key);
+					XKit.extensions.retags.request($t,cls,$c,cache,'https://api.tumblr.com/v2/blog/'+host+'/posts/info?id='+id+'&api_key='+XKit.extensions.retags.api_key);
 				}
 			}
 		});
 	},
+
 	request:
 		(typeof GM_xmlhttpRequest !== 'undefined')
 		// if userscript or XKit
@@ -94,10 +92,10 @@ var retags = {
 				onload: function(data){
 					var tags = JSON.parse(data.responseText).response.posts[0].tags;
 					localStorage.setItem(cache,JSON.stringify(tags));
-					retags.append($t,cls,$c,tags);
+					XKit.extensions.retags.append($t,cls,$c,tags);
 				},
 				onerror: function(data){
-					retags.append($t,cls,$c,'ERROR: '+data.status);
+					XKit.extensions.retags.append($t,cls,$c,'ERROR: '+data.status);
 				}
 			});
 		}
@@ -106,12 +104,13 @@ var retags = {
 			$.getJSON(url,function(data){
 				var tags = data.response.posts[0].tags;
 				localStorage.setItem(cache,JSON.stringify(tags));
-				retags.append($t,cls,$c,tags);
+				XKit.extensions.retags.append($t,cls,$c,tags);
 			}).fail(function(jqXHR,status,error){
-				retags.append($t,cls,$c,status.toUpperCase()+': '+(error||jqXHR.status));
+				XKit.extensions.retags.append($t,cls,$c,status.toUpperCase()+': '+(error||jqXHR.status));
 			});
 		}
 	,
+
 	append: function($t,cls,$c,tags){
 		if (tags.length) {
 			var $retags = $('<div class="retags">');
@@ -126,31 +125,29 @@ var retags = {
 			$c.append($retags);
 		}
 	},
+
 	css_toggle:
 	$('<style class="retags">\
 		.ui_note { display: none; }\
 		.ui_note.is_retags, .ui_note.is_response, .ui_note.is_user_mention { display: block; }\
 	</style>')
 	,
+
 	html_toggle:
 	$('<label class="retags binary_switch">\
 		<input id="retags-toggle" type="checkbox">\
 		<span class="binary_switch_track"></span>\
 		<span class="binary_switch_button"></span>\
 		<span class="binary_switch_label">Show only retags / responses</span>\
-	</label>')
-};
+	</label>'),
 
-XKit.extensions.retags = {
- 	running: false,
-	run: function(){
-		this.running = true;
-		XKit.tools.init_css("retags");
-		retags.run();
-	},
 	destroy: function(){
 		this.running = false;
 		XKit.tools.remove_css("retags");
-		retags.destroy();
+		this.css_toggle.detach();
+		this.html_toggle.detach();
+		this.observer.disconnect();
+		$('.retags').remove();
+		$('body').off('.retags');
 	}
 };


### PR DESCRIPTION
I was trying to fix this weird issue where the checkbox state for "Show only tags / responses" didn't correspond to the actual state, but then realized that:

- This currently works in Firefox, but not Chrome
- This isn't XKit's fault

So have this refactoring instead.