### PR TITLE
Fix Edible Reblogs display issues

### DIFF
--- a/Extensions/edible_reblogs.css
+++ b/Extensions/edible_reblogs.css
@@ -4,3 +4,8 @@
 	background-repeat: no-repeat !important;
 	background-position: center !important;
 }
+
+.is_reblog .post_wrapper .post-source-footer,
+.is_reblog .post_wrapper .chat_line {
+	background: transparent !important;
+}

--- a/Extensions/edible_reblogs.js
+++ b/Extensions/edible_reblogs.js
@@ -1,5 +1,5 @@
 //* TITLE Edible Reblogs **//
-//* VERSION 1.0.0 **//
+//* VERSION 1.0.1 **//
 //* DESCRIPTION We are serious developers... **//
 //* DETAILS ...with our priorities in order. Puts bread in the background of each post. **//
 //* DEVELOPER new-xkit **//
@@ -9,7 +9,7 @@
 XKit.extensions.edible_reblogs = new Object({
 
 	running: false,
-	
+
 	run: function() {
 		this.running = true;
 		XKit.tools.init_css("edible_reblogs");


### PR DESCRIPTION
The beautiful loaf of bread was being hidden by dialogue lines in chat posts and the div containing post source.