### PR TITLE
Fix some issues with Old Sidebar

### DIFF
--- a/Extensions/estufars_sidebar_fix.css
+++ b/Extensions/estufars_sidebar_fix.css
@@ -38,7 +38,7 @@
 	background-color: transparent;
 }
 
-.right_column .popover_inner_list>.popover_menu_item:hover, .right_column .popover_menu_list .popover_menu_sublist .blog-sub-nav-item:hover, .right_column .blog-list-item:hover {
+.right_column .popover_menu_item_anchor:hover, .right_column .popover_menu_list .popover_menu_sublist .blog-sub-nav-item:hover, .right_column .blog-list-item:hover {
 	background-color: #3c4b61!important;
 	background-color: rgba(255,255,255,.05)!important;
 	box-shadow: none!important;
@@ -99,6 +99,35 @@
 	font-weight: bold;
 }
 
+/* icon styles are from tumblr, they weren't getting applied when the menu is relocated */
+
+.right_column .popover_menu_item_anchor_icon {
+	font-family: "tumblr-icons","Blank";
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-style: normal;
+	font-variant: normal;
+	font-weight: 400;
+	text-decoration: none;
+	text-transform: none;
+}
+
+.right_column .popover_menu_item_anchor_icon.like-icon::before {
+    content: "";
+}
+
+.right_column .popover_menu_item_anchor_icon.following-icon::before {
+    content: "";
+}
+
+.right_column .popover_menu_item_anchor_icon.settings-icon::before {
+    content: "";
+}
+
+.right_column .popover_menu_item_anchor_icon.help-icon::before {
+    content: "";
+}
+
 .right_column .tx-scroll {
 	border-radius: 0!important;
 }
@@ -109,4 +138,11 @@
 
 .right_column .popover_menu+#dashboard_controls_open_blog {
 	display: none;
+}
+
+/* activity line is grey, use blend modes to match blue of other menu items */
+
+.right_column .blog-sub-nav-item-data.sparkline {
+	mix-blend-mode: screen;
+	opacity: 0.6;
 }

--- a/Extensions/estufars_sidebar_fix.js
+++ b/Extensions/estufars_sidebar_fix.js
@@ -1,5 +1,5 @@
 //* TITLE Old Sidebar **//
-//* VERSION 1.1.2 **//
+//* VERSION 1.1.3 **//
 //* DESCRIPTION Get the sidebar back **//
 //* DEVELOPER estufar **//
 //* FRAME false **//
@@ -26,7 +26,25 @@ XKit.extensions.estufars_sidebar_fix = new Object({
 				return;
 			}
 		} else {
-			var disallowedurls = ["://www.tumblr.com/explore", "://www.tumblr.com/search", "://www.tumblr.com/following", "/reblog"];
+			var disallowedurls = [
+				"://www.tumblr.com/explore",
+				"://www.tumblr.com/search",
+				"://www.tumblr.com/following",
+				"/reblog",
+				"://www.tumblr.com/help",
+				"://www.tumblr.com/docs",
+				"://www.tumblr.com/developers",
+				"://www.tumblr.com/about",
+				"://www.tumblr.com/themes",
+				"://www.tumblr.com/policy",
+				"://www.tumblr.com/jobs",
+				"://www.tumblr.com/apps",
+				"://www.tumblr.com/logo",
+				"://www.tumblr.com/business",
+				"://www.tumblr.com/buttons",
+				"://www.tumblr.com/press",
+				"://www.tumblr.com/security"
+			];
 			for (var i = 0; i < disallowedurls.length; i++) {
 				if (document.location.href.indexOf(disallowedurls[i]) !== -1) {
 					return;


### PR DESCRIPTION
Fixes an [issue](https://github.com/estufar/extensions/issues/2) @hujgup opened on my old extensions repository where there were a few pages where Old Sidebar attempted to run when it really shouldn't. I've gone through and blacklisted every page I found where this happens.

This also updates some styles which started to break and makes the activity line semitransparent white rather than grey which looks better, especially for people who use custom backgrounds.