### PR TITLE
Add suggested "Hide explore links" tweak

### DIFF
--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -444,7 +444,7 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_explore_buttons.value) {
-			XKit.extensions.tweaks.add_css("#discover_button, a[href=\"/explore\"] { display: none; } ", "xkit_tweaks_hide_explore_buttons")
+			XKit.extensions.tweaks.add_css("#discover_button, a[href=\"/explore\"] { display: none; } ", "xkit_tweaks_hide_explore_buttons");
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_notes.value) {

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -444,7 +444,7 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_explore_buttons.value) {
-			XKit.extensions.tweaks.add_css("#discover_button, a[href='/explore'] { display: none; } ", "xkit_tweaks_hide_explore_buttons")
+			XKit.extensions.tweaks.add_css("#discover_button, a[href=\"/explore\"] { display: none; } ", "xkit_tweaks_hide_explore_buttons")
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_notes.value) {

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -746,8 +746,6 @@ XKit.extensions.tweaks = new Object({
 		$("#new_post_in_tracked_tags_bubble").remove();
 		$("#tumblr_radar").css("display","block");
 		$("#xkit_customize_button").remove();
-		$("#discover_button").css("display", "block");
-		$("a[href='/explore']").css("display", "block");
 		$("a.spotlight").parent().css("display","block");
 		$("#recommended_tumblelogs, .recommended_tumblelogs, .trending_tumblelogs").css("display","block");
 		$("a.activity").parent().css("display","block");

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Tweaks **//
-//* VERSION 3.4.1 **//
+//* VERSION 3.4.2 **//
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -166,6 +166,11 @@ XKit.extensions.tweaks = new Object({
 		},
 		"hide_explore": {
 			text: "Hide explore button on trending posts",
+			default: false,
+			value: false
+		},
+		"hide_explore_buttons": {
+			text: "Hide the explore link at the top of the page and in the sidebar",
 			default: false,
 			value: false
 		},
@@ -436,6 +441,10 @@ XKit.extensions.tweaks = new Object({
 
         if (XKit.extensions.tweaks.preferences.hide_explore.value) {
 			XKit.extensions.tweaks.add_css(".post .explore-trending-badge-footer { display: none; } ", "xkit_tweaks_hide_explore");
+		}
+
+		if (XKit.extensions.tweaks.preferences.hide_explore_buttons.value) {
+			XKit.extensions.tweaks.add_css("#discover_button, a[href="/explore"] { display: none; } ", "xkit_tweaks_hide_explore_buttons")
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_notes.value) {

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -746,6 +746,8 @@ XKit.extensions.tweaks = new Object({
 		$("#new_post_in_tracked_tags_bubble").remove();
 		$("#tumblr_radar").css("display","block");
 		$("#xkit_customize_button").remove();
+		$("#discover_button").css("display", "block");
+		$("a[href='/explore']").css("display", "block");
 		$("a.spotlight").parent().css("display","block");
 		$("#recommended_tumblelogs, .recommended_tumblelogs, .trending_tumblelogs").css("display","block");
 		$("a.activity").parent().css("display","block");

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -444,7 +444,7 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_explore_buttons.value) {
-			XKit.extensions.tweaks.add_css("#discover_button, a[href="/explore"] { display: none; } ", "xkit_tweaks_hide_explore_buttons")
+			XKit.extensions.tweaks.add_css("#discover_button, a[href='/explore'] { display: none; } ", "xkit_tweaks_hide_explore_buttons")
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_notes.value) {


### PR DESCRIPTION
Based on an ask.

>Could it be possible to hide the Explore button? See, not only does literally no one need it, but also at least ,I with my slow internet, sometimes accidentally click on the dashboard icon before xKit has properly loaded so when xKit does load, it moves all links one "spot" left, which leads to me going to the Explore page instead of dash. If the Explore button disappeared when xKit button leads, this problem would be solved. 