### PR TITLE
Use new root_id attribute for extensions

### DIFF
--- a/Extensions/disable_gifs.js
+++ b/Extensions/disable_gifs.js
@@ -1,8 +1,8 @@
 //* TITLE Disable Gifs **//
-//* VERSION 0.3.0 **//
+//* VERSION 0.3.1 **//
 //* DESCRIPTION Stops GIFs on dashboard **//
 //* DETAILS This is a very early preview version of an extension that allows you to stop the GIFs from playing on your dashboard. If you still would like to view them, you can click on the Play button on the post. Please note that for now, this extension can't stop GIFs added to text posts. **//
-//* DEVELOPER STUDIOXENIX **//
+//* DEVELOPER new-xkit **//
 //* FRAME false **//
 //* BETA false **//
 //* SLOW true **//
@@ -253,7 +253,7 @@ XKit.extensions.disable_gifs = new Object({
 			}
 
 			var this_id = m_post.root_id;
-			XKit.interface.add_control_button(this, "disable_gifs_button", "data-root-id=\"" + this_id + "\"");
+			XKit.interface.add_control_button(this, "disable_gifs_button", "data-root_id=\"" + this_id + "\"");
 
 		});
 

--- a/Extensions/notificationblock.js
+++ b/Extensions/notificationblock.js
@@ -1,7 +1,7 @@
 //* TITLE NotificationBlock **//
-//* VERSION 1.3.2 **//
+//* VERSION 1.3.3 **//
 //* DESCRIPTION Blocks notifications from a post **//
-//* DEVELOPER STUDIOXENIX **//
+//* DEVELOPER new-xkit **//
 //* DETAILS One post got way too popular and now just annoying you? Click on the notification block icon on that post to hide the notifications from that post. If you have Go-To-Dash installed, you can click on a notification, then click View button on top-right corner to quickly go back to the post on your dashboard.  **//
 //* FRAME false **//
 //* BETA false **//
