### PR TITLE
Xkit preferences shows installed extensions in gallery

### DIFF
--- a/Extensions/xkit_preferences.css
+++ b/Extensions/xkit_preferences.css
@@ -234,12 +234,6 @@
 
 }
 
-.xkit-installed-extension .xkit-install-extension, .xkit-installed-extension .xkit-install-extension:hover {
-	background: rgba(60,190,47,0.8);
-	color: white;
-	text-shadow: 0px 1px 2px rgba(0,0,0,0.44);
-}
-
 .xkit-unable-to-load-extension-gallery {
 	display: none;
 }
@@ -253,8 +247,16 @@
 	padding: 4px 0px;
 	margin-left: -40px;
 	border-radius: 40px;
+	background: rgba(60,190,47,0.8);
+	color: white;
 	display: block;
+	text-shadow: 0px 1px 2px rgba(0,0,0,0.44);
 
+}
+
+.xkit-installed-extension {
+	background: #F3F3F3;
+	font-style: oblique;
 }
 
 .xkit-gallery-extension .xkit-button:active {
@@ -1278,6 +1280,29 @@
 	top: auto !important;
 }
 
+.xkit-gallery-extension .xkit-button:hover {
+	background: rgba(60,190,47,0.8);
+	color: white;
+	text-shadow: 0px 1px 2px rgba(0,0,0,0.44);
+	box-shadow: inset 0px 1px 1px rgba(0,0,0,0.53);
+}
+
+.xkit-installed-extension .xkit-install-extension {
+	box-shadow: none;
+	cursor: default;
+	background: rgb(240, 240, 240)/* #66a820 */;
+	color: rgb(100, 100, 100);
+	text-shadow: none;
+}
+
+.xkit-installed-extension:hover .xkit-install-extension, .xkit-installed-extension .xkit-install-extension:active {
+	box-shadow: none;
+	cursor: default;
+	background: rgb(240, 240, 240)/* #66a820 */;
+	color: black;
+	text-shadow: none;
+}
+
 .xkit-checkbox { padding-left: 1px; }
 
 .xkit-checkbox b, .xkit-checkbox strong {
@@ -1299,7 +1324,7 @@
 #xkit-panel-hide-installed-extensions-from-gallery {
 	position: absolute;
 	top: 6px;
-	left: 250px;
+	right: 13px;
 }
 
 .xkit-button {
@@ -1384,11 +1409,6 @@
 	top: 0px;
 	color: rgb(170,170,170) !important;
 	border: 1px dashed rgb(160,160,160) !important;
-}
-
-.xkit-installed-extension .xkit-install-extension.installed {
-	box-shadow: none;
-	cursor: default;
 }
 
 .xkit-button:active {

--- a/Extensions/xkit_preferences.css
+++ b/Extensions/xkit_preferences.css
@@ -1386,6 +1386,11 @@
 	border: 1px dashed rgb(160,160,160) !important;
 }
 
+.xkit-installed-extension .xkit-install-extension.installed {
+	box-shadow: none;
+	cursor: default;
+}
+
 .xkit-button:active {
 	top: 0;
 	color: black;

--- a/Extensions/xkit_preferences.css
+++ b/Extensions/xkit_preferences.css
@@ -234,6 +234,16 @@
 
 }
 
