### PR TITLE
Silently replace Old Stats with Old Sidebar

### DIFF
--- a/Extensions/old_stats.js
+++ b/Extensions/old_stats.js
@@ -1,5 +1,5 @@
 //* TITLE Old Stats **//
-//* VERSION 0.2.2 **//
+//* VERSION 0.3.0 **//
 //* DESCRIPTION  **//
 //* DEVELOPER STUDIOXENIX **//
 //* FRAME false **//
@@ -7,102 +7,42 @@
 
 XKit.extensions.old_stats = new Object({
 
-	running: false,
+    running: false,
 
-	run: function() {
-		this.running = true;
-		var m_user = XKit.interface.user();
-		var posts_show = " ";
-		var followers_show = " ";
-		var drafts_show	= " ";
-		var queue_show = " ";
+    preferences: {
+        "sep-0": {
+            text: "Old Stats is now Old Sidebar",
+            type: "separator"
+        },
+    },
 
-		if (XKit.interface.where().inbox) { 
-			return;
-		}
-		if (XKit.interface.where().likes) { 
-			return; 
-		}
+    run: function() {
+        this.running = true;
+        XKit.install("old_sidebar", function(mdata) {
+            if (mdata.errors) {
+                if (mdata.storage_error === true) {
+                    show_error_installation("[Code: 631] Can't store data on browser");
+                    return;
+                }
+                if (mdata.server_down === true) {
+                    show_error_installation("[Code: 101] Can't reach XKit servers");
+                } else {
+                    if (mdata.file === "not_found") {
+                        show_error_installation("Can't download " + to_install + ": Not found");
+                    } else {
+                        show_error_installation("Can't download " + to_install);
+                    }
+                }
+                return;
+            }
 
-		if (m_user.posts === 0) {
-			posts_show = " count_0 ";
-		}
-		if (m_user.followers === 0) {
-			followers_show = " count_0 ";
-		}
-		if (m_user.drafts === 0) {
-			drafts_show = " count_0 ";
-		}
-		if (m_user.processing === 0) {
-			processing_show = " count_0 ";
-		}
-		if (m_user.queue === 0) {
-			queue_show = " count_0 ";
-		}
+            XKit.installed.remove("old_stats");
+            window.location = window.location;
+        });
+    },
 
-		var xf_html = '<ul data-blog-name="' + m_user.name + '" id="dashboard_controls_open_blog" class="controls_section">' +
-					'<li class="no_push selected_blog">' +
-						'<div class="open_blog with_subtitle">' +
-							'<a class="currently_selected_blog hide_overflow blog_title">' + m_user.name + '</a>' +
-							'<small>' +
-								'<div class="hide_overflow">' +
-									'<a target="_blank" href="http://' + m_user.name + '.tumblr.com/" class="open_blog_link" id="open_blog_link">' + m_user.title + '</a>' +
-								'</div>' +
-							'</small>' +
-						'</div>' +
-					'</li>' +
-					'<li class="controls_section_item' + posts_show + '" data-blog-controls-count="post_count" id="posts_control">' +
-						'<a class="control-item control-anchor posts" href="/blog/' + m_user.name + '">' +
-							'<div class="hide_overflow">Posts</div>' +
-							'<span class="count">' + m_user.posts.toLocaleString() + '</span>' +
-						'</a>' +
-					'</li>' +
-					'<li class="controls_section_item' + followers_show + '" data-blog-controls-count="follower_count">' +
-						'<a class="control-item control-anchor followers" href="/blog/' + m_user.name + '/followers">' +
-							'<div class="hide_overflow">Followers</div>' +
-							'<span class="count">' + m_user.followers.toLocaleString() + '</span>' +
-						'</a>' +
-					'</li>' +
-					'<li class="controls_section_item popover_menu_item_blog_details">' +
-						'<a class="control-item control-anchor activity" href="/blog/' + m_user.name + '/activity">' +
-							'<div class="hide_overflow" id="old_stats_activity">Activity</div>' +
-							'<span data-sparkline="' + m_user.activity + '" class="count sparkline">' +
-								'<canvas style="display: inline-block; vertical-align: top; height: 15px; width: 36px;" width="72" height="30"></canvas>' +
-							'</span>' +
-						'</a>' +
-					'</li>' +
-					'<li class="controls_section_item' + drafts_show + '" data-blog-controls-count="draft_count">' +
-						'<a class="control-item control-anchor drafts" href="/blog/' + m_user.name + '/drafts">' +
-							'<div class="hide_overflow">Drafts</div>' +
-							'<span class="count">' + m_user.drafts.toLocaleString() + '</span>' +
-							'</a>' +
-					'</li>' +
-					'<li class="controls_section_item' + processing_show + '" data-blog-controls-count="transcoding_count">' +
-						'<a class="control-item control-anchor queue" href="/blog/' + m_user.name + '/processing">' +
-							'<div class="hide_overflow">Processing</div>' +
-							'<span class="count">' + m_user.processing.toLocaleString() + '</span>' +
-						'</a>' +
-					'</li>' +
-					'<li class="controls_section_item' + queue_show + '" data-blog-controls-count="queued_post_count">' +
-						'<a class="control-item control-anchor queue" href="/blog/' + m_user.name + '/queue">' +
-							'<div class="hide_overflow">Queue</div>' +
-							'<span class="count">' + m_user.queue.toLocaleString() + '</span>' +
-						'</a>' +
-					'</li>' +
-					'<li class="controls_section_item no_push">' +
-						'<a class="control-item control-anchor customize" href="/settings/blog/' + m_user.name + '">' +
-							'<div class="hide_overflow">' +
-								'Edit appearance<i class="sub_control link_arrow icon_right icon_arrow_carrot_right"></i>' +
-							'</div>' +
-						'</a>' +
-					'</li>' +
-				'</ul>' +
-				'<ul id="xkit-dashboard-account" class="controls_section"></ul>';
+    destroy: function() {
+        this.running = false;
+    }
 
-		$(".recommended_tumblelogs").before(xf_html);
-
-	},
-	destroy: function() {
-		this.running = false;
-	}
 });

--- a/Extensions/postarchive.css
+++ b/Extensions/postarchive.css
@@ -10,22 +10,12 @@
 }
 
 .xkit-post-archive-avatar {
-	width: 12px;
-	height: 12px;
 	/* margin-left: 8px; */
 	margin-right: 7px;
 	vertical-align: middle;
 	border-radius: 3px;
 	display: inline-block;
 	margin-bottom: 3px;
-}
-
-.xkit-postarchive-post-not-supported {
-	border: 1px dashed rgb(200,200,200);
-	text-align: center;
-	color: rgb(140,140,140);
-	height: 200px;
-	line-height: 200px;
 }
 
 #postarchive_view:after {
@@ -48,12 +38,6 @@
 	text-shadow: 0px 1px 0px white;
 	position: relative;
 	cursor: pointer;
-}
-
-.xkit-postarchive-hidden-category-item {
-
-	display: none;
-
 }
 
 .xkit-postarchive-cat-separator.xkit-pac-opened {
@@ -113,10 +97,6 @@
 	padding: 3px 15px;
 	border-bottom: 1px solid rgb(190,190,190);
 }
-
-#xkit-postarchive-rename-this.hidden,
-#xkit-postarchive-remove-this.hidden,
-#xkit-postarchive-recategorize-this.hidden { display: none; }
 
 #xkit-postarchive-remove-this {
 	position: absolute;
@@ -221,28 +201,6 @@
 
 }
 
-#xkit-postarchive-share-code {
-
-	height: 203px;
-	border: 1px solid rgb(190,190,190);
-	margin-top: 10px;
-	background: rgb(244,244,244);
-
-}
-
-#xkit-postarchive-share-code-inner {
-
-	font-family: "Courier New", Courier, monospace;
-	font-size: 14px;
-	background: rgb(244,244,244);
-	padding: 15px;
-	word-wrap: break-word;
-	-moz-user-select: text !important;
-	-webkit-user-select: text !important;
-	user-select: text !important;
-
-}
-
 #xkit-postarchive-sidebar {
 
 	width: 230px;
