### PR TITLE
recommended posts and see more blogs are hidden on scroll

### DIFF
--- a/Extensions/retags.js
+++ b/Extensions/retags.js
@@ -1,6 +1,6 @@
 //* TITLE       Retags **//
 //* DEVELOPER   alexhong **//
-//* VERSION     0.6.8 **//
+//* VERSION     0.6.7 **//
 //* DESCRIPTION Adds tags to reblog notes **//
 //* FRAME       false **//
 //* SLOW        false **//
@@ -9,7 +9,7 @@
 XKit.extensions.retags = {
 	running: false,
 	api_key: '3DFxEZm0tGISOmdvWe9Fl1QsQMo1LFqEatnc8GQ68wgF1YTZ4w',
-	selectors: '.reblog,.is_reblog,.notification_reblog',
+	selectors: '.reblog,.is_reblog,.notification_reblog,.is_reply,.is_answer',
 	blog_name: "",
 
 	run: function(){
@@ -69,6 +69,10 @@ XKit.extensions.retags = {
 			} else if ($t.hasClass('notification')) {
 				$c = $t.find('.notification_sentence');
 				url = $c.find('.notification_target').attr('href');
+			}
+			//we don't need to put tags on a reply, but we also don't need to hide it
+			if ($t.hasClass('is_reply') || $t.hasClass('is_answer')) {
+				return;
 			}
 			if (url) {
 				url = url.split('/');

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -487,7 +487,7 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.fix_blockquotes.value) {
-			XKit.extensions.tweaks.add_css("#posts .post_content blockquote { border-left: solid 3px #dcdcdc; padding-left: 8px; margin-left: 6px; }", "xkit_tweaks_fix_blockquotes");
+			XKit.extensions.tweaks.add_css("#posts .post_content blockquote { border-left: solid 2px #e7e7e7; padding-left: 8px; margin-left: 0px; }", "xkit_tweaks_fix_blockquotes");
 		}
 
 		if (XKit.extensions.tweaks.preferences.dont_show_liked_on_dashboard.value) {

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Tweaks **//
-//* VERSION 3.4.3 **//
+//* VERSION 3.4.5 **//
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -428,7 +428,10 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_recommended.value) {
-			$("#recommended_tumblelogs, .recommended_tumblelogs, .trending_tumblelogs, .is_recommended").css("display","none");
+			$("#recommended_tumblelogs, .recommended_tumblelogs, .trending_tumblelogs").css("display","none");
+			XKit.post_listener.add("tweaks_hide_recommended", function() {
+				$(".is_recommended, .recommended-unit-container").css("display","none");
+			});
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_share.value) {
@@ -739,6 +742,7 @@ XKit.extensions.tweaks = new Object({
 		XKit.post_listener.remove("tweaks_check_for_share_on_private_posts");
 		XKit.post_listener.remove("tweaks_fix_hidden_post_height");
 		XKit.post_listener.remove("tweaks_dont_show_liked");
+		XKit.post_listener.remove("tweaks_hide_recommended");
 		clearInterval(this.run_interval);
 		clearInterval(this.run_interval_2);
 		XKit.post_listener.remove("tweaks_split_gear");

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -428,10 +428,7 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_recommended.value) {
-			$("#recommended_tumblelogs, .recommended_tumblelogs, .trending_tumblelogs").css("display","none");
-			XKit.post_listener.add("tweaks_hide_recommended", function() {
-				$(".is_recommended, .recommended-unit-container").css("display","none");
-			});
+			XKit.extensions.tweaks.add_css("#recommended_tumblelogs, .recommended_tumblelogs, .trending_tumblelogs, .is_recommended, .recommended-unit-container { display: !important none; } ", "xkit_tweaks_hide_recommended");
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_share.value) {
@@ -742,7 +739,6 @@ XKit.extensions.tweaks = new Object({
 		XKit.post_listener.remove("tweaks_check_for_share_on_private_posts");
 		XKit.post_listener.remove("tweaks_fix_hidden_post_height");
 		XKit.post_listener.remove("tweaks_dont_show_liked");
-		XKit.post_listener.remove("tweaks_hide_recommended");
 		clearInterval(this.run_interval);
 		clearInterval(this.run_interval_2);
 		XKit.post_listener.remove("tweaks_split_gear");


### PR DESCRIPTION
this should fix issues with recommended posts not being hidden because post_listener is being used to hide posts versus in #337 when the jquery was only called once