+.xkit-installed-extension .xkit-install-extension, .xkit-installed-extension .xkit-install-extension:hover {
+	background: rgba(60,190,47,0.8);
+	color: white;
+	text-shadow: 0px 1px 2px rgba(0,0,0,0.44);
+}
+
+.xkit-unable-to-load-extension-gallery {
+	display: none;
+}
+
 .xkit-gallery-extension .xkit-button {
 
 	position: absolute;
@@ -1284,6 +1294,12 @@
 .xkit-checkbox.selected:hover b, .xkit-checkbox.selected:hover strong {
 	border: 1px solid rgba(0,0,0,0.22);
 	background-color: #cedff4;
+}
+
+#xkit-panel-hide-installed-extensions-from-gallery {
+	position: absolute;
+	top: 6px;
+	left: 250px;
 }
 
 .xkit-button {

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -979,7 +979,12 @@ XKit.extensions.xkit_preferences = new Object({
 
 			$("#xkit-extensions-panel-right-inner").html(m_html + '<div class="xkit-gallery-clearer">&nbsp;</div>');
 			
-			if (XKit.tools.get_setting("xkit_hide_installed_extensions","false") === "true") { XKit.tools.add_css(".xkit-installed-extension { display: none; } .xkit-unable-to-load-extension-gallery { display: block; }", "xkit_hide_installed_extensions"); }
+			if (XKit.tools.get_setting("xkit_hide_installed_extensions","false") === "true") { 
+				XKit.tools.add_css(".xkit-installed-extension { display: none; }", "xkit_hide_installed_extensions");
+				if($("#xkit-extensions-panel-right-inner .xkit-gallery-extension").length === $("#xkit-extensions-panel-right-inner .xkit-installed-extension").length) {
+					XKit.tools.add_css(".xkit-unable-to-load-extension-gallery { display: block; }", "xkit_hide_installed_extensions");
+				}
+			}
 			
 			$("#xkit-extensions-panel-right").nanoScroller();
 			$("#xkit-extensions-panel-right").nanoScroller({ scroll: 'top' });
@@ -998,7 +1003,7 @@ XKit.extensions.xkit_preferences = new Object({
 						$(".xkit-unable-to-load-extension-gallery").css("display", "block");
 					}
 				}
-			})
+			});
 			
 			$("#xkit-gallery-search").keyup(function() {
 

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 5.0.0 **//
+//* VERSION 5.1.0 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER STUDIOXENIX **//
 
@@ -39,7 +39,8 @@ XKit.extensions.lang_english.xkit_preferences = new Object({
 		"error": "<strong>Unable to load extension gallery.<br>Sorry about that.</strong><br><br>"+
 		"XKit servers might be experiencing some problems. Please try again, and if you cant't reach "+
 		"the servers for more than a few days, please"+'<a href="https://github.com/hobinjk/XKit/issues">report a problem</a>.',
-		"search": "Search the gallery"
+		"search": "Search the gallery",
+		"hide_installed": "Hide installed extensions"
 	},
 
 	extension: {
@@ -968,22 +969,37 @@ XKit.extensions.xkit_preferences = new Object({
 
 			}
 
-			m_html = '<div id="xkit-gallery-toolbar"><input type="text" id="xkit-gallery-search" '+
-				'placeholder="'+ XKit.lang.get("xkit_preferences.gallery.search") + '"></div>' + m_html;
+			m_html = 
+					'<div id="xkit-gallery-toolbar">' +
+						'<input type="text" id="xkit-gallery-search" placeholder="'+ XKit.lang.get("xkit_preferences.gallery.search") + '">' + 
+						'<div id="xkit-panel-hide-installed-extensions-from-gallery" class="xkit-checkbox ' + (XKit.tools.get_setting("xkit_hide_installed_extensions","false") === "true" ? "selected" : "") + '">' +
+						'<b>&nbsp;</b>' + XKit.lang.get("xkit_preferences.gallery.hide_installed") + '</div>' + 
+					'</div>' + m_html + '<div class="xkit-unable-to-load-extension-gallery"><b>No new extensions</b><br/><br/>'+
+										"It looks like you've installed all the currently available extensions.<br/>Come back later!</div>";
 
 			$("#xkit-extensions-panel-right-inner").html(m_html + '<div class="xkit-gallery-clearer">&nbsp;</div>');
+			
+			if (XKit.tools.get_setting("xkit_hide_installed_extensions","false") === "true") { XKit.tools.add_css(".xkit-installed-extension { display: none; } .xkit-unable-to-load-extension-gallery { display: block; }", "xkit_hide_installed_extensions"); }
+			
 			$("#xkit-extensions-panel-right").nanoScroller();
 			$("#xkit-extensions-panel-right").nanoScroller({ scroll: 'top' });
-
-			if ($("#xkit-extensions-panel-right-inner .xkit-gallery-extension").length === 0) {
-
-				$("#xkit-extensions-panel-right-inner").html(
-					'<div class="xkit-unable-to-load-extension-gallery"><b>No new extensions</b><br/><br/>'+
-					"It looks like you've installed all the currently available extensions.<br/>Come back later!</div>");
-				return;
-
-			}
-
+			
+			$("#xkit-panel-hide-installed-extensions-from-gallery").click(function () {
+				if ($(this).hasClass("selected")) {
+					$(this).removeClass("selected");
+					XKit.tools.set_setting("xkit_hide_installed_extensions","false");
+					XKit.tools.remove_css("xkit_hide_installed_extensions");
+					$(".xkit-unable-to-load-extension-gallery").css("display", "none");
+				} else { 
+					$(this).addClass("selected");
+					XKit.tools.set_setting("xkit_hide_installed_extensions","true");
+					XKit.tools.add_css(".xkit-installed-extension { display: none }", "xkit_hide_installed_extensions");
+					if ($("#xkit-extensions-panel-right-inner .xkit-gallery-extension").length === $("#xkit-extensions-panel-right-inner .xkit-installed-extension").length) {
+						$(".xkit-unable-to-load-extension-gallery").css("display", "block");
+					}
+				}
+			})
+			
 			$("#xkit-gallery-search").keyup(function() {
 
 				var m_value = $(this).val().toLowerCase();
@@ -1031,7 +1047,9 @@ XKit.extensions.xkit_preferences = new Object({
 			});
 
 			$(".xkit-gallery-extension .xkit-install-extension").click(function() {
-
+				
+				if ($(this).parent().hasClass("xkit-installed-extension")) { return; }
+				
 				$(this).parent().addClass("overlayed");
 
 				XKit.install($(this).attr('data-extension-id'), function(mdata) {
@@ -1080,10 +1098,9 @@ XKit.extensions.xkit_preferences = new Object({
 			obj.icon = XKit.extensions.xkit_preferences.default_extension_icon;
 		}
 
-		if (XKit.installed.check(obj.name) === true) { return ""; }
-		if (obj.name.startsWith("xkit_")) { return ""; }
-
-		var m_html = '<div class="xkit-gallery-extension" id="xkit-gallery-extension-' + obj.name + '" data-extension-id="' + obj.name + '">' +
+		if (obj.name.startsWith("xkit_") && XKit.tools.get_setting("xkit_show_internals","false") === "false") { return ""; }
+		
+		var m_html = '<div class="xkit-gallery-extension' + (XKit.installed.check(obj.name) ? " xkit-installed-extension" : "") + '" id="xkit-gallery-extension-' + obj.name + '" data-extension-id="' + obj.name + '">' +
 			'<div class="overlay">downloading</div>' +
 			'<div class="title">' + obj.title + '</div>' +
 			'<div class="description">' + obj.description + '</div>';
@@ -1094,7 +1111,7 @@ XKit.extensions.xkit_preferences = new Object({
 
 		m_html = m_html +
 				'<div class="icon"><img src="' + obj.icon + '"></div>' +
-					'<div class="xkit-button xkit-install-extension" data-extension-id="' + obj.name + '">Install</div>' +
+					'<div class="xkit-button xkit-install-extension" data-extension-id="' + obj.name + '">' + (XKit.installed.check(obj.name) ? "Installed" : "Install") + '</div>' +
 				'</div>';
 
 		return m_html;

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -709,7 +709,7 @@ XKit.extensions.xkit_preferences = new Object({
 
 				XKit.storage.set("xkit_preferences","festivus","no");
 
-        stopFestivusInterval();
+		stopFestivusInterval();
 			} else {
 
 				$("#xkit-festivus-toggle").html(festivus_off);
@@ -717,42 +717,42 @@ XKit.extensions.xkit_preferences = new Object({
 
 				XKit.storage.set("xkit_preferences","festivus","yes");
 
-        startFestivusInterval();
+		startFestivusInterval();
 			}
 
 		});
 
 		// $("#xkit-festivus").css("background-image","url('" + XKit.extensions.xkit_preferences.festivus_lights + "')");
 
-    function stopFestivusInterval() {
-      clearInterval(XKit.extensions.xkit_preferences.festivus_lights_interval);
-    }
+	function stopFestivusInterval() {
+	  clearInterval(XKit.extensions.xkit_preferences.festivus_lights_interval);
+	}
 
-    function startFestivusInterval() {
-      stopFestivusInterval();
+	function startFestivusInterval() {
+	  stopFestivusInterval();
 
-      XKit.extensions.xkit_preferences.festivus_lights_interval = setInterval(function() {
+	  XKit.extensions.xkit_preferences.festivus_lights_interval = setInterval(function() {
 
-        if ($("#xkit-festivus").attr('data-id-light') === "1") {
-          $("#xkit-festivus").css("background-position","0px 33px");
-          $("#xkit-festivus").attr('data-id-light', "2");
-          return;
-        }
+		if ($("#xkit-festivus").attr('data-id-light') === "1") {
+		  $("#xkit-festivus").css("background-position","0px 33px");
+		  $("#xkit-festivus").attr('data-id-light', "2");
+		  return;
+		}
 
-        if ($("#xkit-festivus").attr('data-id-light') === "2") {
-          $("#xkit-festivus").css("background-position","0px 66px");
-          $("#xkit-festivus").attr('data-id-light', "3");
-          return;
-        }
+		if ($("#xkit-festivus").attr('data-id-light') === "2") {
+		  $("#xkit-festivus").css("background-position","0px 66px");
+		  $("#xkit-festivus").attr('data-id-light', "3");
+		  return;
+		}
 
-        if ($("#xkit-festivus").attr('data-id-light') === "3") {
-          $("#xkit-festivus").css("background-position","0px 0px");
-          $("#xkit-festivus").attr('data-id-light', "1");
-          return;
-        }
+		if ($("#xkit-festivus").attr('data-id-light') === "3") {
+		  $("#xkit-festivus").css("background-position","0px 0px");
+		  $("#xkit-festivus").attr('data-id-light', "1");
+		  return;
+		}
 
-      }, 1000);
-    }
+	  }, 1000);
+	}
 
 		if (XKit.extensions.xkit_preferences.hide_xcloud_if_not_installed === true) {
 			if (XKit.installed.check("xcloud") === false) {
@@ -969,33 +969,33 @@ XKit.extensions.xkit_preferences = new Object({
 
 			}
 
-			m_html = 
+			m_html =
 					'<div id="xkit-gallery-toolbar">' +
-						'<input type="text" id="xkit-gallery-search" placeholder="'+ XKit.lang.get("xkit_preferences.gallery.search") + '">' + 
+						'<input type="text" id="xkit-gallery-search" placeholder="'+ XKit.lang.get("xkit_preferences.gallery.search") + '">' +
 						'<div id="xkit-panel-hide-installed-extensions-from-gallery" class="xkit-checkbox ' + (XKit.tools.get_setting("xkit_hide_installed_extensions","false") === "true" ? "selected" : "") + '">' +
-						'<b>&nbsp;</b>' + XKit.lang.get("xkit_preferences.gallery.hide_installed") + '</div>' + 
+						'<b>&nbsp;</b>' + XKit.lang.get("xkit_preferences.gallery.hide_installed") + '</div>' +
 					'</div>' + m_html + '<div class="xkit-unable-to-load-extension-gallery"><b>No new extensions</b><br/><br/>'+
-										"It looks like you've installed all the currently available extensions.<br/>Come back later!</div>";
+					"It looks like you've installed all the currently available extensions.<br/>Come back later!</div>";
 
 			$("#xkit-extensions-panel-right-inner").html(m_html + '<div class="xkit-gallery-clearer">&nbsp;</div>');
-			
-			if (XKit.tools.get_setting("xkit_hide_installed_extensions","false") === "true") { 
+
+			if (XKit.tools.get_setting("xkit_hide_installed_extensions","false") === "true") {
 				XKit.tools.add_css(".xkit-installed-extension { display: none; }", "xkit_hide_installed_extensions");
 				if($("#xkit-extensions-panel-right-inner .xkit-gallery-extension").length === $("#xkit-extensions-panel-right-inner .xkit-installed-extension").length) {
 					XKit.tools.add_css(".xkit-unable-to-load-extension-gallery { display: block; }", "xkit_hide_installed_extensions");
 				}
 			}
-			
+
 			$("#xkit-extensions-panel-right").nanoScroller();
 			$("#xkit-extensions-panel-right").nanoScroller({ scroll: 'top' });
-			
+
 			$("#xkit-panel-hide-installed-extensions-from-gallery").click(function () {
 				if ($(this).hasClass("selected")) {
 					$(this).removeClass("selected");
 					XKit.tools.set_setting("xkit_hide_installed_extensions","false");
 					XKit.tools.remove_css("xkit_hide_installed_extensions");
 					$(".xkit-unable-to-load-extension-gallery").css("display", "none");
-				} else { 
+				} else {
 					$(this).addClass("selected");
 					XKit.tools.set_setting("xkit_hide_installed_extensions","true");
 					XKit.tools.add_css(".xkit-installed-extension { display: none }", "xkit_hide_installed_extensions");
@@ -1004,7 +1004,7 @@ XKit.extensions.xkit_preferences = new Object({
 					}
 				}
 			});
-			
+
 			$("#xkit-gallery-search").keyup(function() {
 
 				var m_value = $(this).val().toLowerCase();
@@ -1052,9 +1052,9 @@ XKit.extensions.xkit_preferences = new Object({
 			});
 
 			$(".xkit-gallery-extension .xkit-install-extension").click(function() {
-				
+
 				if ($(this).parent().hasClass("xkit-installed-extension")) { return; }
-				
+
 				$(this).parent().addClass("overlayed");
 
 				XKit.install($(this).attr('data-extension-id'), function(mdata) {
@@ -1104,8 +1104,19 @@ XKit.extensions.xkit_preferences = new Object({
 		}
 
 		if (obj.name.startsWith("xkit_") && XKit.tools.get_setting("xkit_show_internals","false") === "false") { return ""; }
-		
-		var m_html = '<div class="xkit-gallery-extension' + (XKit.installed.check(obj.name) ? " xkit-installed-extension" : "") + '" id="xkit-gallery-extension-' + obj.name + '" data-extension-id="' + obj.name + '">' +
+
+		var blacklisted_extensions = ["xkit_installer"];
+
+		for(var i = 0; i < blacklisted_extensions.length; i++) {
+			if (obj.name.toLowerCase() === blacklisted_extensions[i].toLowerCase()) {
+				return "";
+			}
+		}
+
+		var installed_extension_class = "";
+		if(XKit.installed.check(obj.name)) { installed_extension_class = " xkit-installed-extension"; }
+
+		var m_html = '<div class="xkit-gallery-extension' + installed_extension_class + '" id="xkit-gallery-extension-' + obj.name + '" data-extension-id="' + obj.name + '">' +
 			'<div class="overlay">downloading</div>' +
 			'<div class="title">' + obj.title + '</div>' +
 			'<div class="description">' + obj.description + '</div>';
@@ -1114,9 +1125,16 @@ XKit.extensions.xkit_preferences = new Object({
 			m_html = m_html + '<div class="more-info" data-more-info="' + obj.details + '">more info</div>';
 		}
 
+
+		var install_button_text = "Install";
+		if(XKit.installed.check(obj.name)) { install_button_text = "Installed"; }
+
+		var install_button_installed_class = "";
+		if(XKit.installed.check(obj.name)) { install_button_installed_class = " installed"; }
+
 		m_html = m_html +
 				'<div class="icon"><img src="' + obj.icon + '"></div>' +
-					'<div class="xkit-button xkit-install-extension" data-extension-id="' + obj.name + '">' + (XKit.installed.check(obj.name) ? "Installed" : "Install") + '</div>' +
+					'<div class="xkit-button xkit-install-extension ' + install_button_installed_class + '" data-extension-id="' + obj.name + '">' + install_button_text + '</div>' +
 				'</div>';
 
 		return m_html;

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,7 +1,7 @@
 //* TITLE XKit Preferences **//
 //* VERSION 5.1.0 **//
 //* DESCRIPTION Lets you customize XKit **//
-//* DEVELOPER STUDIOXENIX **//
+//* DEVELOPER new-xkit **//
 
 XKit.extensions.lang_english.xkit_preferences = new Object({
 
@@ -1079,7 +1079,7 @@ XKit.extensions.xkit_preferences = new Object({
 					}
 
 					$("#xkit-gallery-extension-" + mdata.id).find(".overlay").addClass("green");
-					$("#xkit-gallery-extension-" + mdata.id).find(".overlay").html("installed!");
+					$("#xkit-gallery-extension-" + mdata.id).find(".overlay").html("Installed!");
 
 					try {
 						/* jshint evil: true */
@@ -1107,17 +1107,15 @@ XKit.extensions.xkit_preferences = new Object({
 
 		var blacklisted_extensions = ["xkit_installer"];
 
-		for(var i = 0; i < blacklisted_extensions.length; i++) {
-			if (obj.name.toLowerCase() === blacklisted_extensions[i].toLowerCase()) {
-				return "";
-			}
+		if (blacklisted_extensions.indexOf(obj.name.toLowerCase()) !== -1) {
+			return "";
 		}
 
 		var installed_extension_class = "";
-		if(XKit.installed.check(obj.name)) { installed_extension_class = " xkit-installed-extension"; }
+		if(XKit.installed.check(obj.name)) { installed_extension_class = "xkit-installed-extension"; }
 
-		var m_html = '<div class="xkit-gallery-extension' + installed_extension_class + '" id="xkit-gallery-extension-' + obj.name + '" data-extension-id="' + obj.name + '">' +
-			'<div class="overlay">downloading</div>' +
+		var m_html = '<div class="xkit-gallery-extension ' + installed_extension_class + '" id="xkit-gallery-extension-' + obj.name + '" data-extension-id="' + obj.name + '">' +
+			'<div class="overlay">Downloading</div>' +
 			'<div class="title">' + obj.title + '</div>' +
 			'<div class="description">' + obj.description + '</div>';
 
@@ -1129,12 +1127,9 @@ XKit.extensions.xkit_preferences = new Object({
 		var install_button_text = "Install";
 		if(XKit.installed.check(obj.name)) { install_button_text = "Installed"; }
 
-		var install_button_installed_class = "";
-		if(XKit.installed.check(obj.name)) { install_button_installed_class = " installed"; }
-
 		m_html = m_html +
 				'<div class="icon"><img src="' + obj.icon + '"></div>' +
-					'<div class="xkit-button xkit-install-extension ' + install_button_installed_class + '" data-extension-id="' + obj.name + '">' + install_button_text + '</div>' +
+					'<div class="xkit-button xkit-install-extension" data-extension-id="' + obj.name + '">' + install_button_text + '</div>' +
 				'</div>';
 
 		return m_html;

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -709,7 +709,7 @@ XKit.extensions.xkit_preferences = new Object({
 
 				XKit.storage.set("xkit_preferences","festivus","no");
 
-		stopFestivusInterval();
+        stopFestivusInterval();
 			} else {
 
 				$("#xkit-festivus-toggle").html(festivus_off);
@@ -717,42 +717,42 @@ XKit.extensions.xkit_preferences = new Object({
 
 				XKit.storage.set("xkit_preferences","festivus","yes");
 
-		startFestivusInterval();
+        startFestivusInterval();
 			}
 
 		});
 
 		// $("#xkit-festivus").css("background-image","url('" + XKit.extensions.xkit_preferences.festivus_lights + "')");
 
-	function stopFestivusInterval() {
-	  clearInterval(XKit.extensions.xkit_preferences.festivus_lights_interval);
-	}
+    function stopFestivusInterval() {
+      clearInterval(XKit.extensions.xkit_preferences.festivus_lights_interval);
+    }
 
-	function startFestivusInterval() {
-	  stopFestivusInterval();
+    function startFestivusInterval() {
+      stopFestivusInterval();
 
-	  XKit.extensions.xkit_preferences.festivus_lights_interval = setInterval(function() {
+      XKit.extensions.xkit_preferences.festivus_lights_interval = setInterval(function() {
 
-		if ($("#xkit-festivus").attr('data-id-light') === "1") {
-		  $("#xkit-festivus").css("background-position","0px 33px");
-		  $("#xkit-festivus").attr('data-id-light', "2");
-		  return;
-		}
+        if ($("#xkit-festivus").attr('data-id-light') === "1") {
+          $("#xkit-festivus").css("background-position","0px 33px");
+          $("#xkit-festivus").attr('data-id-light', "2");
+          return;
+        }
 
-		if ($("#xkit-festivus").attr('data-id-light') === "2") {
-		  $("#xkit-festivus").css("background-position","0px 66px");
-		  $("#xkit-festivus").attr('data-id-light', "3");
-		  return;
-		}
+        if ($("#xkit-festivus").attr('data-id-light') === "2") {
+          $("#xkit-festivus").css("background-position","0px 66px");
+          $("#xkit-festivus").attr('data-id-light', "3");
+          return;
+        }
 
-		if ($("#xkit-festivus").attr('data-id-light') === "3") {
-		  $("#xkit-festivus").css("background-position","0px 0px");
-		  $("#xkit-festivus").attr('data-id-light', "1");
-		  return;
-		}
+        if ($("#xkit-festivus").attr('data-id-light') === "3") {
+          $("#xkit-festivus").css("background-position","0px 0px");
+          $("#xkit-festivus").attr('data-id-light', "1");
+          return;
+        }
 
-	  }, 1000);
-	}
+      }, 1000);
+    }
 
 		if (XKit.extensions.xkit_preferences.hide_xcloud_if_not_installed === true) {
 			if (XKit.installed.check("xcloud") === false) {
@@ -975,7 +975,7 @@ XKit.extensions.xkit_preferences = new Object({
 						'<div id="xkit-panel-hide-installed-extensions-from-gallery" class="xkit-checkbox ' + (XKit.tools.get_setting("xkit_hide_installed_extensions","false") === "true" ? "selected" : "") + '">' +
 						'<b>&nbsp;</b>' + XKit.lang.get("xkit_preferences.gallery.hide_installed") + '</div>' +
 					'</div>' + m_html + '<div class="xkit-unable-to-load-extension-gallery"><b>No new extensions</b><br/><br/>'+
-					"It looks like you've installed all the currently available extensions.<br/>Come back later!</div>";
+										"It looks like you've installed all the currently available extensions.<br/>Come back later!</div>";
 
 			$("#xkit-extensions-panel-right-inner").html(m_html + '<div class="xkit-gallery-clearer">&nbsp;</div>');
 


### PR DESCRIPTION
The extension gallery now shows all extensions by default with a "Installed" mark in case of the user already having it installed.

Also listens to the Show Internals flag and won't show the Internals if the checkbox isn't set.

![image](https://cloud.githubusercontent.com/assets/1437010/9983501/577c6f2c-5ffe-11e5-9456-5c2a43cfe524.png)
![image](https://cloud.githubusercontent.com/assets/1437010/9983503/623d53fe-5ffe-11e5-9a5a-b90547caaa12.png)
![image](https://cloud.githubusercontent.com/assets/1437010/9983504/731ede22-5ffe-11e5-8375-4a525aef863a.png)
![image](https://cloud.githubusercontent.com/assets/1437010/9983506/7df5245a-5ffe-11e5-9e64-a87010800367.png)


Fixes #517