### PR TITLE
Fix issue with disappearing chat menu in Chrome

### DIFF
--- a/Extensions/estufars_sidebar_fix.css
+++ b/Extensions/estufars_sidebar_fix.css
@@ -141,8 +141,8 @@
 }
 
 /* activity line is grey, use blend modes to match blue of other menu items */
-
-.right_column .blog-sub-nav-item-data.sparkline {
+/* nevermind, chrome has a bug that causes the message dropdown to disappear? */
+/*.right_column .blog-sub-nav-item-data.sparkline {
 	mix-blend-mode: screen;
 	opacity: 0.6;
-}
+}*/

--- a/Extensions/estufars_sidebar_fix.js
+++ b/Extensions/estufars_sidebar_fix.js
@@ -1,5 +1,5 @@
 //* TITLE Old Sidebar **//
-//* VERSION 1.1.3 **//
+//* VERSION 1.1.4 **//
 //* DESCRIPTION Get the sidebar back **//
 //* DEVELOPER estufar **//
 //* FRAME false **//


### PR DESCRIPTION
So it turns out Chrome has a bug where the chat menu is invisible if the activity line has a blend mode set. Not sure why this happens, or why the activity menu doesn't disappear too, but I've just removed it for the time being. I'll look in to this more later but for now the grey activity line works fine.

Fixes #976 