@@ -348,7 +348,7 @@ XKit.extensions.notificationblock = new Object({
 
 				var this_id = m_post.id;
 
-				XKit.interface.add_control_button(this, "xnotificationblockbutton", "data-root-id=\"" + this_id + "\"");
+				XKit.interface.add_control_button(this, "xnotificationblockbutton", "data-root_id=\"" + this_id + "\"");
 
 				if (XKit.extensions.notificationblock.blacklisted.indexOf(this_id) !== -1) {
 

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,7 +1,7 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.0.6 **//
+//* VERSION 4.0.7 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
-//* DEVELOPER STUDIOXENIX **//
+//* DEVELOPER new-xkit **//
 //* FRAME false **//
 //* BETA false **//
 
@@ -242,7 +242,7 @@ XKit.extensions.one_click_postage = new Object({
 
 		var post_type = "";
 		var channel_id = $("#tumblelog_name").attr('data-tumblelog-name');
-		var root_id = $(XKit.extensions.one_click_postage.last_object).attr('data-root-id');
+		var root_id = $(XKit.extensions.one_click_postage.last_object).attr('data-root_id');
 		var m_object = {};
 		var m_blogs = XKit.tools.get_blogs();
 		var blog_id = "";
@@ -937,7 +937,7 @@ XKit.extensions.one_click_postage = new Object({
 
 		$(".post").not(".xkit_already_reblogged_check").each(function() {
 
-			var post_id = $(this).attr('data-root-id');
+			var post_id = $(this).attr('data-root_id');
 			$(this).addClass("xkit_already_reblogged_check");
 
 			if (XKit.extensions.one_click_postage.is_alreadyreblogged(post_id)) {

--- a/Extensions/postarchive.js
+++ b/Extensions/postarchive.js
@@ -1,8 +1,8 @@
 //* TITLE Post Archiver **//
-//* VERSION 0.5.4 **//
+//* VERSION 0.5.5 **//
 //* DESCRIPTION Never lose a post again. **//
 //* DETAILS Post Archiver lets you save posts to your XKit.<br><br>Found a good recipe? Think those hotline numbers on that signal boost post might come in handy in the future?<br><br>Click on the save button, then click on the My Archive button on your sidebar anytime to access those posts. You can also name and categorize posts. **//
-//* DEVELOPER STUDIOXENIX **//
+//* DEVELOPER new-xkit **//
 //* FRAME false **//
 //* BETA false **//
 
@@ -736,7 +736,7 @@ var rows = [];
 
 		}
 
-		m_html = m_html + "<div class=\"xkit-dont-run-extensions post post_full " + post_class + " same_user_as_last with_permalink no_source xkit_view_on_dash_post\" id=\"post_" + data.id + "\"  data-post-id='" + data.id + "' data-root-id='" + data.id + "' data-tumblelog-name='" + username + "' data-reblog-key='" + data.reblog_key + "' data-type='" + data.type + "'>" +
+		m_html = m_html + "<div class=\"xkit-dont-run-extensions post post_full " + post_class + " same_user_as_last with_permalink no_source xkit_view_on_dash_post\" id=\"post_" + data.id + "\"  data-post-id='" + data.id + "' data-root_id='" + data.id + "' data-tumblelog-name='" + username + "' data-reblog-key='" + data.reblog_key + "' data-type='" + data.type + "'>" +
 					"<div class=\"post_wrapper\">" +
 						"<div class=\"post_header\">" +
 							"<div class=\"post_info\">" +

--- a/Extensions/postblock.js
+++ b/Extensions/postblock.js
@@ -48,8 +48,8 @@ XKit.extensions.postblock = new Object({
 				$(parent).remove();
 				XKit.extensions.postblock.call_tumblr_resize();
 			});
-			if (XKit.extensions.postblock.blacklisted.indexOf($(obj).attr('data-root-id')) === -1) {
-				XKit.extensions.postblock.blacklisted.push($(obj).attr('data-root-id'));
+			if (XKit.extensions.postblock.blacklisted.indexOf($(obj).attr('data-root_id')) === -1) {
+				XKit.extensions.postblock.blacklisted.push($(obj).attr('data-root_id'));
 				XKit.storage.set("postblock","posts",XKit.extensions.postblock.blacklisted.join(","));
 			}
 			return;
@@ -64,8 +64,8 @@ XKit.extensions.postblock = new Object({
 				$(parent).remove();
 				XKit.extensions.postblock.call_tumblr_resize();
 			});
-			if (XKit.extensions.postblock.blacklisted.indexOf($(obj).attr('data-root-id')) === -1) {
-				XKit.extensions.postblock.blacklisted.push($(obj).attr('data-root-id'));
+			if (XKit.extensions.postblock.blacklisted.indexOf($(obj).attr('data-root_id')) === -1) {
+				XKit.extensions.postblock.blacklisted.push($(obj).attr('data-root_id'));
 				XKit.storage.set("postblock","posts",XKit.extensions.postblock.blacklisted.join(","));
 			}
 

--- a/Extensions/postblock.js
+++ b/Extensions/postblock.js
@@ -1,8 +1,8 @@
 //* TITLE PostBlock **//
-//* VERSION 0.2 REV B **//
+//* VERSION 0.2.3 **//
 //* DESCRIPTION Block the posts you don't like **//
 //* DETAILS This is an experimental extension that blocks posts you don't like on your dashboard. When you block a post, it will be hidden completely, including reblogs of it. **//
-//* DEVELOPER STUDIOXENIX **//
+//* DEVELOPER new-xkit **//
 //* FRAME false **//
 //* SLOW true **//
 //* BETA false **//
@@ -104,7 +104,7 @@ XKit.extensions.postblock = new Object({
 			}
 
 			var this_id = m_post.root_id;
-			XKit.interface.add_control_button(this, "xpostblockbutton", "data-root-id=\"" + this_id + "\"");
+			XKit.interface.add_control_button(this, "xpostblockbutton", "data-root_id=\"" + this_id + "\"");
 
 		});
 

--- a/Extensions/view_on_dash.js
+++ b/Extensions/view_on_dash.js
@@ -1,7 +1,7 @@
 //* TITLE View On Dash **//
-//* VERSION 0.7.3 **//
+//* VERSION 0.7.4 **//
 //* DESCRIPTION View blogs on your dash **//
-//* DEVELOPER STUDIOXENIX **//
+//* DEVELOPER new-xkit **//
 //* DETAILS This is a preview version of an extension, missing most features due to legal/technical reasons for now. It lets you view the last 20 posts a person has made on their blogs right on your dashboard. If you have User Menus+ installed, you can also access it from their user menu under their avatar. **//
 //* FRAME false **//
 //* BETA false **//
@@ -396,7 +396,7 @@ XKit.extensions.view_on_dash = new Object({
 
 		}
 
-		m_html = m_html + "<div class=\"post post_full " + post_class + " same_user_as_last with_permalink no_source xkit_view_on_dash_post\" id=\"post_" + data.id + "\"  data-post-id='" + data.id + "' data-root-id='" + data.id + "' data-tumblelog-name='" + username + "' data-reblog-key='" + data.reblog_key + "' data-type='" + data.type + "'>" +
+		m_html = m_html + "<div class=\"post post_full " + post_class + " same_user_as_last with_permalink no_source xkit_view_on_dash_post\" id=\"post_" + data.id + "\"  data-post-id='" + data.id + "' data-root_id='" + data.id + "' data-tumblelog-name='" + username + "' data-reblog-key='" + data.reblog_key + "' data-type='" + data.type + "'>" +
 					"<div class=\"post_wrapper\">" +
 						"<div class=\"post_header\">" +
 							"<div class=\"post_info\">" +

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 5.3.1 **//
+//* VERSION 5.3.2 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -1522,7 +1522,7 @@ XKit.tools.dump_config = function(){
 				m_return.error = false;
 
 				m_return.id = $(obj).attr('data-post-id');
-				m_return.root_id = $(obj).attr('data-root-id');
+				m_return.root_id = $(obj).attr('data-root_id');
 				m_return.reblog_key = $(obj).attr('data-reblog-key');
 				m_return.owner = $(obj).attr('data-tumblelog-name');
 				m_return.tumblelog_key = $(obj).attr('data-tumblelog-key');


### PR DESCRIPTION
Tumblr changed their post attribute ``data-root-id`` to ``data-root_id`` which broke OCR's Already Reblogged function, as well as XKit Interface's post() function of retrieving the root_id and postblock

Fixes #542 