### PR TITLE
[one_click_postage] Code cleanup and reblog button fix.

### DIFF
--- a/Extensions/one_click_postage.css
+++ b/Extensions/one_click_postage.css
@@ -1,20 +1,6 @@
-.xkit-one-click-reblog-done:after,
-.xkit-one-click-reblog-done {
-
-	background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABUAAAAVCAYAAACpF6WWAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6RDFENEQ1MDI2MENGMTFFMUE4RjdCNEM0NEFGNjFDQjMiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6RDFENEQ1MDM2MENGMTFFMUE4RjdCNEM0NEFGNjFDQjMiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo5OEM2NDYyNzYwQ0IxMUUxQThGN0I0QzQ0QUY2MUNCMyIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo5OEM2NDYyODYwQ0IxMUUxQThGN0I0QzQ0QUY2MUNCMyIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PtmUDCEAAAEFSURBVHjarJPPCgFRFIevPylSvI4dC6WUUkQzG0qRjfIAxAPIjqWIFI0oa89kpZT4nTqnptss3Jn7q6+ZzuLr3HvPifX3RRUxqbXzePsLcRU9p8GhlLItrQHPL7YhpVTBVcQiPYFvSCQVEYu0YaljEo9tHV9yBosgaQbEDJBcgEvjFSR9heiQhG2ZV106DSG8iRCPNNKlQzCnDTGUNlk4wf/SL3XBCqR5vP4OC0k2k1qSvwfu0AOFEFcwClrTBDjynBkFXWb1WpKFW1DnWk7bFONQpx3g2NwAkm7AzpLvLsf/gC4/VAs8Qd7g9VXQnSoWu3y/ZRvHV5r4YlNKod3tRZX+BBgA/epL4VrrHtgAAAAASUVORK5CYII=') !important;
-	background-repeat: no-repeat !important;
-	background-position: 50% 50% !important;
-	background-size: auto auto !important;
-	cursor: default !important;
-
-}
-
-
 #x1cpostage_quick_tags {
-
 	max-height: 70px;
 	overflow-y: auto;
-
 }
 
 #x1cpostage_quick_tags .xkit-no-tags {
