### PR TITLE
Quick Tags: Added some forgotten CSS classes

### DIFF
--- a/Extensions/quick_tags.css
+++ b/Extensions/quick_tags.css
@@ -112,7 +112,8 @@
 }
 
 #xkit-quick-tags-window .xkit-tag-other,
-#xkit-quick-tags-window .xkit-tag {
+#xkit-quick-tags-window .xkit-tag,
+#xkit-quick-tags-window .xkit-tag-add {
 
 	background: rgb(228,232,238);
 	color: #7a7f8e;
@@ -135,7 +136,8 @@
 
 }
 
-#x1cpostage_quick_tags .xkit-tag-add {
+#x1cpostage_quick_tags .xkit-tag-add,
+#xkit-quick-tags-window .xkit-tag-add {
 	text-align: center;
 }
 
@@ -149,7 +151,8 @@
 
 #x1cpostage_quick_tags .xkit-tag:hover,
 #x1cpostage_quick_tags .xkit-tag-add:hover,
-#xkit-quick-tags-window .xkit-tag:hover {
+#xkit-quick-tags-window .xkit-tag:hover,
+#xkit-quick-tags-window .xkit-tag-add:hover {
 
 	background-color: rgba(234,239,246,1);
 	color: #696d7a;

--- a/Extensions/quick_tags.js
+++ b/Extensions/quick_tags.js
@@ -1,5 +1,5 @@
 //* TITLE Quick Tags **//
-//* VERSION 0.5.5 **//
+//* VERSION 0.5.6 **//
 //* DESCRIPTION Quickly add tags to posts **//
 //* DETAILS Allows you to create tag bundles and add tags to posts without leaving the dashboard. **//
 //* DEVELOPER STUDIOXENIX **//


### PR DESCRIPTION
Not sure whether `quick_tags.js` needs a version bump for just styling.