### PR TITLE
XCloud Fix

### DIFF
--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,6 +1,6 @@
 
 //* TITLE Tweaks **//
-//* VERSION 4.0.3 **//
+//* VERSION 4.0.4 **//
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//

--- a/Extensions/xcloud.js
+++ b/Extensions/xcloud.js
@@ -18,7 +18,7 @@ XKit.extensions.xcloud = new Object({
 
 	get_xcloud_url: function() {
 		if (XKit.extensions.xcloud.useoldserver) {
-			return "https://www.xkitcs.com";
+			return "https://uyjv93kxna.execute-api.us-west-2.amazonaws.com/production";
 		} else {
 			return "https://cloud.new-xkit.com";
 		}
@@ -214,6 +214,7 @@ XKit.extensions.xcloud = new Object({
 
 			var registerRequest = {
 				url: xcloud_url + "/xcloud/register",
+
 				onerror: function() {
 
 					XKit.extensions.xcloud.hide_overlay();
@@ -272,7 +273,7 @@ XKit.extensions.xcloud = new Object({
 
 			if(XKit.extensions.xcloud.useoldserver){
 				registerRequest.method = "GET";
-				registerRequest += "?username=" + m_username + "&password=" + m_password;
+				registerRequest.url += "?username=" + m_username + "&password=" + m_password;
 				registerRequest.json = false;
 			} else {
 				registerRequest.method = "POST";
@@ -879,7 +880,6 @@ XKit.extensions.xcloud = new Object({
 
 
 		if(XKit.extensions.xcloud.useoldserver){
-			uploadRequest.url = "http://xcloud.puaga.com/upload/?ftch_id=" + XKit.tools.random_string();
 			uploadRequest.data = "username=" + m_username + "&password=" + m_password + "&" + "data=" + to_send;
 			uploadRequest.json = false;
 		} else {

--- a/Extensions/xcloud.js
+++ b/Extensions/xcloud.js
@@ -249,17 +249,21 @@ XKit.extensions.xcloud = new Object({
 					} else {
 
 						var err_desc = "";
+						var err_title = "";
 						if (mdata.error_code === "102") {
 							err_desc = "<br/>Usernames can only have letters and numbers.";
+							err_title = "Invalid Username";
 						}
 						if (mdata.error_code === "202") {
 							err_desc = "<br/>Please enter a password.";
+							err_title = "No Password";
 						}
 						if (mdata.error_code === "100") {
 							err_desc = "<br/>Please pick another username.";
+							err_title = "Username Taken";
 						}
 
-						XKit.window.show("Unable to sign up","<b>" + mdata.error_str + "</b> (code: " + mdata.error_code + ")" + err_desc,"error","<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
+						XKit.window.show("Unable to sign up","<b>" + err_title + "</b> (code: " + mdata.error_code + ")" + err_desc,"error","<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
 						return;
 
 					}
@@ -340,23 +344,29 @@ XKit.extensions.xcloud = new Object({
 					} else {
 
 						var err_desc = "";
+						var err_title = "";
 						if (mdata.error_code === "102") {
 							err_desc = "<br/>Usernames can only have letters and numbers.";
+							err_title = "Invalid Username";
 						}
 						if (mdata.error_code === "202") {
 							err_desc = "<br/>Please enter a password.";
+							err_title = "No Password";
 						}
 						if (mdata.error_code === "100") {
 							err_desc = "<br/>Please pick another username.";
+							err_title = "Username taken.";
 						}
 						if (mdata.error_code === "400") {
 							err_desc = "<br/>Please check your username and try again.";
+							err_title = "Invalid Username";
 						}
 						if (mdata.error_code === "602") {
-							err_desc = "<br/>Please check your password and try again.";
+							err_desc = "<br/>Please check your password and try again.<br/>If you have changed your password, you might need to log out of XCloud and sign back in.";
+							err_title = "Wrong Password";
 						}
 
-						XKit.window.show("Unable to sign in", "<b>" + mdata.error_str + "</b> (code: " + mdata.error_code + ")" + err_desc, "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
+						XKit.window.show("Unable to sign in", "<b>" + err_title + "</b> (code: " + mdata.error_code + ")" + err_desc, "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
 						return;
 
 					}
@@ -839,23 +849,29 @@ XKit.extensions.xcloud = new Object({
 				} else {
 					XKit.extensions.xcloud.hide_overlay();
 					var err_desc = "";
+					var err_title = "";
 					if (mdata.error_code === "102") {
 						err_desc = "<br/>Usernames can only have letters and numbers.";
+						err_title = "Invalid Username";
 					}
 					if (mdata.error_code === "202") {
 						err_desc = "<br/>Please enter a password.";
+						err_title = "No Password";
 					}
 					if (mdata.error_code === "100") {
 						err_desc = "<br/>Please pick another username.";
+						err_title = "Username taken.";
 					}
 					if (mdata.error_code === "400") {
 						err_desc = "<br/>Please check your username and try again.";
+						err_title = "Invalid Username";
 					}
 					if (mdata.error_code === "602") {
 						err_desc = "<br/>Please check your password and try again.<br/>If you have changed your password, you might need to log out of XCloud and sign back in.";
+						err_title = "Wrong Password";
 					}
 
-					XKit.window.show("Unable to complete synchronization","<b>" + mdata.error_str + "</b> (code: " + mdata.error_code + ")" + err_desc,"error","<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
+					XKit.window.show("Unable to complete synchronization","<b>" + err_title + "</b> (code: " + mdata.error_code + ")" + err_desc,"error","<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
 				}
 			}
 		};

--- a/Extensions/xcloud.js
+++ b/Extensions/xcloud.js
@@ -733,7 +733,6 @@ XKit.extensions.xcloud = new Object({
 
 	start_upload: function() {
 
-		// XKit.extensions.xkit_preferences.close();
 		XKit.extensions.xcloud.show_overlay();
 
 		// Get list of installed extensions:
@@ -754,7 +753,9 @@ XKit.extensions.xcloud = new Object({
 
 
 			var m_data;
-			//XCloud data was being pushed up with user's md5 hash which is kind of a security issue.  Let's not do that.
+
+			//XCloud data was being pushed up with user's md5 hash which is kind of a security issue.
+			//	Instead we'll just not upload the XCloud extension.  We know the user will have it when they restore.
 			if (installed[i] === "xcloud"){
 				m_data = this.utf8_to_b64(JSON.stringify({}));
 			} else {

--- a/Extensions/xcloud.js
+++ b/Extensions/xcloud.js
@@ -1,8 +1,8 @@
 //* TITLE XCloud **//
-//* VERSION 0.3.0 **//
+//* VERSION 1.0.0 **//
 //* DESCRIPTION Sync XKit data on clouds **//
 //* DETAILS XCloud stores your XKit configuration on New-XKit servers so you can back up your data and synchronize it with other computers and browsers easily. Also compatable with STUDIOXENIX servers.**//
-//* DEVELOPER STUDIOXENIX **//
+//* DEVELOPER new-xkit **//
 //* FRAME false **//
 //* BETA false **//
 


### PR DESCRIPTION
Finished up fixing the server.

With the blog post to get the old xcloud working I added a button to use the old xcloud at the xcloud home page.

I would still recommend upgrading to the new xcloud since it's using https for everything.
Also I change the preferences so xcloud doesn't upload its own settings since it was uploading the user's password in md5 hash insecurely.

The file is also modular so it no longer requires the xkit god object's page get function.

XCloud source is https://github.com/ChuckL/XCloud
XCloud-Portal https://github.com/ChuckL/XCloud-Portal | https://portal.new-xkit.com/

XCloud portal is for user's xcloud management.  It will allow the user to check if their extensions are there before upgrading to new xkit.