### PR TITLE
Use "tighter" Jquery classes for extensions running on Index pages

### DIFF
--- a/Extensions/audio_downloader.js
+++ b/Extensions/audio_downloader.js
@@ -1,5 +1,5 @@
 //* TITLE Audio Downloader **//
-//* VERSION 2.0 REV F **//
+//* VERSION 2.0.1 **//
 //* DESCRIPTION Lets you download audio posts hosted on Tumblr **//
 //* DEVELOPER STUDIOXENIX **//
 //* FRAME false **//
@@ -24,7 +24,7 @@ XKit.extensions.audio_downloader = new Object({
 			XKit.storage.set("audio_downloader","shown_welcome","true");
 		}
 
-		if ($(".post").length > 0) {
+		if ($(".posts .post").length > 0) {
 
 			XKit.interface.create_control_button("xkit-audio-downloader", this.button_icon, "Audio Downloader", "");
 			XKit.extensions.audio_downloader.init();

--- a/Extensions/autoloadimages.js
+++ b/Extensions/autoloadimages.js
@@ -1,5 +1,5 @@
 //* TITLE Auto Load Images **//
-//* VERSION 0.1 REV A **//
+//* VERSION 0.1.1 **//
 //* DESCRIPTION Load inline photos automatically **//
 //* DETAILS This extension removes the &quot;gray box&quot; that appears on the photos attached to non-photo posts, allowing the photos to load automatically without you having to click on them. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -14,7 +14,7 @@ XKit.extensions.autoloadimages = new Object({
 
 		this.running = true;
 
-		if ($(".post").length === 0) {return; }
+		if ($(".posts .post").length === 0) {return; }
 
 		XKit.post_listener.add("autoloadimages", XKit.extensions.autoloadimages.do);
 		XKit.extensions.autoloadimages.do();

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1,5 +1,5 @@
 //* TITLE Blacklist **//
-//* VERSION 2.7.3 **//
+//* VERSION 2.7.4 **//
 //* DESCRIPTION Clean your dash **//
 //* DETAILS This extension allows you to block posts based on the words you specify. If a post has the text you've written in the post itself or it's tags, it will be replaced by a warning, or won't be shown on your dashboard, depending on your settings. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -168,7 +168,7 @@ XKit.extensions.blacklist = new Object({
 
 		}
 
-		if ($(".post").length > 0) {
+		if ($(".posts .post").length > 0) {
 			XKit.post_listener.add("blacklist", XKit.extensions.blacklist.check);
 			XKit.extensions.blacklist.check();
 
@@ -457,7 +457,7 @@ XKit.extensions.blacklist = new Object({
 
 		if (XKit.extensions.blacklist.running !== true) {return; }
 
-		$(".post").not(".xblacklist-done").each(function() {
+		$(".posts .post").not(".xblacklist-done").each(function() {
 
 			try {
 

--- a/Extensions/bookmarker.js
+++ b/Extensions/bookmarker.js
@@ -1,5 +1,5 @@
 //* TITLE Bookmarker **//
-//* VERSION 2.3.2 **//
+//* VERSION 2.3.3 **//
 //* DESCRIPTION Dashboard Time Machine **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS The Bookmarker extension allows you to bookmark posts and get back to them whenever you want to. Just click on the Bookmark icon on posts and the post will be added to your Bookmark List on your sidebar. **//
@@ -402,7 +402,7 @@ XKit.extensions.bookmarker = new Object({
 			m_array.push(XKit.extensions.bookmarker.bookmarks[i].id);
 		}
 
-		$(".post").not(".note").not(".xbookmarker_done").each(function() {
+		$(".posts .post").not(".note").not(".xbookmarker_done").each(function() {
 
 			var post_id = $(this).attr('data-post-id');
 			$(this).addClass("xbookmarker_done");

--- a/Extensions/cleanfeed.js
+++ b/Extensions/cleanfeed.js
@@ -1,5 +1,5 @@
 //* TITLE CleanFeed **//
-//* VERSION 1.5.0 **//
+//* VERSION 1.5.1 **//
 //* DESCRIPTION Browse safely in public **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS This extension, when enabled, hides photo posts until you hover over them. Useful to browse Tumblr in a workspace or in public, and not worry about NSFW stuff appearing. You can also set it to hide avatars and not show non-text posts at all. To activate or disable it, click on the CleanFeed button on your sidebar. It will remember it's on/off setting. **//
@@ -303,7 +303,7 @@ XKit.extensions.cleanfeed = new Object({
 			XKit.extensions.cleanfeed.added_css = true;
 		}
 
-		$(".post").not(".xkit-cleanfeed-smart-checked").each(function() {
+		$(".posts .post").not(".xkit-cleanfeed-smart-checked").each(function() {
 
 			var rating = $(this).attr('data-tumblelog-content-rating');
 			var is_nsfw = false;
@@ -364,7 +364,7 @@ XKit.extensions.cleanfeed = new Object({
 
 		if (!hide) {
 
-			$(".post").removeClass("xkit-cleanfeed-smart-checked").removeClass("xkit-cleanfeed-smart-checked-flagged");
+			$(".posts .post").removeClass("xkit-cleanfeed-smart-checked").removeClass("xkit-cleanfeed-smart-checked-flagged");
 
 		}
 

--- a/Extensions/drafts_plus.js
+++ b/Extensions/drafts_plus.js
@@ -1,5 +1,5 @@
 //* TITLE Drafts+ **//
-//* VERSION 0.2 REV B **//
+//* VERSION 0.2.1 **//
 //* DESCRIPTION Enhancements for Drafts page **//
 //* DEVELOPER STUDIOXENIX **//
 //* FRAME false **//
@@ -142,7 +142,7 @@ XKit.extensions.drafts_plus = new Object({
 
 		console.log("drafts_plus -> Adding overlays...");
 
-		$(".post").not(".drafts-plus-overlay-done").not(".radar").each(function() {
+		$(".posts .post").not(".drafts-plus-overlay-done").not(".radar").each(function() {
 
 			$(this).addClass("drafts-plus-overlay-done");
 
@@ -353,7 +353,7 @@ XKit.extensions.drafts_plus = new Object({
 	stop_mass_editor: function() {
 
 		XKit.tools.remove_css("drafts_plus_mass_editor");
-		$(".post").removeClass("drafts-plus-overlay-done");
+		$(".posts .post").removeClass("drafts-plus-overlay-done");
 		$(".xkit-drafts-plus-overlay").remove();
 
 	},

--- a/Extensions/highlighter.js
+++ b/Extensions/highlighter.js
@@ -1,5 +1,5 @@
 //* TITLE Highlighter **//
-//* VERSION 0.1 REV A **//
+//* VERSION 0.1.1 **//
 //* DESCRIPTION Don't miss things **//
 //* DETAILS The cousin of Blacklister, this extension highlights posts depending on the words you decide. When a word you add is found on a post, the post will get a yellow-ish background. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -49,7 +49,7 @@ XKit.extensions.highlighter = new Object({
 			this.highlightered = m_highlighter;
 		}
 
-		if ($(".post").length > 0) {
+		if ($(".posts .post").length > 0) {
 			XKit.post_listener.add("highlighter", XKit.extensions.highlighter.check);
 			XKit.extensions.highlighter.check();
 		}
@@ -58,7 +58,7 @@ XKit.extensions.highlighter = new Object({
 
 	check: function() {
 
-		$(".post").not(".mine").not(".xhighlighter-done").each(function() {
+		$(".posts .post").not(".mine").not(".xhighlighter-done").each(function() {
 
 			// Check if it's something we should not touch.
 			if ($(this).attr('id') === "new_post") { return; }

--- a/Extensions/mass_deleter.js
+++ b/Extensions/mass_deleter.js
@@ -1,5 +1,5 @@
 //* TITLE Mass Deleter **//
-//* VERSION 0.1.1 **//
+//* VERSION 0.1.2 **//
 //* DESCRIPTION Mass unlike likes / delete drafts **//
 //* DETAILS Used to mass unlike posts or delete drafts. Please use with caution, especially Mass Unlike part is extremely experimental. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -119,7 +119,7 @@ XKit.extensions.mass_deleter = new Object({
 		XKit.extensions.mass_deleter.delete_last_post_id = $(".post_container").last().find(".post").attr('data-post-id');
 
 		if (typeof XKit.extensions.mass_deleter.delete_last_post_id === "undefined") {
-			XKit.extensions.mass_deleter.delete_last_post_id = $(".post").last().attr('data-post-id');
+			XKit.extensions.mass_deleter.delete_last_post_id = $(".posts .post").last().attr('data-post-id');
 		}
 
 		XKit.extensions.mass_deleter.delete_drafts_page++;
@@ -227,7 +227,7 @@ XKit.extensions.mass_deleter = new Object({
 
 				XKit.extensions.mass_deleter.delete_next_current = 0;
 
-				$(".post",m_div).each(function() {
+				$(".posts .post",m_div).each(function() {
 					var m_post = XKit.interface.post($(this));
 					if (XKit.extensions.mass_deleter.delete_drafts_array.length >= XKit.extensions.mass_deleter.delete_drafts_limit) {
 						XKit.extensions.mass_deleter.delete_current_array();
@@ -407,7 +407,7 @@ XKit.extensions.mass_deleter = new Object({
 
 				XKit.extensions.mass_deleter.unlike_next_current = 0;
 
-				$(".post",m_div).each(function() {
+				$(".posts .post",m_div).each(function() {
 					var m_post = XKit.interface.post($(this));
 					if (XKit.extensions.mass_deleter.unlike_likes_array.length >= XKit.extensions.mass_deleter.unlike_likes_limit) {
 						XKit.extensions.mass_deleter.unlike_current_array();

--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -1,5 +1,5 @@
 //* TITLE No Recommended **//
-//* VERSION 2.1.0 **//
+//* VERSION 2.1.1 **//
 //* DESCRIPTION Removes recommended posts **//
 //* DETAILS This extension removes recommended posts from your dashboard. To remove Recommended Blogs on the sidebar, please use Tweaks extension. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -45,7 +45,7 @@ XKit.extensions.norecommended = new Object({
 		
 		var doResize = false;
 		
-		$(".post").not(".norecommended-done").each(function() {
+		$(".posts .post").not(".norecommended-done").each(function() {
 			
 			$(this).addClass(".norecommended-done");
 			

--- a/Extensions/notificationblock.js
+++ b/Extensions/notificationblock.js
@@ -1,5 +1,5 @@
 //* TITLE NotificationBlock **//
-//* VERSION 1.3.0 **//
+//* VERSION 1.3.1 **//
 //* DESCRIPTION Blocks notifications from a post **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS One post got way too popular and now just annoying you? Click on the notification block icon on that post to hide the notifications from that post. If you have Go-To-Dash installed, you can click on a notification, then click View button on top-right corner to quickly go back to the post on your dashboard.  **//
@@ -338,7 +338,7 @@ XKit.extensions.notificationblock = new Object({
 		});
 
 
-		if ($(".post").length > 0) {
+		if ($(".posts .post").length > 0) {
 
 			var posts = XKit.interface.get_posts("xnotificationblockchecked");
 

--- a/Extensions/people_notifier.js
+++ b/Extensions/people_notifier.js
@@ -1,5 +1,5 @@
 //* TITLE Blog Tracker **//
-//* VERSION 0.3.3 **//
+//* VERSION 0.3.4 **//
 //* DESCRIPTION Track people like tags **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS Blog Tracker lets you track blogs like you can track tags. Add them on your dashboard, and it will let you know how many new posts they've made the last time you've checked their blogs, or if they've changed their URLs. **//
@@ -88,7 +88,7 @@ XKit.extensions.people_notifier = new Object({
 
 		this.load_blogs();
 
-		if ($(".post").length > 0) {
+		if ($(".posts .post").length > 0) {
 
 			XKit.post_listener.add("people_notifier", XKit.extensions.people_notifier.do_posts);
 			this.do_posts();

--- a/Extensions/postarchive.js
+++ b/Extensions/postarchive.js
@@ -1,5 +1,5 @@
 //* TITLE Post Archiver **//
-//* VERSION 0.5.2 **//
+//* VERSION 0.5.3 **//
 //* DESCRIPTION Never lose a post again. **//
 //* DETAILS Post Archiver lets you save posts to your XKit.<br><br>Found a good recipe? Think those hotline numbers on that signal boost post might come in handy in the future?<br><br>Click on the save button, then click on the My Archive button on your sidebar anytime to access those posts. You can also name and categorize posts. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -99,7 +99,7 @@ XKit.extensions.postarchive = new Object({
 
 		});
 
-		if ($(".post").length > 0) {
+		if ($(".posts .post").length > 0) {
 
 			XKit.interface.create_control_button("xkit-postarchive", this.button_icon, "Archive this post", "", this.button_on);
 			XKit.extensions.postarchive.init();

--- a/Extensions/read_more_now.js
+++ b/Extensions/read_more_now.js
@@ -1,5 +1,5 @@
 //* TITLE Read More Now **//
-//* VERSION 1.4.4 **//
+//* VERSION 1.4.5 **//
 //* DESCRIPTION Read Mores in your dash **//
 //* DETAILS This extension allows you to read 'Read More' posts without leaving your dash. Just click on the 'Read More Now!' button on posts and XKit will automatically load and display the post on your dashboard. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -127,7 +127,7 @@ XKit.extensions.read_more_now = new Object({
 	do: function() {
 		var need_reflow = false;
 
-		$(".post").not(".xread-more-now-done").each(function() {
+		$(".posts .post").not(".xread-more-now-done").each(function() {
 			var post = $(this);
 			if (post.hasClass("xread-more-now-done")) {
 				return;

--- a/Extensions/reblog_as_text.js
+++ b/Extensions/reblog_as_text.js
@@ -1,5 +1,5 @@
 //* TITLE Reblog As Text **//
-//* VERSION 1.1.0 **//
+//* VERSION 1.1.1 **//
 //* DESCRIPTION Text posts remain text **//
 //* DETAILS This post allows you to always reblog text posts as text posts, and not as links. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -17,7 +17,7 @@ XKit.extensions.reblog_as_text = new Object({
 			setTimeout(function() { XKit.extensions.reblog_as_text.fix_page(); }, 10);
 		}
 
-		if ($(".post").length > 0) {
+		if ($(".posts .post").length > 0) {
 			$(document).on("click", ".reblog_button, .post_control.reblog", XKit.extensions.reblog_as_text.fix_page);
 		}
 

--- a/Extensions/reblog_yourself.js
+++ b/Extensions/reblog_yourself.js
@@ -1,5 +1,5 @@
 //* TITLE Reblog Yourself **//
-//* VERSION 1.3 REV C **//
+//* VERSION 1.3.1 **//
 //* DESCRIPTION Allows you to reblog posts back to your blog **//
 //* DEVELOPER STUDIOXENIX **//
 //* FRAME false **//
@@ -32,7 +32,7 @@ XKit.extensions.reblog_yourself = {
 
 		if ($("body").hasClass("is_private_channel")) {return; }
 
-		if ($(".post").length > 0) {
+		if ($(".posts .post").length > 0) {
 			$(document).on("click", ".post_control.reblog", function() {
 				if ($(this).parentsUntil(".post").parent().hasClass("is_mine") === true) {
 					XKit.extensions.reblog_yourself.fix_page();
@@ -157,7 +157,7 @@ XKit.extensions.reblog_yourself = {
 			return false;
 		}
 
-		if ($(".post").length === 0) { return; }
+		if ($(".posts .post").length === 0) { return; }
 
 		/*
 			blog_id +

--- a/Extensions/replyviewer.js
+++ b/Extensions/replyviewer.js
@@ -1,5 +1,5 @@
 //* TITLE ReplyViewer **//
-//* VERSION 0.1 REV G **//
+//* VERSION 0.2 REV G **//
 //* DESCRIPTION View post replies easily **//
 //* DETAILS The close relative of TagViewer, this extension allows you to see what replies, answers and additional content added to it while reblogging on any post. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -19,7 +19,7 @@ XKit.extensions.replyviewer = new Object({
 
 		this.running = true;
 
-		if ($(".post").length > 0) {
+		if ($(".posts .post").length > 0) {
 			XKit.tools.init_css("replyviewer");
 			XKit.interface.create_control_button("xkit-replyviewer", this.button_icon, "ReplyViewer", "");
 			XKit.extensions.replyviewer.init();

--- a/Extensions/separator.js
+++ b/Extensions/separator.js
@@ -1,5 +1,5 @@
 //* TITLE Separator **//
-//* VERSION 1.1.0 **//
+//* VERSION 1.1.1 **//
 //* DESCRIPTION Where were we again? **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS A simple extension that puts a divider showing where you left off on your dashboard. **//
@@ -78,7 +78,7 @@ XKit.extensions.separator = new Object({
 
 		var last_loaded_post = XKit.storage.get("separator","last_post","");
 
-		var current_last_post = $("body").find(".post").not("#tumblr_radar").not(".new_post_buttons").first();
+		var current_last_post = $("body").find(".posts .post").not("#tumblr_radar").not(".new_post_buttons").first();
 
 		//$(last_loaded_post).css("background","red");
 
@@ -106,7 +106,7 @@ XKit.extensions.separator = new Object({
 					if (find_closest) {
 						XKit.extensions.separator.find_closest(100);
 					} else {
-						var current_last = $(".post").first();
+						var current_last = $(".posts .post").first();
 						current_last_id = $(current_last).attr('data-post-id');
 						if (current_last_id < XKit.extensions.separator.check_for) {
 							XKit.extensions.separator.find_closest(100);
@@ -136,7 +136,7 @@ XKit.extensions.separator = new Object({
 
 		if (distance >= 5000000000) { return; }
 
-		$(".post").not("#new_post").each(function() {
+		$(".posts .post").not("#new_post").each(function() {
 
 			var m_id = $(this).attr('data-post-id');
 
@@ -167,7 +167,7 @@ XKit.extensions.separator = new Object({
 
 	check_if_passed: function() {
 
-		var current_last = $(".post").last();
+		var current_last = $(".posts .post").last();
 		current_last_id = $(current_last).attr('data-post-id');
 
 		// alert("checking for: " + XKit.extensions.separator.check_for + "\n\n" + "current last: " + current_last_id);

--- a/Extensions/servant.js
+++ b/Extensions/servant.js
@@ -1,5 +1,5 @@
 //* TITLE Servant **//
-//* VERSION 0.4 REV F **//
+//* VERSION 0.5 REV F **//
 //* DESCRIPTION XKit Personal Assistant **//
 //* DETAILS Automator for XKit: lets you create little Servants that does tasks for you when the conditions you've set are met. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -1304,7 +1304,7 @@ XKit.extensions.servant = new Object({
 
 			} else {
 
-				m_object = $(".post").not(".xkit-servant-" + obj.id).not("#new_post").first();
+				m_object = $(".posts .post").not(".xkit-servant-" + obj.id).not("#new_post").first();
 				if (m_object.length === 0) { return false; }
 
 			}

--- a/Extensions/shorten_posts.js
+++ b/Extensions/shorten_posts.js
@@ -1,5 +1,5 @@
 //* TITLE Shorten Posts **//
-//* VERSION 0.2.0 **//
+//* VERSION 0.2.1 **//
 //* DESCRIPTION Makes scrolling easier **//
 //* DETAILS This extension shortens long posts, so if you are interested, you can just click on Show Full Post button to see it all, or scroll down if you are not interested. Useful for screens where long posts take a lot of space, and making it hard to scroll down.<br><br>By default, this extension only shortens text posts. You can toggle the setting to let it shorten the photo posts too. (This will 'cut off' long, vertical posts.) **//
 //* DEVELOPER STUDIOXENIX **//
@@ -53,7 +53,7 @@ XKit.extensions.shorten_posts = new Object({
 		this.running = true;
 		XKit.extensions.shorten_posts.cpanel_check_height();
 
-		if ($(".post").length > 0) {
+		if ($(".posts .post").length > 0) {
 			XKit.tools.init_css("shorten_posts");
 			$(document).on("click", ".xkit-shorten-posts-embiggen", XKit.extensions.shorten_posts.embiggen);
 			XKit.post_listener.add("shorten_posts", XKit.extensions.shorten_posts.check);
@@ -66,7 +66,7 @@ XKit.extensions.shorten_posts = new Object({
 
 		var shortened_count = 0;
 
-		$(".post").not(".xkit-shorten-posts-done").not(".xkit-shorten-posts-embiggened").each(function() {
+		$(".posts .post").not(".xkit-shorten-posts-done").not(".xkit-shorten-posts-embiggened").each(function() {
 
 			var m_height = $(this).height();
 			$(this).addClass("xkit-shorten-posts-done");

--- a/Extensions/soft_refresh.js
+++ b/Extensions/soft_refresh.js
@@ -1,5 +1,5 @@
 //* TITLE Soft Refresh **//
-//* VERSION 0.4 REV D **//
+//* VERSION 0.5 REV D **//
 //* DESCRIPTION Refresh without refreshing **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS This extension allows you to see new posts on your dashboard without refreshing the page. When you get the New Posts bubble, click on the Tumblr logo, and new posts will appear on your dashboard.<br><br>If you still want to refresh the page completely (perform a Hard Refresh), hold the ALT key while clicking on logo and the page will refresh.<br><br>Please note that this extension is highly experimental, and might not work properly all the time. **//
@@ -61,7 +61,7 @@ XKit.extensions.soft_refresh = new Object({
 
 	do_post_ids: function() {
 
-		$(".post").each(function() {
+		$(".posts .post").each(function() {
 
 			$(this).parent().attr('data-xkit-post-id', $(this).attr('data-post-id'));
 

--- a/Extensions/tagviewer.js
+++ b/Extensions/tagviewer.js
@@ -1,5 +1,5 @@
 //* TITLE TagViewer **//
-//* VERSION 0.3 REV a **//
+//* VERSION 0.4 REV a **//
 //* DESCRIPTION View post tags easily **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS This extension allows you to see what tags people added to a post while they reblogged it. It also provides access to the post, and to Tumblr search pages to find similar posts.<br><br>Based on the work of <a href='http://inklesspen.tumblr.com'>inklesspen</a> **//
@@ -27,7 +27,7 @@ XKit.extensions.tagviewer = new Object({
 
 		this.running = true;
 
-		if ($(".post").length > 0) {
+		if ($(".posts .post").length > 0) {
 			XKit.tools.init_css("tagviewer");
 			XKit.interface.create_control_button("xkit-tagviewer", this.button_icon, "TagViewer", "");
 			XKit.extensions.tagviewer.init();

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -1,5 +1,5 @@
 //* TITLE Timestamps **//
-//* VERSION 2.7.3 **//
+//* VERSION 2.7.4 **//
 //* DESCRIPTION See when a post has been made. **//
 //* DETAILS This extension lets you see when a post was made, in full date or relative time (eg: 5 minutes ago). It also works on asks, and you can format your timestamps. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -118,7 +118,7 @@ XKit.extensions.timestamps = new Object({
 	},
 
 	add_timestamps: function() {
-		var posts = $(".post").not(".xkit_timestamps");
+		var posts = $(".posts .post").not(".xkit_timestamps");
 
 		if (posts.length === 0) {
 			return;

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Tweaks **//
-//* VERSION 3.3.2 **//
+//* VERSION 3.3.3 **//
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -672,7 +672,7 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		var call_update_rect = false;
-		$(".post").not(".xkit-tweaks-checked-for-likes").each(function() {
+		$(".posts .post").not(".xkit-tweaks-checked-for-likes").each(function() {
 			$(this).addClass("xkit-tweaks-checked-for-likes");
 			if ($(this).find(".post_control.like").hasClass("liked")) {
 				$(this).addClass("is_liked");


### PR DESCRIPTION
It will prevent extensions from running on Reblog/Edit popups, and
*potentially* avoid creating conflicts with Editable reblogs.