### PR TITLE
Pull master before merging into gh-pages

### DIFF
--- a/create-extensions-dist.sh
+++ b/create-extensions-dist.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+git checkout master &&\
+git pull &&\
 git checkout gh-pages &&\
 git merge master -m "Merge master" &&\
 gulp build:extensions &&\


### PR DESCRIPTION
That way gh-pages automatically stays up to date with master, before you had to make sure that master was pulled before rebuilding the distribution