@@ -97,17 +83,14 @@
 
 .xkit-one-click-reblog-working:after,
 .xkit-one-click-reblog-working {
-
 	background-image: url(data:image/gif;base64,R0lGODlhEgASAOYAAIjJ9Wmq14e42KXZ+rbo/Kz8/Lz+/KT0/OTu9pTk/ITT/OT0/Izc/Hq02XzM/Hi45pzs/LT9/HTE/JbH6Mz+/HapysT+/IjD6jyMxGeky9T+/Eyc1DSEvGy89ESNu9zq9Ie+5ix8tHWt2FSl3GS17LzZ7CR1rNzz/JTN9cTb7Fyt5ESVzLfc99Ts/Mvj9Oz2/KTs/JTc/IzT/KTk/KTL6K3j/Jzc/Lzy/JfB3Jzj/Kzz/FydxMT0/Kzs/FSUvLTx/EyVxHzD9Fyj1JTV/Mz0/MTs/FSbzGScxOz+/OT+/Nz+/ESSxCx6rDSCtFyq3FSi1Oz6/PT6/EyazPz6/DyKvGSy5OT6/NTq9Mze7Gy67DR+tDyGvGy27Mzi7NTm9GSu41SWxHTC9PT2/HS+9FyezJzW/FSe1HzG/Nzu/FyWxNzm9MTW5EyRvOzy9ESOxDR6rD+GtGyy5HzB6szu/KzT77TQ5OTy9J3Q88nm/FSaxNTy/Fym3NTi7PT+/Pz+/P///yH/C05FVFNDQVBFMi4wAwEAAAAh+QQJCQB/ACwAAAAAEgASAAAHtYB/gn9+KRVwJoOKix87IUwmiYuLWFRNISEmTJOKH0tbHFsCH1Ocgn4BGBh5H6aKLksYKwiug34gK0A0tX69qBsbL7x+fX0jI061gn1IfU4jVcp/zEkPKl9RvElJSHdVJHi1fUpKSC0kWQB+pn7kSn1+AGESA+uLfkkUFErrCw7/NhbYm0bBggUNfQadUMCQwYwbNwxEMGCAApJFL2wwSJAAwoECBSJQSDjJz4kbMDyKRDLwTyAAIfkECQkAfwAsAAAAABIAEgAAB7OAf4J/fikNbE0hHhUug45/HxkYHFohTCYmBo+CLlIYkxyJTBybfwhmK0tLOB9TUwgam34NGxsBCKWPLiMjT7i5jhNOI3TAjw8qKi/GjlwkDcyOWR1h0X7XAGESUcZ+fX1+AxISc919SH1oDg4xfrl+SPHXNgoMBO6P8ElJSO5QDAwS9LCC708fJQiVFFyQIAGEAxEsUJhIQYOSPo+g/HhYIIIBAxI1YJRlhUIEjxaU9HMUCAAh+QQJCQB/ACwAAAAAEgASAAAHtoB/gn9+XQJGVBxsFSl+g48IIisYGBwcISEmPmqPf14jGytLGFRbTUwmJl+PC06gZhMffn5qOFtLj34grgELnX9tfY8tKipfvr+/dx0kLMnJAB0dL8+/EhJn1b8O3NqdMg4KwtWOgjUKMnras7MnDAwz5b9+fX3sNQkJN/KD9Ej1jqBAgHDAABJ5fpIkQXJwkJUDBwpEsKChogYlCvn96WNAogEDFChcTKJRkB8kFCxYEJnE3qNAACH5BAkJAH8ALAAAAAARABIAAAe1gH+Cf34uIEJLbmANKX6DgwsPGxsrSxyXWjsfj1dfT0+UlVscIUxaKYILXCpOTjQffn4IOFQmJm9qfgAkVQ8Ij4JtPiZVfS0dyG3Agy8GggMSYSzL1DIOElDUywoOMtrbMgzfwDYMMX3jgwQMCSfpgkkJEDqO1LGCfj8HBxb1j7H3/kDRUaCABST+/PRB0idgkggRDBigoCSJxSQM/f3pY8GABQsUNCip2HCZHyRKNIRUknFQIAAh+QQJCQB/ACwAAAAAEgASAAAHuIB/gn9+VxNxTxtCAlh+g48LFyoqiVIrGBgZH49/aGMkVSojiZdUHFRYgwtnHR1cdAtTfnY0QBxNTZt+ZRISAAucfy87ISFpficOyi/BgmIeJiZrBAoKRc2DddEVOQwKUdiCUTkUfwkJOeHBEAkH6pw9EAeO74I8BwdJ9YJJBQUG9N75sRAhgoaA6voYMGBBQ5+AfhAOQmLBAgUKSpIgQdLnYbM+GihoUJKR40OJgvz0SZJR48lHgQAAIfkECQkAfwAsAAAAABIAEgAAB7KAf4J/fi0DciQqcTh4foOPL0MSHVmJI08bIh+PfycKDhJhHSRfmBsrUl2DUAwKnywLU34vdE9LGEubfjUMDEMvnH8vARhUGX5WCcrAwX9iUk0cKTwQCUTNg3VNIRU6Bwd92IJTHCEeBQcF4oM+TEwFBRHrgmAmTBYRBo7rERJgGgYMJJk3CIkBCxT2zfOjgQKFJArX9dFAEWJEbBOVKEmCpI+fi5z8JOHY0ePCPiU/NgsEACH5BAkJAH8ALAAAAAASABIAAAe4gH+Cf34nNTISY0F3V36Dj1AzCgoSEh0kVU4PCI9/VjkMDAoOiSQqTiN7XYNIMAkJDAQvfn4vLF8bG2acfjcQEDBQnX8vDVIrAX5JBQcHYsOCYkJLGFgUBQUa0IMlGBgCBhERfduCU24cUgbr5YNkTRwW8u2CO01NFBYUjuV+WyEelFCggKSdFxMhKvTRoEEJP2gzTJhY40eJkiRIHg7TkIzQxSR9aNEjhBFJyJGE+qjU2I6WyHKBAAAh+QQJCQB/ACwAAAAAEgASAAAHtoB/gn9+CwQxCg4OAy1+g49QBAkMCokSHVkXC49/SQcQk5QOlyRVVVeDfQWfEEUvfn4vLFlOtQiEFgUFP32cfy9yI08NfkgRx0i+glEBGxsuGgYGSsqDJRtLAhQWBr3Vf1NAS2TbFN+DGRgYFBQa54IZHBhKGhqO334eHGlJSkre1fiECCGij5IkSO758rNjYIpiCPsofITDhIk0joohkThREJIQbz4M8tNHYjUKKTjB6viOpbJAACH5BAkJAH8ALAAAAAASABIAAAe4gH+Cf35WPDAxDDE1aH6Dj30GBxAJDAwKDhIoC49/SBEFk5QMDpkdYy2DkaAFFFB+flB4QR1cXJx+FAa7fZ1/UQAqKiB+fRYWBr2+vw8jIy5KFBZJy4MuziAaGhSO1YRPGwHaSt6DIitSSkrU5X8BKytJ8t3VflIYO31JSPTLXhxURPhBgqRPv0d+MnDgkKKYwYOC/AgIoWWHI1gQ/yw4YiJEkw+DMhIKYUJLinaDJPgAiVKQwUeBAAAh+QQJCQB/ACwAAAAAEgASAAAHrIB/gn9+SBQRBzAwNyd+g499hxEFBxAJCQwDL49/fRYWBpM6MJgMCgong5EUoEpIfn5RcwwOtQuEShoUFH2cf1FlEmEAfn25Go6+vw5ZWS1ISq7Kg3gkJHdJ2cnTfiROD0jh048PTk7hveOCDyMjfe/byn5CGwGwsOotK1Ig+Op+IpYscaFOkB8cGDDYK+glQxMOSz6oa+CBSYgmVLAUXMHE4g6JBaXAqZAiXiAAIfkECQkAfwAsAAAAABIAEgAAB7GAf4J/fn1KFgYRBhZWfoOPfkoUFogRBQcHP1CPf4YaFBQGiZcQOQkLg35JShoaSX1+hRowCQwxm35ISauOnH0wDAo2sUi6vZydMQAOJ319SH3Ijy0ODgOFsNKpZx0AscfafwAdEuHIFyRc5pBcKg/rgx9OKhPwhA0bIy7wfhMbGw3ACcom6IOIJSueIJA2Ak6GDGA4YMAgZR8yDSZMMGHSpAmGDB+0XakAhyObBljABQIAIfkECQkAfwAsAAAAABIAEgAAB62Af4J/fn1JGhQWFhpIfoOPfklKiIkGEQUGfY+ESZKTlZcFB1aDfkhInUh9foVKEQcQM0iEfX2njpt9PxAJPayFq5uDfbwMJ7+4woJ6MgoEysp+Cgoy0MplDg7WwkMSEtuQQR0A4INoJFl35YQXJCRem1PCfjQjTiDJfyQ+WMkfDRvsIXikwIQJJh4yiCCzZEVAeI/U+GASIgQHDhiWLBExcF4KEWw4UDEioEu+QAAh+QQJCQB/ACwBAAAAEQASAAAHtoB/gn5+SEoaiEpIfoKNf4VJSYcUFBYGFH2Ofn1ISJJKlAYGERFIg5uci4R9SaMFBaaPfX2Mjn99BgcHP7WEto1+OhAQC7/GJwkJN8a/fgkMOcy/MzIK0rY2CtbXgwpnMtyCCxISA4IaUcx+AB0dLX8KJhlTzXQkJAB+H0wmJmBYtf58AOFEBZdif1JoYRKiCRARDTJseDLiyxVHH3aE4MABA4YVGzY8QKgpRQMwGJYIAeEi4J9AACH5BAkJAH8ALAAAAAASABIAAAe1gH+Cf35+fUhJSUpJfX6Dj4V9h4lKGhQafY+DkYhJGpYUFkiagoWmfkihBgaZpKR+FAYRFo6umn4GBQWjtppJBQcWvbcHBzrDmj8QEMiPPQkJf0owYsN+MQw5FSYmdcMLCgoEa9xsUbZ+ZQ4KJ35pISEV57cDEmdljh8cIRxkXbV/EKDo0OHMgkFY4HCggoFMAxBxnFQhMeaKpg8ZMGBYIWXDExUqLhx81UWAEClPAky4AvBPIAAh+QQJCQB/ACwAAAAAEgASAAAHs4B/goN/fn59iH1+hIyChn1ISElJi42Eh5JJSkp9loOGh5saGp2el0oUFBqVpo4aFhZIrYRIBgYaYB0FrJZ+BhEWTCZas38WEQXCcMUGBQUeIVpirX46BwUVIU11rVYQEDwpHBx5UZ5+NQkJVn4ZHBgNU41+BAwMNYsfSxgrAV6sC2woUMAAyqAuUlZs2BDgwgQ5YSQ4ULCAEYIAG56MUEEiS4cwNl706oIjDkc5A1rIGxQIACH5BAkJAH8ALAAAAAASABIAAAexgH+Cg4R+hn6EiYmGfX2Iiop+jUhIfZCLfkhJm4h+ARSXf5lKSkl+ayYmCqF+pBp9Fak4oX99FBRKHiFMCLR+txRNIVS0ghoWFhxNHsV/FAYGYBxUYr4GEQYCGBgltEgFERRY2wFRl343BwWmASsrII+FPBAQN4gnZhtPD1fxCzUJEhyAMsjLkxFOVARBUQaFAgUMcixIhOCBiipVOkiQ8HAGwUhXUAQZI0FGjRPx/gQCACH5BAkJAH8ALAAAAAASABIAAAe2gH+Cg4SDfoWIhX6LhSlJiX9+fX2Hgh9vHH2Ii31ISId+aSYmAYmSnp8pTCZaH5B+SElKfRUhITiQgn1KSklAHE0IuZFKGkpUHG7DgkoUFBhUQMt/Gs5kGEtRw34WFhQCKyslw0gGBhouQBtfU68WERGfDRsjIJWEfhQFBRaHCE4jVFxAcw/KDwgHCiAZdOWLChIdHAwYEINBAggwFhRacAGiBAcOFFjsAcVUiwEAQsYgsODen0AAIfkECQkAfwAsAAAAABIAEgAAB7CAf4J/fn6Dh4iDHz4OiY5/KVomTI+EiltMk0SOhYZ+RyEhbB+cfaZ+KRxNW6SlfUh+AhwcOJWESElIRhgYdrZ+ScErS1K2gklKSlIrZsZ/yBoBG2ZRvxoUSiBPTym2SBTYLiMjD9WcFBYWsA8qVShTiX4aBgYUhgtcVVkAJ4aCSBYKRDDQZ1CLDh0kOJBRg8AMCAcEIkG0AIVCBwoYJIBoYGI8NDViMIgx44YVf4ICAQA7) !important;
 	background-repeat: no-repeat !important;
 	background-position: 50% 50% !important;
 	background-size: auto auto !important;
 	cursor: default !important;
-
 }
 
 #x1cpostage_caption {
-
 	width: 200px;
 	height: 90px;
 	padding: 10px;
@@ -119,7 +102,6 @@
 	background: white;
 	margin-top: 1px;
 	border-radius: 0;
-
 }
 
 #x1cpostage_clear_tags:hover,
