### PR TITLE
Glowing Follow: Add glowing animation to the follow button

### DIFF
--- a/Extensions/glowing_follow.css
+++ b/Extensions/glowing_follow.css
@@ -1,26 +1,48 @@
 .xglow {
-	animation:glow 1.75s;
-	-moz-animation:glow 1.75s;
-	-webkit-animation:glow 1.75s;
-	animation-iteration-count:infinite;
-	-webkit-animation-iteration-count:infinite;
-	-moz-animation-iteration-count:infinite;
+	text-shadow: 0 0 3px #FFF;
+	background: rgba(0,0,0,0.70);
+	animation: glow 1.75s;
+	-moz-animation: glow 1.75s;
+	-webkit-animation: glow 1.75s;
+	animation-iteration-count: infinite;
+	-moz-animation-iteration-count: infinite;
+	-webkit-animation-iteration-count: infinite;
 }
 
 @keyframes glow {
-	0% {background:rgba(0,0,0,0.70);}
-	50% {background:rgba(0,0,0,0.38);}
-	100% {background:rgba(0,0,0,0.70);}
+	50% {text-shadow: 0 0 0 #FFF;
+		background: rgba(0,0,0,0.38);}
 }
 
 @-moz-keyframes glow {
-	0% {background:rgba(0,0,0,0.70);}
-	50% {background:rgba(0,0,0,0.38);}
-	100% {background:rgba(0,0,0,0.70);}
+	50% {text-shadow: 0 0 0 #FFF;
+		background: rgba(0,0,0,0.38);}
 }
 
 @-webkit-keyframes glow {
-	0% {background:rgba(0,0,0,0.70);}
-	50% {background:rgba(0,0,0,0.38);}
-	100% {background:rgba(0,0,0,0.70);}
+	50% {text-shadow: 0 0 0 #FFF;
+		background: rgba(0,0,0,0.38);}
+}
+
+.xglow::before {
+	filter: drop-shadow(0 0 3px #FFF);
+	-webkit-filter: drop-shadow(0 0 3px #FFF);
+	animation: glow_before 1.75s;
+	-moz-animation: glow_before 1.75s;
+	-webkit-animation: glow_before 1.75s;
+	animation-iteration-count: infinite;
+	-moz-animation-iteration-count: infinite;
+	-webkit-animation-iteration-count: infinite;
+}
+
+@keyframes glow_before {
+	50% {filter: drop-shadow(0 0 0 #FFF);}
+}
+
+@-moz-keyframes glow_before {
+	50% {filter: drop-shadow(0 0 0 #FFF);}
+}
+
+@-webkit-keyframes glow_before {
+	50% {-webkit-filter: drop-shadow(0 0 0 #FFF);}
 }

--- a/Extensions/glowing_follow.js
+++ b/Extensions/glowing_follow.js
@@ -1,8 +1,8 @@
 //* TITLE Glowing Follow **//
-//* VERSION 1.0.4 **//
+//* VERSION 1.0.5 **//
 //* DESCRIPTION Glowing plusses on non-mutual followers' blogs **//
 //* DETAILS Makes the Follow button on people's blogs glow if they are following you and you are not following them. Before proceeding, please keep in mind that sometimes, ignorance is bliss. **//
-//* DEVELOPER STUDIOXENIX **//
+//* DEVELOPER new-xkit **//
 //* FRAME true **//
 //* BETA false **//
 


### PR DESCRIPTION
Fixes #886

This adds an actual glowing animation to the text "Follow" and the plus sign in the follow button. Chrome doesn't like animations on before pseudo-elements (compare http://codepen.io/anon/pen/xZXNqX in Chrome vs FF), but the animation works in FF. The plus sign always glows in Chrome.