### PR TITLE
Editable Reblogs: restore save button dropdown options

### DIFF
--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -1,5 +1,5 @@
 //* TITLE Editable Reblogs **//
-//* VERSION 3.0.3 **//
+//* VERSION 3.0.4 **//
 //* DESCRIPTION Restores ability to edit previous reblogs of a post **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -30,9 +30,6 @@ XKit.extensions.editable_reblogs = new Object({
 				}
 			});
 		}
-		$('body').on('click', '#xkit-editable-reblogs-post', XKit.extensions.editable_reblogs.send_post_request);
-		$('body').on('click', '#xkit-editable-reblogs-queue', XKit.extensions.editable_reblogs.send_queue_request);
-		$('body').on('click', '#xkit-editable-reblogs-draft', XKit.extensions.editable_reblogs.send_draft_request);
 	},
 	post_window: function() {
 		//if we don't have a reblog tree to edit, gtfo
@@ -70,8 +67,8 @@ XKit.extensions.editable_reblogs = new Object({
 				var reblog_data = {
 					reblog_content: $(this).find('.reblog-content').html() ? $(this).find('.reblog-content').html() : '',
 					reblog_author: $(this).find('.reblog-tumblelog-name').text() ? $(this).find('.reblog-tumblelog-name').text() : '',
-					reblog_url: $(this).find('.reblog-tumblelog-name').attr('href') 
-						? $(this).find('.reblog-tumblelog-name').attr('href') 
+					reblog_url: $(this).find('.reblog-tumblelog-name').attr('href')
+						? $(this).find('.reblog-tumblelog-name').attr('href')
 						: 'http://' + $(this).find('.reblog-tumblelog-name').text() + '.tumblr.com'
 				};
 				all_quotes.push(reblog_data);
@@ -107,14 +104,6 @@ XKit.extensions.editable_reblogs = new Object({
 	},
 	add_button_controls: function() {
 		var xkit_button = $('.post-form--save-button');
-		$('.post-form--save-button').empty();
-		var new_button_content = "<div class='control right xkit-editable-reblogs-control'>"
-			+ '<div class="post-form--save-button" data-subview="savePostButton">'
-			+ '<button class="flat-button blue caption create_post_button xkit-editable-reblogs-button" id="xkit-editable-reblogs-post">Post</button>'
-			+ '<button class="flat-button blue caption create_post_button xkit-editable-reblogs-button" id="xkit-editable-reblogs-queue">Queue</button>'
-			+ '<button class="flat-button blue caption create_post_button xkit-editable-reblogs-button" id="xkit-editable-reblogs-draft">Draft</button>'
-			+ '</div></div>';
-		$('.post-form--controls .controls-container').append(new_button_content);
 	},
 	send_post_request: function(e) {
 		e.preventDefault();
@@ -258,9 +247,6 @@ XKit.extensions.editable_reblogs = new Object({
 	destroy: function() {
 		this.running = false;
 		XKit.tools.remove_css("editable_reblogs_remove_content_tree");
-		$('body').off('click', '#xkit-editable-reblogs-post', XKit.extensions.editable_reblogs.send_post_request);
-		$('body').off('click', '#xkit-editable-reblogs-queue', XKit.extensions.editable_reblogs.send_queue_request);
-		$('body').off('click', '#xkit-editable-reblogs-draft', XKit.extensions.editable_reblogs.send_draft_request);
 		XKit.interface.post_window_listener.remove("editable_reblogs");
 	}
 });

--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -44,10 +44,7 @@ XKit.extensions.editable_reblogs = new Object({
 		$("body").on("click", XKit.extensions.editable_reblogs.record_post_settings);
 	},
 	post_window: function() {
-		//if we don't have a reblog tree to edit, gtfo
-		//this also applies to new posts
-		//which saves us from worrying about things like photo replies
-		if ($(".post-form .reblog-list").length === 0) {
+		if (!XKit.extensions.editable_reblogs.reblog_tree_exists()) {
 			return;
 		}
 		//also just let chat, link, and quote posts do what they do
@@ -117,6 +114,12 @@ XKit.extensions.editable_reblogs = new Object({
 		$(".btn-remove-trail .icon").click();
 		$(".control-reblog-trail").hide();
 	},
+	reblog_tree_exists: function() {
+		//if we don't have a reblog tree to edit, gtfo
+		//this also applies to new posts
+		//which saves us from worrying about things like photo replies
+		return $(".post-form .reblog-list").length !== 0;
+	},
 	initialize_selected_post_type: function() {
 		var where = XKit.interface.where();
 		if (where.dashboard) {
@@ -151,6 +154,9 @@ XKit.extensions.editable_reblogs = new Object({
 		XKit.extensions.editable_reblogs.scheduled_date = e.target.value;
 	},
 	make_post: function(e) {
+		if (!XKit.extensions.editable_reblogs.reblog_tree_exists()) {
+			return;
+		}
 		var post_types = XKit.extensions.editable_reblogs.post_types;
 		switch (post_types[XKit.extensions.editable_reblogs.selected_post_type]) {
 			case post_types.PUBLISH:

--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -89,6 +89,9 @@ XKit.extensions.editable_reblogs = new Object({
 		XKit.interface.fetch(post_fetch_request, function(response) {
 			self.post_date_metadata = response.data.post.date;
 			self.post_slug_metadata = response.data.post.slug;
+			if (response.data.post.is_private === 1) {
+				self.selected_post_type = "PRIVATE";
+			}
 		});
 	},
 	process_existing_content: function() {

--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -58,7 +58,7 @@ XKit.extensions.editable_reblogs = new Object({
 		var xkit_button = $('.post-form--save-button');
 		// Prevent Tumblr's event handler from acting on the save button
 		xkit_button.find("[data-js-clickablesave]").removeAttr("data-js-clickablesave");
-		XKit.extensions.editable_reblogs.selected_post_type = "PUBLISH";
+		XKit.extensions.editable_reblogs.initialize_selected_post_type();
 		XKit.extensions.editable_reblogs.scheduled_date = "Next Tuesday, 10am";
 		XKit.extensions.editable_reblogs.process_existing_content();
 	},
@@ -116,6 +116,16 @@ XKit.extensions.editable_reblogs = new Object({
 
 		$(".btn-remove-trail .icon").click();
 		$(".control-reblog-trail").hide();
+	},
+	initialize_selected_post_type: function() {
+		var where = XKit.interface.where();
+		if (where.dashboard) {
+			XKit.extensions.editable_reblogs.selected_post_type = "PUBLISH";
+		} else if (where.drafts) {
+			XKit.extensions.editable_reblogs.selected_post_type = "DRAFT";
+		} else if (where.queue) {
+			XKit.extensions.editable_reblogs.selected_post_type = "QUEUE";
+		}
 	},
 	record_post_settings: function(e) {
 		var post_dropdown_exists = $(e.target).parents(".popover--save-post-dropdown").length > 0;

--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -141,7 +141,7 @@ XKit.extensions.editable_reblogs = new Object({
 				XKit.extensions.editable_reblogs.send_draft_request(e);
 				break;
 			case post_types.PRIVATE:
-				// TODO
+				XKit.extensions.editable_reblogs.send_private_request(e);
 				break;
 			case post_types.SCHEDULE:
 				// TODO
@@ -164,6 +164,12 @@ XKit.extensions.editable_reblogs = new Object({
 		e.preventDefault();
 		var request = XKit.extensions.editable_reblogs.build_svc_request();
 		request["post[state]"] = "1";
+		XKit.extensions.editable_reblogs.send_request(request);
+	},
+	send_private_request: function(e) {
+		e.preventDefault();
+		var request = XKit.extensions.editable_reblogs.build_svc_request();
+		request["post[state]"] = "private";
 		XKit.extensions.editable_reblogs.send_request(request);
 	},
 	build_svc_request: function() {

--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -351,6 +351,7 @@ XKit.extensions.editable_reblogs = new Object({
 						"Error: XER-SR.<br /><br />There was an error reblogging your post. Please try again shortly. If you continue to receive this, please contact XKit staff.",
 						"error",
 						"<div class=\"xkit-button default\" id=\"xkit-close-message\">OK</div><a href=\"http://new-xkit-extension.tumblr.com/\" class=\"xkit-button\">Visit the New XKit Blog</a>");
+					console.log("editable_reblogs.send_request:\n", response);
 				},
 				onload: function(response) {
 					// We are done!


### PR DESCRIPTION
- [x] Restore dropdown options
- [x] Restore functionality to publish, queue, and draft
- [x] Restore functionality to saving privately
- [x] Restore functionality to scheduling posts
- [x] Test that this works on the dashboard
- [x] Test that this works in drafts
- [x] Test that this works in the queue
- [x] Test that this works from `/blog/username`
  - Should show "save" instead of "post"
- [x] Test that this works from the search page
  - It doesn't
  - Shouldn't block this from going out
  - ~~Need to log issue for this~~ #788 
- [x] Test that this works from the peepr
  - Works for people you follow
  - Doesn't work for people you don't follow
  - Shouldn't block this from going out
  - ~~Need to log issue for this~~ #789
- [x] Squash commits
- [x] Investigate various ER bug reports
  - [x] Reblogging music posts blanks out posts
    - [ER enabled](http://heymrargent.tumblr.com/post/133094171057/kayayeteae-oh-my-feels-just-like-i-dont-try)
    - [ER disabled](http://heymrargent.tumblr.com/post/133094196857/kayayeteae-oh-my-feels-just-like-i-dont-try)
    - Unable to reproduce
  - [x] From the [support Gitter](https://gitter.im/new-xkit/support?at=5646a1975b7a2ea84f082079): "I can't reblog photos. It won't show on the dashboard or my account when I have editable reblogs on."
    - Unable to reproduce
  - [x] #767 
    - Is legitimate, but can be excluded from this PR
- [x] Print the actual XER-SR error message into the console

Since this pull request is only for restoring the dropdown buttons, it may not be in our best interest to include all Editable Reblogs-related fixes as part of this PR.

Fixes #734 