### PR TITLE
Fix styles used to hide notes in Activity+

### DIFF
--- a/Extensions/activity_plus.css
+++ b/Extensions/activity_plus.css
@@ -1,5 +1,6 @@
 .xkit-activity-plus-condensed-item.xkit-activity-plus-yellow-mode-on {
-	display: none; height: 0;
+	display: none !important;
+	height: 0 !important;
 	overflow: hidden;
 }
 
@@ -8,7 +9,8 @@
 }
 
 .xkit-activity-plus-condensed-item-opened.xkit-activity-plus-yellow-mode-on {
-	display: block; height: auto;
+	display: block !important;
+	height: auto !important;
 	overflow: hidden;
    	-webkit-transition: 0.3s ease-in;
    	-moz-transition: 0.3s ease-in;

--- a/Extensions/activity_plus.js
+++ b/Extensions/activity_plus.js
@@ -1,5 +1,5 @@
 //* TITLE Activity+ **//
-//* VERSION 0.3 REV C **//
+//* VERSION 0.3.4 **//
 //* DESCRIPTION Tweaks for the Activity page **//
 //* DETAILS This extension brings a couple of tweaks for the Activity page, such as the ability to filter notes by type and showing timestamps. **//
 //* DEVELOPER STUDIOXENIX **//


### PR DESCRIPTION
When viewing the page https://www.tumblr.com/blog/new-xkit-extension/activity (or equivalent), some notes that would normally be hidden are instead half-displayed due to a selector that ties with XKit's. This ups the specificity of our hiding selector, fixing the issue.
<img width="561" alt="activity_plus_issue" src="https://cloud.githubusercontent.com/assets/2776089/12706259/a7794604-c84e-11e5-8599-26c5cf71d8b3.png">
