### PR TITLE
Re-remove fancier activity line, update icons

### DIFF
--- a/Extensions/estufars_sidebar_fix.css
+++ b/Extensions/estufars_sidebar_fix.css
@@ -113,19 +113,19 @@
 }
 
 .right_column .popover_menu_item_anchor_icon.like-icon::before {
-    content: "";
+    content: "\EA4F";
 }
 
 .right_column .popover_menu_item_anchor_icon.following-icon::before {
-    content: "";
+    content: "\EA44";
 }
 
 .right_column .popover_menu_item_anchor_icon.settings-icon::before {
-    content: "";
+    content: "\EA9B";
 }
 
 .right_column .popover_menu_item_anchor_icon.help-icon::before {
-    content: "";
+    content: "\EA4B";
 }
 
 .right_column .tx-scroll {
@@ -138,26 +138,4 @@
 
 .right_column .popover_menu+#dashboard_controls_open_blog {
 	display: none;
-}
-
-/* activity line is grey, use blend modes to match blue of other menu items */
-
-.right_column .blog-sub-nav-item-data.sparkline {
-	mix-blend-mode: screen;
-	opacity: 0.6;
-}
-
-/* chrome will cause the chat menu to disappear when the blend mode is set for some reason
-   work around this by setting right column z-index which makes it appear again */
-
-.right_column {
-	z-index: 1;
-}
-
-/* z-index change will mess with the first section
-   (another chrome issue, will be fixed in chrome 50) */
-
-.right_column .popover_subsection:first-child .popover_header,
-.right_column .popover_subsection:first-child .popover_header>.popover_item_suffix {
-	position: static;
 }

--- a/Extensions/estufars_sidebar_fix.js
+++ b/Extensions/estufars_sidebar_fix.js
@@ -1,5 +1,5 @@
 //* TITLE Old Sidebar **//
-//* VERSION 1.1.5 **//
+//* VERSION 1.1.6 **//
 //* DESCRIPTION Get the sidebar back **//
 //* DEVELOPER estufar **//
 //* FRAME false **//


### PR DESCRIPTION
So it turns out that the way I had to get around Chrome issues to implement #978 just causes too many issues with the sidebar overlaying other popups (#1004, [this](http://estufarextensions.tumblr.com/post/142223826853/)), so I've removed it again. It was just a small cosmetic change anyway.

Also, I updated the icons used in the top section of the sidebar since for some reason it seems that Tumblr decided to change around where the icons are in their icon font.