### PR TITLE
Create pop out controls for Audio+; Solve minor Audio+ performance bug

### DIFF
--- a/Extensions/audio_plus.css
+++ b/Extensions/audio_plus.css
@@ -32,3 +32,59 @@
 	background: rgba(0,0,0,0.33);
 	border-radius: 6px;
 }
+
+.xkit-audio-plus-controls {
+	position: fixed;
+	bottom: 50px;
+	right: 50px;
+	background-color: #f8f8f8;
+	z-index: 10000;
+	width: 70px;
+	height: 70px;
+	border-radius: 35px;
+	border: 1px solid #d9d9d9;
+	display: none;
+}
+
+.xkit-audio-plus-controls.showing {
+	display: block;
+}
+
+/* The following three heavily use Tumblr's dock_button styles */
+#xkit-audio-plus-controls-undock-container {
+	position: fixed;
+	bottom: 98px;
+	right: 48px;
+
+	background-color: #748089;
+	border-radius: 100%;
+	font-size: 12px;
+	cursor: pointer;
+	height: 21px;
+	width: 21px;
+	color: #fff;
+}
+
+#xkit-audio-plus-controls-undock::before {
+	content: "";
+}
+
+#xkit-audio-plus-controls-undock {
+	font-family: "tumblr-icons","Blank";
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-weight: 400;
+
+	margin-left: -3.5px;
+	margin-top: -3.5px;
+	position: absolute;
+	line-height: 8px;
+	height: 7px;
+	width: 7px;
+	left: 50%;
+	top: 50%;
+
+	font-size: 12px;
+	cursor: pointer;
+	color: #fff;
+}

--- a/Extensions/audio_plus.css
+++ b/Extensions/audio_plus.css
@@ -36,7 +36,9 @@
 .xkit-audio-plus-controls {
 	position: fixed;
 	bottom: 50px;
-	right: 50px;
+	left: 50%;
+	transform: translateX(245px) translateY(0px);
+
 	background-color: #f8f8f8;
 	z-index: 10000;
 	width: 70px;
@@ -53,8 +55,7 @@
 /* The following three heavily use Tumblr's dock_button styles */
 #xkit-audio-plus-controls-undock-container {
 	position: fixed;
-	bottom: 98px;
-	right: 48px;
+	right: -1.5px;
 
 	background-color: #748089;
 	border-radius: 100%;

--- a/Extensions/audio_plus.js
+++ b/Extensions/audio_plus.js
@@ -1,5 +1,5 @@
 //* TITLE Audio+ **//
-//* VERSION 0.4.2 **//
+//* VERSION 0.4.3 **//
 //* DESCRIPTION Enhancements for the Audio Player **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//

--- a/Extensions/audio_plus.js
+++ b/Extensions/audio_plus.js
@@ -1,5 +1,5 @@
 //* TITLE Audio+ **//
-//* VERSION 0.4.1 **//
+//* VERSION 0.4.2 **//
 //* DESCRIPTION Enhancements for the Audio Player **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -14,10 +14,15 @@ XKit.extensions.audio_plus = {
 			text: "Options",
 			type: "separator"
 		},
+		add_volume_control: {
+			text: "Add a volume slider to audio posts",
+			value: true,
+			default: true
+		},
 		pop_out_player: {
 			text: "Pop out controls when you scroll away from playing audio",
-			value: false,
-			default: false,
+			value: true,
+			default: true
 		}
 	},
 
@@ -33,9 +38,13 @@ XKit.extensions.audio_plus = {
 		}
 
 		XKit.tools.init_css("audio_plus");
-		$(document).on("mousemove mousedown mouseup mouseout click", ".xkit-audio-plus-slider", XKit.extensions.audio_plus.slider_handle_event);
-		XKit.post_listener.add("audio_plus", XKit.extensions.audio_plus.do);
-		setTimeout(function() { XKit.extensions.audio_plus.do(); }, 500);
+
+		if (XKit.extensions.audio_plus.preferences.add_volume_control.value) {
+			$(document).on("mousemove mousedown mouseup mouseout click", ".xkit-audio-plus-slider", XKit.extensions.audio_plus.slider_handle_event);
+			XKit.post_listener.add("audio_plus", XKit.extensions.audio_plus.do);
+			setTimeout(function() { XKit.extensions.audio_plus.do(); }, 500);
+		}
+
 		$("body").append("<div id=\"xkit-audio-plus-current-player\"></div>");
 		XKit.extensions.audio_plus.start_check_current();
 


### PR DESCRIPTION
0.4.0: Implement pop out controls that appear if you scroll away from a
playing audio post.

0.4.1: Use setInterval inside of Audio+'s injected function instead of
outside, preventing the creation of over 600 script nodes.