### PR TITLE
Improve processing logic of editable_reblogs

### DIFF
--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -1,5 +1,5 @@
 //* TITLE Editable Reblogs **//
-//* VERSION 1.0.8 **//
+//* VERSION 1.0.9 **//
 //* DESCRIPTION	Restores ability to edit previous reblogs of a post **//
 //* DEVELOPER dlmarquis **//
 //* FRAME false **//
@@ -13,6 +13,7 @@ XKit.extensions.editable_reblogs = new Object({
 		this.running = true;
 
 		XKit.interface.post_window_listener.add("editable_reblogs", XKit.extensions.editable_reblogs.post_window);
+		XKit.tools.add_css(".control-reblog-tree {display: none; }", "editable_reblogs_remove_content_tree");
 	},
 
 	post_window: function() {
@@ -21,28 +22,35 @@ XKit.extensions.editable_reblogs = new Object({
 			return;
 		}
 
+		// Guard against double evaluation by marking the tree as processed
+		var processed_class = 'xkit-editable-reblogs-done';
+		if (reblog_tree.hasClass(processed_class)) {
+			return;
+		}
+		reblog_tree.addClass(processed_class);
+
+		// Convert all of the user links to have class tumblr_blog
+		var top_quote_link = reblog_tree.find('p:first-child > a:first-child');
+		var quote_links = reblog_tree.find('blockquote > p:first-child > a:first-child');
+
+		if (top_quote_link.length > 0) {
+			$(top_quote_link[0]).addClass('tumblr_blog');
+		}
+		quote_links.each(function() {
+			$(this).addClass('tumblr_blog');
+		});
+
 		var reblog_content = reblog_tree.html();
 
-		var old_content = ""; // $(".editor:eq(2)").html(); // (for some reason this is broken)
-
-		// This is actually get_content_html but noooo, some people aren"t updated yet.
-		if (XKit.interface.post_window.get_content_html) {
-			old_content = XKit.interface.post_window.get_content_html();
-		} else {
-			var content_editor = $(".post-form--form").find(".editor.editor-richtext");
-			old_content = content_editor.html();
-		}
-
+		var old_content = XKit.interface.post_window.get_content_html();
 		XKit.interface.post_window.set_content_html(reblog_content + old_content);
 
 		$(".btn-remove-tree").click();
-
-		XKit.tools.add_css(".control-reblog-tree {display: none; }", "editable_reblogs_remove_content_tree");
 	},
 
 	destroy: function() {
 		this.running = false;
 		XKit.tools.remove_css("editable_reblogs_remove_content_tree");
+		XKit.interface.post_window_listener.remove("editable_reblogs");
 	}
-
 });


### PR DESCRIPTION
Possibly fixes issues with a race condition causing editable_reblogs to
evaluate twice. Adds tumblr_blog class to blog links and sets a class on
the reblog tree to signify that it has been processed.

This should not effect normal functioning of the extension, but hopefully
will fix the doubling issues.