### PR TITLE
Messaging Tweaks: Emojis & minor fixes

### DIFF
--- a/Extensions/messaging_tweaks.js
+++ b/Extensions/messaging_tweaks.js
@@ -273,15 +273,13 @@ XKit.extensions.messaging_tweaks = new Object({
 		}
 		if (XKit.extensions.messaging_tweaks.preferences.move_self_to_right.value) {
 			XKit.tools.add_css(".xkit-my_messaging_icon { position: absolute; right: 0px; margin-right: 0px !important; }", "messaging_tweaks");
-			XKit.tools.add_css(".xkit-my_messaging_message .message-bubble { margin-left: 0px !important; margin-right: 40px; text-align: right;}", "messaging_tweaks");
+			XKit.tools.add_css(".xkit-my_messaging_message .message-bubble { margin-left: 0px !important; margin-right: 40px; }", "messaging_tweaks");
 			XKit.tools.add_css(".xkit-my_messaging_message .message-container { justify-content: flex-end !important; }", "messaging_tweaks");
-			XKit.tools.add_css(".xkit-my_messaging_message .message-bubble-header { justify-content: flex-end !important; }", "messaging_tweaks");
 		}
 		if (XKit.extensions.messaging_tweaks.preferences.move_other_to_right.value) {
 			XKit.tools.add_css(".xkit-others_messaging_icon { position: absolute; right: 0px; margin-right: 0px !important; }", "messaging_tweaks");
-			XKit.tools.add_css(".xkit-others_messaging_message .message-bubble { margin-left: 0px !important; margin-right: 40px; text-align: right;}", "messaging_tweaks");
+			XKit.tools.add_css(".xkit-others_messaging_message .message-bubble { margin-left: 0px !important; margin-right: 40px; }", "messaging_tweaks");
 			XKit.tools.add_css(".xkit-others_messaging_message .message-container { justify-content: flex-end !important; }", "messaging_tweaks");
-			XKit.tools.add_css(".xkit-others_messaging_message .message-bubble-header { justify-content: flex-end !important; }", "messaging_tweaks");
 		}
 		
 		XKit.tools.add_css(".messaging-conversation .xkit-others_messaging_message .conversation-message-text .message-bubble { background-color: " + XKit.extensions.messaging_tweaks.preferences.other_chat_bubble_background.value + " !important; }", "messaging_tweaks");

--- a/Extensions/messaging_tweaks.js
+++ b/Extensions/messaging_tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Messaging Tweaks **//
-//* VERSION 1.2.0 **//
+//* VERSION 1.2.1 **//
 //* DESCRIPTION Helpful tweaks for Tumblr IM **//
 //* DETAILS This adds a few helpful tweaks to the Tumblr IM, for example minimising the chat, hiding the IM icon or changing the looks of the chat window. **//
 //* DEVELOPER New-XKit **//
@@ -71,7 +71,7 @@ XKit.extensions.messaging_tweaks = new Object({
 			value: false
 		},
 		"tab_title_notification": {
-			text: "Allow minimising a chat by clicking on the title",
+			text: "Show <[!!]> in Tab when you receive a new message.",
 			default: true,
 			value: true
 		},


### PR DESCRIPTION
This PR fixes the right aligned messages as well as the wrong text on the tab_title_notification preference.

Furthermore it adds emojis from http://www.emoji-cheat-sheet.com/ to Tumblr's IM