### PR TITLE
Editable Reblogs: don't interfere with One-Click Reply

### DIFF
--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -1,5 +1,5 @@
 //* TITLE Editable Reblogs **//
-//* VERSION 2.1.3 **//
+//* VERSION 2.1.4 **//
 //* DESCRIPTION	Restores ability to edit previous reblogs of a post **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -78,9 +78,11 @@ XKit.extensions.editable_reblogs = new Object({
 				'error', "<div id=\"xkit-close-message\" class=\"xkit-button\">OK</div>");
 			return;
 		}
+		var nodes = $(all_quotes_text + old_content);
+		if (nodes.length === 0) return;
+
 		// add 'tumblr_blog' class to all tumblr.com links,
 		// assuming that they're part of a reblog-structure that's not being parsed properly
-		var nodes = $(all_quotes_text + old_content);
 		nodes.find('a[href*="tumblr.com"]').addClass('tumblr_blog');
 		var nodes_text = $('<div>').append($(nodes).clone()).html();
 		XKit.interface.post_window.set_content_html(nodes_text);


### PR DESCRIPTION
There's no need to run Editable Reblogs when there is no content in the post editor.

Fixes #583 