### PR TITLE
Fix wrong user detection

### DIFF
--- a/Extensions/messaging_tweaks.js
+++ b/Extensions/messaging_tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Messaging Tweaks **//
-//* VERSION 1.0.0 **//
+//* VERSION 1.0.1 **//
 //* DESCRIPTION Helpful tweaks for Tumblr IM **//
 //* DETAILS This adds a few helpful tweaks to the Tumblr IM, for example minimising the chat, hiding the IM icon or changing the looks of the chat window. **//
 //* DEVELOPER New-XKit **//
@@ -72,7 +72,11 @@ XKit.extensions.messaging_tweaks = new Object({
 	},
 	
 	get_current_chat_user: function() {
-		return $($(".title").find("a").get(0)).data("js-tumblelog-name");
+		if($(".title").text().indexOf("+") !== -1) {
+			return $($(".title").find("a").get(0)).data("js-tumblelog-name");
+		} else {
+			return XKit.tools.get_current_blog();
+		}
 	},
 	
 	do_messages: function() {


### PR DESCRIPTION
There was a problem with Tumblr Accounts that have only 1 blog associated with them, namely the chat window title bar only showing the name of their chat partners instead of "own blog + partner's blog" This fix checks if there is only 1 blog and if so, uses the get_current_blog() function to substitute for the first name.