### PR TITLE
retags: restore old values from storage on clear properly

### DIFF
--- a/Extensions/retags.js
+++ b/Extensions/retags.js
@@ -1,6 +1,6 @@
 //* TITLE       Retags **//
 //* DEVELOPER   new-xkit **//
-//* VERSION     1.0.4 **//
+//* VERSION     1.0.5 **//
 //* DESCRIPTION Adds tags to reblog notes **//
 //* FRAME       false **//
 //* SLOW        false **//

--- a/Extensions/retags.js
+++ b/Extensions/retags.js
@@ -166,7 +166,7 @@ XKit.extensions.retags = {
 
 		// And finally write back to storage!
 		settingKeys.forEach(function(key) {
-			XKit.storage.set('retags', key, cache[key]);
+			XKit.storage.set('retags', key, cache[key].value);
 		});
 	},
 


### PR DESCRIPTION
I messed up. Sorry. In particular, `XKit.storage.get_all` returns the storage in a *weird* format, where every individual stored item is wrapped in an extra object `{value: value}` - which I didn't unwrap, resulting in `{value: {value: {value: {value: etc}}}}`. I assume it's like this so that XKit storage can store `undefined` under a key and distinguish it from "nothing is stored at all".

This mistake *eventually* breaks Retags, after several cache clears have gone through.

Anyway it's fixed by this pull request, which is a one-liner. :/