@@ -298,7 +256,13 @@
 
 #xkit-postarchive-sidebar .xkit-postarchive-post.xkit-this-post-is-pretty-hidden,
 .xkit-postarchive-cat-separator.xkit-this-post-is-pretty-hidden,
-.xkit-postarchive-no-posts-index.xkit-this-post-is-pretty-hidden { display: none; }
+.xkit-postarchive-no-posts-index.xkit-this-post-is-pretty-hidden,
+.xkit-postarchive-hidden-category-item,
+#xkit-postarchive-rename-this.hidden,
+#xkit-postarchive-remove-this.hidden,
+#xkit-postarchive-recategorize-this.hidden {
+	display: none;
+}
 
 #xkit-postarchive-sidebar .xkit-postarchive-post {
 
@@ -313,8 +277,6 @@
 	overflow: hidden;
 
 }
-
-
 
 #xkit-postarchive-sidebar .xkit-postarchive-post:hover {
 
@@ -333,4 +295,13 @@
 
 #postarchive_view {
   color: rgba(255, 255, 255, 0.5);
+}
+
+#xkit-postarchive-content .post_full.is_photoset .photoset .photoset_row,
+#xkit-postarchive-content .post_full.is_photo .photoset .photoset_row {
+	width: 540px;
+}
+
+#xkit-postarchive-content .post_tags {
+	margin-bottom: 15px;
 }

--- a/Extensions/postarchive.js
+++ b/Extensions/postarchive.js
@@ -1,12 +1,12 @@
 //* TITLE Post Archiver **//
-//* VERSION 0.5.6 **//
+//* VERSION 1.0.0 **//
 //* DESCRIPTION Never lose a post again. **//
 //* DETAILS Post Archiver lets you save posts to your XKit.<br><br>Found a good recipe? Think those hotline numbers on that signal boost post might come in handy in the future?<br><br>Click on the save button, then click on the My Archive button on your sidebar anytime to access those posts. You can also name and categorize posts. **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
 //* BETA false **//
 
