### PR TITLE
Fix new tracked tag redirection to /search/

### DIFF
--- a/Extensions/classic_tags.js
+++ b/Extensions/classic_tags.js
@@ -1,7 +1,7 @@
 //* TITLE Tag Tracking+ **//
-//* VERSION 1.5.0 **//
+//* VERSION 1.6.0 **//
 //* DESCRIPTION Shows your tracked tags on your sidebar **//
-//* DEVELOPER STUDIOXENIX **//
+//* DEVELOPER new-xkit **//
 //* FRAME false **//
 //* BETA false **//
 
@@ -9,9 +9,6 @@ XKit.extensions.classic_tags = new Object({
 
 	running: false,
 	slow: true,
-	observer: new MutationObserver(function(mutations) {
-		$(".result_link").each(function() { $(this).attr("target", "_BLANK"); });
-	}),
 
 	preferences: {
 		"sep-1": {
@@ -20,6 +17,11 @@ XKit.extensions.classic_tags = new Object({
 		},
 		"show_new_notification": {
 			text: "Show a [new] indicator in the tag search bar",
+			default: true,
+			value: true
+		},
+		"redirect_to_tagged": {
+			text: "Redirect the followed tags to /tagged/ instead of /search/",
 			default: true,
 			value: true
 		},
@@ -57,6 +59,19 @@ XKit.extensions.classic_tags = new Object({
 			value: false
 		}
 	},
+	
+	observer: new MutationObserver(function(mutations) {
+		if (XKit.extensions.classic_tags.preferences.open_in_new_tab.value) {
+			$(".result_link").each(function() { $(this).attr("target", "_BLANK"); });
+		} else {
+			$(".result_link").each(function() { $(this).attr("target", ""); });
+		}
+		if (XKit.extensions.classic_tags.preferences.redirect_to_tagged.value) {
+			$(".result_link").each(function() { $(this).attr("href", $(this).attr("href").replace("/search/", "/tagged/")); });
+		} else {
+			$(".result_link").each(function() { $(this).attr("href", $(this).attr("href").replace("/tagged/", "/search/")); });
+		}
+	}),
 
 	run: function() {
 
@@ -184,16 +199,20 @@ XKit.extensions.classic_tags = new Object({
 			});
 
 		}
-		if (XKit.extensions.classic_tags.preferences.open_in_new_tab.value === true) {
-			var target = document.querySelector('#popover_search');
-			XKit.extensions.classic_tags.observer.observe(target, {
-				attributes: true
-			});
+		var target = document.querySelector('#popover_search');
+		XKit.extensions.classic_tags.observer.observe(target, {
+			attributes: true
+		});
+		if (XKit.extensions.classic_tags.preferences.open_in_new_tab.value) {
 			$(".result_link").each(function() { $(this).attr("target", "_BLANK"); });
 		} else {
 			$(".result_link").each(function() { $(this).attr("target", ""); });
 		}
-
+		if (XKit.extensions.classic_tags.preferences.redirect_to_tagged.value) {
+			$(".result_link").each(function() { $(this).attr("href", $(this).attr("href").replace("/search/", "/tagged/")); });
+		} else {
+			$(".result_link").each(function() { $(this).attr("href", $(this).attr("href").replace("/tagged/", "/search/")); });
+		}
 	},
 
 	destroy: function() {

--- a/Extensions/disable_search.js
+++ b/Extensions/disable_search.js
@@ -1,8 +1,8 @@
 //* TITLE Classic Search **//
-//* VERSION 1.0 REV D **//
+//* VERSION 1.0.4 **//
 //* DESCRIPTION Get the old search back **//
 //* DETAILS This is a very simple extension that simply redirects your search requests to the old Tumblr tag search pages. Note that features of the new search page, such as multiple tag search will not work when this extension is enabled. **//
-//* DEVELOPER STUDIOXENIX **//
+//* DEVELOPER new-xkit **//
 //* FRAME false **//
 //* BETA false **//
 
@@ -35,7 +35,7 @@ XKit.extensions.disable_search = new Object({
 
 		$(".popover_menu_item .result a").each(function() {
 
-			var new_link = $(this).attr('href').replace('tumblr.com/search/', 'tumblr.com/tagged/');
+			var new_link = $(this).attr('href').replace('/search/', '/tagged/');
 			console.log(new_link);
 			$(this).attr('href', new_link);
 
@@ -47,7 +47,7 @@ XKit.extensions.disable_search = new Object({
 			ev.preventDefault();
 			ev.stopPropagation();
 
-			var new_link = $(this).attr('href').replace('tumblr.com/search/', 'tumblr.com/tagged/');
+			var new_link = $(this).attr('href').replace('/search/', '/tagged/');
 
 			if (XKit.extensions.disable_search.preferences.open_in_new_tab.value === true) {
 				window.open(new_link);


### PR DESCRIPTION
Tumblr changed their href attributes for the tracked tags list to
/search/<tag>. Classic Search was looking for tumblr.com/search
and Tag Tracking+ didn't have a way to change redirection at all,
which has been added in now.

I did not find a way to restore the little numbers that show how many new posts the tag has so far, if you guys got any idea, go ahead