### PR TITLE
Add Palemoon support

### DIFF
--- a/docs/contributing/Build-XKit.md
+++ b/docs/contributing/Build-XKit.md
@@ -59,6 +59,10 @@ Cleans the `build/chrome/` directory, deleting the previous build for Chrome.
 
 Cleans the `build/firefox/` directory, deleting the previous build for Firefox.
 
+#### `gulp clean:palemoon`
+
+Cleans the `build/palemoon/` directory, deleting the previous build for Pale Moon.
+
 #### `gulp clean:safari`
 
 Cleans the `build/safari.safariextension/` directory, deleting the previous build for Safari.
@@ -79,7 +83,7 @@ Lints CSS files using CSSLint and reports the output.
 
 #### `gulp build`
 
-Top-level build task.
+Top-level build task. Does not run [`gulp build:palemoon`](#gulp-buildpalemoon).
 
 See also: [`gulp build:chrome`](#gulp-buildchrome), [`gulp build:firefox`](#gulp-buildfirefox), [`gulp build:safari`](#gulp-buildsafari).
 
@@ -116,6 +120,28 @@ See also: [`gulp build`](#gulp-build), [`gulp build:firefox`](#gulp-buildfirefox
 Creates a [Cross-platform Installer Module](https://developer.mozilla.org/en/docs/XPI), `@new-xkit-x.x.x.xpi`, from an existing Firefox source build and outputs it to `build/firefox/`.
 
 See also: [`gulp build`](#gulp-build), [`gulp build:firefox`](#gulp-buildfirefox), [`gulp copy:firefox`](#gulp-copyfirefox).
+
+#### `gulp build:palemoon`
+
+Builds the Pale Moon browser extension from source and outputs it to `build/palemoon/`.  Also creates a [Cross-platform Installer Module](https://developer.mozilla.org/en/docs/XPI), `new-xkit.xpi`, and outputs it to `build/palemoon/`.
+
+See also: [`gulp compress:palemoon`](#gulp-compresspalemoon), [`gulp copy:palemoon`](#gulp-copypalemoon).
+
+This tasks requires Python 2.7 to be installed on the Computer and available in the path.
+
+#### `gulp copy:palemoon`
+
+Builds the Pale Moon browser extension from source and outputs it to `build/palemoon/`.
+
+See also: [`gulp build`](#gulp-build), [`gulp build:palemoon`](#gulp-buildpalemoon), [`gulp compress:palemoon`](#gulp-compresspalemoon).
+
+#### `gulp compress:palemoon`
+
+Creates a [Cross-platform Installer Module](https://developer.mozilla.org/en/docs/XPI), `new-xkit.xpi`, from an existing Firefox source build and outputs it to `build/palemoon/`.
+
+See also: [`gulp build`](#gulp-build), [`gulp build:palemoon`](#gulp-buildpalemoon), [`gulp copy:palemoon`](#gulp-copypalemoon).
+
+This tasks requires Python 2.7 to be installed on the Computer and available in the path.
 
 #### `gulp build:safari`
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -302,6 +302,18 @@
       "from": "center-align@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.1.tgz"
     },
+    "cfx": {
+      "version": "0.0.3",
+      "from": "cfx@0.0.3",
+      "resolved": "https://registry.npmjs.org/cfx/-/cfx-0.0.3.tgz",
+      "dependencies": {
+        "underscore": {
+          "version": "1.8.3",
+          "from": "underscore@latest",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
+        }
+      }
+    },
     "chalk": {
       "version": "1.1.1",
       "from": "chalk@>=1.0.0 <2.0.0",
@@ -950,6 +962,23 @@
           "version": "3.0.0",
           "from": "xtend@>=3.0.0 <3.1.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+        }
+      }
+    },
+    "gulp-cfx-xpi": {
+      "version": "0.0.4",
+      "from": "gulp-cfx-xpi@0.0.4",
+      "resolved": "https://registry.npmjs.org/gulp-cfx-xpi/-/gulp-cfx-xpi-0.0.4.tgz",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.0.33",
+          "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.3 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
         }
       }
     },
@@ -1893,7 +1922,8 @@
       "dependencies": {
         "esprima-fb": {
           "version": "15001.1.0-dev-harmony-fb",
-          "from": "esprima-fb@>=15001.1.0-dev-harmony-fb <15001.2.0"
+          "from": "esprima-fb@15001.1.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "merge-stream": "^0.1.8",
     "morgan": "^1.6.1",
     "serve-static": "^1.10.0",
-    "through2": "^2.0.0"
+    "through2": "^2.0.0",
+    "gulp-cfx-xpi": "0.0.4"
   }
 }


### PR DESCRIPTION
A new task has been introduced to gulp that allows building an extension
compatible with the Palemoon browser. Palemoon extensions need to be
built using Mozilla's old CFX tool, which unfortunately requires Python
2.7 to be installed. This is also the main reason why `build:palemoon`
is not part of the `build` task.
The source to built from is the Firefox extension, since there are no
incompatibilities in the Firefox code we use, it was just the build
tool being incompatible.
Closes #112