### PR TITLE
Change fixed width header to reduced width header

### DIFF
--- a/Extensions/classic_header.js
+++ b/Extensions/classic_header.js
@@ -1,5 +1,5 @@
 //* TITLE Header Options **//
-//* VERSION 2.3.1 **//
+//* VERSION 2.3.2 **//
 //* DESCRIPTION Customize the header. **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS This extension adds your blogs on the top of the page, so you can easily switch between blogs. The blog limit on the header is five, but you can limit this to three blogs and turn off the blog title bubble from the settings. **//
@@ -17,7 +17,7 @@ XKit.extensions.classic_header = new Object({
 			type: "separator",
 		},
 		"fixed_width": {
-			text: "Fixed width header",
+			text: "Reduce the max width of the header to match the dashboard",
 			default: false,
 			value: false
 		},
@@ -80,8 +80,7 @@ XKit.extensions.classic_header = new Object({
 		}
 
 		if (XKit.extensions.classic_header.preferences.fixed_width.value === true) {
-			XKit.tools.add_css(" #search_query, .search_form_field, .search_form_row { width: 150px !important; } .ui_search { width: 160px !important; } .l-header { width: 925px !important; min-width: 925px !important; } .l-header.l-fixed-header { width: 925px !important; }", "classic_header_fixed_width");
-			$(".l-header").addClass("l-fixed-header");
+			XKit.tools.add_css(" @media screen and (min-width: 900px){.l-header {max-width: 900px!important;}}", "classic_header_fixed_width");
 		}
 
 		if (XKit.extensions.classic_header.preferences.fixed_position.value === true) {

--- a/Extensions/classic_header.js
+++ b/Extensions/classic_header.js
@@ -1,7 +1,7 @@
 //* TITLE Header Options **//
 //* VERSION 2.3.2 **//
 //* DESCRIPTION Customize the header. **//
-//* DEVELOPER STUDIOXENIX **//
+//* DEVELOPER new-xkit **//
 //* DETAILS This extension adds your blogs on the top of the page, so you can easily switch between blogs. The blog limit on the header is five, but you can limit this to three blogs and turn off the blog title bubble from the settings. **//
 //* FRAME false **//
 //* BETA false **//


### PR DESCRIPTION
Prevents header controls from being cut off when the fixed width header option is enabled, but no longer truly fixes the width. This only reduces the max-width to 925px, which does the same thing until the window is less than the width of the header. See @Wolvan 's concerns in the discussion for #785 for more background and a better explanation of the original problem.

Also mentioning @nightpool because they asked about this.