### PR TITLE
add "Restore Old Reblogs" extension

### DIFF
--- a/Extensions/old_reblogs.js
+++ b/Extensions/old_reblogs.js
@@ -1,0 +1,70 @@
+//* TITLE Restore Old Reblogs **//
+//* VERSION 1.0.1 **//
+//* DESCRIPTION	Restores the old reblogging style **//
+//* DEVELOPER eli <eli@csh.rit.edu> (forked from Editable Reblogs by dlmarquis) **//
+//* FRAME false **//
+//* BETA true **//
+
+XKit.extensions.old_reblogs = new Object({
+
+	running: false,
+
+	run: function() {
+		this.running = true;
+
+		XKit.interface.post_window_listener.add("old_reblogs", XKit.extensions.old_reblogs.post_window);
+		XKit.tools.add_css(".btn-toggle-reblog {display: none; }", "old_reblogs_remove_content_chain");
+		XKit.tools.add_css(".xkit-old-reblogs-done {display: none; }", "old_reblogs_remove_content_chain");
+	},
+
+	post_window: function() {
+		var reblog_chain = $(".reblog-list");
+		if (reblog_chain.length <= 0) {
+			return;
+		}
+
+		// Guard against double evaluation by marking the tree as processed
+		var processed_class = 'xkit-old-reblogs-done';
+		if (reblog_chain.hasClass(processed_class)) {
+			return;
+		}
+		if (reblog_chain.attr('data-subview') === "reblogCollectionView") {
+			reblog_chain.addClass(processed_class);
+		}
+
+		// re-enable display of the reblog chain when the form is closed
+		$(".post-form--close").click(function({
+			reblog_chain.delClass(processed_class);
+		});
+
+		// Convert all of the user links to have class tumblr_blog
+		var users_chain = reblog_chain.find('div.reblog-tumblelog-name');
+		var content_chain = reblog_chain.find('div.reblog-content');
+
+		var reblog_content = "";
+
+		if (top_quote_link.length > 0) {
+			$(top_quote_link[0]).addClass('tumblr_blog');
+		}
+		
+		$(users_chain.get().reverse()).each(function() {
+			reblog_content += '<p><a class="tumblr_blog" href="' + $(this).attr('href') + '">' + $(this).html() + '</a><blockquote>';
+		});
+		content_chain.each(function() {
+			reblog_content += $(this).html();
+			reblog_content += '</blockquote></p>';
+		});
+
+		console.log(reblog_content);
+		var old_content = XKit.interface.post_window.get_content_html();
+		XKit.interface.post_window.set_content_html(reblog_content + old_content);
+
+		$(".btn-remove-tree").click();
+	},
+
+	destroy: function() {
+		this.running = false;
+		XKit.tools.remove_css("old_reblogs_remove_content_chain");
+		XKit.interface.post_window_listener.remove("old_reblogs");
+	}
+});

--- a/Extensions/old_reblogs.js
+++ b/Extensions/old_reblogs.js
@@ -1,5 +1,5 @@
 //* TITLE Restore Old Reblogs **//
-//* VERSION 1.0.1 **//
+//* VERSION 1.1.1 **//
 //* DESCRIPTION	Restores the old reblogging style on the Dashboard **//
 //* DEVELOPER eli <eli@csh.rit.edu> (forked from Editable Reblogs by dlmarquis) **//
 //* FRAME false **//

--- a/Extensions/old_reblogs.js
+++ b/Extensions/old_reblogs.js
@@ -1,9 +1,9 @@
 //* TITLE Restore Old Reblogs **//
-//* VERSION 1.1.1 **//
+//* VERSION 1.2.1 **//
 //* DESCRIPTION	Restores the old reblogging style on the Dashboard **//
 //* DEVELOPER eli <eli@csh.rit.edu> (forked from Editable Reblogs by dlmarquis) **//
 //* FRAME false **//
-//* BETA true **//
+//* BETA false **//
 
 XKit.extensions.old_reblogs = new Object({
 

--- a/Extensions/old_reblogs.js
+++ b/Extensions/old_reblogs.js
@@ -1,6 +1,6 @@
 //* TITLE Restore Old Reblogs **//
 //* VERSION 1.0.1 **//
-//* DESCRIPTION	Restores the old reblogging style **//
+//* DESCRIPTION	Restores the old reblogging style on the Dashboard **//
 //* DEVELOPER eli <eli@csh.rit.edu> (forked from Editable Reblogs by dlmarquis) **//
 //* FRAME false **//
 //* BETA true **//
@@ -12,59 +12,52 @@ XKit.extensions.old_reblogs = new Object({
 	run: function() {
 		this.running = true;
 
-		XKit.interface.post_window_listener.add("old_reblogs", XKit.extensions.old_reblogs.post_window);
-		XKit.tools.add_css(".btn-toggle-reblog {display: none; }", "old_reblogs_remove_content_chain");
-		XKit.tools.add_css(".xkit-old-reblogs-done {display: none; }", "old_reblogs_remove_content_chain");
+		XKit.post_listener.add("old_reblogs", XKit.extensions.old_reblogs.main);
+		XKit.extensions.old_reblogs.main();
 	},
 
-	post_window: function() {
-		var reblog_chain = $(".reblog-list");
-		if (reblog_chain.length <= 0) {
+	main: function() {
+		var post_list = $(".post_content_inner");
+		if (post_list.length <= 0) {
 			return;
 		}
 
-		// Guard against double evaluation by marking the tree as processed
-		var processed_class = 'xkit-old-reblogs-done';
-		if (reblog_chain.hasClass(processed_class)) {
-			return;
-		}
-		if (reblog_chain.attr('data-subview') === "reblogCollectionView") {
+		post_list.each(function() {
+			var reblog_chain = $(this).find("div.reblog-list");
+			var reblog_text = $(this).find("div.contributed-content > div.reblog-content");
+
+			// Guard against double evaluation by marking the tree as processed
+			var processed_class = 'xkit-old-reblogs-done';
+			if (reblog_chain.hasClass(processed_class)) {
+				return;
+			}
 			reblog_chain.addClass(processed_class);
-		}
 
-		// re-enable display of the reblog chain when the form is closed
-		$(".post-form--close").click(function({
-			reblog_chain.delClass(processed_class);
+			var users_chain = reblog_chain.find('a.reblog-tumblelog-name');
+			var content_chain = reblog_chain.find('div.reblog-content');
+			var reblog_content = '<div class="reblog-list-item"><div class="reblog-content">';
+
+			$(users_chain.get().reverse()).each(function() {
+				reblog_content += '<p><a class="tumblr_blog" href="' + $(this).attr('href') + '">' + $(this).html() + '</a>:<blockquote>';
+			});
+			content_chain.each(function() {
+				reblog_content += $(this).html();
+				reblog_content += '</blockquote></p>';
+			});
+			if (typeof(reblog_text.html()) !== "undefined") {
+				// add the user's reblog text to the bottom
+				reblog_content += '<p>';
+				reblog_content += reblog_text.html();
+				reblog_content += '</p>';
+			}
+			reblog_content += '</div></div>';
+
+			reblog_chain.html(reblog_content);
 		});
-
-		// Convert all of the user links to have class tumblr_blog
-		var users_chain = reblog_chain.find('div.reblog-tumblelog-name');
-		var content_chain = reblog_chain.find('div.reblog-content');
-
-		var reblog_content = "";
-
-		if (top_quote_link.length > 0) {
-			$(top_quote_link[0]).addClass('tumblr_blog');
-		}
-		
-		$(users_chain.get().reverse()).each(function() {
-			reblog_content += '<p><a class="tumblr_blog" href="' + $(this).attr('href') + '">' + $(this).html() + '</a><blockquote>';
-		});
-		content_chain.each(function() {
-			reblog_content += $(this).html();
-			reblog_content += '</blockquote></p>';
-		});
-
-		console.log(reblog_content);
-		var old_content = XKit.interface.post_window.get_content_html();
-		XKit.interface.post_window.set_content_html(reblog_content + old_content);
-
-		$(".btn-remove-tree").click();
 	},
 
 	destroy: function() {
 		this.running = false;
-		XKit.tools.remove_css("old_reblogs_remove_content_chain");
 		XKit.interface.post_window_listener.remove("old_reblogs");
 	}
 });

--- a/Extensions/old_reblogs.js
+++ b/Extensions/old_reblogs.js
@@ -13,29 +13,38 @@ XKit.extensions.old_reblogs = new Object({
 		this.running = true;
 
 		XKit.post_listener.add("old_reblogs", XKit.extensions.old_reblogs.main);
+		XKit.tools.add_css('.xkit-old-reblogs-done div.reblog-list { display: none }','xkit_old_reblogs_remove_reblog_list');
+		XKit.tools.add_css('.xkit-old-reblogs-done div.contributed-content { display: none }','xkit_old_reblogs_remove_reblog_content');
 		XKit.extensions.old_reblogs.main();
 	},
 
 	main: function() {
-		var post_list = $(".post_content_inner");
-		if (post_list.length <= 0) {
+		var posts = XKit.interface.get_posts('xkit-old-reblogs-done', false);
+		window.console.log(posts);
+		if (posts.length <= 0) {
+			// no posts
 			return;
 		}
 
-		post_list.each(function() {
+		$(posts).each(function() {
+			// get the reblog-list for the post
 			var reblog_chain = $(this).find("div.reblog-list");
+			// get the text that the user added to the post (might not exist but it's
+			// sanity checked later)
 			var reblog_text = $(this).find("div.contributed-content > div.reblog-content");
 
 			// Guard against double evaluation by marking the tree as processed
 			var processed_class = 'xkit-old-reblogs-done';
-			if (reblog_chain.hasClass(processed_class)) {
+			if ($(this).hasClass(processed_class)) {
 				return;
 			}
-			reblog_chain.addClass(processed_class);
+			$(this).addClass(processed_class);
 
 			var users_chain = reblog_chain.find('a.reblog-tumblelog-name');
 			var content_chain = reblog_chain.find('div.reblog-content');
-			var reblog_content = '<div class="reblog-list-item"><div class="reblog-content">';
+
+			// reconstitute the text post
+			var reblog_content = '<div class="reblog-list-item xkit-old-reblogs-new"><div class="reblog-content">';
 
 			$(users_chain.get().reverse()).each(function() {
 				reblog_content += '<p><a class="tumblr_blog" href="' + $(this).attr('href') + '">' + $(this).html() + '</a>:<blockquote>';
@@ -52,12 +61,20 @@ XKit.extensions.old_reblogs = new Object({
 			}
 			reblog_content += '</div></div>';
 
-			reblog_chain.html(reblog_content);
+			// add the newly formatted text to the post body
+			$(this).find('.post_content_inner').append(reblog_content);
 		});
 	},
 
 	destroy: function() {
+		$("div.xkit-old-reblogs-new").remove();
+		$('.xkit-old-reblogs-done').each(function() {
+			$(this).removeClass('xkit-old-reblogs-done');
+		});
+
 		this.running = false;
+		XKit.tools.remove_css("xkit_old_reblogs_remove_reblog_list");
+		XKit.tools.remove_css("xkit_old_reblogs_remove_reblog_content");
 		XKit.interface.post_window_listener.remove("old_reblogs");
 	}
 });

--- a/Extensions/old_reblogs.js
+++ b/Extensions/old_reblogs.js
@@ -28,10 +28,12 @@ XKit.extensions.old_reblogs = new Object({
 
 		$(posts).each(function() {
 			// get the reblog-list for the post
-			var reblog_chain = $(this).find("div.reblog-list");
+			var reblog_chain = $(this).find('div.reblog-list');
 			// get the text that the user added to the post (might not exist but it's
 			// sanity checked later)
-			var reblog_text = $(this).find("div.contributed-content > div.reblog-content");
+			var reblog_text = $(this).find('div.contributed-content > div.reblog-content').html();
+			// get the title of the post (only necessary if it was reblogged)
+			var title_text = $(this).find('div.reblog-title').html();
 
 			// Guard against double evaluation by marking the tree as processed
 			var processed_class = 'xkit-old-reblogs-done';
@@ -43,26 +45,34 @@ XKit.extensions.old_reblogs = new Object({
 			var users_chain = reblog_chain.find('a.reblog-tumblelog-name');
 			var content_chain = reblog_chain.find('div.reblog-content');
 
-			// reconstitute the text post
-			var reblog_content = '<div class="reblog-list-item xkit-old-reblogs-new"><div class="reblog-content">';
+			// the tag we will insert the new post content into
+			post_entrypoint = $(this).find('.post_content_inner');
 
+			if (typeof(title_text) !== 'undefined') {
+				// append the title of the post
+				post_entrypoint.append(
+					$(document.createElement('div')).addClass('post_title xkit-old-reblogs-new').html(title_text)
+				);
+			}
+
+			// (re)construct the post, starting from the list of usernames in the reblog list and working backwards
+			post_body = $(document.createElement('div')).addClass('post_body xkit-old-reblogs-new');
+			body_content = "";
 			$(users_chain.get().reverse()).each(function() {
-				reblog_content += '<p><a class="tumblr_blog" href="' + $(this).attr('href') + '">' + $(this).html() + '</a>:<blockquote>';
+				body_content += '<p><a class="tumblr_blog" href="' + $(this).attr('href') + '">' + $(this).html() + '</a>:<blockquote>';
 			});
 			content_chain.each(function() {
-				reblog_content += $(this).html();
-				reblog_content += '</blockquote></p>';
+				body_content += $(this).html();
+				body_content += '</blockquote></p>';
 			});
-			if (typeof(reblog_text.html()) !== "undefined") {
+			if (typeof(reblog_text) !== "undefined") {
 				// add the user's reblog text to the bottom
-				reblog_content += '<p>';
-				reblog_content += reblog_text.html();
-				reblog_content += '</p>';
+				body_content += '<p>';
+				body_content += reblog_text;
+				body_content += '</p>';
 			}
-			reblog_content += '</div></div>';
 
-			// add the newly formatted text to the post body
-			$(this).find('.post_content_inner').append(reblog_content);
+			post_entrypoint.append(post_body.html(body_content));
 		});
 	},
 


### PR DESCRIPTION
This extension restores the look + feel of the old-style post reblogs on Tumblr as best as possible.

**Advantages:**
* Tested working with every type of post 
* Preserves the title of a post
* Plays nicely with version 2.0 of Editable Reblogs
* Fully cleans up after itself in the extension destructor.

**Disadvantages:**
* Might break things for people who don't have the update, I can't test for that case.
* No extension icon yet.
* The name's kind of clunky, I'm open to suggestions.

**Screenshots:**
*without Restore Old Reblogs*
![](http://i.imgur.com/HKsU3AQ.png)

*with Restore Old Reblogs*
![](http://i.imgur.com/LA9dlya.png)

