### PR TITLE
Fix recommended badges showing up again

### DIFF
--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -463,7 +463,7 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_explore.value) {
-			XKit.extensions.tweaks.add_css(".post .recommendation-reason-footer { display: none; } ", "xkit_tweaks_hide_explore");
+			XKit.extensions.tweaks.add_css(".post .explore-trending-badge-footer, .post .recommendation-reason-footer { display: none; } ", "xkit_tweaks_hide_explore");
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_explore_buttons.value) {

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,6 +1,6 @@
 
 //* TITLE Tweaks **//
-//* VERSION 5.0.1 **//
+//* VERSION 5.0.2 **//
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -463,7 +463,7 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_explore.value) {
-			XKit.extensions.tweaks.add_css(".post .explore-trending-badge-footer { display: none; } ", "xkit_tweaks_hide_explore");
+			XKit.extensions.tweaks.add_css(".post .recommendation-reason-footer { display: none; } ", "xkit_tweaks_hide_explore");
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_explore_buttons.value) {


### PR DESCRIPTION
Our good friends at Tumblr HQ decided the recommended post footers needed a different class. Luckily, we are happy to stand in their way.