### PR TITLE
Link to the build docs on the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,34 +21,19 @@ finding something going wrong. There's a long list of known issues
 Check out [the wiki page](https://github.com/new-xkit/XKit/wiki/Writing-a-New-Extension)!
 
 ## Develop XKit
-Download [Node.js](https://nodejs.org/download/) for your platform.
+Review the project prerequisites and learn how to build XKit from source [over on the wiki](/wiki/Build-XKit).
 
+### Quickstart
 In your clone of this repository run:
 
 ```sh
 npm install
 ```
 
-and then:
-
-```sh
-gulp watch
-```
-
-to automatically run the project tests whenever files are edited.
-
 To build XKit from source, run:
 
 ```sh
 gulp build
 ```
-
-or
-
-```sh
-gulp build:<platform>
-```
-
-where `<platform>` is one of: `chrome`, `firefox`.
 
 Builds can be found in the `build/` directory.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ finding something going wrong. There's a long list of known issues
 Check out [the wiki page](https://github.com/new-xkit/XKit/wiki/Writing-a-New-Extension)!
 
 ## Develop XKit
-Review the project prerequisites and learn how to build XKit from source [over on the wiki](/wiki/Build-XKit).
+Review the project prerequisites and learn how to build XKit from source [over on the wiki](https://github.com/new-xkit/XKit/wiki/Build-XKit).
 
 ### Quickstart
 In your clone of this repository run:
@@ -37,3 +37,5 @@ gulp build
 ```
 
 Builds can be found in the `build/` directory.
+
+For a list of available build tasks, see [the documentation](https://github.com/new-xkit/XKit/wiki).

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ gulp build
 
 Builds can be found in the `build/` directory.
 
-For a list of available build tasks, see [the documentation](https://github.com/new-xkit/XKit/wiki).
+For a list of available build tasks, see [the documentation](https://github.com/new-xkit/XKit/wiki/Build-XKit#gulp-tasks).


### PR DESCRIPTION
Per my comments at the end of PR #175, update the README to point to the full list of Gulp tasks now on the wiki.

Are the instructions here self-explanatory, or do we need to have a longer 'Quickstart' section before shunting them off to the wiki?