### PR TITLE
Add video ads to anticapitalism

### DIFF
--- a/Extensions/anti_capitalism.js
+++ b/Extensions/anti_capitalism.js
@@ -1,7 +1,7 @@
 //* TITLE Anti-Capitalism **//
-//* VERSION 1.2.2 **//
+//* VERSION 1.2.3 **//
 //* DESCRIPTION	Removes sponsored posts, vendor buttons, and other nonsense that wants your money. **//
-//* DEVELOPER dlmarquis **//
+//* DEVELOPER new-xkit **//
 //* FRAME false **//
 //* BETA false **//
 
@@ -48,7 +48,7 @@ XKit.extensions.anti_capitalism = new Object({
 		}
 
 	    if (XKit.extensions.anti_capitalism.preferences.sponsored_ads.value) {
-	        XKit.tools.add_css(" .remnant-unit-container, .yamplus-unit-container, .yam-plus-ad-container, .yam-plus-header {display: none;}", "anti_capitalism_sponsored_ads");
+	        XKit.tools.add_css(" .remnant-unit-container, .yamplus-unit-container, .yam-plus-ad-container, .yam-plus-header, .video-ad-container {display: none;}", "anti_capitalism_sponsored_ads");
 	    }
 
 		if (XKit.extensions.anti_capitalism.preferences.asktime.value) {


### PR DESCRIPTION
It seems that Tumblr implemented another ad-container for video ads. The
container with the class "video-ad-container" should now be successfully
blocked by anti-capitalism as well. This is untested though, since as of
now, no video ad has come up for me. The class comes from a helpful user
in the live support chat.