### PR TITLE
update author credit of read_posts and alternative_timestamps per their reqeust

### DIFF
--- a/Extensions/alternative_timestamps.js
+++ b/Extensions/alternative_timestamps.js
@@ -1,7 +1,7 @@
 //* TITLE Alternative Timestamps **//
-//* VERSION 1.1.0 **//
+//* VERSION 1.1.1 **//
 //* DESCRIPTION Adds timestamps to dashboard posts using a parsing method instead of AJAX calls. English tumblr interface only for now. **//
-//* DEVELOPER Bit Shift **//
+//* DEVELOPER jesskay **//
 //* FRAME false **//
 //* BETA true **//
 

--- a/Extensions/read_posts.js
+++ b/Extensions/read_posts.js
@@ -1,8 +1,8 @@
 //* TITLE Read Posts **//
-//* VERSION 0.2.1 **//
+//* VERSION 0.2.2 **//
 //* DESCRIPTION Dim old posts **//
 //* DETAILS Dims the posts on the dashboard that you've already seen on previous page loads. **//
-//* DEVELOPER bit-shift **//
+//* DEVELOPER jesskay **//
 //* FRAME false **//
 //* BETA true **//
 


### PR DESCRIPTION
update author credit of read_posts and alternative_timestamps per their reqeust

this leaves unanswered the question of third-party extensions in general
and how to credit them going forward with developement being done on all
extensions by the new-xkit community.

maybe replacing the xkit support+other page with a "credits" page crediting
every contributor, along with specific extensions they've worked on?