### PR TITLE
added color coding to xinbox.

### DIFF
--- a/Extensions/outbox.js
+++ b/Extensions/outbox.js
@@ -103,7 +103,6 @@ XKit.extensions.outbox = new Object({
 
 		if (wait === true) {
 			if (!get_fanmail_send_button()) {
-				XKit.console.add("Waiting for fan-mail window to pop up..");
 				setTimeout(function() { XKit.extensions.outbox.run_fan_mail(true); }, 200);
 				return;
 			}


### PR DESCRIPTION
posts now have a color tag based on which blog they were submitted to.

bikesheds in the PR are expected to include: which color should your default blog be (should it even get a color??), should this be enabled by default, and other things related to me coding at 3 in the morning.

really just a nice little feature that I was inspired to make by an ask.

also maybe should include a news post.