### PR TITLE
Upgrade TravisCI nodejs version to 0.12.x and update global npm packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "0.12"
+before_install:
+  - npm install -g npm@latest
+  - npm install -g gulp
+script: gulp lint:scripts


### PR DESCRIPTION
This is another pass at addressing Travis CI build failures that was started with #469.

Upgrades the NodeJS version we require on Travis CI to `v0.12.x`.

Also adds a pre-install step to upgrade the `npm` version to `npm@latest` as builds with node `v0.10.x` use the pre-packaged `npm@1.4.x` which is _really_ old.

Adds a step to install `gulp` cli globally.  I'm not entirely sure how `gulp` was running before, but this pre-install step is [recommended in the Travis CI docs](http://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Using-Gulp).