### PR TITLE
Fix firefox rdf url so the extension installs

### DIFF
--- a/Firefox/package.json
+++ b/Firefox/package.json
@@ -12,5 +12,5 @@
   },
   "license": "GPL",
   "icon": "icon.png",
-  "updateURL": "http://new-xkit.github.io/XKit/Extensions/dist/page/FirefoxUpdate.rdf"
+  "updateURL": "https://new-xkit.github.io/XKit/Extensions/dist/page/FirefoxUpdate.rdf"
 }


### PR DESCRIPTION
I already fixed the xpi file in the 7.7.2 release, because a lot of people were trying to download it and it wouldn't work.