@@ -132,17 +114,14 @@
 
 #x1cpostage_clear_tags:active,
 #x1cpostage_remove_caption:active {
-
 	color: black;
 	background: -moz-linear-gradient(top,  #D1D1D1 0%, #ffffff 100%); /* FF3.6+ */
 	background: -webkit-linear-gradient(top,  #D1D1D1 0%,#ffffff 100%); /* Chrome10+,Safari5.1+ */
 	background: linear-gradient(to bottom,  #D1D1D1 0%,#ffffff 100%); /* W3C */
-
 }
 
 #x1cpostage_clear_tags,
 #x1cpostage_remove_caption {
-
 	background: #ffffff; /* Old browsers */
 	background: -moz-linear-gradient(top,  #ffffff 0%, #D1D1D1 100%); /* FF3.6+ */
 	background: -webkit-linear-gradient(top,  #ffffff 0%,#D1D1D1 100%); /* Chrome10+,Safari5.1+ */
@@ -158,17 +137,13 @@
 	margin: 0;
 	position: relative;
 	cursor: pointer;
-
 }
 
 #x1cpostage_clear_tags {
-
 	border-top: 1px solid #abafbc;
-
 }
 
 #x1cpostage_replace {
-
 	width: 200px;
 	padding: 5px 10px;
 	padding-left: 22px;
@@ -181,29 +156,23 @@
 	margin-top: 2px;
 	position: relative;
 	cursor: pointer;
-
 }
 
 #x1cpostage_replace.selected div {
-
 	background: #4c990d;
-
 }
 
 #x1cpostage_replace div {