-XKit.extensions.postarchive = new Object({
+XKit.extensions.postarchive = {
 
 	running: false,
 
@@ -81,17 +81,16 @@ XKit.extensions.postarchive = new Object({
 
 		if (XKit.interface.where().inbox === true) { return; }
 
-    if ($('#postarchive_ul').length === 0) {
-      var xf_html = '<ul class="controls_section" id="postarchive_ul">' +
-            '<li class="section_header selected">Post Archive</li>' +
-            '<li class="no_push" style="height: 36px;"><a href="#" onclick="return false;" id="postarchive_view">' +
-              '<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">My Archive <span class="count" id="postarchive_view_count" style="padding-top: 8px;">' + XKit.extensions.postarchive.archived_posts.length + '</span></div>' +
-            '</a></li>' +
-          '</ul>';
+		if ($('#postarchive_ul').length === 0) {
+			var xf_html = '<ul class="controls_section" id="postarchive_ul">' +
+				'<li class="section_header selected">Post Archive</li>' +
+					'<li class="no_push" style="height: 36px;"><a href="#" onclick="return false;" id="postarchive_view">' +
+						'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">My Archive <span class="count" id="postarchive_view_count" style="padding-top: 8px;">' + XKit.extensions.postarchive.archived_posts.length + '</span></div>' +
+					'</a></li>' +
+				'</ul>';
 
-      //$("ul.controls_section:first").before(xf_html);
-      $(".controls_section_radar").before(xf_html);
-    }
+			$(".controls_section_radar").before(xf_html);
+		}
 
 		$("#postarchive_view").click(function() {
 
@@ -183,7 +182,7 @@ XKit.extensions.postarchive = new Object({
 			// we have a storage bug on chrome.
 			if (show === true) {
 				XKit.storage.set("postarchive","collapse_uncategorized", "false");
-			} else{
+			} else {
 				XKit.storage.set("postarchive","collapse_uncategorized", "true");
 			}
 			return;
@@ -218,11 +217,8 @@ XKit.extensions.postarchive = new Object({
 		if (XKit.extensions.postarchive.archived_posts.length === 0) {
 
 			XKit.window.show("No posts yet.","<b>You have no archived posts yet.</b><br/>If you've archived them on another computer, you might need to sync them using XCloud.","error","<div class=\"xkit-button default\" id=\"xkit-close-message\">OK</div>");
-			//return;
 
 		}
-
-		console.log(XKit.extensions.postarchive.archived_posts);
 
 		var m_post_list_html = "";
 
@@ -236,8 +232,6 @@ XKit.extensions.postarchive = new Object({
 
 				var m_collapse_class = "xkit-pac-opened";
 				var m_collapse_class_post = "";
-
-				// alert(XKit.extensions.postarchive.categories[i].title + "\n" + XKit.extensions.postarchive.categories[i].collapsed);
 
 				if (XKit.extensions.postarchive.categories[i].collapsed === true) { m_collapse_class = ""; m_collapse_class_post = "xkit-postarchive-hidden-category-item"; }
 
@@ -334,27 +328,19 @@ XKit.extensions.postarchive = new Object({
 
 		}
 
-		$("#xkit-postarchive-export").bind("click", function() {
+		$("#xkit-postarchive-export").on("click", function() {
 
 			var m_data = {};
 
 			m_data.posts = XKit.storage.get("postarchive", "archived_posts","");
 			m_data.categories = XKit.storage.get("postarchive", "categories","");
 
-			var m_html = "<div id=\"xkit-postarchive-share-code\" class=\"nano\">" +
-					"<div class=\"content\">" +
-						"<div id=\"xkit-postarchive-share-code-inner\">" +
-							JSON.stringify(m_data) +
-						"</div>" +
-					"</div>" +
-				"</div>";
+			var blob = new Blob([JSON.stringify(m_data)], {type: 'text/plain'});
 
-			XKit.window.show("Export Archive","Copy and paste the following into a file:" + m_html,"info","<div class=\"xkit-button default\" id=\"xkit-postarchive-export-confirm\">OK</div>");
-
-			$("#xkit-postarchive-share-code").nanoScroller();
-			$("#xkit-postarchive-share-code").nanoScroller({ scroll: 'top' });
-
-			$("#xkit-postarchive-share-code").click(function() { $(this).selectText();});
+			XKit.window.show("Export Archive","Click OK to download a file with the contents of your Archive.","info","<a id='xkit-postarchive-download-export'><div class=\"xkit-button default\" id=\"xkit-postarchive-export-confirm\">OK</div></a>");
+			var a = $('#xkit-postarchive-download-export')[0];
+			a.href = window.URL.createObjectURL(blob);
+			a.download = 'PostArchive export - ' + Date() + '.txt';
 
 			$("#xkit-postarchive-export-confirm").click(function() {
 
@@ -365,9 +351,9 @@ XKit.extensions.postarchive = new Object({
 
 		});
 
-		$("#xkit-postarchive-import").bind("click", function() { //Import Function
+		$("#xkit-postarchive-import").on("click", function() { //Import Function
 
-			XKit.window.show("Import","<b>You can import settings from XKit.</b><br/>Click XKit's Export button and paste the text below to import your archived posts.<input type=\"text\" placeholder=\"Paste preferences text here.\" class=\"xkit-textbox\" id=\"xkit-postarchive-import-words\">","question","<div class=\"xkit-button default\" id=\"xkit-postarchive-add-words\">Import!</div><div class=\"xkit-button\" id=\"xkit-close-message\">Cancel</div>");
+			XKit.window.show("Import","<b>You can import settings from XKit.</b><br/>Click XKit's Export button and select the file here (or drag and drop it).<br/><br/>If you need to import your archive from old XKit, click <a href='http://new-xkit-extension.tumblr.com/postarchive-migration'>here for the PostArchive migration guide.</a><br/><br/><input type='file' accept='text/plain' id=\"xkit-postarchive-import-file\" />","question","<div class=\"xkit-button default\" id=\"xkit-postarchive-add-words\">Import!</div><div class=\"xkit-button\" id=\"xkit-close-message\">Cancel</div>");
 
 			$("#xkit-postarchive-replace-on-import").click(function() {
 				$(this).toggleClass("selected");
@@ -375,47 +361,49 @@ XKit.extensions.postarchive = new Object({
 
 			$("#xkit-postarchive-add-words").click(function() {
 
-			var m_to_add = $("#xkit-postarchive-import-words").val();
+				var file = $("#xkit-postarchive-import-file")[0].files[0];
+				// TODO: check if import will push XKit over browser storage limit
 
-				if (m_to_add === "" ||$.trim(m_to_add) === "") {
-					XKit.window.close();
-					XKit.window.show("Noodlebops!", "m_to_add is being weird?? " + m_to_add,"error","<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
-					return;
-				}
+				var f_reader = new FileReader();
 
-				var m_obj = null;
-				try {
+				var progress_bar = XKit.progress.add('postarchive-import-progress');
 
-					m_obj = JSON.parse(m_to_add);
-					//XKit.window.show("m_obj:", JSON.stringify(m_obj),"error","<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
-					//return;
+				$('.xkit-window-msg').append(progress_bar);
+				$('.xkit-window-title').text('Importing...');
 
-				} catch(e) {
-					alert("Invalid/Corrupt JSON object found.\nImport can not continue.");
-					return;
-				}
+				f_reader.onload = function(event) {
+					var m_data = event.target.result;
 
-				m_posts = JSON.parse(m_obj.posts);
-				m_categories = JSON.parse(m_obj.categories);
+					var m_obj = null;
+					try {
+						m_obj = JSON.parse(m_data);
+					} catch (e) {
+						XKit.extensions.postarchive.show_error("Invalid/Corrupt JSON object found.\nImport can not continue.");
+						return;
+					}
 
-				XKit.extensions.postarchive.load_posts();
+					m_posts = JSON.parse(m_obj.posts);
+					m_categories = JSON.parse(m_obj.categories);
 
-				for (var n=0;n<m_categories.length;n++) {
-					XKit.extensions.postarchive.categories.push(m_categories[n]);
-					console.log(XKit.extensions.postarchive.categories);
+					XKit.extensions.postarchive.load_posts();
+
+					Array.prototype.push.apply(XKit.extensions.postarchive.categories, m_categories);
+					Array.prototype.push.apply(XKit.extensions.postarchive.archived_posts, m_posts);
 					XKit.extensions.postarchive.save_posts();
-				}
 
-				for (var i=0;i<m_posts.length;i++) {
-					XKit.extensions.postarchive.archived_posts.push(m_posts[i]);
-					console.log(XKit.extensions.postarchive.archived_posts);
-					XKit.extensions.postarchive.save_posts();
-				}
+					XKit.extensions.postarchive.update_sidebar();
 
-				XKit.extensions.postarchive.update_sidebar();
+					XKit.window.show("Done!", "Your posts should exist!", "info","<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
+					XKit.extensions.postarchive.view();
+					return;
 
-				XKit.window.show("Done!", "Your posts should exist!", "info","<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
-				return;
+				};
+
+				f_reader.onprogress = function(event) {
+					XKit.progress.value('postarchive-import-progress', 100*event.loaded/file.size);
+				};
+
+				f_reader.readAsText(file);
 
 			});
 
@@ -506,8 +494,6 @@ XKit.extensions.postarchive = new Object({
 
 	parse_item: function(data, username) {
 
-		console.log(data);
-
 		var m_html = "<li class=\"post_container\">";
 		var post_class = "";
 		var additional_classes_for_post = "";
@@ -585,16 +571,20 @@ XKit.extensions.postarchive = new Object({
 
 			post_class = "is_video";
 
-			var m_post_inner_html = ""; // data.player[2].embed_code; // '<div class="view-on-dash-not-supported">' + data.type + ' posts are not currently supported.</div>';
+			var m_post_inner_html = "";
 
 			var last_width = 0;
 			for (var obj in data.player) {
-				if (data.player[obj].width > last_width && data.player[obj].width <= 500) {
+				if (data.player[obj].width > last_width && data.player[obj].width <= 540) {
 					m_post_inner_html = data.player[obj].embed_code;
 					last_width = data.player[obj].width;
 				}
 			}
-
+			if (m_post_inner_html.indexOf("<video") !== -1) {
+				m_post_inner_html = m_post_inner_html.slice(0,8) + ' controls ' + m_post_inner_html.slice(8);
+			} else {
+				m_post_inner_html = m_post_inner_html.replace('width="500"','width="540"');
+			}
 
 			post_contents = post_contents + "<div class=\"post_media\">" + m_post_inner_html + "</div>";
 
@@ -620,19 +610,17 @@ XKit.extensions.postarchive = new Object({
 
 			post_class = "is_photo";
 
-			//var photo_post_inner_html = '<img class="image" width="500" alt="" src="' + data["photo-url-500"] + '" data-thumbnail="' + data["photo-url-100"] + '">';
-
-			if (data.photos.length === 1) { post_class = "is_photo"; }else {post_class = "is_photoset"; }
+			if (data.photos.length === 1) { post_class = "is_photo"; } else { post_class = "is_photoset"; }
 
 			var photo_post_inner_html = "";
 
 			if (data.photos.length === 1) {
 
-				photo_post_inner_html = '<img class="image" width="500" alt="" src="' + XKit.extensions.postarchive.get_photo(data, 0, "500") + '" data-thumbnail="' + XKit.extensions.postarchive.get_photo(data, 0, "100") + '">';
+				photo_post_inner_html = '<img class="image" width="540" alt="" src="' + XKit.extensions.postarchive.get_photo(data, 0, "540") + '" data-thumbnail="' + XKit.extensions.postarchive.get_photo(data, 0, "100") + '">';
 
 			} else {
 
-var rows = [];
+				var rows = [];
 
 				for (var i=0;i<data.photoset_layout.length;i++) {
 					rows.push(data.photoset_layout[i]);
@@ -644,7 +632,10 @@ var rows = [];
 
 				rows.forEach(function(row) {
 					var shortest = 0;
-					var m_width = 500 / row;
+					var m_width = 540 / row;
+					if (row > 1) {
+						m_width -= row;
+					}
 
 					// Calculate the shortest!
 					var m_temp_photo = current_photo;
@@ -655,7 +646,7 @@ var rows = [];
 
 							var scaled_height = (m_width * XKit.extensions.postarchive.get_photo_height(data, m_temp_photo, "500")) / 500;
 
-							if (scaled_height <= shortest ||shortest === 0) {
+							if (scaled_height <= shortest || shortest === 0) {
 								shortest = scaled_height;
 							}
 
@@ -676,8 +667,6 @@ var rows = [];
 						var m_height = (m_width * XKit.extensions.postarchive.get_photo_height(data, current_photo, "500")) / 500;
 						var margin_top = 0;
 
-						console.log("m_height = " + m_height + "\nshortest = " + shortest);
-
 						if (m_height > shortest) {
 							margin_top = (m_height - shortest) / 2;
 						}
@@ -695,8 +684,6 @@ var rows = [];
 				});
 
 				photo_post_inner_html = photo_post_inner_html + "</div>";
-
-				// photo_post_inner_html = '<div class="view-on-dash-not-supported">Photosets are not currently supported.</div>';
 
 			}
 
@@ -740,7 +727,7 @@ var rows = [];
 					"<div class=\"post_wrapper\">" +
 						"<div class=\"post_header\">" +
 							"<div class=\"post_info\">" +
-								"<img src=\"http://api.tumblr.com/v2/blog/" + data.blog_name + ".tumblr.com/avatar/24\" class=\"xkit-post-archive-avatar\"><span style=\"font-weight:normal; margin-right: 8px;\">Archived from:</span><a target=\"_BLANK\" href=\"" + data.post_url + "\">" + data.blog_name + "</a>" +
+								"<img src=\"http://api.tumblr.com/v2/blog/" + data.blog_name + ".tumblr.com/avatar/48\" class=\"xkit-post-archive-avatar\"><span style=\"font-weight:normal; margin-right: 8px;\">Archived from:</span><a target=\"_BLANK\" href=\"" + data.post_url + "\">" + data.blog_name + "</a>" +
 							"</div>" +
 							source_div +
 						"</div>" +
@@ -751,14 +738,11 @@ var rows = [];
 								"</div>" +
 							"</div>" +
 						"</div>" +
-						post_tags +
-					"</div>";
+					post_tags +
+				"</div>" +
+			"</div>" +
+		"</li>";
 
-		//alert("<a style=\"display: none;\" class=\"post_permalink\" id=\"permalink_" + data.id + "\" href=\"" + data.post_url + "\" target=\"_blank\" title=\"View post - whatever\"></a>");
-		m_html = m_html + "</div>";
-		m_html = m_html + "</li>";
-
-		//console.log(m_html);
 		return m_html;
 
 	},
@@ -784,9 +768,6 @@ var rows = [];
 			}
 		}
 
-
-		console.log(post_obj);
-
 		XKit.extensions.postarchive.current_post_id = post_id;
 
 		$("#xkit-postarchive-content").removeClass("xkit-postarchive-no-post-selected").html(XKit.extensions.postarchive.parse_item(post_obj, "xenix"));
@@ -795,8 +776,8 @@ var rows = [];
 		$("#xkit-postarchive-recategorize-this").removeClass("hidden");
 		$("#xkit-postarchive-rename-this").removeClass("hidden");
 
-		$("#xkit-postarchive-remove-this").unbind("click");
-		$("#xkit-postarchive-remove-this").bind("click", function() {
+		$("#xkit-postarchive-remove-this").off("click");
+		$("#xkit-postarchive-remove-this").on("click", function() {
 
 			XKit.window.show("Remove","You sure you want to remove this?","warning","<div class=\"xkit-button default\" id=\"xkit-postarchive-remove-item-confirm\">Remove</div><div id=\"xkit-close-message\" class=\"xkit-button\">Cancel</div>");
 
@@ -810,8 +791,8 @@ var rows = [];
 
 		});
 
-		$("#xkit-postarchive-rename-this").unbind("click");
-		$("#xkit-postarchive-rename-this").bind("click", function() {
+		$("#xkit-postarchive-rename-this").off("click");
+		$("#xkit-postarchive-rename-this").on("click", function() {
 
 			XKit.window.show("Rename This Post", "<b>Title:</b><input type=\"text\" value=\"" + m_post.title + "\"maxlength=\"150\" placeholder=\"Enter a title (example: 'hotline phone list')\" class=\"xkit-textbox\" id=\"xkit-postarchive-title\">", "question", "<div class=\"xkit-button default\" id=\"xkit-postarchive-save-new-name\">Save</div><div class=\"xkit-button\" id=\"xkit-close-message\">Cancel</div>");
 
@@ -839,8 +820,8 @@ var rows = [];
 
 		});
 
-		$("#xkit-postarchive-recategorize-this").unbind("click");
-		$("#xkit-postarchive-recategorize-this").bind("click", function() {
+		$("#xkit-postarchive-recategorize-this").off("click");
+		$("#xkit-postarchive-recategorize-this").on("click", function() {
 
 			if (XKit.extensions.postarchive.categories.length === 0) {
 
@@ -895,11 +876,7 @@ var rows = [];
 
 	load_posts: function() {
 
-		//console.log("Post Archiver: Loading posts...");
-
 		var m_storage = XKit.storage.get("postarchive", "archived_posts","");
-
-		//console.log("Post Archiver storage result:\n\n" + m_storage + "\n\n");
 
 		if (m_storage !== "") {
 			try {
@@ -927,21 +904,15 @@ var rows = [];
 			XKit.extensions.postarchive.categories = [];
 		}
 
-		//console.log("Load result:");
-		//console.log(XKit.extensions.postarchive.archived_posts);
-
 	},
 
 	save_posts: function() {
 
 		try {
-			console.log("Trying to save " + XKit.extensions.postarchive.archived_posts.length + " posts..");
-			console.log(JSON.stringify(XKit.extensions.postarchive.archived_posts));
 			XKit.storage.set("postarchive", "archived_posts", JSON.stringify(XKit.extensions.postarchive.archived_posts));
 			XKit.storage.set("postarchive", "categories", JSON.stringify(XKit.extensions.postarchive.categories));
 		} catch(e) {
 			XKit.window.show("Unable to save data","Post Archiver could not save data<br/><br/>Error:<br/>" + e.message, "error", "<div class=\"xkit-button default\" id=\"xkit-close-message\">OK</div>");
-			alert("Can't save data:\n" + e.message);
 		}
 	},
 
@@ -1084,25 +1055,37 @@ var rows = [];
 
 			var dpostobj = $("#post_" + post_id);
 
-			if ($(dpostobj).find(".post_title").length > 0) {
+			if ($(dpostobj).find(".post-title").length > 0) {
+
+				m_title = $(dpostobj).find(".post-title").text();
+
+			} else if ($(dpostobj).find(".post_title").length > 0) {
 
 				m_title = $(dpostobj).find(".post_title").text();
 
-			} else {
+			} else if ($(dpostobj).find(".title").length > 0) {
 
-				if ($(dpostobj).find(".post_body").length > 0) {
+				m_title = $(dpostobj).find(".title").text();
 
-					m_title = $(dpostobj).find(".post_body").text();
+			} else if ($(dpostobj).find(".reblog-title").length > 0) {
 
-				} else {
+				m_title = $(dpostobj).find(".reblog-title").text();
 
-					if ($(dpostobj).find(".track_name").length > 0) {
+			} else if ($(dpostobj).find(".post_body").length > 0) {
 
-						m_title = $(dpostobj).find(".track_name").text();
+				m_title = $(dpostobj).find(".post_body").text();
 
-					}
+			} else if ($(dpostobj).find(".track_name").length > 0) {
 
-				}
+				m_title = $(dpostobj).find(".track_name").text();
+
+			} else if ($(dpostobj).find(".chat_line").length > 0) {
+
+				m_title = $(dpostobj).find(".chat_line:first").text();
+
+			} else if ($(dpostobj).find('.reblog-list').length > 0) {
+
+				m_title = $(dpostobj).find('.reblog-list-item:first .reblog-content').text();
 
 			}
 
@@ -1429,4 +1412,4 @@ var rows = [];
 
 	}
 
-});
+};

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -533,7 +533,7 @@ XKit.extensions.tweaks = new Object({
 		if (XKit.extensions.tweaks.preferences.wrap_tags.value &&
 				XKit.interface.is_tumblr_page()) {
 			XKit.extensions.tweaks.add_css(".post .tags { width: 100% !important; display: block !important; overflow:visible; height:auto; white-space: normal; }  .post .footer_links.with_tags { overflow:visible !important; display: block !important; }.post .footer_links.with_tags span, .footer_links.with_tags .source_url { display:block !important; overflow:visible !important; } .source_url_gradient { display: none !important; } span.tags { white-space:normal !important; } span.with_blingy_tag a.blingy { height:auto !important; display:inline-block !important; }  .source_url, .post_tags_wrapper { display: block !important; } ", "xkit_tweaks_wrap_tags");
-			XKit.extensions.tweaks.add_css("#posts .post.post_full .post_tags { white-space: normal; } .post .post_tags a { font-size: 12px; } .post_full .post_tags:after { background: none !important; }", "xkit_tweaks_wrap_tags_v2");
+			XKit.extensions.tweaks.add_css(".post.post_full .post_tags { white-space: normal; } .post .post_tags a { font-size: 12px; } .post_full .post_tags:after { background: none !important; }", "xkit_tweaks_wrap_tags_v2");
 			$(document).on('mouseup mousemove mouseover mousedown mouseout', '.post_tags_inner', function(e) {
 				$(this).parent().removeClass("draggable");
 				$(this).removeClass("post_tags_inner");

--- a/Extensions/xkit_preferences.css
+++ b/Extensions/xkit_preferences.css
@@ -8,32 +8,6 @@
 
 }
 
-#xkit-festivus {
-
-	z-index: 1000;
-	width: 100%;
-	position: absolute;
-	top: -1px;
-	left: 0px;
-	height: 33px;
-	background-position: 0px 0px;
-	display: none;
-
-}
-
-#xkit-festivus-toggle {
-	float: right !important;
-	border-right: 0 !important;
-	font-size: 11px !important;
-	padding: 0px 14px !important;
-	opacity: 0.8;
-}
-
-#xkit-festivus-toggle:hover {
-	background: transparent !important;
-	opacity: 1; text-decoration: underline;
-}
-
 #xkit-spring-cleaning-list {
 
 	margin-top: 10px;

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 5.2.1 **//
+//* VERSION 6.0.1 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER new-xkit **//
 
@@ -72,9 +72,6 @@ XKit.extensions.xkit_preferences = new Object({
 	default_extension_icon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QUJCMUU3MkZGNEJGMTFFMzg3RDJDMTc0MUZBMDc1NDQiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QUJCMUU3MzBGNEJGMTFFMzg3RDJDMTc0MUZBMDc1NDQiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDpBQkIxRTcyREY0QkYxMUUzODdEMkMxNzQxRkEwNzU0NCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDpBQkIxRTcyRUY0QkYxMUUzODdEMkMxNzQxRkEwNzU0NCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Ph1S7d4AAA2gSURBVHja7FpZb2O3FebhXbTLsiRvI7dN2iIe29MCCdC+dEGB/qk+9KEP/St96w/oS4CgKdA+5CVoJhnHUzuTRB7bY8mSrO1qYz+Sd+FdZDsFgjZAhWv5ijyHPOTZD0m/+9NHz9u967sZW/P57dEOvt//9Ip988+3irtdcY9bNZtzOt7fZO3eG2MNgjFKgBPRmoE0cIiSxg1RM4ZNzZiAyZxWBNRzYrx9O8G/Z60amiK0FA6t3yqKAzwIeX8XPYI5OxX3maIexNsnV0M0tepFzYcMWdJ7QPQfiMG3gav3Hs3t7hjE24A4uR7hW62hxr7uXw9n/7ML2C67x/sbkCtJvSIbC5Bc+/x6CMgnm1jDBmv336g1aHEkYzQRcDkh9+uE2MTN1IHMEZg5i4ErqW9J6i9ux5pgfLjUEvVgQRe9idLp2lYlJ9VHd+nB1DsFjea37FZvPkzwoh5NFDETPkBJtKR6/Wb9bFdyIAzkgciTqxELurm5HxAprdNY6FbZfaxaPajF37Ql1bul9l5rrVTaSDCYzdUer8AL1XIqBYvtbxae7W88bw+gD+gXilN6rBAy/TG79HvI5XWQK/XNs9C1bAO3KamvkqIe5JmU4GPrpZg0yTUwwhqAxi7ufDICGvh6TvCMd8rcUX4fiv+u6GdNSM6TCoj+WlFvDsXNBUTqqdfwRtrW/XoByDEJEQ9Z9YR2k6GP6RdTf9MDKpjjlqK+C+qHMfQQ6vd//ph9lz+cfcc/9genNxnCYDD6N+80ZYNgz1/f3Yy8SIoCrI2C83ajVCvYGmzgLe4m8+FsOZ4t3/veBhr/etpxbMpZVjFnlV2rUnCqOVurYm+yOO+M+pO5OWmznDverWiADz6/iclMypXY2W4yZhNJO6PjvcrzS7oZehH74DR2K42SNLiT+bIznHXGs9vxPDEQzIW3EN5igbXp1s2i0yi6jbJbKzjv7tc6o9nzy7vVSq5AUV+OYrgEeSli7Uea+XZv0qoVjvfKzy+ZXkPJtX7SquZta75cXQ28yztvqOmj9S4i+NxO5nguh95uJbdTzWElP3+r9s/2oODamno93WO8kG0GrIIlFV0EAe3pzRhv+3IN4AObLVbv7sOzEPb7oj+9HnoUQJoihhYRfqf4DzH7V2c88JZPNvK1ovOzH2xqhwPqX96M9zeLIQdofdxhkza4wgifDDUwOEkYFKCtWv54t8pV++XA+6o3GXlL0t6Oso1huIKMLsHejGbQlh9vlzcLIIYhHNabFcsHEuhC9atG7tshMgO3wD7xuDIQO+2MroYeV+3d8fysOx7Nlz4ijw9ijknGUIlv1V7IWRsFW0PC75ZyVhIsMTIPcCXHWBSl6TcWfgcBFwviLIs41E6/bxZdaIAZkYXzRKPFw7qsSJC2Sq5iKb3ue1eDmcXpp0+qmCgTODGyDqeJ7o3NfAD1BQXIO/bteDZbih04+b3qp5ewrfO1rtmI6TO1sVlyjnYrSu6nkJyia+Ucjq3BRI/JJRQbiD3wBLC1og2LOVuuLgbTz66H7f4UE2P6Ztl5EDfzAaJPfX8K4UTLeL7E4JhCm+Z7cMOHR/IT/yTYhc/b9SJeEJ++GS/wctoZtwdTzjkEAGJwD6szh/Ulh3NQ/LIzDttvxguZEqZw2RoipaiJpLjKFoonJTBzG0UX3upqNAvHetmZYHqMcbRXbQZrCJchIr0gFu/CBh/uVYGILTjtTBKzY4pJaBsC8hJ0ioBIHmQ2sSfdsitzNNYZyxjB7AUf4AcwzNFeBQJt4tI6ySk5EHGYMiCqvU8CYwpMlCaG4hRSKEIPPApjp5pHnNNF0JICOO1OLvoeaX2A7KZwzRYAHMk4h4ACxHWTyokULmTsfvI4Wy9hCZN65y1702WmqkAMXvv6UNkqupHxDYBC6gEg5V7u/YQlDKUB3PP8iWqGpU7bYfzjkbFKp7akcmb9zSVnY96KomAPAJIP0AfwAbKk8mkyvBXeldZWMKHU2tuJLxI85QR5jBiY7RAmLA9E4uT7YUq5gCzjKxeQtsMGpNQHuQZ2tFNuajsY9DaLLhrRdSEt5vjxtYIyvPK9OaBtRmCZGV/YOJmvEk4vHV1psW5VcyD3s+uRxm2WckfbJUn9wHvZnaTLnSKr1qS/C44VUkhZlaUonKasmhRjURTlIWCn7OSHjHWedqVheVLNHe6UNPzRTklWRAbQ2nHasYp1JRUVH8IxmzEipRZMf/jLyf9z4v9qTvzhF31BKREMfqDr12/V9M9/fDlA8pUhRYYQ+CokWKPgPFWSI1NKwV5cjW6mc1JJs8wdBDPi/LgGBl2/wryMYca/fzWISVcwnQiNUzpQD3+YP/MOZ5QZcibNUqPkHO761OuQHT+bRSddck6YPUpFn95SJCJDFsflZqn1fidacngSIAHMdJzjHEqbQ+07PyZrD2b4h0Z0xSz5PUMFP6cLEbP8KfjAEycCPz/MC6rNqqWUc2Jek1PMR3L5yPh+C/YeMebsrDvVQ531plgMGtGFNUgMbuRPhluNRg7cv8z4mBl5GigsgGUBQhBiq4cF7UGNvSIzPdWVYhcp+EbROQT18LV3HogO1i77z3tTNMq4dTtYg1FVp2A6f3y/Xi8/d4gdeUBSWMrXhPGwvJ7p0imZ1Fbydq1gxQTWyE0bJVtJDmsr6iMLF4yg+IA1sMMtyJIdS7vNqVW7nEj1DrxlMreO52M85IsvEqHkcCO6YnQ9muO1XnCT3FQ7idwKZMncajg7v/VMgFAwmOSDB1lCz2GzBJREdmuSUc+7ul2sy7MiHXjEMSKakWSQDGnssssTnhPb+bRRlDVk7P3tVG+ViFeyQyt5fqv4QASUetGOlN+wwuUcb2oWsdQ4qXw1O9pOlRSo7636swUy+q1SLh7fO0+bJUTI2Fps8JrqQWzYs553AT5wDj5Iu5QCwBSY6J5xWMKUZFgnIxMMDqzYq748+dstu1tSC2Wj1NpmyZIR8uysP42XUAx7yFji3Oy8D52WFRS5hqITOgcVdTuYIpo6dsiWYfAjM2rmnYJH1kYKIpMtg9myO104Ft8r54quVS+62HtSZv5sMCXDVIswkWWRNYsyWi7fseBQH6RqqUYMu1fJYYrOdKFXJIGVtRFp0WC+H8jIhoklG/UmvehMvOUKWdKPNguHzaKFCHnogfqEHQtHXZdn6y5pl1Sd73AL+uDkLNqv5jA4pnhxM4nNzo2YIG6RbINPRmzDs4tTK2KfdMbv7ZRrBRkXSHvf95LeXxhRohk5pEvHHGuQ6K1KDtvR8xb1nLMS4pOb8UpLoUhFHSnzYks3kRg6COOSly7U76Jth4PZnEquNZ6voijLXLyIlfZEqtAmFPB533M4bZfcel5uysfX48lSUFBnzsxm/In840nK8CZCvQgjuxHqkTFmswCGXiuqt8vuD2v5puJGVBJmcaejxzG0OYzOVBwjx3Rt359izLzFRWaZJ0hx9E+fwkiE4ikZxb2d3sVG3nlaz8vMcAib4309mj1rFCGyZdeujKw3k8VwvszIRylefTUYW7atrZK9U3Rti80WojddbJedp1uFFx3qTOdGycBADAVKV/+5kROvK8BqREl9A9TTa9j7vowuJ3Px0dUYS2oUbCgf+ADT0Z0se7MFi+4nmCRELK25dr1gNfI2QnQhD2wWL7pTSD9Cz1bFxUQnneThSJosLaG2oHVViMARKoCnzTxMHoz32cATkeMUn3YnNdf6fjW3kbdarrtXEXfeCiEknvFc+GLKmcO5ywkWv+RYZTw5rus5/enyy4HXn/msOx948s5JxT1o5v2DF8rO5SNO//HDV9/tlDImQmsSS7MekFmYMM1OWhpNo5GuQ6RP6UV4oCQCQyoii5o4wrP/djHMNE9K7q2DekFnhgCLHeCJmEybp1d6JqHE55etssRtDyl1t0BQMs1NyMkvnpT1OC+6k5vpkoy9MyFtc69NmWtq6o3zPrPIlTBWwrifFL+o5Bv/xNUl42AxOZphwJRTIfZOvSi6ky7WkHWziqcPI2SMWbDV3lN7NE9EIPeEmUTZF5tozQj0UCCMPxBgIfauF2CyWNYsPH1CKfd+M6+zky8Gs8yTHpZRCM4+UGTrjxvpQVxiIABuB9sMe91EtJQagSccXl3vPSLk0fwLWVbIzjApddDgO0jT0Zqu3QAT9555iRTw+d3sYjxHyHPQKNQLdoIGbgYLYJPva0fz8ztPpA7q9OiCRaWlxAYSredCnJVm2KspFllc0GAg5kLmtEz7TZOtdhilNfP2QS2kfhYFABS5ckroXFqYRKJd/eJkFt/I9EM8KsVpS0UmrqH7mqQnJedgs3BC085koddpq/ybbWLvazJXhMC9UqBw8St/RNIXU3SREP9XATVcBdjcvPqmUHRjhEuG/eM+gK7YhevXF+YkYhiPyRyIRVf6BHulLuW2yi5U9HPykF1hKB5STwH1q4AUruYQ5u28YOKwdBRe1uOGkPBUBL+K63ICnsV/ruLXA8O1aT605T1EOqjl6tIuMRtR+MFmTtZzhvNXw7lmePqwnWcW9sNdXHf8EAzB77/6zcKbG7HFEEXzhl2SSORAUpbyJz0PNieHVlD/pbph6Su0iLxp7PatWRmmWAans5PMAxyKn76tW4gg38GzQBmSs5AfaLwayhpPq+yAD/8WYAAEUx7gvW1wxAAAAABJRU5ErkJggg==",
 	kernel_extension_icon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QUJCMUU3MjdGNEJGMTFFMzg3RDJDMTc0MUZBMDc1NDQiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QUJCMUU3MjhGNEJGMTFFMzg3RDJDMTc0MUZBMDc1NDQiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo3OTQ0Nzk5Q0Y0QjYxMUUzODdEMkMxNzQxRkEwNzU0NCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDpBQkIxRTcyNkY0QkYxMUUzODdEMkMxNzQxRkEwNzU0NCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PrBB3m4AABEISURBVHja1DprcBvHebcHEC8CBAiCJEgCBEmIpEjKIiWKYvQoJSuiJCpjx+44sRM3bRy7rjx229hp3CSu2lHbcZ06qdw6kyZtxpPUk9jyyHIaO46lSpYUy5IckXpRpPh+EyRAggDxfl/3bu8Oew+ATP5553g87H777e6333tX2Xn0feLTXJQEAOgLYLUU9hN9U0IAQgLMA6wJmb8pDwwOzM9ZKQsNJN95kIoA1oTM3wTWQXUguwOfehb69C5AwO6EhPulzAfkBOMPkwFqreGkoihmIYDtAJBlNQwNkOV7BgBwYCD3REDeGgByt0pH5Aip/P1E5g+T4hw1ztLCdkdxU6WxyqwzaOiZrEaSwwuB83fdN+dW1zUlQChJZuEZgiC5Sul3rlZRWSdYlUmzu6G0q7Fsk82oUIihNjuKH+p0XB1beuXMyLwvSuRGmOFlgBC2Sb/h227W1Vp05UUaXYEinaFWY6nlYHzWF10MRFNpKldHUbHo1X+209HTVqUpUOSjLyB21JfWWAqffePmnC+SCyGJL0BGOhBnE8QDW6oO3VNRbzWolOJRE6n0UjA+5Ar0Tnp7p/0Lq9FcZk+lIB/eZntkR61RV5AlIUV5g/EZb2TRH01lMnB5DRVFpUUa1FpRrPv24aZn3uijqHxSDHa9eDYXJWzF2m/3NLU6itejziKJ9K2ZlQ8HPRdGlqLJNN60vcb87MFGuId8jdsfPT2weHHIM+uPwo58PdyZnhbrkX0bCtWscH7/g6F3bszn2y64AFm1WFWsPf5wGyQDD5pKZyBT+kKJRCYDRadQo4Q0MxeqRYZkwRc5O+j+cNA9thxWKsBTXc6HOqtJDmgpEPv5lan3+xfRImV17o66kn95qFWhoFsG5vxHXu+T1bMU60oAwJsCXKl9fX8DP/t0mjrVN/PerYVJX4TKZDVAoUphM2nb7MaO2pJNNhMiG+z1lV21D3dW902uwG/Iygg8HE+93Tt78vq8L5JgWBgIVCfGxlemVuBwX9jugL8g61abdTP+KDs9iU6Xt8StNmOn08IPfOxXd65M+NheGHg4kRn2hOFzos8F5fveBsv+5vLGiiKa6ZUKKIg85K1p/8tnhqZXogJCgZza9r3biw+225UKEuKBJJjxx3JpZJKukjx7Gy38un50YfzKpE8WDH/cwdibfXNPvN73nbdvz65EROJx5u7iNNSJayHhH7jV835Wh5YVqfNAwgVkC8G9G6xFLMsG46fvelAlIQQTdeFLm92EyyssOpXim4c2/tefbN1UaQSSvjjybA0BfKEk6g45M9e4sJCMBLDL4Rt4ZTeyGIwlM7IjoV4Ae8P/T++p++L2atQXqvCXTw+Pu0PoJ7S4rzzS+rWdDgEephcgBLRATzLDSls6Q7BgknHhfyVtDyjMHRCKujcczxkQUJh1YbAdPdTY3WJFFbdn/X/37qA/moQb+OVttq/scBQoSLVS8dVdtY1Ww8v/N7ocSrBskCOYgooOVQTiqSwkhdkw5AvRbhgumbRuIEKxFOvrkVABAnkHExAdDlP3xrKtDhPD6BlHCcs5vVMrR391N5JMQ8TJNPWzT2ahmXtsp6Oj1kxrSaflPy36H5wf/+24V+rn8iPxpmA5FM96nMJ5ULwMENgDi4uTeqtRKwVAD5z9U111BzdZSw0a+PCz/2hk6flfDkZSGRx4wB36m3cGXrs0lWQYotyoOfb55j/ttBMS6UKPTq0s0atoYw+Njz9OyE0A9ZLXQnfdQTQbu1kLRVAWBtLeWaYX7YovnHjxzGgaWn+5Lj+7Nvv8qX53IMaYAfD47toXDjaQjBiKHptJY9arkeFbDMXXq4X4Ar1Z6LHB/pAM9mKtqBWtfquciwGnjmgP5FQWLNfng8+d7B9wsd7ygZbyf+hpKFQpRWBtNiNilmF3KEURUjw8cobFJVsz7osNuAKITl0bSmT3Tj7mogie5SiJYkE/54OJZ04OnOI8nL2NZa88dI+lUCXgzxozau2b8fN48HlSzMOyEJDsC6y5xElYd1OZVkWKWuH75pxfuoDrs34gBJN9KIL6j4+m/ufqNOrVUK5/8b4mk1aJWssNqhbGnEMLeH0+IIuQU6cMC8k+H0/5Yina34I+wqGNZVIAet+FZXwpfHZ4ORdC6fPatflXL4yjvlC3vnR/s1FD89LeDZZCNe26355fXaC1bT4kDPPJeYWuYOKDAc8DrRXw+8sdtotjKz6ojzm4PXXmnc4S3lOA/hKk/bmR5V5IMAJUGlR76y3b7EZnqZ5ZWKh3dvXDseWFYAJwnAYYJXiq3wNRPt1VpyDBRqvhHw83fuvdoX2NrBN1YZQmB+BcZaTuBY4zRShqP/c4CoKkoe3YUgTSXl1AQmJD9XdjPkBbEEBUFWmOHW7QMlHVzVn/107cPnFz4dKUzxWM045gpeGJnY77N1srjBrYFz7wo73aZDdpYRDnDidYZuAGHVoKu1djO2rNUN6sRZqtdmOT1UC75auxVz+eTmWyCg0QWUYCWS0km2xgPrzRxInrrKj9cVtltUmLvp/4jL1YRyvpYCx1/OJUKsOn+ohKg/pL7VWdNTIKClbCpkpGOYpM0unR5Z9enUHfzczsYflwZFkUGMmmF0hZJ4dXW2/fcc8xkTW0Bs/dW6tWkp12U1c962m/2Tc/G4jh6nLvhhLZ2fNruHdDiaw2/PnNhXduLWDBE3Vh3Avyeo1AZMhgK4VJN3rD4OvVj6YQiVurjE9st//5jmrkpAwuBk/0LxBML777tmpj/sizHQKINBIgttuM39pXt9tpTnObCbGplCTFIRdxDoW9SRHJpWJ+zRU4dXOBY6QKZykdYUGR+PHlmQwh3jcktXkKDSDEv91menKn48DGslK9WsE5cPDj+X1ODQxJc3gQ/JtdAMk8/Af/jd4/uTY36gkjhkMDvHvHM7AUxuHZXuspwlE+W1/itOikUA6z7pFWKymZkvibJLKGk+StHYFmwzZBY/7ShQlkFhgHnfr18BK/wqxdgSZ8OZx/8hCAHoXI0nKLLSfXPdpe1Vympzi7iw/HT5UURfRAqI74n/E0H8zT+/v1P3Jkk1MY3a/nTwlyADm8YwLPgNDOvIJ8eld1AZlV8tKImhSRkMCiHrx+l8OkwRJb91QUHdvvpBODQGDiz0/5fzfjzzV72HR+0i8a8ca8zJp75wJIoBvL9LtptSbcaqw7yYd2Ym+TzMoKpMThJtY6DntYJmm3G4/uq9OplCgoRSzpDiVP3HLLrgFWwqbFUJJGS2YlkZJsw4Q38stBzweQS5nyhc1WJS3d7JSyOoPprnB+/i/QD8zF5h0lFnqHveiBTeUQF2Sk75weS6ao5nJa21QXazdb9ZdnVhMZit8xdzg56An5IkmSsR7xVOauO/TroaW3+t3QyRWoOwK0WvVPdtpIRvlAl8QfS12e9J284+5zhUaXI4c3WmAgCh3VKV90ejXO0x5gGJRZ0yvNznEf3fWs29M3G5gJxH/cO1+sVX6WqWyx6v/pgPPYuYmVaIrvvhhOvtnvefOOR+xjCWPfSqPq+b21SiZB/cmM/+jZCYqPiQHhjaVuzgd31tDx6n3NpRen/dmoHQvESX5fssoJcCzBFIuuoK2SzbKcG19Bzd+9NAOJyhr/cv33Djc0WnQsb2AcKG9KGQAoP3/bVVPGxI3uUOL4lVkCnwbznB5ZRkNsKtc7zVqRKeZkYC1nY2ulQc84t95I8sZikAf79ytzv7jBGji7SfOvh+u7nWaeMBSiFBDgpriwHRrRIx0ViA8h9/3o6uxKJJU9P+V4+dpCyMXEn1AEupjUgcCKZ7VQDlPHBkecnu5fDIWSFA7201vuH1yeQc6crkDxzS7HX33GRidlJUG6CO1X2yoeaClHaF+/7vp4LkjIuQLQ/gy6WZ2xARo7CTZ2w2S0E5voIjRKsr5Eyy+AIIQqF5rk0ZWXLk6HuRT5fU2lL3U7q4vUAj0s7PVgo+XRLWz66NzYyi/6Pbx3LdXk42w6FfrwalmFTwoyZJx5o0hWF9mM6nID6wCPrEQBBswaSAJ8NLP6jQ/Gbi+yGbjWCsPxzzV8saWMJDlgMov5/kbLUztsCPK3k/7vXaZZn2JkRhqaw7+lCJuhMmoLxFtEcJZYGu8CjtvgulGGLBBPQ/2I8x+Lh6TZcHI19sK5ifeGWJkzqBWPb6s8fnBDS5kOxUAI8/4605HtVQhm1Bv5tyuzGcBwMSmJodEESMblFEkp/5Bskg7thHBl3M/SQhXqGIqngskMW08K4ZknQRGv9rr++eK0j6NZU1nhd7udR9orzQzxvtRS9tzOauRvDi9H/v78dBRZD6n5x2xRuV6FBy8SBgJKwBw0CI6fsAC0kHN4kmmK4k9CKC6HKfBR6JpLswForR5rK9/tMEHE0Aw92FzaVWNyBeL3WFlPm579BWiXUqw7z/SkOAcJ/4BtnVVFuBubPUvnU6i4SuI/KA5FgYKtIkkhGLdaisL8PybduxBOvHh5tmPC99gWa10xrQBKdAUlXLobzv6FC1MhKPRcZExjINkJUcyBOcVpkT3VRZsr9FyaOcEOB9iEAGD6ktlNJLNCzpcUe0RIQFkw0HkUwLMck5kHAGM/QGbxXHOH//rMxP8OLaexiBmWmmLNNzqrdtuL9AibsBfvJsHPzaWFz3TYeKINeaOAB+Z8H0CzEMCOniSGLJJkhzdqlLVGze3liPhQC4g7oko40KHa4kP1Zj7IQgUGXTvsRvhAs3jHE77jiQyvRD3hZJA+DqC7GgoUNUZ1d53p3hqTktt/OgIZ8wGhXUQzU/L7JVvmmEwJ6xHVmfq9EUJynCAtLWbtk+3WRi5fHUtlXruxCLXZQWcx9MpRJWSqPTWmPYyrA1UctCSJdAZGkAa10qgRH0j/sNc16o+JZolGVwLpvQosXT/uj6/G0ggjJMnZqVXRJohODks0ikdbSg/UFfOEn16NHf/ENeyLQbD3xv1brbruGhN0QvWq7CyL1IoitfzZfTSV+cn1xfcnVgX3P7DbIKDnxKD0sgyFzezZ9opupwmhC8bTP+xbuDgXFA0Dg6atZboDtXBmhTpOcaXS1BsDS6dGVmIZCghvzpRoFW1lhR0V0EXTlBeqlKQMB0DC/W4+eGrEOx1MiNSUYCE9bw0KZi9JMtYYVN/fX6tVkvze3F4MQzfLzRz3luoKnCZNs0VXYVDhvYa9kf++4RlcifKqQ3T7Byk6DQmqDKqqQhXEoysAUO1CzyqcyMyH4mO+mDeeRr3QxPiTJIHL3/PWXfGaJKnSnhrjX3ZUrPMK1Yg3+vaw96ornOQ0mPQeFZH7IuGal5xEzKIkhKl+2RO930wHoMJ6aku5gsyZOIGKYmA5+v6477KLPpIgsNAd/D73+9acjKi7Ms/icGL8ZnJ1bCV22GlqNGstumxi3R9Pu0IJaH0vzQUnAglASCVNflfzX9ak1nHVig3dek4OgXVfa1uzXnZgWR7ItYD89/akgypxuwCEty8oQmwiKPx+G6YZcL1G5bmoKsnqAF5GCU7Wc3NUFgC/M8daZTlLDAiZ+098A5BlZ0oODxAMKfKd+DsrCAzkJnh29mSWukrGoRDfjaM/KCLDYCQxvs4wPzPcbOgugO3Inp8zXVClTIKDGzsDWO+Yb2UnAOhx+V4sHm4+vFBn+L4Uc6Cfwe7GZa/XAfaNr40UDSx7HY8bFScej1MAgIGRhHgx+M0+nFKivkomjyvYNdH8yFyX+ChsMbluiGN7tca1biq7MFJuJqTozccDbGJFuN1IXCgpQ3NgFCG8p0oyJ8SkWGwojMWzwUYutYZuz2LiQcndlaUowbWr/xdgAByudcuL/46dAAAAAElFTkSuQmCC",
 
-	festivus_lights: XKit.servers.next() + "/seven/festivus/l.png",
-	festivus_lights_interval: 0,
-
 	hide_xcloud_if_not_installed: false,
 
 	showing_help_button: false,
@@ -82,9 +79,6 @@ XKit.extensions.xkit_preferences = new Object({
 	run: function() {
 
 		console.log(XKit.storage.size("xkit_preferences"));
-
-		// Load the festivus thing.
-		// $('<img />').attr('src', XKit.extensions.xkit_preferences.festivus_lights).appendTo('body').css('display','none');
 
 		this.running = true;
 
@@ -647,21 +641,7 @@ XKit.extensions.xkit_preferences = new Object({
 			$("#xkit-control-panel").remove();
 		}
 
-		var festivus_on = "Festivus person?";
-		var festivus_off = "Presents!";
-		var festivus_text;
-		var festivus_display;
-
-		if (XKit.storage.get("xkit_preferences", "festivus", "") === "yes") {
-			festivus_text = festivus_off;
-			festivus_display = "none";
-		} else {
-			festivus_text = festivus_on;
-			festivus_display = "block";
-		}
-
 		var m_html = '<div id="xkit-control-panel">' +
-					'<div data-id-light="1" style="display: none;" id="xkit-festivus">&nbsp;</div>' +
 					'<div id="xkit-control-panel-inner"></div>' +
 					'<div id="xkit-control-panel-tabs">' +
 						'<div id="xkit-cp-tab-my-extensions" class="selected">' + XKit.lang.get("xkit_preferences.tabs.my_xkit") + '</div>' +
@@ -670,7 +650,6 @@ XKit.extensions.xkit_preferences = new Object({
 						'<div id="xkit-cp-tab-xcloud">XCloud</div>' +
 						'<div id="xkit-cp-tab-other">' + XKit.lang.get("xkit_preferences.tabs.other") + '</div>' +
 						'<div id="xkit-cp-tab-about">' + XKit.lang.get("xkit_preferences.tabs.about") + '</div>' +
-						'<div id="xkit-festivus-toggle" style="display: none;">' + festivus_text + '</div>' +
 					'</div>' +
 				'</div>' +
 				'<div id="xkit-control-panel-shadow">&nbsp;</div>';
@@ -678,60 +657,6 @@ XKit.extensions.xkit_preferences = new Object({
 		$("body").append(m_html);
 		//$('#container').foggy({ blurRadius: 2 });
 		$(".l-container").css("opacity","0.66");
-
-		$("#xkit-festivus-toggle").click(function() {
-
-			if (XKit.storage.get("xkit_preferences","festivus","") === "yes") {
-
-				$("#xkit-festivus-toggle").html(festivus_on);
-				$("#xkit-festivus").css("display","block");
-
-				XKit.storage.set("xkit_preferences","festivus","no");
-
-				stopFestivusInterval();
-			} else {
-
-				$("#xkit-festivus-toggle").html(festivus_off);
-				$("#xkit-festivus").css("display","none");
-
-				XKit.storage.set("xkit_preferences","festivus","yes");
-
-				startFestivusInterval();
-			}
-
-		});
-
-		// $("#xkit-festivus").css("background-image","url('" + XKit.extensions.xkit_preferences.festivus_lights + "')");
-
-		function stopFestivusInterval() {
-			clearInterval(XKit.extensions.xkit_preferences.festivus_lights_interval);
-		}
-
-		function startFestivusInterval() {
-			stopFestivusInterval();
-
-			XKit.extensions.xkit_preferences.festivus_lights_interval = setInterval(function() {
-
-				if ($("#xkit-festivus").attr('data-id-light') === "1") {
-					$("#xkit-festivus").css("background-position","0px 33px");
-					$("#xkit-festivus").attr('data-id-light', "2");
-					return;
-				}
-
-				if ($("#xkit-festivus").attr('data-id-light') === "2") {
-					$("#xkit-festivus").css("background-position","0px 66px");
-					$("#xkit-festivus").attr('data-id-light', "3");
-					return;
-				}
-
-				if ($("#xkit-festivus").attr('data-id-light') === "3") {
-					$("#xkit-festivus").css("background-position","0px 0px");
-					$("#xkit-festivus").attr('data-id-light', "1");
-					return;
-				}
-
-			}, 1000);
-		}
 
 		if (XKit.extensions.xkit_preferences.hide_xcloud_if_not_installed === true) {
 			if (XKit.installed.check("xcloud") === false) {
@@ -812,8 +737,6 @@ XKit.extensions.xkit_preferences = new Object({
 		$("#xkit-control-panel-tabs div").click(function() {
 
 			var div_id = $(this).attr('id');
-
-			if (div_id === "xkit-festivus-toggle") { return; }
 
 			$("#xkit-control-panel-tabs div").not(this).removeClass("selected");
 			$(this).addClass("selected");
@@ -1083,7 +1006,7 @@ XKit.extensions.xkit_preferences = new Object({
 
 		if (obj.name.startsWith("xkit_") && XKit.tools.get_setting("xkit_show_internals","false") === "false") { return ""; }
 
-		var blacklisted_extensions = ["xkit_installer"];
+		var blacklisted_extensions = ["xkit_installer", "old_stats"];
 
 		if (blacklisted_extensions.indexOf(obj.name.toLowerCase()) !== -1) {
 			return "";


### PR DESCRIPTION
Old Stats has been obsolete for forever and apparently can cause issues with the dashboard when installed. This deletes the Old Stats extension and adds it to the spring cleaning list.

Point to note: Old Sidebar basically has all the functionality of Old Stats with none of the breaking.

Closes #100.
Closes #341.