### PR TITLE
Improved Handling of Gist requests and responses

### DIFF
--- a/Extensions/pokes.js
+++ b/Extensions/pokes.js
@@ -9,6 +9,7 @@
 
 XKit.extensions.pokes = {
 	running: false,
+	pokedex_url: "https://gist.githubusercontent.com/ThePsionic/54a1f629dba66e53aaa4/raw/pokedex.json",
 	
 	preferences: {
 		"catch_backgrounds": {
@@ -123,7 +124,7 @@ XKit.extensions.pokes = {
 	fetchPoke: function(db_nr, pokedThing) {
 		GM_xmlhttpRequest({
 			method: "GET",
-			url: "https://gist.githubusercontent.com/ThePsionic/54a1f629dba66e53aaa4/raw/pokedex.json",
+			url: XKit.extensions.pokes.pokedex_url,
 			json: true,
 			onerror: function(response) {
 				console.log("Poke data could not be retrieved. Skipping instance.");
@@ -164,7 +165,7 @@ XKit.extensions.pokes = {
 		
 		GM_xmlhttpRequest({
 			method: "GET",
-			url: "https://gist.githubusercontent.com/ThePsionic/54a1f629dba66e53aaa4/raw/73da44a7295f99c3cd7e29cd8012bbbe341a78d8/pokedex.json",
+			url: XKit.extensions.pokes.pokedex_url,
 			json: true,
 			onerror: function(response) {
 				console.log("Poke data could not be retrieved. Not showing Pokémon.");

--- a/Extensions/pokes.js
+++ b/Extensions/pokes.js
@@ -26,6 +26,33 @@ XKit.extensions.pokes = {
 		XKit.extensions.pokes.checkEligibility();
 	},
 
+	fetch_pokedex: function(callback, error) {
+		if (!XKit.extensions.pokes.gist_cache) {
+			GM_xmlhttpRequest({
+				method: "GET",
+				url: XKit.extensions.pokes.pokedex_url,
+				json: true,
+				onerror: function(response) {
+					console.log("Poke data could not be retrieved. Skipping instance.");
+					if (error) { error(response); }
+				},
+				onload: function(response) {
+					var mdata = {};
+					try {
+						mdata = JSON.parse(response.responseText);
+						XKit.extensions.pokes.gist_cache = mdata;
+						callback(mdata);
+					} catch(e) {
+						console.log("Poke data received was not valid JSON. Skipping instance.");
+						if (error) { error(response); }
+					}
+				}
+			});
+		} else {
+			callback(XKit.extensions.pokes.gist_cache);
+		}
+	},
+	
 	checkEligibility: function() {
 		$(".post_avatar:not(.poked):not(.unpokable)").each(function() {
 			if (XKit.extensions.pokes.chanceGen()) {
@@ -122,28 +149,9 @@ XKit.extensions.pokes = {
 	},
 
 	fetchPoke: function(db_nr, pokedThing) {
-		if (!XKit.extensions.pokes.gist_cache) {
-			GM_xmlhttpRequest({
-				method: "GET",
-				url: XKit.extensions.pokes.pokedex_url,
-				json: true,
-				onerror: function(response) {
-					console.log("Poke data could not be retrieved. Skipping instance.");
-				},
-				onload: function(response) {
-					var mdata = {};
-					try {
-						mdata = JSON.parse(response.responseText);
-						XKit.extensions.pokes.gist_cache = mdata;
-						XKit.extensions.pokes.parse_pokemon(mdata, db_nr, pokedThing);
-					} catch(e) {
-						console.log("Poke data received was not valid JSON. Skipping instance.");
-					}
-				}
-			});
-		} else {
-			XKit.extensions.pokes.parse_pokemon(XKit.extensions.pokes.gist_cache, db_nr, pokedThing);
-		}
+		XKit.extensions.pokes.fetch_pokedex(function(mdata) {
+			XKit.extensions.pokes.parse_pokemon(mdata, db_nr, pokedThing);
+		});
 	},
 
 	chanceGen: function() {
@@ -167,50 +175,18 @@ XKit.extensions.pokes = {
 	
 	cpanel: function(m_div) {
 		m_div.append('<div id="xkit-loading_pokemon">Loading Pokémon, please wait...</div>');
-		if (!XKit.extensions.pokes.gist_cache) {
-			GM_xmlhttpRequest({
-				method: "GET",
-				url: XKit.extensions.pokes.pokedex_url,
-				json: true,
-				onerror: function(response) {
-					console.log("Poke data could not be retrieved. Not showing Pokémon.");
-					$(m_div).html("<div id='xkit-pokes-custom-panel'>Failed to load Pokémon Data!<br>Please refresh the page or try again later!</div>");
-				},
-				onload: function(response) {
-					var mdata = {};
-					try {
-						mdata = JSON.parse(response.responseText);
-						XKit.extensions.pokes.gist_cache = mdata;
-						var m_html = "<table id=\"xkit-pokes-custom-panel\" class='pokemon_display'>";
-						var caught = JSON.parse(XKit.storage.get("pokes","pokemon_storage","[]"));
-						$.each(caught, function(index, value) {
-							m_html = m_html + "<tr class='caught' data-pokegender='" + value.gender + "'><td class='poke_sprite'><div><img src='" + mdata[value.id].sprite + "'></div></td><td class='poke_gender'><div></div></td><td class='poke_stats'><div>Name: " + mdata[value.id].name + "</div></td></tr>";
-						});
-						m_html = m_html + "</table>";
-
-						$("#xkit-loading_pokemon").html(m_html);
-					} catch(e) {
-						console.log("Poke data received was not valid JSON. Not showing Pokémon.");
-						$("#xkit-loading_pokemon").html("<div id='xkit-pokes-custom-panel'>Failed to load Pokémon Data!<br>Please refresh the page or try again later!</div>");
-					}
-				}
+		XKit.extensions.pokes.fetch_pokedex(function(mdata) {
+			var m_html = "<table id=\"xkit-pokes-custom-panel\" class='pokemon_display'>";
+			var caught = JSON.parse(XKit.storage.get("pokes","pokemon_storage","[]"));
+			$.each(caught, function(index, value) {
+				m_html = m_html + "<tr class='caught' data-pokegender='" + value.gender + "'><td class='poke_sprite'><div><img src='" + mdata[value.id].sprite + "'></div></td><td class='poke_gender'><div></div></td><td class='poke_stats'><div>Name: " + mdata[value.id].name + "</div></td></tr>";
 			});
-		} else {
-			try {
-				var mdata = XKit.extensions.pokes.gist_cache;
-				var m_html = "<table id=\"xkit-pokes-custom-panel\" class='pokemon_display'>";
-				var caught = JSON.parse(XKit.storage.get("pokes","pokemon_storage","[]"));
-				$.each(caught, function(index, value) {
-					m_html = m_html + "<tr class='caught' data-pokegender='" + value.gender + "'><td class='poke_sprite'><div><img src='" + mdata[value.id].sprite + "'></div></td><td class='poke_gender'><div></div></td><td class='poke_stats'><div>Name: " + mdata[value.id].name + "</div></td></tr>";
-				});
-				m_html = m_html + "</table>";
+			m_html = m_html + "</table>";
 
-				$("#xkit-loading_pokemon").html(m_html);
-			} catch(e) {
-				console.log("Poke data received was not valid JSON. Not showing Pokémon.");
-				$("#xkit-loading_pokemon").html("<div id='xkit-pokes-custom-panel'>Failed to load Pokémon Data!<br>Please refresh the page or try again later!</div>");
-			}
-		}
+			$("#xkit-loading_pokemon").html(m_html);
+		}, function(response) {
+			$("#xkit-loading_pokemon").html("<div id='xkit-pokes-custom-panel'>Failed to load Pokémon Data!<br>Please refresh the page or try again later!</div>");
+		});
 
 		$("#xkit-extensions-panel-right").nanoScroller();
 		$("#xkit-extensions-panel-right").nanoScroller({ scroll: 'top' });


### PR DESCRIPTION
This PR improves the gist requesting and responses in 2 ways:
- Centralize the Gist URL

We had the URL to the pokedex.json twice in the code and when @ThePsionic updated the gist (#815) we had to change the URL to point to the new gist version. What I realised while working on the seconnd change was that only 1 of the 2 URLs actually got changed. Having the URL in one place should avoid something like that in the future

- Cache Gist response

Everytime a Pokémon spawns or you open the control panel again, the extension requested the gist. Especially with this many users, this is a serious load on Github's servers, which is being fixed by just saving the response we get the first time until the user refreshes