### PR TITLE
Point Users to new Support Chat

### DIFF
--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 3.4.5 **//
+//* VERSION 3.4.6 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER STUDIOXENIX **//
 
@@ -2631,7 +2631,8 @@ XKit.extensions.xkit_preferences = new Object({
 					'<a href="http://new-xkit-extension.tumblr.com">New XKit Blog</a>' +
 					'<a href="http://www.xkit.info/seven/donate">Donate to XKit</a>' +
 					'<a href="http://www.xkit.info/seven/spread">Spread XKit</a>' +
-					'<a href="http://www.xkit.info/seven/support">Support & Documentation</a>' +
+					'<a href="http://new-xkit-support.tumblr.com/support">Support</a>' +
+					'<a href="https://github.com/new-xkit/XKit/wiki">Documentation</a>' +
 					'<a href="http://www.xkit.info/eula">Legal</a>' +
 				'</div>';
 		$("#xkit-control-panel-inner").html(m_html);

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We support Opera unofficially using the same file as the Chrome extension, [whic
 
 ## Support [![Join the chat at https://gitter.im/new-xkit/support](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/new-xkit/support?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-First, [check the list of issues](https://github.com/new-xkit/XKit/issues), and see if there's something there that looks like the problem you're having. Otherwise, [file a new issue](https://github.com/new-xkit/XKit/issues) or come join [our support chat](http://new-xkit-support.tumblr.com/support). We don't bite!
+First, [check the list of issues](https://github.com/new-xkit/XKit/issues), and see if there's something there that looks like the problem you're having. Otherwise, [file a new issue](https://github.com/new-xkit/XKit/issues) or come join our support chat: Have a GitHub Account? [Click here](https://gitter.im/new-xkit/support). If not, [click here](http://new-xkit-support.tumblr.com/support). We don't bite!
 
 ## Contribute
 XKit needs all the help it can get! If you want to help out, the first step is

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We support Opera unofficially using the same file as the Chrome extension, [whic
 
 ## Support [![Join the chat at https://gitter.im/new-xkit/support](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/new-xkit/support?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-First, [check the list of issues](https://github.com/new-xkit/XKit/issues), and see if there's something there that looks like the problem you're having. Otherwise, [file a new issue](https://github.com/new-xkit/XKit/issues) or come join [our support chat](https://gitter.im/new-xkit/support). We don't bite!
+First, [check the list of issues](https://github.com/new-xkit/XKit/issues), and see if there's something there that looks like the problem you're having. Otherwise, [file a new issue](https://github.com/new-xkit/XKit/issues) or come join [our support chat](http://new-xkit-support.tumblr.com/support). We don't bite!
 
 ## Contribute
 XKit needs all the help it can get! If you want to help out, the first step is

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We support Opera unofficially using the same file as the Chrome extension, [whic
 
 ## Support [![Join the chat at https://gitter.im/new-xkit/support](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/new-xkit/support?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-First, [check the list of issues](https://github.com/new-xkit/XKit/issues), and see if there's something there that looks like the problem you're having. Otherwise, [file a new issue](https://github.com/new-xkit/XKit/issues) or come join our support chat: Have a GitHub Account? [Click here](https://gitter.im/new-xkit/support). If not, [click here](http://new-xkit-support.tumblr.com/support). We don't bite!
+First, [check the list of issues](https://github.com/new-xkit/XKit/issues), and see if there's something there that looks like the problem you're having. Otherwise, [file a new issue](https://github.com/new-xkit/XKit/issues) or come join our support chat; visit our [live support page](http://new-xkit-support.tumblr.com/support) or join our [Gitter chat](https://gitter.im/new-xkit/support) if you have a GitHub account. We don't bite!
 
 ## Contribute
 XKit needs all the help it can get! If you want to help out, the first step is


### PR DESCRIPTION
Change Support Chat link in README.md to point to the IRC Channel
Split Documentation & Support link in the XKit Preferences panel into 2 different links, Documentation pointing to the wiki on github, Support pointing to the IRC Client