### PR TITLE
Fast follow on get_blogs changes

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -159,7 +159,7 @@ XKit.tools.get_blogs = function() {
 	// Approach 1: Scrape the tumblelog models for ones we control
 	// code is above
 
-	if (XKit.blogs_from_tumblr.length){
+	if (XKit.blogs_from_tumblr){
 		m_blogs = XKit.blogs_from_tumblr;
 		XKit.tools.set_setting('xkit_cached_blogs', m_blogs.join(';'));
 		return m_blogs;

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 6.2.2 **//
+//* VERSION 6.2.3 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -127,18 +127,19 @@ XKit.tools.parse_version = function(versionString) {
 var blogs_get = document.createElement("script");
 blogs_get.textContent = "("+(function(){
 	var blogs = [];
-	var models = Tumblr.dashboardControls.allTumblelogs;
-
-	models.filter(function(model){
-		return model.attributes.hasOwnProperty("is_current");
-	}).forEach(function(model){
-		blogs.push(model.attributes.name);
-	});
-	if(blogs.length){
-		window.postMessage({
-			xkit_blogs: blogs,
-		}, window.location.protocol+"//"+window.location.host);
-	}
+	try {
+		var models = Tumblr.dashboardControls.allTumblelogs;
+		models.filter(function(model){
+			return model.attributes.hasOwnProperty("is_current");
+		}).forEach(function(model){
+			blogs.push(model.attributes.name);
+		});
+		if(blogs.length){
+			window.postMessage({
+				xkit_blogs: blogs,
+			}, window.location.protocol+"//"+window.location.host);
+		}
+	} catch (_) {}
 }).toString()+")();";
 document.body.appendChild(blogs_get);
 

--- a/docs/API/XKit.tools.md
+++ b/docs/API/XKit.tools.md
@@ -58,6 +58,14 @@ destroy: function() {
 }
 ```
 
+<a name"escape_html" href="XKit.tools.md#escape_html">#</a> XKit.tools.**escape_html**(_text_)
+
+Will return the passed text, with all potentially dangerous-for-HTML characters escaped.
+
+see also [the OWASP wiki](https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet#XSS_Prevention_Rules) for the source of the list of escaping rules in this function.
+
+Under no circumstances should the output of this function be injected into an unquoted element attribute, as there are many ways to escape from an unquoted attribute that aren't covered here. Don't use unquoted attributes.
+
 <a name"random_string" href="XKit.tools.md#random_string">#</a> XKit.tools.**random_string**()
 
 Returns a random 30-character string.


### PR DESCRIPTION
A few fixes from today's changes

 - Silence extraneous errors 
 - Added external docs for escape_html. (are we supposed to be maintaining both of these?)
 - fix small correctness problem with blogs_from_tumblr
(Sorry, I was doign a lot of jQuery code checking at the time, and got the two patterns mixed up. Mia culpa)

fixes #945 