### PR TITLE
Add option to hide newly loaded posts by default

### DIFF
--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -105,6 +105,12 @@ XKit.extensions.blacklist = new Object({
 			default: false,
 			value: false
 		},
+		"hide_by_default": {
+			text: "Hide newly loaded posts until Blacklist makes sure they aren't blocked",
+			default: false,
+			value: false,
+			experimental: true
+		},
 		"sep3": {
 			text: "Blacklisted Words",
 			type: "separator"
@@ -166,6 +172,18 @@ XKit.extensions.blacklist = new Object({
 
 			XKit.tools.add_css(mini_ui, "xkit_blacklist_mini_ui");
 
+		}
+
+		if (this.preferences.hide_by_default.value) {
+			// Set opacity of all post content to 0, upon Blacklist's
+			// completion set it back to 1
+			XKit.tools.add_css(
+				".post_content { opacity: 0; }" +
+				".post.xblacklist-done .post_content { opacity: 1; }" +
+				".post .post_header::after { content: \"Hidden by Blacklist\"; }" +
+				".post.xblacklist-done .post_header::after { content: \"\"; }",
+				"xkit_blacklist_hide_by_default"
+			);
 		}
 
 		if ($(".posts .post").length > 0) {
@@ -944,6 +962,7 @@ XKit.extensions.blacklist = new Object({
 			$(".xblacklist_blacklisted_post").removeClass("xblacklist_blacklisted_post");
 		}, 500);
 		XKit.tools.remove_css("xkit_blacklist_mini_ui");
+		XKit.tools.remove_css("xkit_blacklist_hide_by_default");
 		XKit.tools.remove_css("blacklist");
 	},
 


### PR DESCRIPTION
The option works by making all post content transparent until contained
in a ".post.xblacklist-done". Note that it does not work on the posts
present when the page is loaded because that would require rewriting
XKit and having this option be always on.