### PR TITLE
Fix Go To Dash 'View' button

### DIFF
--- a/Extensions/go_to_dash.js
+++ b/Extensions/go_to_dash.js
@@ -1,5 +1,5 @@
 //* TITLE Go-To-Dash **//
-//* VERSION 1.2.0 **//
+//* VERSION 1.2.1 **//
 //* DESCRIPTION View a post on a blog on your dashboard. **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS This extension adds a 'view' button on peoples blogs that allows you to go back to that post on your dashboard. This feature only works on the blogs you follow. If the post was made before you followed them, you might not see them on your dashboard when you click the view button. **//
@@ -29,8 +29,10 @@ XKit.extensions.go_to_dash = new Object({
 		var post_id = XKit.iframe.single_post_id();
 		var next_post_id = parseInt(post_id) + 1;
 
-		var go_back_html = '<a href="/dashboard/2/' + next_post_id + '" class="tx-button btn" target="_top" '+
-			'id="xkit_gotodash" title="View on dashboard">View</a>';
+		// The CSS class 'embed-button' uses Tumblr's CSS to add padding
+		// to the button itself.
+		var go_back_html = '<a href="/dashboard/2/' + next_post_id + '" class="tx-button btn embed-button" target="_top" '+
+			'id="xkit_gotodash" title="View on dashboard"><span class="button-label">View</span></a>';
 
 		// Remove the text from the dashboard button because otherwise the iframe
 		// overflows

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 6.2.6 **//
+//* VERSION 6.2.7 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -505,7 +505,7 @@ XKit.tools.getParameterByName = function(name){
 						return this.nodeType === 3;
 					}).wrap('<span class="hidden">');
 
-				button.children(".icon-wrapper").addClass("xkit-hidden");
+				button.children(".button-label").hide();
 			},
 
 			/**


### PR DESCRIPTION
Fixed Go To Dash 'View' button previously messing up the iframe. Fixes #1014.

Used the old jQuery style of setting the Dashboard text as empty as I could not find documentation on how to use `XKit.iframe.hide_button();`