-
 	position: absolute;
 	top: 8px; left: 8px;
 	width: 10px; height: 10px;
 	border: 1px solid #abafbc;
 	border-radius: 10px;
-
 }
 
 #x1cpostage_reblog,
 #x1cpostage_queue,
 #x1cpostage_draft {
-
 	background: rgba(245,245,245,1);
 	color: #7a7f8e;
 	border-bottom: 0;
@@ -218,8 +187,6 @@
 	background-repeat: no-repeat;
 	margin-top: 1px;
 	position: relative;
-	bodx-shadow: inset 0px 1px 2px rgba(0,0,0,0.12);
-
 }
 
 .xkit-1xcpostage-non-reversed #x1cpostage_reblog,
@@ -231,7 +198,6 @@
 #x1cpostage_reblog:hover,
 #x1cpostage_queue:hover,
 #x1cpostage_draft:hover {
-
 	background-color: rgba(234,239,246,1);
 	color: #7a7f8e;
 }
@@ -239,7 +205,6 @@
 #x1cpostage_reblog:active,
 #x1cpostage_queue:active,
 #x1cpostage_draft:active {
-
 	background-color: #bdc1c6;
 	box-shadow: inset 0px 1px 2px rgba(0,0,0,0.42);
 	color: #7a7f8e;
