### PR TITLE
Fix Glowing Follow on blogname.tumblr.com/archive

### DIFF
--- a/Extensions/glowing_follow.css
+++ b/Extensions/glowing_follow.css
@@ -1,6 +1,6 @@
 .xglow {
 	text-shadow: 0 0 3px #FFF;
-	background: rgba(0,0,0,0.70);
+	background: rgba(0,0,0,0.70) !important;
 	animation: glow 1.75s;
 	-moz-animation: glow 1.75s;
 	-webkit-animation: glow 1.75s;

--- a/Extensions/glowing_follow.js
+++ b/Extensions/glowing_follow.js
@@ -1,5 +1,5 @@
 //* TITLE Glowing Follow **//
-//* VERSION 1.0.5 **//
+//* VERSION 1.0.6 **//
 //* DESCRIPTION Glowing plusses on non-mutual followers' blogs **//
 //* DETAILS Makes the Follow button on people's blogs glow if they are following you and you are not following them. Before proceeding, please keep in mind that sometimes, ignorance is bliss. **//
 //* DEVELOPER new-xkit **//

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 6.2.3 **//
+//* VERSION 6.2.4 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -388,8 +388,9 @@ XKit.tools.getParameterByName = function(name){
 
 			get_tumblelog: function() {
 				var new_channel_id = document.location.href.match(/[&?]tumblelogName=([\w-]+)/);
+				var archive_channel_id = document.location.href.match(/[&?]name=([\w-]+)/);
 				var old_channel_id = $("#tumblelog_name").attr('data-tumblelog-name');
-				return (new_channel_id && new_channel_id[1]) || old_channel_id;
+				return (new_channel_id && new_channel_id[1]) || (archive_channel_id && archive_channel_id[1]) || old_channel_id;
 			},
 
 			single_post_id: function() {


### PR DESCRIPTION
Brought up on the support chat:
>`XKit|47636` Some blog themes make it impossible to see the glowing follow working.
`XKit|47636` So i usually go their archive page and look to see it there.
`XKit|47636` But nothing blinks or "glows".