### PR TITLE
Fix the Alternative Timestamps description being too big for the gallery

### DIFF
--- a/Extensions/alternative_timestamps.js
+++ b/Extensions/alternative_timestamps.js
@@ -1,6 +1,7 @@
 //* TITLE Alternative Timestamps **//
 //* VERSION 1.1.1 **//
-//* DESCRIPTION Adds timestamps to dashboard posts using a parsing method instead of AJAX calls. English tumblr interface only for now. **//
+//* DESCRIPTION Adds timestamps to dashboard posts using a parsing method **//
+//* DETAILS This version of Timestamps uses parsing methods to display the timestamp instead of AJAX calls. Currently only in English. **//
 //* DEVELOPER jesskay **//
 //* FRAME false **//
 //* BETA true **//


### PR DESCRIPTION
This moves some stuff from the description to the details of Alternative Timestamps in order to stop the text from being cut off in the extension gallery.