### PR TITLE
XKit.interface.where().user_url populates on blogs

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -2048,6 +2048,10 @@ XKit.tools.dump_config = function(){
 					m_return.likes = true;
 				}
 
+				if ($('meta[name="twitter:title"]').length) {
+					m_return.user_url = $('meta[name="twitter:title"]').attr("content");
+				}
+
 				m_return.dashboard = $("body").hasClass("is_dashboard") === true;
 				m_return.channel = $("body").hasClass("is_channel") === true;
 				m_return.endless = $("body").hasClass("without_auto_paginate") === false;


### PR DESCRIPTION
`<meta name="twitter:title" content="user-url">` looks like it's tumblr's code that appears on all blogs, so this should allow extensions that run on blogs to easily obtain the blog's tumblr username.

Fixes #232 