### PR TITLE
Fix Classic User Menu button + ask posts

### DIFF
--- a/Extensions/show_more.js
+++ b/Extensions/show_more.js
@@ -875,7 +875,8 @@ XKit.extensions.show_more = new Object({
 		XKit.tools.remove_css("show_more_hide_follows");
 		XKit.tools.remove_css("show_more_hide_previews");
 		$(document).off('mouseover', '.post_info_fence a, .post_info a, a.username', XKit.extensions.show_more.store_data_username);
-		$(document).off('mouseover', '.post_avatar .post_avatar_link', XKit.extensions.show_more.store_data_avatar);
+		$(document).off('mouseover', '.post_avatar_link', XKit.extensions.show_more.store_data_avatar);
+		$(document).off('mouseover', '.post_avatar .post_avatar_link', XKit.extensions.show_more.enable_classic_menu);
 		$(document).off('click','.tumblelog_menu_btn', XKit.extensions.show_more.add_links_new);
 		$(document).off('click', '#xkit-classic-user-menu .xkit-ask', XKit.extensions.show_more.intercept_classic_menu_ask);
 		this.running = false;

--- a/Extensions/show_more.js
+++ b/Extensions/show_more.js
@@ -875,7 +875,7 @@ XKit.extensions.show_more = new Object({
 		XKit.tools.remove_css("show_more_hide_follows");
 		XKit.tools.remove_css("show_more_hide_previews");
 		$(document).off('mouseover', '.post_info_fence a, .post_info a, a.username', XKit.extensions.show_more.store_data_username);
-		$(document).off('mouseover', '.post_avatar_link', XKit.extensions.show_more.store_data_avatar);
+		$(document).off('mouseover', '.post_avatar .post_avatar_link', XKit.extensions.show_more.store_data_avatar);
 		$(document).off('click','.tumblelog_menu_btn', XKit.extensions.show_more.add_links_new);
 		$(document).off('click', '#xkit-classic-user-menu .xkit-ask', XKit.extensions.show_more.intercept_classic_menu_ask);
 		this.running = false;

--- a/Extensions/show_more.js
+++ b/Extensions/show_more.js
@@ -1,5 +1,5 @@
 //* TITLE User Menus+ **//
-//* VERSION 2.5.3 **//
+//* VERSION 2.5.4 **//
 //* DESCRIPTION More options on the user menu **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS This extension adds additional options to the user menu (the one that appears under user avatars on your dashboard), such as Avatar Magnifier, links to their Liked Posts page if they have them enabled. Note that this extension, especially the Show Likes and Show Submit options use a lot of network and might slow your computer down. **//
@@ -93,7 +93,7 @@ XKit.extensions.show_more = new Object({
 		if (this.preferences.use_classic_menu.value) {
 
 			XKit.tools.add_css(".tumblelog_popover_v1, .tumblelog_popover_v2, .tumblelog_popover { display: none !important; }", "show_more_classic_menu");
-			$(document).on('mouseover', '.post_avatar_link', XKit.extensions.show_more.enable_classic_menu);
+			$(document).on('mouseover', '.post_avatar .post_avatar_link', XKit.extensions.show_more.enable_classic_menu);
 
 			$(document).scroll(function() {
 


### PR DESCRIPTION
The Classic User Menu button would appear in the bottom left of a post when mousing over the avatars in ask posts. Making the selector more specific fixes that.