### PR TITLE
Suggestion: Messaging Tweaks - left-align text in own bubbles that have been moved to the right

### DIFF
--- a/Extensions/dist/page/FirefoxUpdate.rdf
+++ b/Extensions/dist/page/FirefoxUpdate.rdf
@@ -12,7 +12,7 @@
         <!-- Each li is a different version of the same add-on -->
         <RDF:li>
           <RDF:Description>
-            <em:version>7.7.2</em:version> <!-- This is the version number of the add-on -->
+            <em:version>7.7.3</em:version> <!-- This is the version number of the add-on -->
 
             <!-- One targetApplication for each application the add-on is compatible with -->
             <em:targetApplication>
@@ -22,7 +22,7 @@
                 <em:maxVersion>45.0</em:maxVersion>
 
                 <!-- This is where this version of the add-on will be downloaded from -->
-                <em:updateLink>https://github.com/new-xkit/XKit/releases/download/v7.7.2/new-xkit-7.7.2.xpi</em:updateLink>
+                <em:updateLink>https://github.com/new-xkit/XKit/releases/download/v7.7.3/new-xkit-7.7.3.xpi</em:updateLink>
 
                 <!-- A page describing what is new in this updated version -->
                 <!-- <em:updateInfoURL></em:updateInfoURL> -->
@@ -37,7 +37,7 @@
                 <em:maxVersion>45.0</em:maxVersion>
 
                 <!-- This is where this version of the add-on will be downloaded from -->
-                <em:updateLink>https://github.com/new-xkit/XKit/releases/download/v7.7.2/new-xkit-7.7.2.xpi</em:updateLink>
+                <em:updateLink>https://github.com/new-xkit/XKit/releases/download/v7.7.3/new-xkit-7.7.3.xpi</em:updateLink>
 
                 <!-- A page describing what is new in this updated version -->
                 <!-- <em:updateInfoURL></em:updateInfoURL> -->

--- a/Extensions/dist/page/FirefoxUpdate.rdf
+++ b/Extensions/dist/page/FirefoxUpdate.rdf
@@ -22,7 +22,7 @@
                 <em:maxVersion>45.0</em:maxVersion>
 
                 <!-- This is where this version of the add-on will be downloaded from -->
-                <em:updateLink>https://github.com/new-xkit/XKit/releases/download/v7.7.3/new-xkit-7.7.3.xpi</em:updateLink>
+                <em:updateLink>https://github.com/new-xkit/XKit/releases/download/firefox-v7.7.3/new-xkit-7.7.3.xpi</em:updateLink>
 
                 <!-- A page describing what is new in this updated version -->
                 <!-- <em:updateInfoURL></em:updateInfoURL> -->
@@ -37,7 +37,7 @@
                 <em:maxVersion>45.0</em:maxVersion>
 
                 <!-- This is where this version of the add-on will be downloaded from -->
-                <em:updateLink>https://github.com/new-xkit/XKit/releases/download/v7.7.3/new-xkit-7.7.3.xpi</em:updateLink>
+                <em:updateLink>https://github.com/new-xkit/XKit/releases/download/firefox-v7.7.3/new-xkit-7.7.3.xpi</em:updateLink>
 
                 <!-- A page describing what is new in this updated version -->
                 <!-- <em:updateInfoURL></em:updateInfoURL> -->


### PR DESCRIPTION
For the messaging tweaks, recommend to use this CSS:

 .messaging-conversation .conversation-message .message { text-align: left; } 

so that the "move your own message bubbles to the right" option doesn't right-align the text in those bubbles. This gives an appearance like the message interfaces of Skype, iOS, and all the Android devices I'm aware of. 

(If I'm putting this in the wrong place again, I apologize, but hitting the "add pull request" button on the new-xkit page compares with atesh's master by default, and there's no obvious way to add a request.)
