### PR TITLE
Remove Safari Warning

### DIFF
--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 5.1.0 **//
+//* VERSION 5.1.1 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER new-xkit **//
 
@@ -240,21 +240,6 @@ XKit.extensions.xkit_preferences = new Object({
 		}
 
 		XKit.extensions.xkit_preferences.spring_cleaning();
-
-		var shown_safari = XKit.storage.get("xkit_preferences","shown_safari","0");
-		if (shown_safari == "0" && XKit.browser().safari) {
-			XKit.notifications.add("<strong>Safari no longer supported.</strong>"+
-			"<br>Unfortunately, I've been forced to discontinue all Safari support for XKit. "+
-			"Please click here to learn more, and dismiss this message.", "warning", true,
-			function() {
-				XKit.window.show("Safari Support Ended.","<strong>Unfortunately, due to various reasons, "+
-					"XKit is no longer supported on Safari.</strong><br><br>I'm terribly sorry about this. "+
-					'Please see <a href="http://xkit-extension.tumblr.com/post/84236134977/a-few-changes-for-the-summer" target="_BLANK">this post</a> '+
-					"to learn why it was discontinued and what you can do. This warning notification will not show up again after you click OK.",
-					"warning", '<div class="xkit-button default" id="xkit-close-message">OK</div>');
-				XKit.storage.set("xkit_preferences","shown_safari","yass");
-			});
-		}
 
 		/*if (shown_notification_notification === "0") {
 			XKit.notifications.add("<b>Turn off notifications</b><br/>You can turn off \"Unread XKit News\" notifications from XKit Control Panel > Other > News. If you have unread mail, please read them first.<br/>Click here to close this notification. This message will be shown only once.","warning",true);


### PR DESCRIPTION
Since we are now at a stage where safari is supported again the message telling people it was unsupported has to be removed from ``xkit_preferences``