### PR TITLE
blacklist.js - preserve href links

### DIFF
--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -553,7 +553,7 @@ XKit.extensions.blacklist = new Object({
 				m_content = m_content.toLowerCase();
 				
 			    // Preserve href links.
-			    m_content = m_content.replace(/<a\s+(?:[^>]*?\s+)?href="([^"]*)">/gm, "$1" + ' ');
+			    m_content = m_content.replace(/<a\s+(?:[^>]*?\s+)?href="([^"]*)".*?>/gm, "$1" + ' ');
 				// Strip HTML tags.
 				m_content = m_content.replace(/<(?:.|\n)*?>/gm, ' ');
 

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -551,7 +551,9 @@ XKit.extensions.blacklist = new Object({
 
 				m_content = XKit.tools.replace_all(m_content, "&nbsp;", " ");
 				m_content = m_content.toLowerCase();
-
+				
+			    // Preserve href links.
+			    m_content = m_content.replace(/<a\s+(?:[^>]*?\s+)?href="([^"]*)">/gm, "$1" + ' ');
 				// Strip HTML tags.
 				m_content = m_content.replace(/<(?:.|\n)*?>/gm, ' ');
 


### PR DESCRIPTION
Spam Tumblrs can often be identified by the presence of an external link - often to http://ift.tt or http://smarturl.it.  However, you can't currently blacklist those URLs if the link text isn't the URL itself.  That is, <a href="http://spamlink.com">Click here</a> isn't caught with a blacklist of "http://spamlink.com*".  This patch fixes that problem.