### PR TITLE
fix bug #451: jump to next page even if top of last post is still visible

### DIFF
--- a/Extensions/jk_across_pages.js
+++ b/Extensions/jk_across_pages.js
@@ -9,11 +9,11 @@ XKit.extensions.jk_across_pages = new Object({
 	/*
 	 * If the top of the last post is this far below the top of the screen or less, j will move to the next page.
 	 */
-	scrollBufferJ: 8,
+	scrollBufferJ: 52 + 8,
 	/*
 	 * If the top of first post is this far below the top of the screen or more, k will move to the previous page.
 	 */
-	scrollBufferK: 7,
+	scrollBufferK: 52 + 7,
 	/*
 	 * Leave this much overlap when using view_entire_posts
 	 */
@@ -87,7 +87,7 @@ XKit.extensions.jk_across_pages = new Object({
 
 				that.$posts = jQuery('.post_container').not('#new_post_buttons');
 
-				if (that.preferences.view_entire_posts.value && evt.which === 74 /* j */ &&
+				if (that.preferences.view_entire_posts.value == true && evt.which === 74 /* j */ &&
 					that.postAtY(that.scrollBufferJ+1)[0] == that.postAtY(window.innerHeight - that.scrollBufferJ)[0]){
 
 					evt.stopPropagation(); // Try to stop Tumblr's event listener
@@ -107,7 +107,7 @@ XKit.extensions.jk_across_pages = new Object({
 					'top scroll', that.$posts.first().offset().top + that.$posts.first().height() - window.scrollY,
 					'(threshold', that.scrollBufferK, ')'); */
 
-				if (evt.which === 74 /* j */ && that.$posts.last().offset().top - window.scrollY <= that.scrollBufferJ) {
+				if (evt.which === 74 /* j */ && ((that.$posts.last().offset().top - window.scrollY <= that.scrollBufferJ) || (window.scrollY + window.innerHeight >= that.$posts.last().offset().top + that.$posts.last().height()))) {
 					if (jQuery('#next_page_link').length > 0) {
 						if (that.preferences.show_notifications.value === true) XKit.notifications.add("Moving to next page", "ok");
 						window.location = jQuery('#next_page_link').attr('href') + '#jk_across_pages_first';


### PR DESCRIPTION
This adds a check for the case when the last post is too short to scroll above the top of the screen, which j/k across pages did not handle before. I've been using it for a few months and it seems to work fine.

However, I don't use the 'scroll through entire post' option, and IIRC when I turned it on briefly, it was even more broken than it already was in the first place, so that might need some more attention by someone whose qualifications are not "read JS for dummies in high school once".