### PR TITLE
Remove new remnant-unit-container ads that start popping up

### DIFF
--- a/Extensions/anti_capitalism.js
+++ b/Extensions/anti_capitalism.js
@@ -1,5 +1,5 @@
 //* TITLE Anti-Capitalism **//
-//* VERSION 1.2.1 **//
+//* VERSION 1.2.2 **//
 //* DESCRIPTION	Removes sponsored posts, vendor buttons, and other nonsense that wants your money. **//
 //* DEVELOPER dlmarquis **//
 //* FRAME false **//
@@ -48,7 +48,7 @@ XKit.extensions.anti_capitalism = new Object({
 		}
 
 	    if (XKit.extensions.anti_capitalism.preferences.sponsored_ads.value) {
-	        XKit.tools.add_css(" .yamplus-unit-container, .yam-plus-ad-container, .yam-plus-header {display: none;}", "anti_capitalism_sponsored_ads");
+	        XKit.tools.add_css(" .remnant-unit-container, .yamplus-unit-container, .yam-plus-ad-container, .yam-plus-header {display: none;}", "anti_capitalism_sponsored_ads");
 	    }
 
 		if (XKit.extensions.anti_capitalism.preferences.asktime.value) {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1437010/10260995/4baf0c1a-6984-11e5-9176-3550b1aa1b0b.png)
looks like tumblr introduced a new ad container, no clue why it doesn't show the ads though (might be noscript protecting me). Anyways, added the new class to anti-capitalism