### PR TITLE
Changes to add Microsoft Edge compatibility

### DIFF
--- a/Chrome/bridge.js
+++ b/Chrome/bridge.js
@@ -12,6 +12,16 @@ var bridge_error_object;
 var xkit_storage = {};
 var bridge_ver = "2.1";
 
+// If chrome isn't defined, check for browser or msBrowser and use those instead. 
+if (typeof chrome === 'undefined') {
+	// Probably ms edge
+	if (typeof msBrowser !== 'undefined') {
+		chrome = msBrowser; // jshint ignore:line
+	} else if (typeof browser !== 'undefined') {
+		chrome = browser;	// jshint ignore:line
+	}
+}
+
 try {
 	var storage = chrome.storage.local;
 	var storage_loaded = false;

--- a/Edge/FIX_PERMISSIONS.cmd
+++ b/Edge/FIX_PERMISSIONS.cmd
@@ -1,3 +1,6 @@
 REM Grant necessary fs permissions to the Edge sandbox user to allow access to the extension's directory
 cd /d %~dp0
-icacls "." /grant "*S-1-15-2-3624051433-2125758914-1423191267-1740899205-1073925389-3782572162-737981194":"(OI)(CI)(WDAC,WO,GE)" 
+SET "InstallFolder=."
+
+icacls "%InstallFolder%" /grant "*S-1-15-2-3624051433-2125758914-1423191267-1740899205-1073925389-3782572162-737981194":"(OI)(CI)(WDAC,WO,GE)" >> "%Logfile%"
+icacls "%InstallFolder%" /grant "*S-1-15-2-3624051433-2125758914-1423191267-1740899205-1073925389-3782572162-737981194":"(OI)(CI)(WDAC,WO,GE)" >> "%Logfile%"

--- a/Edge/FIX_PERMISSIONS.cmd
+++ b/Edge/FIX_PERMISSIONS.cmd
@@ -1,0 +1,3 @@
+REM Grant necessary fs permissions to the Edge sandbox user to allow access to the extension's directory
+cd /d %~dp0
+icacls "." /grant "*S-1-15-2-3624051433-2125758914-1423191267-1740899205-1073925389-3782572162-737981194":"(OI)(CI)(WDAC,WO,GE)" 

--- a/Edge/README.md
+++ b/Edge/README.md
@@ -1,0 +1,4 @@
+#XKit New
+XKit for Microsoft Edge 34.14291.1001.0 and newer
+
+Must run FIX_PRESMISSIONS.cmd to allow Edge to sideload the unpacked extension.

--- a/Edge/manifest.json
+++ b/Edge/manifest.json
@@ -1,0 +1,21 @@
+{
+   "content_scripts": [ {
+      "all_frames": true,
+			"run_at": "document_end",
+      "css": [ "xkit.css" ],
+      "exclude_matches": [ "https://www.tumblr.com/upload/image*, http://www.tumblr.com/upload/image*" ],
+      "js": [ "bridge.js", "jquery.js", "tiptip.js", "moment.js", "nano.js", "xkit.js" ],
+      "matches": [ "http://*.tumblr.com/*", "https://*.tumblr.com/*" ]
+   } ],
+   "description": "A fork of XKit, the extension framework for Tumblr.",
+   "homepage_url": "https://github.com/new-xkit/XKit",
+   "icons": {
+      "128": "icon.png"
+   },
+   "manifest_version": 2,
+   "minimum_edge_version": "34.14291.1001.0",	 
+   "name": "New XKit",
+   "permissions": ["*://*/*", "*://*/", "unlimitedStorage", "storage", "http://*.tumblr.com/", "https://*.tumblr.com/" ],
+   "version": "7.7.1",
+   "web_accessible_resources": [ "manifest.json", "editor.js" ]
+}

--- a/Edge/manifest.json
+++ b/Edge/manifest.json
@@ -9,6 +9,7 @@
    } ],
    "description": "A fork of XKit, the extension framework for Tumblr.",
    "homepage_url": "https://github.com/new-xkit/XKit",
+   "author": "New XKit",
    "icons": {
       "128": "icon.png"
    },

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,6 +61,10 @@ gulp.task('clean:safari', function(cb) {
 	del([BUILD_DIR + '/safari.safariextension'], cb);
 });
 
+gulp.task('clean:edge', function(cb) {
+	del([BUILD_DIR + '/edge'], cb);
+});
+
 gulp.task('clean:extensions', function(cb) {
 	del(['Extensions/dist/*.json',
 	     'Extensions/dist/page/gallery.json',
@@ -167,11 +171,25 @@ gulp.task('copy:safari', ['clean:safari', 'lint'], function() {
 
 });
 
+gulp.task('copy:edge', ['clean:edge', 'lint'], function() {
+	var src = [].concat(
+		paths.scripts.core,
+		paths.css.core,
+		paths.vendor,
+		['Chrome/bridge.js', 'Chrome/icon.png', 'Edge/**/*']
+	);
+
+	return gulp.src(src)
+		.pipe(gulp.dest(BUILD_DIR + '/edge'));
+});
+
 gulp.task('build:chrome', ['compress:chrome']);
 
 gulp.task('build:firefox', ['compress:firefox']);
 
 gulp.task('build:safari', ['copy:safari']);
+
+gulp.task('build:edge', ['copy:edge']);
 
 gulp.task('build:extensions', ['lint:scripts', 'clean:extensions'], function() {
 	var extensionBuilder = require('./dev/builders/extension');
@@ -192,7 +210,7 @@ gulp.task('build:themes', ['clean:themes'], function(cb) {
 		.pipe(gulp.dest('Extensions/dist/page'));
 });
 
-gulp.task('build', ['build:chrome', 'build:firefox', 'build:safari']);
+gulp.task('build', ['build:chrome', 'build:firefox', 'build:safari', 'build:edge']);
 
 gulp.task('watch', function() {
 	gulp.watch('**/*.js', ['lint:scripts']);

--- a/xkit.js
+++ b/xkit.js
@@ -28,7 +28,7 @@ XKit = {
 
 		XKit.init_flags();
 		// If not in an iframe
-		if ((window.window === window.top) && document.location.href.indexOf("://www.tumblr.com/dashboard/iframe?") === -1) {
+		if ((window.self === window.top) && document.location.href.indexOf("://www.tumblr.com/dashboard/iframe?") === -1) {
 			XKit.page.standard = true;
 			XKit.init_extension();
 		} else {


### PR DESCRIPTION
Changes needed so the version of Microsoft Edge (34.14291.1001.0) included in latest Windows 10 Insider Preview (14291) can sideload an unpacked xkit extension.

Small changes to xkit.js and Chrome\bridge.js so they work in Edge.

manifest.json could be shared between Edge and Chrome but the changes needed by Edge cause a warning when the extension is loaded in Chrome. I made a new edge specific manifest.js instead.

Added FIX_PERMISSIONS.cmd for Edge so the appropriate fs permissions can be set on the unpacked extension allowing Edge to load it.

Added edge to the build system.
