### PR TITLE
Remove out of place grey from the file selector dialog.

### DIFF
--- a/xkit.css
+++ b/xkit.css
@@ -31,7 +31,6 @@
 }
 
 .xkit-file-selector {
-	background: rgb(230,230,230);
 	height: 140px;
 	padding: 5px 15px 10px 15px;
 	overflow-y: auto;


### PR DESCRIPTION
Minor style change but this removes the grey background inside the extension editor open page.

Before: http://i.imgur.com/zP3VcGJ.png
After: http://i.imgur.com/RApBEYs.png