@@ -247,17 +212,13 @@
 
 #x1cpostage_queue,
 #x1cpostage_draft {
-
 	border-left: 0;
 	width: 64px;
-
 }
 
 #x1cpostage_reblog,
 #x1cpostage_draft {
-
 	width: 65px;
-
 }
 
 #x1cpostage_queue {
@@ -269,7 +230,6 @@
 }
 
 #x1cpostage_blog {
-
 	width: 100%;
 	-webkit-appearance: none;
 	margin: 0; padding: 5px 10px;
@@ -285,7 +245,6 @@
 	border-bottom: 0;
 	margin: 1px 0px 0px 0px;
 	background: white;
-
 }
 
 #x1cpostage_draft {
@@ -324,16 +283,13 @@
 }
 
 #x1cpostage_tags {
-
 	width: 200px;
 	padding: 5px 10px;
 	resize: none;
 	border-top: 0;
-	bdox-shadow: 0px 1px 0px rgba(255,255,255,0.53);
 	border-radius: 0px 0px 3px 3px;
 	margin: 0; border: 0;
 	background: white;
-
 }
 
 #x1cpostage_box *{
@@ -343,7 +299,6 @@
 }
 
 #x1cpostage_box {
-
 	width: 200px;
 	position: absolute;
 	z-index: 1000;
@@ -352,13 +307,7 @@
 	background-color: #bcbcbc;
 	box-shadow: 0 4px 9px rgba(0,0,0,0.35);
 	border-radius: 4px;
