### PR TITLE
Add option to hide recommended posts on the Optica theme

### DIFF
--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -1,5 +1,5 @@
 //* TITLE No Recommended **//
-//* VERSION 2.1.1 **//
+//* VERSION 2.2.0 **//
 //* DESCRIPTION Removes recommended posts **//
 //* DETAILS This extension removes recommended posts from your dashboard. To remove Recommended Blogs on the sidebar, please use Tweaks extension. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -13,7 +13,7 @@ XKit.extensions.norecommended = new Object({
 	run: function() {
 		this.running = true;
 		XKit.post_listener.add("norecommended", XKit.extensions.norecommended.do);
-		XKit.extensions.norecommended.do();		
+		XKit.extensions.norecommended.do();
 	},
 
 	preferences: {
@@ -30,44 +30,60 @@ XKit.extensions.norecommended = new Object({
 		    text: "Get rid of two-column recommended blogs",
 		    default: true,
 		    value: true
+		},
+		"hide_recommended_optica": {
+			text: "Hide recommended posts under permalinked posts on the Optica (default) blog theme",
+			default: false,
+			value: false
 		}
 	},
 
 	do: function() {
-	    
-	    if (XKit.extensions.norecommended.preferences.no_mini_recs.value === true) {
+
+	    if (XKit.extensions.norecommended.preferences.no_mini_recs.value) {
 			XKit.tools.add_css(" .recommended-unit-container.blog-card-compact {display: none;}", "norecommended_no_mini_recs");
 		}
 
-		if (XKit.extensions.norecommended.preferences.no_liked.value === true) {
+		if (XKit.extensions.norecommended.preferences.no_liked.value) {
 			XKit.tools.add_css(" .rapid-recs {display: none;}", "norecommended_no_liked");
 		}
-		
+
 		var doResize = false;
-		
+
 		$(".posts .post").not(".norecommended-done").each(function() {
-			
+
 			$(this).addClass(".norecommended-done");
-			
+
 			if ($(this).hasClass("is_recommended") || $(this).find(".post_info_recommended").length > 0) {
-				$(this).remove();	
+				$(this).remove();
 				doResize = true;
 			}
-			
-		});	
-		
+
+		});
+
 		if (doResize) {
-			XKit.extensions.norecommended.call_tumblr_resize();	
+			XKit.extensions.norecommended.call_tumblr_resize();
 		}
-		
+
+		if (XKit.extensions.norecommended.preferences.hide_recommended_optica.value) {
+			XKit.extensions.norecommended.hide_recommended_optica();
+		}
+
 	},
-	
+
 	call_tumblr_resize: function() {
-		
+
 		XKit.tools.add_function(function() {
 			Tumblr.Events.trigger("DOMEventor:updateRect");
 		}, true, "");
-		
+
+	},
+
+	hide_recommended_optica: function() {
+		if (!XKit.interface.is_tumblr_page()) {
+			//We're not going to expect other themes have this class as well.
+			XKit.tools.add_css(".related-posts-wrapper {display:none;}","norecommended_hide_recommended_optica");
+		}
 	},
 
 	destroy: function() {

--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -31,8 +31,8 @@ XKit.extensions.norecommended = new Object({
 		    default: true,
 		    value: true
 		},
-		"hide_recommended_optica": {
-			text: "Hide recommended posts under permalinked posts on the Optica (default) blog theme",
+		"hide_recommended_on_blogs": {
+			text: "Hide recommended posts under permalinked posts on user blogs",
 			default: false,
 			value: false
 		}
@@ -65,8 +65,8 @@ XKit.extensions.norecommended = new Object({
 			XKit.extensions.norecommended.call_tumblr_resize();
 		}
 
-		if (XKit.extensions.norecommended.preferences.hide_recommended_optica.value) {
-			XKit.extensions.norecommended.hide_recommended_optica();
+		if (XKit.extensions.norecommended.preferences.hide_recommended_on_blogs.value) {
+			XKit.extensions.norecommended.hide_recommended_on_blogs();
 		}
 
 	},
@@ -79,10 +79,10 @@ XKit.extensions.norecommended = new Object({
 
 	},
 
-	hide_recommended_optica: function() {
+	hide_recommended_on_blogs: function() {
 		if (!XKit.interface.is_tumblr_page()) {
 			//We're not going to expect other themes have this class as well.
-			XKit.tools.add_css(".related-posts-wrapper {display:none;}","norecommended_hide_recommended_optica");
+			XKit.tools.add_css(".related-posts-wrapper {display:none;}","norecommended_hide_recommended_on_blogs");
 		}
 	},
 
@@ -90,6 +90,7 @@ XKit.extensions.norecommended = new Object({
 		this.running = false;
 		XKit.tools.remove_css("norecommended_no_mini_recs");
 		XKit.tools.remove_css("norecommended_no_liked");
+		XKit.tools.remove_css("norecommended_hide_recommended_on_blogs");
 	}
 
 });

--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -82,7 +82,7 @@ XKit.extensions.norecommended = new Object({
 	hide_recommended_on_blogs: function() {
 		if (!XKit.interface.is_tumblr_page()) {
 			//We're not going to expect other themes have this class as well.
-			XKit.tools.add_css(".related-posts-wrapper {display:none;}","norecommended_hide_recommended_on_blogs");
+			XKit.tools.add_css(".related-posts-wrapper, .recommended-posts-wrapper {display:none;}","norecommended_hide_recommended_on_blogs");
 		}
 	},
 


### PR DESCRIPTION
Tumblr [added this a while ago](http://staff.tumblr.com/post/130631908085/related-posts). If you scroll down on a post permalink page on any blog using the Optica theme, you get to see recommended posts unless the owner of the blog decides to turn it off. This PR adds an option in No Recommended to hide these recommendations independently of the blog settings.