### PR TITLE
Blog Tracker: don't render when browsing documentation and legal stuff

### DIFF
--- a/Extensions/people_notifier.js
+++ b/Extensions/people_notifier.js
@@ -1,5 +1,5 @@
 //* TITLE Blog Tracker **//
-//* VERSION 0.4.1 **//
+//* VERSION 0.4.2 **//
 //* DESCRIPTION Track people like tags **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS Blog Tracker lets you track blogs like you can track tags. Add them on your dashboard, and it will let you know how many new posts they've made the last time you've checked their blogs, or if they've changed their URLs. **//
@@ -332,7 +332,7 @@ XKit.extensions.people_notifier = new Object({
 			} else {
 				$(".controls_section_radar").before(m_html);
 			}
-		} else {
+		} else if (document.location.href.indexOf("www.tumblr.com/docs/") === -1 && document.location.href.indexOf("www.tumblr.com/policy/") === -1) {
 			$("#right_column").append(m_html);
 		}
 


### PR DESCRIPTION
Fixes the following issue:

1. Log into Tumblr and enable Blog Tracker
2. Visit [Tumblr's API documentation](https://www.tumblr.com/docs/en/api/v2) or [Privacy Policy](https://www.tumblr.com/policy/en/privacy)
3. Expect not to see Blog Tracker rendered
4. Observe that Blog Tracker is rendered