### PR TITLE
Add minor mobile site compatibility & Add New XKit Team to 1st-party devs

### DIFF
--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -21,6 +21,12 @@ XKit.extensions.tweaks = new Object({
 			text: "Popular tweaks",
 			type: "separator",
 		},
+		"no_mobile_banner": {
+			text: "Remove mobile app banner",
+			default: true,
+			value: true,
+			mobile_only: true
+		},
 		"wrap_tags": {
 			text: "Wrap tags for easier reading",
 			default: true,
@@ -29,7 +35,8 @@ XKit.extensions.tweaks = new Object({
 		"grey_urls": {
 			text: "Make URLs grey again",
 			default: false,
-			value: false
+			value: false,
+			desktop_only: true
 		},
 		"fix_blockquotes": {
 			text: "Slim block quotes for easier reading",
@@ -44,12 +51,14 @@ XKit.extensions.tweaks = new Object({
 		"hide_share": {
 			text: "Hide the share button on posts",
 			default: false,
-			value: false
+			value: false,
+			desktop_only: true
 		},
 		"hide_follows": {
 			text: "Hide the mini-follow buttons on posts and notifications",
 			default: false,
-			value: false
+			value: false,
+			desktop_only: true
 		},
 		"photo_replies": {
 			text: "Auto-enable photo replies on all posts I create",
@@ -83,8 +92,8 @@ XKit.extensions.tweaks = new Object({
 		},
 		"full_width_gifs": {
 			text: "Add a button in post editor options to toggle full-width GIFs",
-			default: false,
-			value: false
+			default: true,
+			value: true
 		},
 		"sep1": {
 			text: "User Interface tweaks",
@@ -113,7 +122,8 @@ XKit.extensions.tweaks = new Object({
 		"slim_popups": {
 			text: "Slim down the popup menus such as the user menu",
 			default: false,
-			value: false
+			value: false,
+			desktop_only: true
 		},
 		"always_show_move_to_top": {
 			text: "Always show 'Move to top' button on the queued posts page",
@@ -124,7 +134,8 @@ XKit.extensions.tweaks = new Object({
 			text: "Move the edit/remove buttons out of the gear menu",
 			default: false,
 			value: false,
-			experimental: true
+			experimental: true,
+			desktop_only: true
 		},
 		"sep2": {
 			text: "Dashboard tweaks",
@@ -143,7 +154,8 @@ XKit.extensions.tweaks = new Object({
 		"pin_avatars": {
 			text: "Stop avatars from scrolling along with the post",
 			default: false,
-			value: false
+			value: false,
+			desktop_only: true
 		},
 		"no_footer_background": {
 			text: "Classic Post Footer look",
@@ -163,17 +175,20 @@ XKit.extensions.tweaks = new Object({
 		"hide_asktime": {
 			text: "Hide the asktime banner at the top of the dash",
 			default: false,
-			value: false
+			value: false,
+			desktop_only: true
 		},
 		"hide_explore": {
 			text: "Hide explore button on trending posts",
 			default: false,
-			value: false
+			value: false,
+			desktop_only: true
 		},
 		"hide_explore_buttons": {
 			text: "Hide the explore link at the top of the page and in the sidebar",
 			default: false,
-			value: false
+			value: false,
+			desktop_only: true
 		},
 		"hide_notes": {
 			text: "Hide the notes on posts",
@@ -224,36 +239,43 @@ XKit.extensions.tweaks = new Object({
 		"sep4": {
 			text: "Sidebar tweaks",
 			type: "separator",
+			desktop_only: true,
 		},
 		"slim_sidebar": {
 			text: "Slim sidebar buttons",
 			default: false,
-			value: false
+			value: false,
+			desktop_only: true
 		},
 		"hide_section_headers": {
 			text: "Hide section headers on sidebar",
 			default: false,
-			value: false
+			value: false,
+			desktop_only: true
 		},
 		"hide_radar": {
 			text: "Hide the Tumblr radar",
 			default: false,
-			value: false
+			value: false,
+			desktop_only: true
 		},
 		"hide_find_blogs": {
 			text: "Hide \"Find Blogs\" button",
 			default: false,
-			value: false
+			value: false,
+			desktop_only: true
 		},
 		"hide_recommended": {
 			text: "Hide Recommended blogs",
 			default: false,
-			value: false
+			value: false,
+			desktop_only: true
 		},
 		"show_customize": {
 			text: "Show Mass Post Editor and Blog Settings buttons",
 			default: true,
-			value: true
+			value: true,
+			desktop_only: true
 		}
 	},
 
@@ -263,7 +285,7 @@ XKit.extensions.tweaks = new Object({
 	run: function() {
 		this.running = true;
 
-		if ($(".is_mobile").length > 0) { //mobile stuff
+		if (XKit.extensions.tweaks.preferences.no_mobile_banner.value) { //mobile stuff
 			XKit.tools.add_css(".mobile_app_banner {display: none}", "tweaks_no_mobile_banner");
 			$(".mobile_banner_active").removeClass("mobile_banner_active");
 			$(".mobile-app-banner-visible").removeClass("mobile-app-banner-visible");
@@ -314,7 +336,7 @@ XKit.extensions.tweaks = new Object({
 
 			if (document.location.href.indexOf('/dashboard') !== -1) {
 
-				if (!$(".is_mobile").length) { // mobile stuff
+				if (XKit.browser.mobile) { // mobile stuff
 					if ($("#new_post_buttons").length > 0) {
 
 						// Save this.
@@ -427,7 +449,7 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.pin_avatars.value) {
-			if (!$(".is_mobile").length) { // mobile stuff
+			if (!XKit.browser.mobile) { // mobile stuff
 				XKit.extensions.tweaks.add_css(".post_avatar.post-avatar--fixed { position: absolute !important; top: 0 !important; left: -85px !important; }  .post_avatar.post-avatar--absolute { position: absolute; top: 0 !important; left: -85px !important; bottom: inherit !important; }  .post_avatar.post-avatar--sticky .avatar-wrapper { position: absolute !important; top: 0px !important; height: auto; width: auto; } .post_avatar.post-avatar--sticky { height: 64px !important; }", "xkit_pin_avatars");
 			}
 		}
@@ -523,7 +545,7 @@ XKit.extensions.tweaks = new Object({
 		if (document.location.href.indexOf('/dashboard') !== -1) {
 
 			if (XKit.extensions.tweaks.preferences.dont_show_mine_on_dashboard.value) {
-				if (!$(".is_mobile").length) { //mobile stuff
+				if (!XKit.browser.mobile) { //mobile stuff
 					XKit.extensions.tweaks.add_css("#posts .post.is_mine { display: none !important; } #posts .post.new_post_buttons { display: block !important; }", "xkit_tweaks_dont_show_mine_on_dashboard");
 					//XKit.post_listener.add("tweaks_fix_hidden_post_height", XKit.extensions.tweaks.fix_hidden_post_height);
 					XKit.extensions.tweaks.fix_hidden_post_height();
@@ -533,7 +555,7 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.scroll_new_posts.value) {
-			if (!$(".is_mobile").length) { // mobile stuff
+			if (!XKit.browser.mobile) { // mobile stuff
 				$(window).scroll(function () {
 					if ($("#new_post").length > 0) {
 						if ($(window).scrollTop() >= 200) {
@@ -653,7 +675,7 @@ XKit.extensions.tweaks = new Object({
 
 	split_gear: function() {
 
-		if (!$(".is_mobile").length) { // mobile stuff
+		if (!XKit.browser.mobile) { // mobile stuff
 			$(".post.is_mine").not(".xkit-tweaks-split-gear-done").each(function() {
 				$(this).addClass("xkit-tweaks-split-gear-done");
 
@@ -676,7 +698,7 @@ XKit.extensions.tweaks = new Object({
 
 	check_for_share_on_private_posts: function() {
 
-		if (!$(".is_mobile").length) { // mobile stuff
+		if (!XKit.browser.mobile) { // mobile stuff
 			$(".post.is_mine").not(".xtweaks-checked-share").each(function() {
 
 				if ($(this).find(".private_label").length > 0) {

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,6 @@
+
 //* TITLE Tweaks **//
-//* VERSION 3.4.5 **//
+//* VERSION 4.0.0 **//
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -262,10 +263,14 @@ XKit.extensions.tweaks = new Object({
 	run: function() {
 		this.running = true;
 
-		XKit.extensions.tweaks.css_to_add = "";
+		if ($(".is_mobile").length > 0) { //mobile stuff
+			XKit.tools.add_css(".mobile_app_banner {display: none}", "tweaks_no_mobile_banner");
+			$(".mobile_banner_active").removeClass("mobile_banner_active");
+			$(".mobile-app-banner-visible").removeClass("mobile-app-banner-visible");
+		}
 
 		if (XKit.extensions.tweaks.preferences.grey_urls.value) {
-		    XKit.tools.add_css(".xkit-outbox-link {color: #A1A1A1 !important; } .post_full .post_header .post_info .post_info_link:first-child {color: #A1A1A1 !important; } .post-form--header .tumblelog-select .caption {color: #A1A1A1 !important; } .post_brick .post_header .post_info_tumblelog {color: #A1A1A1 !important; }", "tweaks_grey_urls");
+				XKit.tools.add_css(".xkit-outbox-link {color: #A1A1A1 !important; } .post_full .post_header .post_info .post_info_link:first-child {color: #A1A1A1 !important; } .post-form--header .tumblelog-select .caption {color: #A1A1A1 !important; } .post_brick .post_header .post_info_tumblelog {color: #A1A1A1 !important; }", "tweaks_grey_urls");
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_bubble.value && !XKit.interface.where().dashboard) {
@@ -309,20 +314,22 @@ XKit.extensions.tweaks = new Object({
 
 			if (document.location.href.indexOf('/dashboard') !== -1) {
 
-				if ($("#new_post_buttons").length > 0) {
+				if (!$(".is_mobile").length) { // mobile stuff
+					if ($("#new_post_buttons").length > 0) {
 
-					// Save this.
-					var m_to_save = $("#new_post_buttons")[0].outerHTML;
-					m_to_save = "!" + btoa(m_to_save);
-					XKit.storage.set("tweaks","new_post_buttons_html", m_to_save);
+						// Save this.
+						var m_to_save = $("#new_post_buttons")[0].outerHTML;
+						m_to_save = "!" + btoa(m_to_save);
+						XKit.storage.set("tweaks","new_post_buttons_html", m_to_save);
 
-				} else {
+					} else {
 
-					var m_btn_html = XKit.storage.get("tweaks","new_post_buttons_html","");
-					if (m_btn_html !== "" ||typeof m_btn_html !== "undefined") {
-						if (m_btn_html.substring(0,1) === "!") {
-							m_btn_html = atob(m_btn_html.substring(1));
-							$("#posts").prepend(m_btn_html);
+						var m_btn_html = XKit.storage.get("tweaks","new_post_buttons_html","");
+						if (m_btn_html !== "" ||typeof m_btn_html !== "undefined") {
+							if (m_btn_html.substring(0,1) === "!") {
+								m_btn_html = atob(m_btn_html.substring(1));
+								$("#posts").prepend(m_btn_html);
+							}
 						}
 					}
 				}
@@ -420,7 +427,9 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.pin_avatars.value) {
-			XKit.extensions.tweaks.add_css(".post_avatar.post-avatar--fixed { position: absolute !important; top: 0 !important; left: -85px !important; }  .post_avatar.post-avatar--absolute { position: absolute; top: 0 !important; left: -85px !important; bottom: inherit !important; }  .post_avatar.post-avatar--sticky .avatar-wrapper { position: absolute !important; top: 0px !important; height: auto; width: auto; } .post_avatar.post-avatar--sticky { height: 64px !important; }", "xkit_pin_avatars");
+			if (!$(".is_mobile").length) { // mobile stuff
+				XKit.extensions.tweaks.add_css(".post_avatar.post-avatar--fixed { position: absolute !important; top: 0 !important; left: -85px !important; }  .post_avatar.post-avatar--absolute { position: absolute; top: 0 !important; left: -85px !important; bottom: inherit !important; }  .post_avatar.post-avatar--sticky .avatar-wrapper { position: absolute !important; top: 0px !important; height: auto; width: auto; } .post_avatar.post-avatar--sticky { height: 64px !important; }", "xkit_pin_avatars");
+				}
 		}
 
 		if (XKit.extensions.tweaks.preferences.small_quotes.value) {
@@ -441,7 +450,7 @@ XKit.extensions.tweaks = new Object({
 			XKit.extensions.tweaks.add_css(".notification.single_notification.alt.takeover-container { display: none; } ", "xkit_tweaks_hide_asktime");
 		}
 
-        if (XKit.extensions.tweaks.preferences.hide_explore.value) {
+				if (XKit.extensions.tweaks.preferences.hide_explore.value) {
 			XKit.extensions.tweaks.add_css(".post .explore-trending-badge-footer { display: none; } ", "xkit_tweaks_hide_explore");
 		}
 
@@ -502,7 +511,7 @@ XKit.extensions.tweaks = new Object({
 
 		if (XKit.extensions.tweaks.preferences.wrap_tags.value &&
 				XKit.interface.is_tumblr_page()) {
-			XKit.extensions.tweaks.add_css(".post .tags { width: 500px !important; display: block !important; }  .post .footer_links.with_tags { overflow:visible !important; display: block !important; }.post .footer_links.with_tags span, .footer_links.with_tags .source_url { display:block !important; overflow:visible !important; } .source_url_gradient { display: none !important; } span.tags { white-space:normal !important; } span.with_blingy_tag a.blingy { height:auto !important; display:inline-block !important; }  .source_url, .post_tags_wrapper { display: block !important; } ", "xkit_tweaks_wrap_tags");
+			XKit.extensions.tweaks.add_css(".post .tags { width: 500px !important; display: block !important; overflow:visible; height:auto; white-space: normal; }  .post .footer_links.with_tags { overflow:visible !important; display: block !important; }.post .footer_links.with_tags span, .footer_links.with_tags .source_url { display:block !important; overflow:visible !important; } .source_url_gradient { display: none !important; } span.tags { white-space:normal !important; } span.with_blingy_tag a.blingy { height:auto !important; display:inline-block !important; }  .source_url, .post_tags_wrapper { display: block !important; } ", "xkit_tweaks_wrap_tags");
 			XKit.extensions.tweaks.add_css("#posts .post.post_full .post_tags { white-space: normal; } .post .post_tags a { font-size: 12px; } .post_full .post_tags:after { background: none !important; }", "xkit_tweaks_wrap_tags_v2");
 			$(document).on('mouseup mousemove mouseover mousedown mouseout', '.post_tags_inner', function(e) {
 				$(this).parent().removeClass("draggable");
@@ -514,38 +523,43 @@ XKit.extensions.tweaks = new Object({
 		if (document.location.href.indexOf('/dashboard') !== -1) {
 
 			if (XKit.extensions.tweaks.preferences.dont_show_mine_on_dashboard.value) {
-				XKit.extensions.tweaks.add_css("#posts .post.is_mine { display: none !important; } #posts .post.new_post_buttons { display: block !important; }", "xkit_tweaks_dont_show_mine_on_dashboard");
-				XKit.extensions.tweaks.fix_hidden_post_height();
+				if (!$(".is_mobile").length) { //mobile stuff
+					XKit.extensions.tweaks.add_css("#posts .post.is_mine { display: none !important; } #posts .post.new_post_buttons { display: block !important; }", "xkit_tweaks_dont_show_mine_on_dashboard");
+					//XKit.post_listener.add("tweaks_fix_hidden_post_height", XKit.extensions.tweaks.fix_hidden_post_height);
+					XKit.extensions.tweaks.fix_hidden_post_height();
+				}
 			}
 
 		}
 
 		if (XKit.extensions.tweaks.preferences.scroll_new_posts.value) {
-			$(window).scroll(function () {
-				if ($("#new_post").length > 0) {
-					if ($(window).scrollTop() >= 200) {
-						$("body").addClass("xkit-new-post-scrolls-page");
-						$("#new_post").addClass("xkit-new-post-scrolls");
-					} else {
-						$("#new_post").removeClass("xkit-new-post-scrolls");
-						$("body").removeClass("xkit-new-post-scrolls-page");
+			if (!$(".is_mobile").length) { // mobile stuff
+				$(window).scroll(function () {
+					if ($("#new_post").length > 0) {
+						if ($(window).scrollTop() >= 200) {
+							$("body").addClass("xkit-new-post-scrolls-page");
+							$("#new_post").addClass("xkit-new-post-scrolls");
+						} else {
+							$("#new_post").removeClass("xkit-new-post-scrolls");
+							$("body").removeClass("xkit-new-post-scrolls-page");
+						}
 					}
-				}
-			});
-			$("#new_post").click(function() {
-				$('html, body').animate({
-					scrollTop: 30
-				}, 500);
+				});
+				$("#new_post").click(function() {
+					$('html, body').animate({
+						scrollTop: 30
+					}, 500);
 
-				$("#new_post").removeClass("xkit-new-post-scrolls");
-				$("body").removeClass("xkit-new-post-scrolls-page");
+					$("#new_post").removeClass("xkit-new-post-scrolls");
+					$("body").removeClass("xkit-new-post-scrolls-page");
 
-			});
-			XKit.extensions.tweaks.add_css(	".xkit-new-post-scrolls-page #posts { padding-top: 85px; }" +
+				});
+				XKit.extensions.tweaks.add_css(	".xkit-new-post-scrolls-page #posts { padding-top: 85px; }" +
 						"#new_post.xkit-new-post-scrolls { min-width: 540px; position: fixed; top: -5px; z-index: 100; opacity: 0.75; min-height: 88px !important; }" +
 						"#new_post.xkit-new-post-scrolls:hover { opacity: 1; }" +
 						"#new_post.xkit-new-post-scrolls #post_buttons { top: -5px !important; }" +
 						"#new_post.xkit-new-post-scrolls .post_avatar { display: none; }", "xkit_tweaks_scroll_new_posts");
+			}
 		}
 
 		if (XKit.extensions.tweaks.preferences.show_customize.value) {
@@ -639,37 +653,41 @@ XKit.extensions.tweaks = new Object({
 
 	split_gear: function() {
 
-		$(".post.is_mine").not(".xkit-tweaks-split-gear-done").each(function() {
-			$(this).addClass("xkit-tweaks-split-gear-done");
+		if (!$(".is_mobile").length) { // mobile stuff
+			$(".post.is_mine").not(".xkit-tweaks-split-gear-done").each(function() {
+				$(this).addClass("xkit-tweaks-split-gear-done");
 
-			// Remove captions
-			$(this).find(".post_control.edit").html("<span class=\"offscreen\">Edit</span>");
-			$(this).find(".post_control.delete").html("<span class=\"offscreen\">Delete</span>");
-			$(this).find(".post_control.queue").html("<span class=\"offscreen\">Queue</span>");
+				// Remove captions
+				$(this).find(".post_control.edit").html("<span class=\"offscreen\">Edit</span>");
+				$(this).find(".post_control.delete").html("<span class=\"offscreen\">Delete</span>");
+				$(this).find(".post_control.queue").html("<span class=\"offscreen\">Queue</span>");
 
-			// Remove their menu-specific classes
-			$(this).find(".post_control.edit, .post_control.queue, .post_control.delete").removeClass("show_label");
+				// Remove their menu-specific classes
+				$(this).find(".post_control.edit, .post_control.queue, .post_control.delete").removeClass("show_label");
 
-			$(this).find(".post_control.edit").appendTo($(this).find(".post_controls_inner"));
-			$(this).find(".post_control.delete").appendTo($(this).find(".post_controls_inner"));
-			$(this).find(".post_control.queue").appendTo($(this).find(".post_controls_inner"));
-			$(this).find(".post_control.post_control_menu.creator").css("display","none");
-		});
+				$(this).find(".post_control.edit").appendTo($(this).find(".post_controls_inner"));
+				$(this).find(".post_control.delete").appendTo($(this).find(".post_controls_inner"));
+				$(this).find(".post_control.queue").appendTo($(this).find(".post_controls_inner"));
+				$(this).find(".post_control.post_control_menu.creator").css("display","none");
+			});
+		}
 
 	},
 
 	check_for_share_on_private_posts: function() {
 
-		$(".post.is_mine").not(".xtweaks-checked-share").each(function() {
+		if (!$(".is_mobile").length) { // mobile stuff
+			$(".post.is_mine").not(".xtweaks-checked-share").each(function() {
 
-			if ($(this).find(".private_label").length > 0) {
+				if ($(this).find(".private_label").length > 0) {
 
-				$(this).find(".post_control.share").css("display","inline-block");
-				$(this).addClass("xtweaks-checked-share");
+					$(this).find(".post_control.share").css("display","inline-block");
+					$(this).addClass("xtweaks-checked-share");
 
-			}
+				}
 
-		});
+			});
+		}
 
 	},
 
@@ -735,6 +753,7 @@ XKit.extensions.tweaks = new Object({
 
 		this.running = false;
 		XKit.tools.remove_css("xkit_tweaks");
+		XKit.tools.remove_css("tweaks_no_mobile_banner");
 
 		XKit.post_listener.remove("tweaks_check_for_share_on_private_posts");
 		XKit.post_listener.remove("tweaks_fix_hidden_post_height");
@@ -757,3 +776,4 @@ XKit.extensions.tweaks = new Object({
 	}
 
 });
+

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,6 +1,6 @@
 
 //* TITLE Tweaks **//
-//* VERSION 4.0.0 **//
+//* VERSION 4.0.2 **//
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -336,7 +336,7 @@ XKit.extensions.tweaks = new Object({
 
 			if (document.location.href.indexOf('/dashboard') !== -1) {
 
-				if (XKit.browser.mobile) { // mobile stuff
+				if (!XKit.browser().mobile) { // mobile stuff
 					if ($("#new_post_buttons").length > 0) {
 
 						// Save this.
@@ -449,7 +449,7 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.pin_avatars.value) {
-			if (!XKit.browser.mobile) { // mobile stuff
+			if (!XKit.browser().mobile) { // mobile stuff
 				XKit.extensions.tweaks.add_css(".post_avatar.post-avatar--fixed { position: absolute !important; top: 0 !important; left: -85px !important; }  .post_avatar.post-avatar--absolute { position: absolute; top: 0 !important; left: -85px !important; bottom: inherit !important; }  .post_avatar.post-avatar--sticky .avatar-wrapper { position: absolute !important; top: 0px !important; height: auto; width: auto; } .post_avatar.post-avatar--sticky { height: 64px !important; }", "xkit_pin_avatars");
 			}
 		}
@@ -545,7 +545,7 @@ XKit.extensions.tweaks = new Object({
 		if (document.location.href.indexOf('/dashboard') !== -1) {
 
 			if (XKit.extensions.tweaks.preferences.dont_show_mine_on_dashboard.value) {
-				if (!XKit.browser.mobile) { //mobile stuff
+				if (!XKit.browser().mobile) { //mobile stuff
 					XKit.extensions.tweaks.add_css("#posts .post.is_mine { display: none !important; } #posts .post.new_post_buttons { display: block !important; }", "xkit_tweaks_dont_show_mine_on_dashboard");
 					//XKit.post_listener.add("tweaks_fix_hidden_post_height", XKit.extensions.tweaks.fix_hidden_post_height);
 					XKit.extensions.tweaks.fix_hidden_post_height();
@@ -555,7 +555,7 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.scroll_new_posts.value) {
-			if (!XKit.browser.mobile) { // mobile stuff
+			if (!XKit.browser().mobile) { // mobile stuff
 				$(window).scroll(function () {
 					if ($("#new_post").length > 0) {
 						if ($(window).scrollTop() >= 200) {
@@ -675,7 +675,7 @@ XKit.extensions.tweaks = new Object({
 
 	split_gear: function() {
 
-		if (!XKit.browser.mobile) { // mobile stuff
+		if (!XKit.browser().mobile) { // mobile stuff
 			$(".post.is_mine").not(".xkit-tweaks-split-gear-done").each(function() {
 				$(this).addClass("xkit-tweaks-split-gear-done");
 
@@ -698,7 +698,7 @@ XKit.extensions.tweaks = new Object({
 
 	check_for_share_on_private_posts: function() {
 
-		if (!XKit.browser.mobile) { // mobile stuff
+		if (!XKit.browser().mobile) { // mobile stuff
 			$(".post.is_mine").not(".xtweaks-checked-share").each(function() {
 
 				if ($(this).find(".private_label").length > 0) {

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -429,7 +429,7 @@ XKit.extensions.tweaks = new Object({
 		if (XKit.extensions.tweaks.preferences.pin_avatars.value) {
 			if (!$(".is_mobile").length) { // mobile stuff
 				XKit.extensions.tweaks.add_css(".post_avatar.post-avatar--fixed { position: absolute !important; top: 0 !important; left: -85px !important; }  .post_avatar.post-avatar--absolute { position: absolute; top: 0 !important; left: -85px !important; bottom: inherit !important; }  .post_avatar.post-avatar--sticky .avatar-wrapper { position: absolute !important; top: 0px !important; height: auto; width: auto; } .post_avatar.post-avatar--sticky { height: 64px !important; }", "xkit_pin_avatars");
-				}
+			}
 		}
 
 		if (XKit.extensions.tweaks.preferences.small_quotes.value) {

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -270,7 +270,7 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.grey_urls.value) {
-				XKit.tools.add_css(".xkit-outbox-link {color: #A1A1A1 !important; } .post_full .post_header .post_info .post_info_link:first-child {color: #A1A1A1 !important; } .post-form--header .tumblelog-select .caption {color: #A1A1A1 !important; } .post_brick .post_header .post_info_tumblelog {color: #A1A1A1 !important; }", "tweaks_grey_urls");
+			XKit.tools.add_css(".xkit-outbox-link {color: #A1A1A1 !important; } .post_full .post_header .post_info .post_info_link:first-child {color: #A1A1A1 !important; } .post-form--header .tumblelog-select .caption {color: #A1A1A1 !important; } .post_brick .post_header .post_info_tumblelog {color: #A1A1A1 !important; }", "tweaks_grey_urls");
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_bubble.value && !XKit.interface.where().dashboard) {
@@ -450,7 +450,7 @@ XKit.extensions.tweaks = new Object({
 			XKit.extensions.tweaks.add_css(".notification.single_notification.alt.takeover-container { display: none; } ", "xkit_tweaks_hide_asktime");
 		}
 
-				if (XKit.extensions.tweaks.preferences.hide_explore.value) {
+		if (XKit.extensions.tweaks.preferences.hide_explore.value) {
 			XKit.extensions.tweaks.add_css(".post .explore-trending-badge-footer { display: none; } ", "xkit_tweaks_hide_explore");
 		}
 

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 3.1.13 **//
+//* VERSION 4.0.0 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER STUDIOXENIX **//
 
@@ -463,6 +463,7 @@ XKit.tools.dump_config = function(){
 		to_return.safari = false;
 		to_return.opera = false;
 		to_return.version = 0;
+		to_return.mobile = false;
 
 		// First, let's check if it's chrome.
 		if (window.chrome) {
@@ -492,6 +493,7 @@ XKit.tools.dump_config = function(){
 			to_return.version = get_ua_version("firefox/");
 		}
 
+		// Blahblah Safari blah.
 		if (/Safari/.test(navigator.userAgent) && /Apple Computer/.test(navigator.vendor)) {
 			to_return.name = "Apple Safari";
 			to_return.safari = true;
@@ -505,6 +507,11 @@ XKit.tools.dump_config = function(){
 		// A lot of people now switch to IE.
 		if (navigator.userAgent.indexOf('MSIE') > -1) {
 			to_return.spoofed = true;
+		}
+
+		// Check if you're viewing the mobile version
+		if ($('.is_mobile').length > 0) {
+			to_return.mobile = true;
 		}
 
 		return to_return;

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1664,8 +1664,8 @@ XKit.tools.dump_config = function(){
 				selection.each(function() {
 					// If can_edit is requested and we don't have an edit post control,
 					// don't push the post
-					if (can_edit && $(this).find(".post_control.edit").length === 0) {
-						//return;
+					if (can_edit && ($(this).find(".icon-trash").length === 0 || $(this).find(".post_control.edit").length === 0)) {
+						return;
 					}
 					posts.push($(this));
 				});
@@ -1678,12 +1678,12 @@ XKit.tools.dump_config = function(){
 
 				if ($("body").find("#post_" + post_id).length > 0) {
 					return XKit.interface.post($("#post_" + post_id));
-				} else {
-
-					///var m_error = {};
-					//m_rror.error = true;
-					//m_error.error_message = "Object not found on page.";
+				} else if ($(".mh_post").length > 0) {
 					return XKit.interface.post($(".mh_post"));
+				} else {
+					var m_error = {};
+					m_rror.error = true;
+					m_error.error_message = "Object not found on page.";
 				}
 
 			},
@@ -1692,9 +1692,9 @@ XKit.tools.dump_config = function(){
 
 				var m_return = {};
 
-				if (typeof $(obj).attr('data-post-id') == "undefined") {
+				if (typeof $(obj).attr('data-post-id') == "undefined" && $(".mh_post_head_link").length === 0) {
 					// Something is wrong.
-					//m_return.error = true;
+					m_return.error = true;
 
 					m_return.id = $(obj).find(".mh_post_head_link").attr('href').split('/')[4];
 

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 4.0.0 **//
+//* VERSION 4.0.4 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER STUDIOXENIX **//
 
@@ -1625,6 +1625,8 @@ XKit.tools.dump_config = function(){
 
 				if ($(obj).find(".post_controls_inner").length > 0) {
 					$(obj).find(".post_controls_inner").prepend(m_html);
+				} else if (XKit.browser().mobile) {
+					$(obj).find(".mh_post_foot_control.show_notes").after(m_html);
 				} else {
 					$(obj).find(".post_controls").prepend(m_html);
 				}
@@ -1663,11 +1665,10 @@ XKit.tools.dump_config = function(){
 					// If can_edit is requested and we don't have an edit post control,
 					// don't push the post
 					if (can_edit && $(this).find(".post_control.edit").length === 0) {
-						return;
+						//return;
 					}
 					posts.push($(this));
 				});
-
 				return posts;
 			},
 
@@ -1678,10 +1679,11 @@ XKit.tools.dump_config = function(){
 				if ($("body").find("#post_" + post_id).length > 0) {
 					return XKit.interface.post($("#post_" + post_id));
 				} else {
-					var m_error = {};
-					m_error.error = true;
-					m_error.error_message = "Object not found on page.";
-					return m_error;
+
+					///var m_error = {};
+					//m_rror.error = true;
+					//m_error.error_message = "Object not found on page.";
+					return XKit.interface.post($(".mh_post"));
 				}
 
 			},
@@ -1692,8 +1694,29 @@ XKit.tools.dump_config = function(){
 
 				if (typeof $(obj).attr('data-post-id') == "undefined") {
 					// Something is wrong.
-					m_return.error = true;
-					return;
+					//m_return.error = true;
+
+					m_return.id = $(obj).find(".mh_post_head_link").attr('href').split('/')[4];
+
+					m_return.permalink = $(obj).find(".mh_post_head_link").attr('href');
+
+					if ($(obj).hasClass("post_type_regular")) {
+						m_return.type = 'regular';
+					} else if ($(obj).hasClass("post_type_audio")) {
+						m_return.type = 'audio';
+					} else if ($(obj).hasClass("post_type_quote")) {
+						m_return.type = 'quote';
+					} else if ($(obj).hasClass("post_type_photo")) {
+						m_return.type = 'photo';
+					} else if ($(obj).hasClass("post_type_photoset")) {
+						m_return.type = 'photoset';
+					} else if ($(obj).hasClass("post_type_video")) {
+						m_return.type = 'video';
+					} else if ($(obj).hasClass("post_type_panorama")) {
+						m_return.type = 'panorama';
+					}
+
+					return m_return;
 				}
 
 				m_return.error = false;

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 4.0.0 **//
+//* VERSION 4.0.6 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER STUDIOXENIX **//
 
@@ -86,9 +86,6 @@ XKit.extensions.xkit_preferences = new Object({
 		// $('<img />').attr('src', XKit.extensions.xkit_preferences.festivus_lights).appendTo('body').css('display','none');
 
 		this.running = true;
-
-		// Only load if header is somewhere to be found.
-		if (!$(".l-header").length) { return; }
 
 		XKit.tools.init_css("xkit_preferences");
 		// $("#help_button, .tab_help").css("display","none");
@@ -1464,7 +1461,7 @@ XKit.extensions.xkit_preferences = new Object({
 		$(".xkit-third-party-warning").click(function() {
 
 			XKit.window.show("Third Party Extension",
-				"This extension was not created by STUDIOXENIX. Since it is not developed by me, I can not make any guarantees about it, "+
+				"This extension was not created by the New XKit Team. Since it is not developed by me, I can not make any guarantees about it, "+
 				"nor provide support for this extension, accept bug reports or feature requests."+
 				'<div style="border: 1px solid rgb(200,200,200); background: rgb(235,235,235); margin: 15px 0px; padding: 10px; '+
 				'color: rgb(100,100,100); text-align: center; border-radius: 4px; box-shadow: inset 0px 1px 0px white, 0px 1px 2px rgba(0,0,0,0.22); ">'+
@@ -1819,9 +1816,9 @@ XKit.extensions.xkit_preferences = new Object({
 				}
 
 				var m_extra_style = "";
-				if (XKit.extensions[extension_id].preferences[pref].mobile_only === true && XKit.browser.mobile === false) {
+				if (XKit.extensions[extension_id].preferences[pref].mobile_only === true && XKit.browser().mobile === false) {
 					m_extra_style = "display: none;";
-				} else if (XKit.extensions[extension_id].preferences[pref].desktop_only === true && XKit.browser.mobile === true) {
+				} else if (XKit.extensions[extension_id].preferences[pref].desktop_only === true && XKit.browser().mobile === true) {
 					m_extra_style = "display: none;";
 				}
 
@@ -1893,7 +1890,16 @@ XKit.extensions.xkit_preferences = new Object({
 					m_extra_classes = "xkit-experimental-option";
 				}
 
-				m_return = m_return + '<div class="xkit-extension-setting xkit-combo-preference ' + m_extra_classes + '" data-extension-id="' + extension_id + '" data-setting-id="' + pref + '">';
+				var m_extra_style = "";
+				if (XKit.extensions[extension_id].preferences[pref].mobile_only === true && XKit.browser().mobile === false) {
+					m_extra_style = "display: none;";
+				} else if (XKit.extensions[extension_id].preferences[pref].desktop_only === true && XKit.browser().mobile === true) {
+					m_extra_style = "display: none;";
+				}
+
+				m_return = m_return + '<div class="xkit-extension-setting xkit-combo-preference ' + m_extra_classes +
+						'" style="' + m_extra_style +
+						'" data-extension-id="' + extension_id + '" data-setting-id="' + pref + '">';
 
 				if (XKit.extensions[extension_id].preferences[pref].experimental === true) {
 					m_return = m_return + '<div class="xkit-extension-experimental-bong">&nbsp;</div>';
@@ -1954,7 +1960,16 @@ XKit.extensions.xkit_preferences = new Object({
 					m_extra_classes = "xkit-experimental-option";
 				}
 
-				m_return = m_return + '<div class="xkit-extension-setting ' + m_extra_classes + '" data-extension-id="' + extension_id + '" data-setting-id="' + pref + '">';
+				var m_extra_style = "";
+				if (XKit.extensions[extension_id].preferences[pref].mobile_only === true && XKit.browser().mobile === false) {
+					m_extra_style = "display: none;";
+				} else if (XKit.extensions[extension_id].preferences[pref].desktop_only === true && XKit.browser().mobile === true) {
+					m_extra_style = "display: none;";
+				}
+
+				m_return = m_return + '<div class="xkit-extension-setting ' + m_extra_classes +
+						'" style="' + m_extra_style +
+						'" data-extension-id="' + extension_id + '" data-setting-id="' + pref + '">';
 
 				if (XKit.extensions[extension_id].preferences[pref].experimental === true) {
 					m_return = m_return + '<div class="xkit-extension-experimental-bong">&nbsp;</div>';
@@ -2002,7 +2017,14 @@ XKit.extensions.xkit_preferences = new Object({
 
 				}
 
-				m_return = m_return + '<div class="xkit-extension-setting-separator">' + pref_title + "</div>";
+				var m_extra_style = "";
+				if (XKit.extensions[extension_id].preferences[pref].mobile_only === true && XKit.browser().mobile === false) {
+					m_extra_style = "display: none;";
+				} else if (XKit.extensions[extension_id].preferences[pref].desktop_only === true && XKit.browser().mobile === true) {
+					m_extra_style = "display: none;";
+				}
+
+				m_return = m_return + '<div class="xkit-extension-setting-separator" style="' + m_extra_style +'">' + pref_title + "</div>";
 
 			}
 
@@ -2014,7 +2036,16 @@ XKit.extensions.xkit_preferences = new Object({
 					m_extra_classes = "xkit-experimental-option";
 				}
 
-				m_return = m_return + '<div class="xkit-extension-setting ' + m_extra_classes + ' checkbox" data-extension-id="' + extension_id + '" data-setting-id="' + pref + '">';
+				var m_extra_style = "";
+				if (XKit.extensions[extension_id].preferences[pref].mobile_only === true && XKit.browser().mobile === false) {
+					m_extra_style = "display: none;";
+				} else if (XKit.extensions[extension_id].preferences[pref].desktop_only === true && XKit.browser().mobile === true) {
+					m_extra_style = "display: none;";
+				}
+
+				m_return = m_return + '<div class="xkit-extension-setting ' + m_extra_classes +
+						' checkbox" style="' + m_extra_style +
+						'" data-extension-id="' + extension_id + '" data-setting-id="' + pref + '">';
 
 				if (XKit.extensions[extension_id].preferences[pref].experimental === true) {
 					m_return = m_return + '<div class="xkit-extension-experimental-bong">&nbsp;</div>';

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1350,8 +1350,9 @@ XKit.extensions.xkit_preferences = new Object({
 			m_html = m_html + '<div class="developer" style="display: block">by ' + m_extension.developer + '</div>';
 		}
 
+		var xkit_developers = ["studioenix","dlmarquis","hobinjk","thepsionic","nightpool","blackjackkent","wolvan","bvtsang","0xazure"];
 		var third_party_extension = false;
-		if (m_extension.developer.toLowerCase() !== "studioxenix" && !this_is_language && !m_extension.pack) {
+		if (xkit_developers.indexOf(m_extension.developer.toLowerCase()) === -1 && !this_is_language && !m_extension.pack) {
 			third_party_extension = true;
 			m_html = m_html + '<div class="xkit-third-party-warning">third party extension</div>';
 		}
@@ -1817,7 +1818,15 @@ XKit.extensions.xkit_preferences = new Object({
 					m_extra_classes = "xkit-experimental-option";
 				}
 
+				var m_extra_style = "";
+				if (XKit.extensions[extension_id].preferences[pref].mobile_only === true && XKit.browser.mobile === false) {
+					m_extra_style = "display: none;";
+				} else if (XKit.extensions[extension_id].preferences[pref].desktop_only === true && XKit.browser.mobile === true) {
+					m_extra_style = "display: none;";
+				}
+
 				m_return = m_return + '<div class="xkit-extension-setting xkit-combo-preference ' + m_extra_classes +
+					'" style="' + m_extra_style +
 					'" data-extension-id="' + extension_id + '" data-setting-id="' + pref + '">';
 
 				if (XKit.extensions[extension_id].preferences[pref].experimental === true) {

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1347,7 +1347,7 @@ XKit.extensions.xkit_preferences = new Object({
 			m_html = m_html + '<div class="developer" style="display: block">by ' + m_extension.developer + '</div>';
 		}
 
-		var xkit_developers = ["studioxenix","new xkit team","dlmarquis","hobinjk","thepsionic","nightpool","blackjackkent","wolvan","bvtsang","0xazure"];
+		var xkit_developers = ["studioxenix","new-xkit","dlmarquis","hobinjk","thepsionic","nightpool","blackjackkent","wolvan","bvtsang","0xazure"];
 		var third_party_extension = false;
 		if (xkit_developers.indexOf(m_extension.developer.toLowerCase()) === -1 && !this_is_language && !m_extension.pack) {
 			third_party_extension = true;

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -93,12 +93,12 @@ XKit.extensions.xkit_preferences = new Object({
 		XKit.tools.init_css("xkit_preferences");
 		// $("#help_button, .tab_help").css("display","none");
 
-		var m_html = '<div class="tab iconic" id="xkit-control">' +
+		var m_html = '<div class="tab iconic" id="new-xkit-control">' +
 			'<a style="width: 26px; margin-left: -6px; margin-right: -6px;" class="tab_anchor" href="#" onclick="return false">XKit Control Panel</a>' +
 			'</div>';
 
 		// mobile stuff
-		var mobile_html = '<div class="tab iconic" id="xkit-control" style="position: relative; top: 50%; height: 26px; transform: translateY(-50%);">' +
+		var mobile_html = '<div class="tab iconic" id="new-xkit-control" style="position: relative; top: 50%; height: 26px; transform: translateY(-50%);">' +
 			'<a style="color:transparent;" class="tab_anchor" href="#" onclick="return false">XKit</a>' +
 			'</div>';
 

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1347,7 +1347,7 @@ XKit.extensions.xkit_preferences = new Object({
 			m_html = m_html + '<div class="developer" style="display: block">by ' + m_extension.developer + '</div>';
 		}
 
-		var xkit_developers = ["studioenix","dlmarquis","hobinjk","thepsionic","nightpool","blackjackkent","wolvan","bvtsang","0xazure"];
+		var xkit_developers = ["studioxenix","new xkit team","dlmarquis","hobinjk","thepsionic","nightpool","blackjackkent","wolvan","bvtsang","0xazure"];
 		var third_party_extension = false;
 		if (xkit_developers.indexOf(m_extension.developer.toLowerCase()) === -1 && !this_is_language && !m_extension.pack) {
 			third_party_extension = true;

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 3.4.6 **//
+//* VERSION 4.0.0 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER STUDIOXENIX **//
 
@@ -93,12 +93,19 @@ XKit.extensions.xkit_preferences = new Object({
 		XKit.tools.init_css("xkit_preferences");
 		// $("#help_button, .tab_help").css("display","none");
 
-		var m_html = '<div class="tab iconic" id="new-xkit-control">' +
+		var m_html = '<div class="tab iconic" id="xkit-control">' +
 			'<a style="width: 26px; margin-left: -6px; margin-right: -6px;" class="tab_anchor" href="#" onclick="return false">XKit Control Panel</a>' +
+			'</div>';
+
+		// mobile stuff
+		var mobile_html = '<div class="tab iconic" id="xkit-control" style="position: relative; top: 50%; height: 26px; transform: translateY(-50%);">' +
+			'<a style="color:transparent;" class="tab_anchor" href="#" onclick="return false">XKit</a>' +
 			'</div>';
 
 		$(".l-header").find("#logout_button").parent().before(m_html);
 		$(".l-header").find("#account_button").before(m_html);
+		$(".no-js").removeClass("no-js"); //possibly unnecessary // mobile stuff
+		$(".mobile-logo").html(mobile_html); // mobile stuff
 
 		//$("#new-xkit-control").tipTip({maxWidth: "auto", edgeOffset: 0, delay: 10 });
 


### PR DESCRIPTION
Firefox for Android users can now see the xkit button, turn on wrapped tags, and remove the Tumblr mobile banner without crying due to desktop site loading times.