### PR TITLE
retags: Use XKit.storage, clear old cached posts

### DIFF
--- a/Extensions/retags.js
+++ b/Extensions/retags.js
@@ -1,6 +1,6 @@
 //* TITLE       Retags **//
 //* DEVELOPER   new-xkit **//
-//* VERSION     1.0.3 **//
+//* VERSION     1.0.4 **//
 //* DESCRIPTION Adds tags to reblog notes **//
 //* FRAME       false **//
 //* SLOW        false **//

--- a/Extensions/retags.js
+++ b/Extensions/retags.js
@@ -147,7 +147,7 @@ XKit.extensions.retags = {
 		var settingKeys = [], postIds = [];
 		Object.keys(cache).forEach(function(key) {
 			var m;
-			if (m = key.match(/^post_([0-9]+)$/)) {
+			if ((m = key.match(/^post_([0-9]+)$/))) {
 				postIds.push(parseInt(m[1], 10));
 			} else {
 				settingKeys.push(key);


### PR DESCRIPTION
Retags was written as a standalone script originally, and so it was using `localStorage` rather than the XKit storage API. This caused problems once `localStorage` was *completely filled up*, because Retags caches every post it sees - in particular, Retags silently stopped working, and resetting XKit changed absolutely nothing because `localStorage` was still full.

I've addressed the problem in two ways - first, XKit storage is used now, so XKit can provide warnings when it's getting full and can clear it. Second, the actual number of cached posts is tracked, and when it exceeds 1000 (or when the extension nears its XKit storage quota), all but the newest 100 are dropped from the cache. Seems to do the trick!