-	/*background-image: -moz-linear-gradient(rgba(0,0,0,0.26),rgba(0,0,0,0.45));
-	background-image: -ms-linear-gradient(rgba(0,0,0,0.26),rgba(0,0,0,0.45));
-	background-image: -o-linear-gradient(rgba(0,0,0,0.26),rgba(0,0,0,0.45));
-	background-image: -webkit-linear-gradient(rgba(0,0,0,0.26),rgba(0,0,0,0.45));
-	background-image: linear-gradient(rgba(0,0,0,0.26),rgba(0,0,0,0.45));*/
 	padding: 1px;
-
 }
 
 #x1cpostage_box:after, #x1cpostage_box:before {

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.1.0 **//
+//* VERSION 4.1.1 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -943,7 +943,7 @@ XKit.extensions.one_click_postage = new Object({
 					if (XKit.interface.where().dashboard === true) { $(this).remove(); }
 				}
 
-				$(this).find(".post_control.reblog").addClass("xkit-one-click-reblog-done");
+				$(this).find(".post_control.reblog").addClass("reblogged");
 
 			}
 
@@ -1291,17 +1291,6 @@ XKit.extensions.one_click_postage = new Object({
 			tags = this.add_auto_tagger_state_tags(tags, state);
 		}
 
-		var xkit_version = XKit.version.split(".");
-		var xkit_version_minor = parseInt(xkit_version[1]);
-
-		if (xkit_version_minor < 3) {
-
-			$(m_button).removeClass("xkit-one-click-reblog-working");
-			XKit.extensions.one_click_postage.show_error("666", state);
-			return;
-
-		}
-
 		GM_xmlhttpRequest({
 			method: "POST",
 			url: "http://www.tumblr.com/svc/post/fetch",
@@ -1547,7 +1536,7 @@ XKit.extensions.one_click_postage = new Object({
 							}
 							if (XKit.extensions.one_click_postage.preferences.enable_alreadyreblogged.value || XKit.extensions.one_click_postage.preferences.dim_posts_after_reblog.value) {
 								if (quick_queue_mode !== true) {
-									$(m_button).addClass("xkit-one-click-reblog-done");
+									$(m_button).addClass("reblogged");
 								} else {
 									XKit.interface.switch_control_button($(m_button), false);
 									XKit.interface.completed_control_button($(m_button), true);
@@ -1633,13 +1622,6 @@ XKit.extensions.one_click_postage = new Object({
 			m_causes = "<ul class=\"xkit-one-click-postage-error-list\">" +
 					"<li><b>You've filled your queue.</b><br/>You can not queue more than 300 posts.</li>" +
 				"</ul>";
-		}
-
-		if (code === "666") {
-
-			XKit.window.show("I could not " + m_word + " your post.","You need XKit <b>7.3.0</b> or higher for One-Click Postage to work.<br/>You currently have XKit <b>" + XKit.version + "</b> installed.<br/><br/>Please <a target=\"_BLANK\" href=\"http://xkit.info/notes/upgrade.php\">click here</a> to learn how to update XKit.","error","<div class=\"xkit-button default\" id=\"xkit-close-message\">OK</div><a href=\"http://new-xkit-extension.tumblr.com/\" class=\"xkit-button\">Visit the New XKit Blog</a>");
-			return;
-
 		}
 
 		XKit.window.show("I could not " + m_word + " your post.","<b>One of the following might be the reason for that:</b>" + m_causes + "<small>Error Code: <b>" + code + "</b>.</small>","error","<div class=\"xkit-button default\" id=\"xkit-close-message\">OK</div><a href=\"http://new-xkit-extension.tumblr.com/\" class=\"xkit-button\">Visit the New XKit Blog</a><a href=\"http://new-xkit-extension.tumblr.com/ask\" class=\"xkit-button\">Send an ask</a>");


### PR DESCRIPTION
# Changes
* Removed code check for old XKit 7.3.0
* Removed newlines before/after the braces inside the OCP stylesheets
* Removed styles that were misspelled or entirely commented out. (`bdox-shadow`)
* Replaced the `xkit-one-click-reblog-done` class with the Tumblr `reblogged` class.

## Before
![oh god this is ugly](https://i.imgur.com/OS6Glpi.png)


## After
![This is better?](https://i.imgur.com/tBXlawT.png)