### PR TITLE
Fix "#" hrefs not being prevented by inline handlers

### DIFF
--- a/Extensions/bookmarker.js
+++ b/Extensions/bookmarker.js
@@ -1,5 +1,5 @@
 //* TITLE Bookmarker **//
-//* VERSION 2.3.3 **//
+//* VERSION 2.3.4 **//
 //* DESCRIPTION Dashboard Time Machine **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS The Bookmarker extension allows you to bookmark posts and get back to them whenever you want to. Just click on the Bookmark icon on posts and the post will be added to your Bookmark List on your sidebar. **//
@@ -120,7 +120,7 @@ XKit.extensions.bookmarker = new Object({
 		}
 
 		m_html = '<ul class="controls_section" id="xbookmarks">' + m_html + '</ul>' +
-			'<div class="small_links" id="xbookmarker_small_links"><a href="#" onclick="return false;" id="xbookmarker_delete_all">delete all</a><a href="#" onclick="return false;" id="xbookmarker_help">bookmarker help</a></div>';
+			'<div class="small_links" id="xbookmarker_small_links"><a href="#" id="xbookmarker_delete_all">delete all</a><a href="#" id="xbookmarker_help">bookmarker help</a></div>';
 
 		if (document.location.href.indexOf("?bookmark=true") !== -1) {
 			$("#right_column").prepend(m_html);
@@ -148,6 +148,7 @@ XKit.extensions.bookmarker = new Object({
 
 			XKit.window.show("Bookmarker Help","Bookmarker lists your bookmarks on the sidebar.<br/><br/>To rename or delete a bookmark, you can click them while holding the <b>ALT</b> key on your keyboard.<br/><br/>To go back to a bookmarked post, just click on the bookmark. If the post you've bookmarked is deleted, you'll get the posts made around that time.", "info", "<div class=\"xkit-button default\" id=\"xkit-close-message\">OK</div>");
 
+			return false;
 		});
 
 		$("#xbookmarker_delete_all").click(function() {
@@ -161,6 +162,7 @@ XKit.extensions.bookmarker = new Object({
 
 			});
 
+			return false;
 		});
 
 		$(document).on("click", ".xkit_bookmarker_button", function(event){

--- a/Extensions/cleanfeed.js
+++ b/Extensions/cleanfeed.js
@@ -1,5 +1,5 @@
 //* TITLE CleanFeed **//
-//* VERSION 1.5.1 **//
+//* VERSION 1.5.2 **//
 //* DESCRIPTION Browse safely in public **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS This extension, when enabled, hides photo posts until you hover over them. Useful to browse Tumblr in a workspace or in public, and not worry about NSFW stuff appearing. You can also set it to hide avatars and not show non-text posts at all. To activate or disable it, click on the CleanFeed button on your sidebar. It will remember it's on/off setting. **//
@@ -76,14 +76,14 @@ XKit.extensions.cleanfeed = new Object({
 
 		xf_html = '<ul class="controls_section" id="xcleanfeed_ul">' +
 			'<li class="section_header selected">CLEANFEED</li>' +
-			'<li class="no_push" style="height: 36px;"><a href="#" onclick="return false;" id="xcleanfeed_button">' +
+			'<li class="no_push" style="height: 36px;"><a href="#" id="xcleanfeed_button">' +
 			'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Filtering</div>' +
 			'<div class="count" id="xcleanfeedstatus" style="padding-top: 8px;">' + XKit.extensions.cleanfeed.lbl_off + '</div>' +
 			'<div id="xcleanfeedindicator">&nbsp;</div>' +
 			'</a></li>' +
 			'<div class="small_links by-xkit-cleanfeed">' +
-				'<a onclick="return false;" id="xkit-cleanfeed-mode">Mode: ' + normal_text + '</a>' +
-				'<a onclick="return false;" id="xkit-cleanfeed-mode-change" href="#">change/help</a>' +
+				'<a id="xkit-cleanfeed-mode">Mode: ' + normal_text + '</a>' +
+				'<a id="xkit-cleanfeed-mode-change" href="#">change/help</a>' +
 			'</div>' +
 			'</ul>';
 		$("ul.controls_section:first").before(xf_html);
@@ -125,12 +125,14 @@ XKit.extensions.cleanfeed = new Object({
 
 			});
 
+			return false;
 		});
 
 		$("#xcleanfeed_button").click(function() {
 
 			XKit.extensions.cleanfeed.toggle();
 
+			return false;
 		});
 
 		if (XKit.extensions.cleanfeed.preferences.full_block.value) {

--- a/Extensions/drafts_plus.js
+++ b/Extensions/drafts_plus.js
@@ -1,5 +1,5 @@
 //* TITLE Drafts+ **//
-//* VERSION 0.2.3 **//
+//* VERSION 0.2.4 **//
 //* DESCRIPTION Enhancements for Drafts page **//
 //* DEVELOPER STUDIOXENIX **//
 //* FRAME false **//
@@ -24,7 +24,7 @@ XKit.extensions.drafts_plus = new Object({
 				'</a>' +
 			'</li>' +
 			'<li class="no_push">' +
-				'<a href="#" onclick="return false;" id="xshrinkposts_button">' +
+				'<a href="#" id="xshrinkposts_button">' +
 					'<div class="hide_overflow">Shrink Posts <div class="count" style="padding-top: 8px;">off</div></div>' +
 				'</a>' +
 			'</li>' +
@@ -48,6 +48,7 @@ XKit.extensions.drafts_plus = new Object({
 
 			}
 
+			return false;
 		});
 
 		$("#xshrinkposts_button").click(function() {
@@ -72,6 +73,7 @@ XKit.extensions.drafts_plus = new Object({
 
 			}
 
+			return false;
 		});
 
 	},

--- a/Extensions/mass_deleter.js
+++ b/Extensions/mass_deleter.js
@@ -1,5 +1,5 @@
 //* TITLE Mass Deleter **//
-//* VERSION 0.1.2 **//
+//* VERSION 0.1.3 **//
 //* DESCRIPTION Mass unlike likes / delete drafts **//
 //* DETAILS Used to mass unlike posts or delete drafts. Please use with caution, especially Mass Unlike part is extremely experimental. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -41,12 +41,12 @@ XKit.extensions.mass_deleter = new Object({
 		if ($("#drafts_plus_sidebar").length > 0) {
 
 			xf_html = '<li class="no_push">' +
-					'<a href="#" class="customize xkit-mass-deleter" onclick="return false;" id="xkit-mass-deleter-100">' +
+					'<a href="#" class="customize xkit-mass-deleter" id="xkit-mass-deleter-100">' +
 						'<div class="hide_overflow">Delete 100 Drafts</div>' +
 					'</a>' +
 				'</li>' +
 				'<li class="no_push">' +
-					'<a href="#" class="customize xkit-mass-deleter" onclick="return false;" id="xkit-mass-deleter-1000">' +
+					'<a href="#" class="customize xkit-mass-deleter" id="xkit-mass-deleter-1000">' +
 						'<div class="hide_overflow">Delete 1,000 Drafts</div>' +
 					'</a>' +
 				'</li>';
@@ -74,10 +74,14 @@ XKit.extensions.mass_deleter = new Object({
 
 		$("#xkit-mass-deleter-100").click(function() {
 			XKit.extensions.mass_deleter.delete_drafts(100);
+
+			return false;
 		});
 
 		$("#xkit-mass-deleter-1000").click(function() {
 			XKit.extensions.mass_deleter.delete_drafts(1000);
+
+			return false;
 		});
 
 	},

--- a/Extensions/outbox.js
+++ b/Extensions/outbox.js
@@ -1,5 +1,5 @@
 //* TITLE Outbox **//
-//* VERSION 0.9.8 **//
+//* VERSION 0.9.9 **//
 //* DESCRIPTION Saves your sent replies, fan mail and asks. **//
 //* DETAILS This extension stores and lets you view the last 50 asks you've answered privately. Please keep in mind that this is a highly experimental extension, so if you hit a bug, please send the XKit blog an ask with the problem you've found. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -237,7 +237,7 @@ XKit.extensions.outbox = new Object({
 		XKit.tools.init_css("outbox");
 
 		xf_html = '<ul class="controls_section" id="xkit_outbox_ul"><li class="section_header selected">OUTGOING</li>' +
-			'<li class="" style="height: 36px;"><a href="#" onclick="return false;" id="xkit-outbox-button">' +
+			'<li class="" style="height: 36px;"><a href="#" id="xkit-outbox-button">' +
 				'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">My Outbox</div>' +
 			'</a></li></ul>';
 		$("ul.controls_section:last").before(xf_html);
@@ -260,6 +260,7 @@ XKit.extensions.outbox = new Object({
 
 			}
 
+			return false;
 		});
 
 		var form_key = $('meta[name=tumblr-form-key]').attr("content");

--- a/Extensions/post_limit_checker.js
+++ b/Extensions/post_limit_checker.js
@@ -1,5 +1,5 @@
 //* TITLE Post Limit Checker **//
-//* VERSION 0.3.0 **//
+//* VERSION 0.3.1 **//
 //* DESCRIPTION Are you close to the limit? **//
 //* DETAILS Shows you how many posts you can reblog today. **//
 //* DEVELOPER new-xkit **//
@@ -20,14 +20,19 @@ XKit.extensions.post_limit_checker = new Object({
 
 		var xf_html = '<ul class="controls_section" id="post_limit_checker_ul">' +
 					'<li class="section_header selected">Post Limit</li>' +
-					'<li class="no_push" style="height: 36px;"><a href="#" onclick="return false;" id="post_limit_checker_view">' +
+					'<li class="no_push" style="height: 36px;"><a href="#" id="post_limit_checker_view">' +
 						'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Check Post Limit</div>' +
 					'</a></li>' +
 				'</ul>';
 
 		$("ul.controls_section:first").before(xf_html);
 
-		$("#post_limit_checker_view").click(function() { XKit.extensions.post_limit_checker.start(); });
+		$("#post_limit_checker_view").click(function() {
+
+			XKit.extensions.post_limit_checker.start();
+
+			return false;
+		});
 	},
 
 	window_id: 0,
@@ -37,7 +42,7 @@ XKit.extensions.post_limit_checker = new Object({
 		var shown_message = XKit.storage.get("post_limit_checker","shown_warning","");
 
 		var m_html = "<div id=\"xkit-plc-list\" class=\"nano\"><div id=\"xkit-plc-list-content\" class=\"content\">" +
-					"<div class=\"xkit-warning-plc-text\"><b>Deleted posts</b><br/>Deleted posts are count by Tumblr, but this tool can't count them. For example, if you've made 250 posts since the last reset but then deleted 50 of them, this tool will tell you that you have 50 more posts to go, but in reality you've already hit your post limit.</div>" +
+					"<div class=\"xkit-warning-plc-text\"><b>Deleted posts</b><br/>Deleted posts are counted by Tumblr, but this tool can't count them. For example, if you've made 250 posts since the last reset but then deleted 50 of them, this tool will tell you that you have 50 more posts to go, but in reality you've already hit your post limit.</div>" +
 					"<div class=\"xkit-warning-plc-text\"><b>Original photo posts</b><br/>There is a separate, 75 uploads per day limit for photo posts. This extension does not check for that.</div>" +
 					"<div class=\"xkit-warning-plc-text\"><b>No Guarantee</b><br/>The New XKit Team is not making any guarantees about the reliability of this tool.</div>" +
 				"</div></div>";

--- a/Extensions/postarchive.js
+++ b/Extensions/postarchive.js
@@ -1,5 +1,5 @@
 //* TITLE Post Archiver **//
-//* VERSION 1.0.0 **//
+//* VERSION 1.0.1 **//
 //* DESCRIPTION Never lose a post again. **//
 //* DETAILS Post Archiver lets you save posts to your XKit.<br><br>Found a good recipe? Think those hotline numbers on that signal boost post might come in handy in the future?<br><br>Click on the save button, then click on the My Archive button on your sidebar anytime to access those posts. You can also name and categorize posts. **//
 //* DEVELOPER new-xkit **//
@@ -84,7 +84,7 @@ XKit.extensions.postarchive = {
 		if ($('#postarchive_ul').length === 0) {
 			var xf_html = '<ul class="controls_section" id="postarchive_ul">' +
 				'<li class="section_header selected">Post Archive</li>' +
-					'<li class="no_push" style="height: 36px;"><a href="#" onclick="return false;" id="postarchive_view">' +
+					'<li class="no_push" style="height: 36px;"><a href="#" id="postarchive_view">' +
 						'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">My Archive <span class="count" id="postarchive_view_count" style="padding-top: 8px;">' + XKit.extensions.postarchive.archived_posts.length + '</span></div>' +
 					'</a></li>' +
 				'</ul>';
@@ -96,6 +96,7 @@ XKit.extensions.postarchive = {
 
 			XKit.extensions.postarchive.view();
 
+			return false;
 		});
 
 		if ($(".posts .post").length > 0) {

--- a/Extensions/search_likes.js
+++ b/Extensions/search_likes.js
@@ -1,5 +1,5 @@
 //* TITLE Search Likes **//
-//* VERSION 0.3.1 **//
+//* VERSION 0.3.2 **//
 //* DESCRIPTION Lets you search likes **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS This is a very experimental extension that lets you search the posts you've liked by URL or text. Just go to your likes page, then click on Search button to get started. **//
@@ -33,10 +33,11 @@ XKit.extensions.search_likes = new Object({
 		$("ul.controls_section:first").after(m_html);
 		$("#xkit-search-likes-ul").before(x_html);
 
-		$("#xkit-search-likes-button").bind("click", function() {
+		$("#xkit-search-likes-button").click(function() {
 
 			XKit.extensions.search_likes.search_start();
 
+			return false;
 		});
 
 		$("#xkit-search-likes-input").keyup(function() {

--- a/Extensions/separator.js
+++ b/Extensions/separator.js
@@ -1,5 +1,5 @@
 //* TITLE Separator **//
-//* VERSION 1.1.2 **//
+//* VERSION 1.1.3 **//
 //* DESCRIPTION Where were we again? **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS A simple extension that puts a divider showing where you left off on your dashboard. **//
@@ -52,7 +52,7 @@ XKit.extensions.separator = new Object({
 
 			xf_html = '<ul class="controls_section" id="separator_ul">' +
 				'<li class="section_header selected">SEPARATOR</li>' +
-				'<li class="no_push" style="height: 36px;"><a href="#" onclick="return false;" id="separator_button">' +
+				'<li class="no_push" style="height: 36px;"><a href="#" id="separator_button">' +
 					'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Go to last viewed post<span class="sub_control link_arrow arrow_right"></span></div>' +
 				'</a></li></ul>';
 			$("ul.controls_section:first").before(xf_html);
@@ -72,6 +72,7 @@ XKit.extensions.separator = new Object({
 
 				}
 
+				return false;
 			});
 
 		}

--- a/Extensions/show_originals.js
+++ b/Extensions/show_originals.js
@@ -56,7 +56,7 @@ XKit.extensions.show_originals = new Object({
 
 		xf_html = '<ul class="controls_section" id="xshow_originals_ul">' +
 			'<li class="section_header selected">SHOW ORIGINALS</li>' +
-			'<li class="no_push" style="height:36px;"><a href="#" onclick="return false;" id="xshoworiginals_button">' +
+			'<li class="no_push" style="height:36px;"><a href="#" id="xshoworiginals_button">' +
 			'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Originals Only</div>' +
 			'<div class="count" id="xshoworiginalsstatus" style="padding-top: 8px;">' + XKit.extensions.show_originals.lbl_off + '</div>' +
 			'<div id="xshoworiginalsindicator">&nbsp;</div>' +

--- a/Extensions/show_originals.js
+++ b/Extensions/show_originals.js
@@ -1,5 +1,5 @@
 //* TITLE Show Originals **//
-//* VERSION 1.2.2 **//
+//* VERSION 1.2.3 **//
 //* DESCRIPTION Only shows non-reblogged posts **//
 //* DETAILS This is a really experimental extension allows you see original (non-reblogged) posts made by users on your dashboard. Please keep in mind that if you don't have enough people creating new posts on your dashboard, it might slow down your computer. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -65,8 +65,10 @@ XKit.extensions.show_originals = new Object({
 
 		XKit.extensions.show_originals.update_button();
 
-		$("#xshow_originals_ul").click(function() {
+		$("#xshoworiginals_button").click(function() {
 			XKit.extensions.show_originals.toggle();
+
+			return false;
 		});
 
 		XKit.tools.init_css("show_originals");

--- a/Extensions/shuffle_queue.js
+++ b/Extensions/shuffle_queue.js
@@ -1,5 +1,5 @@
 //* TITLE Enhanced Queue **//
-//* VERSION 2.0.5 **//
+//* VERSION 2.0.6 **//
 //* DESCRIPTION Additions to the Queue page. **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS Go to your queue and click on the Shuffle button on the sidebar to shuffle the posts. Note that only the posts you see will be shuffled. If you have more than 15 posts on your queue, scroll down and load more posts in order to shuffle them too. Or click on Shrink Posts button to quickly rearrange them. **//
@@ -34,16 +34,16 @@ XKit.extensions.shuffle_queue = new Object({
 
 		var xf_html = '<ul class="controls_section" id="queue_plus_ul">' +
 					'<li class="section_header selected">Queue+</li>' +
-					'<li class="no_push" style="height: 36px;"><a href="#" onclick="return false;" id="xshufflequeue_button">' +
+					'<li class="no_push" style="height: 36px;"><a href="#" id="xshufflequeue_button">' +
 						'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Shuffle Queue <div class="count" style="padding-top: 8px;">&nbsp;</div> </div>' +
 					'</a></li>' +
-					'<li class="no_push" style="height: 36px;"><a class="" href="#" onclick="return false;" id="xdeletequeue_button">' +
+					'<li class="no_push" style="height: 36px;"><a class="" href="#" id="xdeletequeue_button">' +
 						'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Clear Queue</div>' +
 					'</a></li>' +
-					'<li class="no_push" style="height: 36px;"><a href="#" onclick="return false;" id="xshrinkposts_button">' +
+					'<li class="no_push" style="height: 36px;"><a href="#" id="xshrinkposts_button">' +
 						'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Shrink Posts <div class="count" style="padding-top: 8px;">off</div> </div>' +
 					'</a></li>' +
-					'<li class="no_push" style="height: 36px;"><a class="" href="#" onclick="return false;" id="xqueueoptions_button">' +
+					'<li class="no_push" style="height: 36px;"><a class="" href="#" id="xqueueoptions_button">' +
 						'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Queue Options <div class="count" style="padding-top: 8px;">on</div> </div>' +
 					'</a></li>' +
 				'</ul>';
@@ -54,6 +54,8 @@ XKit.extensions.shuffle_queue = new Object({
 
 			$("#xshufflequeue_button").click(function(event) {
 				XKit.extensions.shuffle_queue.shuffle();
+
+				return false;
 			});
 
 			$("#xqueueoptions_button").click(function() {
@@ -78,6 +80,7 @@ XKit.extensions.shuffle_queue = new Object({
 
 				}
 
+				return false;
 			});
 
 			$("#xshrinkposts_button").click(function() {
@@ -108,12 +111,15 @@ XKit.extensions.shuffle_queue = new Object({
 					//If the two of them were to be combined, strange things would happen.
 					XKit.window.show("Unable to turn on Shrink Posts", "Using the Shrink Posts option and Shorten Posts together creates a small mess that no one really wants to see. If you still want to use the Shrink Posts functionality of Enhanced Queue, disable the Shorten Posts extension first.", "error", "<div class=\"xkit-button default\" id=\"xkit-close-message\">OK</div>");
 				}
+
+				return false;
 			});
 
 			$("#xdeletequeue_button").click(function() {
 
 				XKit.extensions.shuffle_queue.clear();
 
+				return false;
 			});
 
 			var shrink_posts = XKit.storage.get("shuffle_queue", "shrink_posts", "false");

--- a/Extensions/stats.js
+++ b/Extensions/stats.js
@@ -1,5 +1,5 @@
 //* TITLE XStats **//
-//* VERSION 0.3.4 **//
+//* VERSION 0.3.3 **//
 //* DESCRIPTION The XKit Statistics Tool **//
 //* DETAILS This extension allows you to view statistics regarding your dashboard, such as the percentage of post types, top 4 posters, and more. In the future, it will allow you to view statistics regarding your and others blogs. **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/stats.js
+++ b/Extensions/stats.js
@@ -1,5 +1,5 @@
 //* TITLE XStats **//
-//* VERSION 0.3 REV C **//
+//* VERSION 0.3.4 **//
 //* DESCRIPTION The XKit Statistics Tool **//
 //* DETAILS This extension allows you to view statistics regarding your dashboard, such as the percentage of post types, top 4 posters, and more. In the future, it will allow you to view statistics regarding your and others blogs. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -30,10 +30,10 @@ XKit.extensions.stats = new Object({
 		if ($('#xstats_ul').length === 0) {
 			var xf_html = '<ul class="controls_section" id="xstats_ul">' +
 				'<li class="section_header selected">XSTATS</li>' +
-				'<li class="no_push" style="height: 36px;"><a href="#" onclick="return false;" id="xstats_dashboard_stats">' +
+				'<li class="no_push" style="height: 36px;"><a href="#" id="xstats_dashboard_stats">' +
 				'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Dashboard Stats</div>' +
 				'</a></li>' +
-				'<li class="no_push" id="xstats_blog_stats_parent" style="height: 36px;"><a href="#" onclick="return false;" style="display: none;" id="xstats_blog_stats">' +
+				'<li class="no_push" id="xstats_blog_stats_parent" style="height: 36px;"><a href="#" style="display: none;" id="xstats_blog_stats">' +
 				'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Blog Stats</div>' +
 				'</a></li>' +
 				'</ul>';
@@ -44,6 +44,7 @@ XKit.extensions.stats = new Object({
 
 			XKit.extensions.stats.dashboard();
 
+			return false;
 		});
 
 		if (XKit.interface.where().user_url === "") {
@@ -59,6 +60,7 @@ XKit.extensions.stats = new Object({
 
 			XKit.extensions.stats.blog(XKit.interface.where().user_url);
 
+			return false;
 		});
 
 	},

--- a/Extensions/tag_replacer.js
+++ b/Extensions/tag_replacer.js
@@ -1,5 +1,5 @@
 //* TITLE Tag Replacer **//
-//* VERSION 0.4.2 **//
+//* VERSION 0.4.3 **//
 //* DESCRIPTION Replace old tags! **//
 //* DETAILS Allows you to bulk replace tags of posts. Go to your Posts page on your dashboard and click on the button on the sidebar and enter the tag you want replaced, and the new tag, and Tag Replacer will take care of the rest. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -25,7 +25,7 @@ XKit.extensions.tag_replacer = new Object({
 		if ($("#tag_replacer.ul").length === 0) {
 			xf_html = '<ul class="controls_section" id="tag_replacer_ul">' +
 				'<li class="section_header selected">Tag Replacer</li>' +
-				'<li class="no_push" style="height: 36px;"><a data-url="' + XKit.interface.where().user_url + '" href="#" onclick="return false;" id="tag_replacer_button">' +
+				'<li class="no_push" style="height: 36px;"><a data-url="' + XKit.interface.where().user_url + '" href="#" id="tag_replacer_button">' +
 				'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Replace a tag<span class="sub_control link_arrow icon_right icon_arrow_carrot_right"></span></div>' +
 				'</a></li></ul>';
 			$("ul.controls_section:first").before(xf_html);
@@ -35,6 +35,8 @@ XKit.extensions.tag_replacer = new Object({
 			var m_url = $("#open_blog_link").attr('href').replace("http://","");
 			if (m_url.substring(m_url.length - 1) === "/") { m_url = m_url.substring(0,m_url.length - 1); }
 			XKit.extensions.tag_replacer.show(m_url);
+
+			return false;
 		});
 
 	},

--- a/Extensions/theme_editor.js
+++ b/Extensions/theme_editor.js
@@ -1,5 +1,5 @@
 //* TITLE Theme Editor **//
-//* VERSION 0.1.5 **//
+//* VERSION 0.1.6 **//
 //* DESCRIPTION For theme developers **//
 //* DETAILS If you are good with CSS, hop in and make your own theme.<br><br>When installed, this extension disables the standard Themes extension, and adds a button on your sidebar on your dashboard that lets you write and load your own theme. When you are done, you can submit it to xkit-dev.tumblr.com so it can be added to the theme gallery.<br><br>This extension is <b>not recommended</b> for people without CSS/HTML experience and only provided for XKit theme developers. Please disable Themes and Yoohoo! extensions before using. For better editing, Textarea Code Formatter for Chrome or Tabinta for Firefox is recommended. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -33,7 +33,7 @@ XKit.extensions.theme_editor = new Object({
 		}
 
 		xf_html = '<ul class="controls_section" id="xkit-theme-editor-ul">' +
-			'<li class="no_push"><a href="#" onclick="return false;" class="customize" id="xkit-theme-editor-button">' +
+			'<li class="no_push"><a href="#" class="customize" id="xkit-theme-editor-button">' +
 			'<div class="hide_overflow">Edit Theme</div>' +
 			'</a></li></ul>';
 		$("ul.controls_section:eq(1)").before(xf_html);
@@ -42,6 +42,7 @@ XKit.extensions.theme_editor = new Object({
 
 			XKit.extensions.theme_editor.open();
 
+			return false;
 		});
 
 		this.load_user_theme();

--- a/Extensions/view_my_tags.js
+++ b/Extensions/view_my_tags.js
@@ -1,5 +1,5 @@
 //* TITLE View My Tags **//
-//* VERSION 0.4.2 **//
+//* VERSION 0.4.3 **//
 //* DESCRIPTION Lets you view your recently used tags **//
 //* DEVELOPER STUDIOXENIX **//
 //* FRAME false **//
@@ -72,7 +72,7 @@ XKit.extensions.view_my_tags = new Object({
 
 		var xf_html = '<ul class="controls_section" id="view_my_tags_ul">' +
 					'<li class="section_header selected">VIEW MY TAGS</li>' +
-					'<li class="no_push" style="height: 36px;"><a href="#" onclick="return false;" id="view_my_tags_view">' +
+					'<li class="no_push" style="height: 36px;"><a href="#" id="view_my_tags_view">' +
 						'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">View recent tags</div>' +
 					'</a></li>' +
 				'</ul>';
@@ -81,7 +81,7 @@ XKit.extensions.view_my_tags = new Object({
 
 			if ($("#xstats_ul").length > 0) {
 
-				xf_html = '<li class="no_push"><a href="#" onclick="return false;" id="view_my_tags_view">' +
+				xf_html = '<li class="no_push"><a href="#" id="view_my_tags_view">' +
 							'<div class="hide_overflow">View recent tags</div>' +
 						'</a></li>';
 
@@ -93,7 +93,11 @@ XKit.extensions.view_my_tags = new Object({
 
 			}
 
-			$("#view_my_tags_view").click(function() { XKit.extensions.view_my_tags.show(); });
+			$("#view_my_tags_view").click(function() {
+				XKit.extensions.view_my_tags.show();
+
+				return false;
+			});
 
 		}
 

--- a/Extensions/view_on_dash.js
+++ b/Extensions/view_on_dash.js
@@ -1,5 +1,5 @@
 //* TITLE View On Dash **//
-//* VERSION 0.7.6 **//
+//* VERSION 0.7.7 **//
 //* DESCRIPTION View blogs on your dash **//
 //* DEVELOPER new-xkit **//
 //* DETAILS This is a preview version of an extension, missing most features due to legal/technical reasons for now. It lets you view the last 20 posts a person has made on their blogs right on your dashboard. If you have User Menus+ installed, you can also access it from their user menu under their avatar. **//
@@ -50,7 +50,7 @@ XKit.extensions.view_on_dash = new Object({
 
 			var xf_html = '<ul class="controls_section" id="view_on_dash_ul">' +
 				'<li class="section_header selected">VIEW BLOGS</li>' +
-				'<li class="no_push"><a href="#" onclick="return false;" id="view_on_dash_button">' +
+				'<li class="no_push"><a href="#" id="view_on_dash_button">' +
 					'<div class="hide_overflow">View on Dash<span class="sub_control link_arrow arrow_right"></span></div>' +
 				'</a></li></ul>';
 			$("ul.controls_section:eq(1)").before(xf_html);
@@ -59,6 +59,7 @@ XKit.extensions.view_on_dash = new Object({
 
 				XKit.extensions.view_on_dash.show_open();
 
+				return false;
 			});
 
 		}

--- a/Extensions/xinbox.js
+++ b/Extensions/xinbox.js
@@ -1,5 +1,5 @@
 //* TITLE XInbox **//
-//* VERSION 1.9.4 **//
+//* VERSION 1.9.5 **//
 //* DESCRIPTION Enhances your Inbox experience **//
 //* DEVELOPER new-xkit **//
 //* DETAILS XInbox allows you to tag posts before posting them, and see all your messages at once, and lets you delete multiple messages at once using the Mass Editor mode. To use this mode, go to your Inbox and click on the Mass Editor Mode button on your sidebar, click on the messages you want to delete then click the Delete Messages button.  **//
@@ -304,10 +304,11 @@ XKit.extensions.xinbox = new Object({
 		var x_html = "<div id=\"xinbox-search-box\"><input type=\"text\" placeholder=\"Enter URL/text...\" id=\"xinbox-search-box-input\"></div>";
 		$("#xinbox_sidebar").before(x_html);
 
-		$("#xinbox_search_button").bind("click", function() {
+		$("#xinbox_search_button").click(function() {
 
 			XKit.extensions.xinbox.inbox_search_start();
 
+			return false;
 		});
 
 		$("#xinbox-search-box-input").keyup(function() {
@@ -522,6 +523,7 @@ XKit.extensions.xinbox = new Object({
 
 			}
 
+			return false;
 		});
 
 	},

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 7.3.0 **//
+//* VERSION 7.3.1 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER new-xkit **//
 
@@ -31,12 +31,12 @@ XKit.extensions.xkit_preferences = new Object({
 		}
 
 		var m_html = '<div class="tab iconic' + holiday_class + '" id="new-xkit-control">' +
-			'<a style="width: 26px; margin-left: -6px; margin-right: -6px;" class="tab_anchor" href="#" onclick="return false">XKit Control Panel</a>' +
+			'<a style="width: 26px; margin-left: -6px; margin-right: -6px;" class="tab_anchor" href="#">XKit Control Panel</a>' +
 			'</div>';
 
 		// mobile stuff
 		var mobile_html = '<div class="tab iconic" id="new-xkit-control" style="position: relative; top: 50%; height: 26px; transform: translateY(-50%);">' +
-			'<a style="color:transparent;" class="tab_anchor" href="#" onclick="return false">XKit</a>' +
+			'<a style="color:transparent;" class="tab_anchor" href="#">XKit</a>' +
 			'</div>';
 
 		if (XKit.browser().mobile) {
@@ -101,6 +101,8 @@ XKit.extensions.xkit_preferences = new Object({
 			} else {
 				document.location.href = ("http://www.tumblr.com/help");
 			}
+
+			return false;
 		});
 
 		// Check and deliver initial messages.
@@ -2433,7 +2435,7 @@ XKit.extensions.xkit_preferences = new Object({
 				'</div>' +
 				'<div id="xkit-about-window-links">' +
 					'<a href="http://www.xkit.info/seven">XKit Website</a>' +
-					'<a href="#" onclick="return false" id="xkit-open-credits">Credits</a>' +
+					'<a href="#" id="xkit-open-credits">Credits</a>' +
 					'<a href="http://new-xkit-extension.tumblr.com">New XKit Blog</a>' +
 					'<a href="http://www.xkit.info/seven/donate">Donate to XKit</a>' +
 					'<a href="http://www.xkit.info/seven/spread">Spread XKit</a>' +
@@ -2456,6 +2458,7 @@ XKit.extensions.xkit_preferences = new Object({
 					'By using this software you are agreeing to <a href="http://www.xkit.info/eula">XKit EULA</a>.',
 				"info", '<div class="xkit-button default" id="xkit-close-message">OK</div>');
 
+				return false;
 		});
 
 	},


### PR DESCRIPTION
Not sure why, but the inline onclick handlers aren't preventing the following of fragment links in both Chrome and Firefox. Lucky jQuery's handlers still prevent it just fine.

I wasn't sure if I should do one big commit or what so I erred on the side of easily squashed.