### PR TITLE
Only run lethe on dashboard

### DIFF
--- a/Extensions/lethe.js
+++ b/Extensions/lethe.js
@@ -1,5 +1,5 @@
 //* TITLE Lethe **//
-//* VERSION 1.1.0 **//
+//* VERSION 1.1.1 **//
 //* DESCRIPTION Forgets posts once they scroll off the screen. **//
 //* DEVELOPER hobinjk **//
 //* FRAME false **//
@@ -27,6 +27,9 @@ function Lethe() {
  * Run Lethe
  */
 Lethe.prototype.run = function() {
+  if (!XKit.interface.where().dashboard) {
+    return;
+  }
   this.running = true;
   this.handleScroll = this.handleScroll.bind(this);
   window.addEventListener('scroll', this.handleScroll, false);


### PR DESCRIPTION
Lethe running on queues/drafts apparently causes issues for people. Lethe is really just meant to be hiding posts that have been scrolled past on the dashboard. If people's queues or drafts are long enough for Lethe to have a performance impact then they are truly exceptional people.