### PR TITLE
Add back nicer activity line

### DIFF
--- a/Extensions/estufars_sidebar_fix.css
+++ b/Extensions/estufars_sidebar_fix.css
@@ -157,6 +157,7 @@
 /* z-index change will mess with the first section
    (another chrome issue, will be fixed in chrome 50) */
 
-.right_column .popover_subsection:first-child .popover_header, .right_column .popover_subsection:first-child .popover_header>.popover_item_suffix {
+.right_column .popover_subsection:first-child .popover_header,
+.right_column .popover_subsection:first-child .popover_header>.popover_item_suffix {
 	position: static;
 }

--- a/Extensions/estufars_sidebar_fix.css
+++ b/Extensions/estufars_sidebar_fix.css
@@ -141,8 +141,22 @@
 }
 
 /* activity line is grey, use blend modes to match blue of other menu items */
-/* nevermind, chrome has a bug that causes the message dropdown to disappear? */
-/*.right_column .blog-sub-nav-item-data.sparkline {
+
+.right_column .blog-sub-nav-item-data.sparkline {
 	mix-blend-mode: screen;
 	opacity: 0.6;
-}*/
+}
+
+/* chrome will cause the chat menu to disappear when the blend mode is set for some reason
+   work around this by setting right column z-index which makes it appear again */
+
+.right_column {
+	z-index: 1;
+}
+
+/* z-index change will mess with the first section
+   (another chrome issue, will be fixed in chrome 50) */
+
+.right_column .popover_subsection:first-child .popover_header, .right_column .popover_subsection:first-child .popover_header>.popover_item_suffix {
+	position: static;
+}

--- a/Extensions/estufars_sidebar_fix.js
+++ b/Extensions/estufars_sidebar_fix.js
@@ -1,5 +1,5 @@
 //* TITLE Old Sidebar **//
-//* VERSION 1.1.4 **//
+//* VERSION 1.1.5 **//
 //* DESCRIPTION Get the sidebar back **//
 //* DEVELOPER estufar **//
 //* FRAME false **//
@@ -32,6 +32,7 @@ XKit.extensions.estufars_sidebar_fix = new Object({
 				"://www.tumblr.com/following",
 				"/reblog",
 				"://www.tumblr.com/help",
+				"://www.tumblr.com/support",
 				"://www.tumblr.com/docs",
 				"://www.tumblr.com/developers",
 				"://www.tumblr.com/about",


### PR DESCRIPTION
This adds back in the (slightly) prettier activity line that was removed in #977 due to a bug in Chrome that caused the chat menu to disappear. I found a workaround that keeps both the semitransparent white activity line and the chat menu. It's slightly hacky, but as far as I can tell the workaround doesn't cause any issues with the rest of XKit or Tumblr, or with Firefox.

Also blacklisted another page I missed last time.