### PR TITLE
Pin `get-stdin` dependency to version that supports `node >=0.10.0`

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2382,9 +2382,9 @@
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
           "dependencies": {
             "get-stdin": {
-              "version": "5.0.0",
-              "from": "get-stdin@*",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.0.tgz"
+              "version": "4.0.1",
+              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "meow": {
               "version": "3.3.0",


### PR DESCRIPTION
This change should fix intermittent issues we've been seeing with Travis CI like the following from [PR build 79010252](https://travis-ci.org/new-xkit/XKit/builds/79010252):

```sh
$ node --version
v0.10.40
$ npm --version
1.4.28
$ nvm --version
0.23.3
$ npm install 
npm WARN engine get-stdin@5.0.0: wanted: {"node":">=0.12.0"} (current: {"node":"0.10.40","npm":"1.4.28"})
npm ERR! cb() never called!
npm ERR! not ok code 0
```

Unfortunately, `dateformat`, a dependency of `gulp-util`, [uses `*` to match against all versions of its dependencies](https://github.com/felixge/node-dateformat/blob/f4f87a497ebdd634c14d1fdb6e6ddececda0c08f/package.json#L19-L20), and it will always pull in the latest versions that are available.  `get-stdn` recently released a new version that [bumps the required `node` engine to `>= 0.12.0`](https://github.com/sindresorhus/get-stdin/blob/7c2839422cf94ef75eb82a039fd9e68ee2da4cbf/package.json#L13), which is causing this version mismatch between the `node` version [we request from Travis](https://github.com/new-xkit/XKit/blob/1d3ba15e1b5346c49802dc0f7f9270984d30b8a0/.travis.yml#L3) and the `node` version `get-stdin` requires.