### PR TITLE
Fix sending asks when classic menu is enabled

### DIFF
--- a/Extensions/show_more.js
+++ b/Extensions/show_more.js
@@ -82,7 +82,7 @@ XKit.extensions.show_more = new Object({
 		if (document.location.href.indexOf('www.tumblr.com/follow/') != -1)
 			return;
 
-		if (XKit.interface.where().inbox === true) {
+		if (XKit.interface.where().inbox) {
 			XKit.extensions.show_more.init_inbox_asks();
 		} else {
 			if ($("#dashboard_ask_template").length > 0) {
@@ -90,7 +90,7 @@ XKit.extensions.show_more = new Object({
 			}
 		}
 
-		if (this.preferences.use_classic_menu.value === true) {
+		if (this.preferences.use_classic_menu.value) {
 
 			XKit.tools.add_css(".tumblelog_popover_v1, .tumblelog_popover_v2, .tumblelog_popover { display: none !important; }", "show_more_classic_menu");
 			$(document).on('mouseover', '.post_avatar_link', XKit.extensions.show_more.enable_classic_menu);
@@ -158,7 +158,7 @@ XKit.extensions.show_more = new Object({
 
 		if (XKit.extensions.show_more.popup_data.show_ask == 1 ||XKit.extensions.show_more.popup_data.asks == 1) {
 			var anon_status = "0";
-			if (XKit.extensions.show_more.popup_data.ask_allows_anonymous === true || XKit.extensions.show_more.popup_data.anonymous_asks === true ||XKit.extensions.show_more.popup_data.ask_allows_anonymous === 1 || XKit.extensions.show_more.popup_data.anonymous_asks === 1) {
+			if (XKit.extensions.show_more.popup_data.ask_allows_anonymous || XKit.extensions.show_more.popup_data.anonymous_asks || XKit.extensions.show_more.popup_data.ask_allows_anonymous === 1 || XKit.extensions.show_more.popup_data.anonymous_asks === 1) {
 				anon_status = "1";
 			}
 			if (user_url === "xkit-extension" || user_url === "new-xkit-extension") {
@@ -178,7 +178,7 @@ XKit.extensions.show_more = new Object({
 			m_html = m_html + "<a data-tumblelog-name=\"" + user_url + "\" class=\"xkit-follow xkit-follow-" + user_url + "\">Follow</a>";
 		}
 
-		if (XKit.extensions.show_more.preferences.show_magnetizer.value === true) {
+		if (XKit.extensions.show_more.preferences.show_magnetizer.value) {
 
 			if (avatar_url !== "" && typeof avatar_url !== "undefined") {
 				m_html = m_html + "<div data-avatar-url=\"" + avatar_url + "\" class=\"xkit-magnetizer xkit-show-more-item xkit-avatar-magnetizer-new xkit-avatar-magnetizer-button-" + user_url + "\" data-user-url=\"" + user_url + "\">" +
@@ -188,13 +188,13 @@ XKit.extensions.show_more = new Object({
 
 		}
 
-		if (XKit.extensions.show_more.preferences.show_archive.value === true) {
+		if (XKit.extensions.show_more.preferences.show_archive.value) {
 
 			m_html = m_html + "<a target=\"_blank\" href=\"http://" + user_url + ".tumblr.com/archive\" class=\"xkit-archive archive\">Archive</a>";
 
 		}
 
-		if (XKit.extensions.show_more.preferences.show_submits.value === true && XKit.extensions.show_more.submit_available[user_url] === true) {
+		if (XKit.extensions.show_more.preferences.show_submits.value && XKit.extensions.show_more.submit_available[user_url]) {
 
 			var m_submit_url = "http://" + user_url + ".tumblr.com/submit";
 
@@ -202,7 +202,7 @@ XKit.extensions.show_more = new Object({
 
 		}
 
-		if (XKit.extensions.show_more.preferences.show_likes.value === true && XKit.extensions.show_more.likes_available[user_url] === true) {
+		if (XKit.extensions.show_more.preferences.show_likes.value && XKit.extensions.show_more.likes_available[user_url]) {
 
 			var m_likes_url = "https://www.tumblr.com/liked/by/" + user_url;
 
@@ -404,8 +404,8 @@ XKit.extensions.show_more = new Object({
 
 		var m_obj = $(e.target);
 
-		if (m_obj.hasClass("post_avatar_link") !== true) {
-			while (m_obj.hasClass("post_avatar_link") !== true) {
+		if (!m_obj.hasClass("post_avatar_link")) {
+			while (!m_obj.hasClass("post_avatar_link")) {
 				m_obj = m_obj.parent();
 			}
 		}
@@ -497,8 +497,8 @@ XKit.extensions.show_more = new Object({
 
 		var m_obj = $(e.target);
 
-		if (m_obj.hasClass("post_avatar_link") !== true) {
-			while (m_obj.hasClass("post_avatar_link") !== true) {
+		if (!m_obj.hasClass("post_avatar_link")) {
+			while (!m_obj.hasClass("post_avatar_link")) {
 				m_obj = m_obj.parent();
 			}
 		}
@@ -545,7 +545,7 @@ XKit.extensions.show_more = new Object({
 
 		}
 
-		if (XKit.extensions.show_more.preferences.show_magnetizer.value === true) {
+		if (XKit.extensions.show_more.preferences.show_magnetizer.value) {
 
 			if (avatar_url !== "" && typeof avatar_url !== "undefined") {
 				m_html = m_html + "<li>" +
@@ -558,7 +558,7 @@ XKit.extensions.show_more = new Object({
 		}
 
 
-		if (XKit.extensions.show_more.preferences.show_submits.value === true && XKit.extensions.show_more.submit_available[user_url] === true) {
+		if (XKit.extensions.show_more.preferences.show_submits.value && XKit.extensions.show_more.submit_available[user_url]) {
 
 			var m_likes_url = "http://" + user_url + ".tumblr.com/submit";
 
@@ -608,7 +608,7 @@ XKit.extensions.show_more = new Object({
 		$('.tumblelog_menu_button').unbind('click', XKit.extensions.show_more.add_links);
 		$('.tumblelog_menu_button').bind('click', XKit.extensions.show_more.add_links);
 
-		if (XKit.extensions.show_more.preferences.show_submits.value === true) {
+		if (XKit.extensions.show_more.preferences.show_submits.value) {
 
 			var submit_delay_count = 0;
 
@@ -618,8 +618,8 @@ XKit.extensions.show_more = new Object({
 
 				var username = $(this).parent().attr('data-tumblelog-name');
 
-				if (XKit.extensions.show_more.submit_available[username] === true ||
-					XKit.extensions.show_more.submit_available[username] === false) {
+				if (XKit.extensions.show_more.submit_available[username] ||
+					!XKit.extensions.show_more.submit_available[username]) {
 					return;
 				}
 
@@ -649,7 +649,7 @@ XKit.extensions.show_more = new Object({
 
 		}
 
-		if (XKit.extensions.show_more.preferences.enable_anon.value === true) {
+		if (XKit.extensions.show_more.preferences.enable_anon.value) {
 
 			var anon_delay_count = 0;
 
@@ -659,8 +659,8 @@ XKit.extensions.show_more = new Object({
 
 				var username = $(this).parent().attr('data-tumblelog-name');
 
-				if (XKit.extensions.show_more.anon_available[username] === true ||
-					XKit.extensions.show_more.anon_available[username] === false) {
+				if (XKit.extensions.show_more.anon_available[username] ||
+					!XKit.extensions.show_more.anon_available[username]) {
 					return;
 				}
 
@@ -692,7 +692,7 @@ XKit.extensions.show_more = new Object({
 
 		}
 
-		if (XKit.extensions.show_more.preferences.show_likes.value === true) {
+		if (XKit.extensions.show_more.preferences.show_likes.value) {
 
 			var m_delay_count = 0;
 
@@ -703,8 +703,8 @@ XKit.extensions.show_more = new Object({
 
 				var username = $(this).parent().attr('data-tumblelog-name');
 
-				if (XKit.extensions.show_more.likes_available[username] === true ||
-					XKit.extensions.show_more.likes_available[username] === false) {
+				if (XKit.extensions.show_more.likes_available[username] ||
+					!XKit.extensions.show_more.likes_available[username]) {
 					return;
 				}
 
@@ -747,13 +747,13 @@ XKit.extensions.show_more = new Object({
 		$(menu_box).find(".xkit-submit").parent().remove();
 		$(menu_box).find(".xkit-likes").parent().remove();
 
-		if (XKit.extensions.show_more.anon_available[user_url] === true) {
+		if (XKit.extensions.show_more.anon_available[user_url]) {
 
 			$(menu_box).find(".tumblelog_menu_link.ask").attr('data-anonymous-ask','1');
 
 		}
 
-		if (XKit.extensions.show_more.preferences.show_likes.value === true && XKit.extensions.show_more.likes_available[user_url] === true) {
+		if (XKit.extensions.show_more.preferences.show_likes.value && XKit.extensions.show_more.likes_available[user_url]) {
 
 			var m_likes_url = "https://www.tumblr.com/liked/by/" + user_url;
 
@@ -765,7 +765,7 @@ XKit.extensions.show_more = new Object({
 
 		}
 
-		if (XKit.extensions.show_more.preferences.show_submits.value === true && XKit.extensions.show_more.submit_available[user_url] === true) {
+		if (XKit.extensions.show_more.preferences.show_submits.value && XKit.extensions.show_more.submit_available[user_url]) {
 
 			var m_submit_url = "http://" + user_url + ".tumblr.com/submit";
 
@@ -779,7 +779,7 @@ XKit.extensions.show_more = new Object({
 
 		$(menu_box).find(".xkit-avatar-magnetizer").parent().remove();
 
-		if (XKit.extensions.show_more.preferences.show_magnetizer.value === true) {
+		if (XKit.extensions.show_more.preferences.show_magnetizer.value) {
 
 			var avatar_url = $(menu_box).parentsUntil(".post_avatar").parent().find(".post_avatar_image").attr('src');
 

--- a/Extensions/show_more.js
+++ b/Extensions/show_more.js
@@ -618,8 +618,7 @@ XKit.extensions.show_more = new Object({
 
 				var username = $(this).parent().attr('data-tumblelog-name');
 
-				if (XKit.extensions.show_more.submit_available[username] ||
-					!XKit.extensions.show_more.submit_available[username]) {
+				if (typeof XKit.extensions.show_more.submit_available[username] === "boolean") {
 					return;
 				}
 
@@ -659,8 +658,7 @@ XKit.extensions.show_more = new Object({
 
 				var username = $(this).parent().attr('data-tumblelog-name');
 
-				if (XKit.extensions.show_more.anon_available[username] ||
-					!XKit.extensions.show_more.anon_available[username]) {
+				if (typeof XKit.extensions.show_more.anon_available[username] === "boolean") {
 					return;
 				}
 
@@ -703,8 +701,7 @@ XKit.extensions.show_more = new Object({
 
 				var username = $(this).parent().attr('data-tumblelog-name');
 
-				if (XKit.extensions.show_more.likes_available[username] ||
-					!XKit.extensions.show_more.likes_available[username]) {
+				if (typeof XKit.extensions.show_more.likes_available[username] === "boolean") {
 					return;
 				}
 

--- a/Extensions/show_more.js
+++ b/Extensions/show_more.js
@@ -1,5 +1,5 @@
 //* TITLE User Menus+ **//
-//* VERSION 2.5.2 **//
+//* VERSION 2.5.3 **//
 //* DESCRIPTION More options on the user menu **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS This extension adds additional options to the user menu (the one that appears under user avatars on your dashboard), such as Avatar Magnifier, links to their Liked Posts page if they have them enabled. Note that this extension, especially the Show Likes and Show Submit options use a lot of network and might slow your computer down. **//
@@ -131,6 +131,7 @@ XKit.extensions.show_more = new Object({
 		$(document).on('mouseover', '.post_info_fence a, .post_info a, a.username', XKit.extensions.show_more.store_data_username);
 		$(document).on('mouseover', '.post_avatar_link', XKit.extensions.show_more.store_data_avatar);
 		$(document).on('click mouseover','.tumblelog_popover .info_popover_button', XKit.extensions.show_more.add_links_new);
+		$(document).on('click', '#xkit-classic-user-menu .xkit-ask', XKit.extensions.show_more.intercept_classic_menu_ask);
 
 	},
 
@@ -869,6 +870,20 @@ XKit.extensions.show_more = new Object({
 
 	},
 
+	intercept_classic_menu_ask: function(event) {
+		event.preventDefault();
+
+		XKit.tools.add_function(function(){
+			var args = JSON.parse(add_tag);
+			var config = jQuery("<div data-tumblelog-name='" + args.recipient + "' />");
+			config.data("anonymous_ask", args.anonymous_asks);
+			Tumblr.DashboardAsk.open_ask(config);
+		}, true, JSON.stringify({
+			recipient: this.getAttribute("data-tumblelog-name"),
+			anonymous_asks: this.getAttribute("data-anonymous-ask")
+		}));
+	},
+
 	destroy: function() {
 		$(".xkit-likes").parent().remove();
 		$(".xkit-submit").parent().remove();
@@ -878,6 +893,7 @@ XKit.extensions.show_more = new Object({
 		$(document).off('mouseover', '.post_info_fence a, .post_info a, a.username', XKit.extensions.show_more.store_data_username);
 		$(document).off('mouseover', '.post_avatar_link', XKit.extensions.show_more.store_data_avatar);
 		$(document).off('click','.tumblelog_menu_btn', XKit.extensions.show_more.add_links_new);
+		$(document).off('click', '#xkit-classic-user-menu .xkit-ask', XKit.extensions.show_more.intercept_classic_menu_ask);
 		this.running = false;
 	}
 

--- a/Extensions/show_more.js
+++ b/Extensions/show_more.js
@@ -847,6 +847,24 @@ XKit.extensions.show_more = new Object({
 			var config = jQuery("<div data-tumblelog-name='" + args.recipient + "' />");
 			config.data("anonymous_ask", args.anonymous_asks);
 			Tumblr.DashboardAsk.open_ask(config);
+
+			// For some reason, option to send anonymous ask isn't available
+			// so we have to add it ourselves
+			if (args.anonymous_asks === "1") {
+				setTimeout(function(){
+					var ask_button_div = jQuery("#ask_button").parent();
+					var ask_anonymously_html = "" +
+						"<div class='control right'>" +
+							"<div class='post-forms--ask-anonymous'>" +
+								"<label class='binary_switch'>" +
+									"<input type='checkbox' name='anonymous' value='1' id='ask_anonymously'>" +
+									"<span class='binary_switch_track'></span> <span class='binary_switch_button'></span>" +
+								"</label><label id='ask_anonymously_label' for='ask_anonymously'>Ask anonymously</label>" +
+							"</div>" +
+						"</div>";
+					ask_button_div.before(ask_anonymously_html);
+				}, 500);
+			}
 		}, true, JSON.stringify({
 			recipient: this.getAttribute("data-tumblelog-name"),
 			anonymous_asks: this.getAttribute("data-anonymous-ask")

--- a/Extensions/show_more.js
+++ b/Extensions/show_more.js
@@ -65,10 +65,7 @@ XKit.extensions.show_more = new Object({
 	init_inbox_asks: function() {
 
 		var askbox_template = XKit.storage.get("show_more","inbox_ask_template","");
-		if (askbox_template !== "") {
-			// console.log("Found Inbox Ask Template!");
-		} else {
-			// console.log("Template not found, quitting init_inbox_asks.");
+		if (askbox_template === "") {
 			return;
 		}
 
@@ -92,18 +89,6 @@ XKit.extensions.show_more = new Object({
 				XKit.storage.set("show_more","inbox_ask_template", $("#dashboard_ask_template")[0].outerHTML);
 			}
 		}
-
-		/*if (this.preferences.hide_previews.value === true) {
-
-			XKit.tools.add_css(".popover .recent_posts { display: none; } .popover .tumblelog_info { border-radius: 6px; border-top: 0px; }", "show_more_hide_previews");
-
-		}
-
-		if (this.preferences.hide_follow.value === true) {
-
-			XKit.tools.add_css(".popover .follow_nav { display: none; }", "show_more_hide_follows");
-
-		}*/
 
 		if (this.preferences.use_classic_menu.value === true) {
 
@@ -153,8 +138,6 @@ XKit.extensions.show_more = new Object({
 		e.stopPropagation();
 
 		var m_obj = $(e.target);
-
-		// console.log(XKit.extensions.show_more.popup_data);
 
 		if (typeof XKit.extensions.show_more.popup_data.avatar_url === "undefined") {
 			return;
@@ -227,7 +210,6 @@ XKit.extensions.show_more = new Object({
 
 		}
 
-		//// console.log("EH? " + XKit.extensions.show_more.custom_menu_extension);
 		if (XKit.extensions.show_more.custom_menu_extension.length >= 0) {
 
 			var m_data = XKit.extensions.show_more.popup_data;
@@ -260,8 +242,6 @@ XKit.extensions.show_more = new Object({
 		$("#xkit-classic-user-menu").css("top", m_top + "px");
 		$("#xkit-classic-user-menu").css("left", m_left + "px");
 
-
-			// console.log("Attaching bindings...");
 
 		setTimeout(function() {
 
@@ -323,7 +303,6 @@ XKit.extensions.show_more = new Object({
 				$(".tumblelog_popover_glass").trigger('click');
 				setTimeout(function() { $(".tumblelog_popover_glass").trigger('click'); }, 10);
 				$(".popover").hide();
-				//$("#glass_overlay").removeClass("show");
 
 			});
 
@@ -368,7 +347,6 @@ XKit.extensions.show_more = new Object({
 
 	unfollow_person: function(user_url, m_parent) {
 
-		// console.log("Unfollowing " + user_url);
 		var m_data = "form_key=" + XKit.interface.form_key() + "&data%5Btumblelog%5D=" + user_url + "&data%5Bsource%5D=FOLLOW_SOURCE_IFRAME";
 		GM_xmlhttpRequest({
 			method: "POST",
@@ -425,8 +403,6 @@ XKit.extensions.show_more = new Object({
 	enable_classic_menu: function(e) {
 
 		var m_obj = $(e.target);
-
-		//// console.log("Trying to add: " + XKit.extensions.show_more.popup_data);
 
 		if (m_obj.hasClass("post_avatar_link") !== true) {
 			while (m_obj.hasClass("post_avatar_link") !== true) {
@@ -594,7 +570,6 @@ XKit.extensions.show_more = new Object({
 
 				}
 
-				// console.log(XKit.extensions.show_more.custom_menu_extension);
 				if (XKit.extensions.show_more.custom_menu_extension.length >= 0) {
 
 					var m_data = XKit.extensions.show_more.popup_data;
@@ -616,8 +591,6 @@ XKit.extensions.show_more = new Object({
 
 		$(m_parent).append(m_html);
 
-		// console.log(m_html);
-
 		$(".xkit-avatar-magnetizer-button-" + user_url).unbind('click');
 		$(".xkit-avatar-magnetizer-button-" + user_url).bind('click', function() {
 
@@ -625,7 +598,6 @@ XKit.extensions.show_more = new Object({
 			$(".tumblelog_popover_glass").trigger('click');
 			setTimeout(function() { $(".tumblelog_popover_glass").trigger('click'); }, 10);
 			$(".popover").hide();
-			//$("#glass_overlay").removeClass("show");
 
 		});
 
@@ -822,8 +794,6 @@ XKit.extensions.show_more = new Object({
 		}
 
 
-		//$(menu_box).find(".open_in_tab").parent().before(m_html);
-
 		$(menu_box).find(".tumblelog_menu_popover").append(m_html);
 
 		var m_target = e.target;
@@ -835,7 +805,6 @@ XKit.extensions.show_more = new Object({
 			setTimeout(function() { $("#glass_overlay").trigger('click'); }, 10);
 
 			$(m_target).trigger('click');
-			//$("#glass_overlay").removeClass("show");
 
 		});
 

--- a/Extensions/show_more.js
+++ b/Extensions/show_more.js
@@ -272,39 +272,39 @@ XKit.extensions.show_more = new Object({
 		}, 300);
 
 
-			$("#xkit-classic-user-menu-glass").unbind("click");
-			$("#xkit-classic-user-menu-glass").bind("click", function() {
-				XKit.extensions.show_more.hide_classic_menu();
-			});
+		$("#xkit-classic-user-menu-glass").unbind("click");
+		$("#xkit-classic-user-menu-glass").bind("click", function() {
+			XKit.extensions.show_more.hide_classic_menu();
+		});
 
-			$("#xkit-classic-user-menu a, #xkit-classic-user-menu div").unbind("click");
-			$("#xkit-classic-user-menu a, #xkit-classic-user-menu div").bind("click", function() {
-				XKit.extensions.show_more.hide_classic_menu();
-			});
+		$("#xkit-classic-user-menu a, #xkit-classic-user-menu div").unbind("click");
+		$("#xkit-classic-user-menu a, #xkit-classic-user-menu div").bind("click", function() {
+			XKit.extensions.show_more.hide_classic_menu();
+		});
 
-			$("#xkit-classic-user-menu a.xkit-fan-mail").unbind("click");
-			$("#xkit-classic-user-menu a.xkit-fan-mail").bind("click", function(e) {
-				e.preventDefault();
-				XKit.extensions.show_more.hide_classic_menu();
-				XKit.tools.add_function(function() {
-							var f = {
-									href: "/send/" + jQuery(".xkit-fan-mail").attr('data-tumblelog-name')
-							};
-					Tumblr.FanMail.show(f);
-				}, true, "");
+		$("#xkit-classic-user-menu a.xkit-fan-mail").unbind("click");
+		$("#xkit-classic-user-menu a.xkit-fan-mail").bind("click", function(e) {
+			e.preventDefault();
+			XKit.extensions.show_more.hide_classic_menu();
+			XKit.tools.add_function(function() {
+				var f = {
+						href: "/send/" + jQuery(".xkit-fan-mail").attr('data-tumblelog-name')
+				};
+				Tumblr.FanMail.show(f);
+			}, true, "");
 
-			});
+		});
 
-			$(".xkit-avatar-magnetizer-button-" + user_url).unbind('click');
-			$(".xkit-avatar-magnetizer-button-" + user_url).bind('click', function() {
+		$(".xkit-avatar-magnetizer-button-" + user_url).unbind('click');
+		$(".xkit-avatar-magnetizer-button-" + user_url).bind('click', function() {
 
-				XKit.extensions.show_more.hide_classic_menu();
-				XKit.extensions.show_more.show_avatar(user_url);
-				$(".tumblelog_popover_glass").trigger('click');
-				setTimeout(function() { $(".tumblelog_popover_glass").trigger('click'); }, 10);
-				$(".popover").hide();
+			XKit.extensions.show_more.hide_classic_menu();
+			XKit.extensions.show_more.show_avatar(user_url);
+			$(".tumblelog_popover_glass").trigger('click');
+			setTimeout(function() { $(".tumblelog_popover_glass").trigger('click'); }, 10);
+			$(".popover").hide();
 
-			});
+		});
 
 	},
 
@@ -547,47 +547,47 @@ XKit.extensions.show_more = new Object({
 
 		if (XKit.extensions.show_more.preferences.show_magnetizer.value === true) {
 
-					if (avatar_url !== "" && typeof avatar_url !== "undefined") {
-						m_html = m_html + "<li>" +
-								"<a onclick=\"return false;\" data-avatar-url=\"" + avatar_url + "\" class=\" xkit-new-menu-fix xkit-show-more-item xkit-avatar-magnetizer-new xkit-avatar-magnetizer-button-" + user_url + "\" data-user-url=\"" + user_url + "\">" +
-									"Magnifier" +
-								"</a>" +
-								"</li>";
-					}
+			if (avatar_url !== "" && typeof avatar_url !== "undefined") {
+				m_html = m_html + "<li>" +
+						"<a onclick=\"return false;\" data-avatar-url=\"" + avatar_url + "\" class=\" xkit-new-menu-fix xkit-show-more-item xkit-avatar-magnetizer-new xkit-avatar-magnetizer-button-" + user_url + "\" data-user-url=\"" + user_url + "\">" +
+							"Magnifier" +
+						"</a>" +
+						"</li>";
+			}
 
+		}
+
+
+		if (XKit.extensions.show_more.preferences.show_submits.value === true && XKit.extensions.show_more.submit_available[user_url] === true) {
+
+			var m_likes_url = "http://" + user_url + ".tumblr.com/submit";
+
+			m_html = m_html + "<li>" +
+					"<a target=\"_new\" href=\"" + m_likes_url + "\" class=\"likes xkit-submit xkit-new-menu-fix\">" +
+						"<span class=\"hide_overflow\">Submit</span>" +
+					"</a>" +
+					"</li>";
+
+		}
+
+		if (XKit.extensions.show_more.custom_menu_extension.length >= 0) {
+
+			var m_data = XKit.extensions.show_more.popup_data;
+
+			for (var i=0;i<XKit.extensions.show_more.custom_menu_extension.length;i++) {
+
+				var returned_menu = "";
+
+				try {
+					returned_menu = XKit.extensions.show_more.custom_menu_function[i](m_data);
+				} catch(e) {
+					returned_menu = "";
 				}
 
+				m_html = m_html + returned_menu;
+			}
 
-				if (XKit.extensions.show_more.preferences.show_submits.value === true && XKit.extensions.show_more.submit_available[user_url] === true) {
-
-					var m_likes_url = "http://" + user_url + ".tumblr.com/submit";
-
-					m_html = m_html + "<li>" +
-							"<a target=\"_new\" href=\"" + m_likes_url + "\" class=\"likes xkit-submit xkit-new-menu-fix\">" +
-								"<span class=\"hide_overflow\">Submit</span>" +
-							"</a>" +
-							"</li>";
-
-				}
-
-				if (XKit.extensions.show_more.custom_menu_extension.length >= 0) {
-
-					var m_data = XKit.extensions.show_more.popup_data;
-
-					for (var i=0;i<XKit.extensions.show_more.custom_menu_extension.length;i++) {
-
-						var returned_menu = "";
-
-						try {
-							returned_menu = XKit.extensions.show_more.custom_menu_function[i](m_data);
-						} catch(e) {
-							returned_menu = "";
-						}
-
-						m_html = m_html + returned_menu;
-					}
-
-				}
+		}
 
 		$(m_parent).append(m_html);
 


### PR DESCRIPTION
Plus some refactoring.

Fixes #42.

The `Tumblr.DashboardAsk.open_ask` function I'm trying to call looks like:

```javascript
function(g) {
    Tumblr.Popover.hide_all();
    var h = g.attr("data-tumblelog-name");
    var i = (parseInt(g.data("anonymous-ask"), 10) === 1) ? true : false;
    this.model = new f();
    if (this.view) {
        this.view.destroy()
    }
    this.view = new b({
        model: this.model,
        recipient: h,
        allow_anonymous: i
    }).show_form()
}
```