### PR TITLE
Disabling extension on search page pending deep-clean

### DIFF
--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -61,11 +61,12 @@ XKit.extensions.editable_reblogs = new Object({
 		if (post_type.chat || post_type.quote) {
 			return;
 		}
-		//disable on search page for now until we've refactored more effectively
+		//disable on pages that don't include reblog_key and post_id in the URL
+		//for now until we've refactored more effectively
 		var location_path = window.location.pathname;
 		var location_items = location_path.split("/");
 		location_items.shift();
-		if (location_items[0] === "search") {
+		if (location_items[0] != "reblog" && location_items[0] != "edit") {
 			return;
 		}
 		var xkit_button = $('.post-form--save-button');

--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -1,5 +1,5 @@
 //* TITLE Editable Reblogs **//
-//* VERSION 3.0.4 **//
+//* VERSION 3.0.5 **//
 //* DESCRIPTION Restores ability to edit previous reblogs of a post **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -59,6 +59,13 @@ XKit.extensions.editable_reblogs = new Object({
 		//also just let chat, link, and quote posts do what they do
 		var post_type = XKit.interface.post_window.post_type();
 		if (post_type.chat || post_type.quote) {
+			return;
+		}
+		//disable on search page for now until we've refactored more effectively
+		var location_path = window.location.pathname;
+		var location_items = location_path.split("/");
+		location_items.shift();
+		if (location_items[0] === "search") {
 			return;
 		}
 		var xkit_button = $('.post-form--save-button');


### PR DESCRIPTION
ER gets borked on the search page because you don't have the reblog_key and post_id in the URL the way you do when reblogging other places. Per discussion with @nightpool, we're going to disable the extension on that page for now and fix this more effectively after a full refactor of the extension.