### PR TITLE
Made sorting pokemons caught possible in PC.

### DIFF
--- a/Extensions/pokes.css
+++ b/Extensions/pokes.css
@@ -12,7 +12,7 @@
 }
 .poke_background {
 	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASBAMAAACk4JNkAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjAuNvyMY98AAAAhUExURf///zAwMEhQUHh4gJhIOKCgwNhYONjI8PiQOPjQOPj4+CJu/FkAAAALdFJOUwC0tLS0tLS0tLS0/fXDXAAAAH1JREFUCNdjYGBgEBQUZAADwY6ODjCTEcjoaBMAsiRmgpiJQKHOVTOArDQBJJZEB1g2LRHIAutAYYmAWWlpjgxCHk1KQEaKIoOQkupStTQnJUUGRiOtVUpKSspA86pMlwIZpUDrxBcbl5eXB4JcEA5khAqAXRUaGgpzINilAJ/TLm7LlTr9AAAAAElFTkSuQmCC) no-repeat;
-    background-size: 100px 100px;
+	background-size: 100px 100px;
 	image-rendering: pixelated;
 }
 .poke img {
@@ -48,7 +48,7 @@
  * Menu of the Pokés extension
 */
 #xkit-pokes-custom-panel {
-	width: 100%
+	width: 100%;
 }
 #xkit-loading_pokemon {
 	text-align: center;
@@ -150,6 +150,102 @@
 	position: relative;
 	margin: 50px auto;
 }
+
+.xkit-pokes-pc-sorter{
+	position: absolute;
+	top: 10px;
+	right: 10px;
+	width: 150px;
+	height: 30px;
+}
+
+.xkit-pokes-sorter {
+	max-height: 0;
+	max-width: 0;
+	opacity: 0;
+	position: absolute;
+}
+
+.xkit-pokes-sorter#alphabetical + label {
+	background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAPUlEQVR42mNgGAVDBXAA8X8kTBPwnwB/aFnyn9ZBhs0nuqNxMigBzfPOoPAZ3Xz4f9SC4W/BgKWuUUA5AABtpyQS9kF4CAAAAABJRU5ErkJggg==");
+}
+
+.xkit-pokes-sorter#chronological + label {
+	background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAUklEQVR42mNgGAVDBfynAJNkCbmOG/UJSXrIinxcBlAUVPhch81QiizAZjAx4lTPOzQxnCY+IcYQqkY6Ph9QlHwJxQPFOf7/aNk1qHwyCgYOAAAYDoN9EGP8FQAAAABJRU5ErkJggg==");
+}
+
+.xkit-pokes-sorter#pokeid + label {
+	background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAP0lEQVR42mNgGAVDHfynhWH/0cT+U9MCdEw3nzAMG5/8p3a8jIx8Mhpsgy/14cpH/2mRYQfEJwxDziejYBgAAHZ7OMgtsFkIAAAAAElFTkSuQmCC");
+}
+
+.xkit-pokes-sorter + label{
+	display: inline-block;
+	width: 25px;
+	height: 25px;
+	border: 1px solid rgba(0, 0, 0, 0.1);
+	border-radius: 50%;
+	margin-left: 3px;
+	box-shadow: inset 0 0 12px rgba(255, 255, 255, 0.7);
+}
+
+.xkit-pokes-sorter:checked + label{
+	box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.5);
+}
+
+.xkit-pokes-sorter#reverse-toggle + label {
+	display: inline-block;
+	position: relative;
+	box-shadow: inset 0 0 0px 1px #d5d5d5;
+	width: 50px;
+	border-radius: 15px;
+}
+
+.xkit-pokes-sorter#reverse-toggle + label:before {
+	content: "+";
+	position: absolute;
+	display: inline-block;
+	height: 25px;
+	width: 25px;
+	top: 0px;
+	right: 0px;
+	transition: .25s ease-in-out;
+	text-align: center;
+	line-height: 20px;
+	font-size: 24px;
+	-moz-transition: .35s ease-in-out;
+	-webkit-transition: .35s ease-in-out;
+	transition: .35s ease-in-out;
+}
+
+.xkit-pokes-sorter#reverse-toggle + label:after {
+	content: "-";
+	position: absolute;
+	display: inline-block;
+	height: 100%;
+	width: 25px;
+	top: 0;
+	left: 0;
+	border-radius: 15px ;
+	background: white;
+	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, .2), 0 2px 4px rgba(0, 0, 0, .2);
+	-moz-transition: .35s ease-in-out;
+	-webkit-transition: .35s ease-in-out;
+	transition: .35s ease-in-out;
+	text-align: center;
+	line-height: 20px;
+	font-size: 24px;
+}
+
+.xkit-pokes-sorter#reverse-toggle:checked + label:after {
+	left: calc(100% - 25px);
+	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, .2), 0 2px 4px rgba(0, 0, 0, .2);
+}
+
+.xkit-pokes-sorter#reverse-toggle:checked + label:before {
+	right: calc(100% - 25px);
+	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, .2), 0 2px 4px rgba(0, 0, 0, .2);
+}
+
 .xkit-pokes-pc-pokemon {
 	height: 350px;
 	width:85%;

--- a/Extensions/pokes.js
+++ b/Extensions/pokes.js
@@ -214,14 +214,14 @@ XKit.extensions.pokes = {
 			'<div class="xkit-pokes-lightbox" style="opacity: 0">' +
 			'<div class="xkit-pokes-pc">' +
 					'<div class="xkit-pokes-pc-sorter">' +
-							'<input type="radio" name="xkit-pokes-sort" class="xkit-pokes-sorter" id="chronological"></input>'+
-							'<label for="chronological"></label>'+
-							'<input type="radio" name="xkit-pokes-sort" class="xkit-pokes-sorter" id="alphabetical"></input>'+
-							'<label for="alphabetical"></label>'+
-							'<input type="radio" name="xkit-pokes-sort" class="xkit-pokes-sorter" id="pokeid"></input>'+
-							'<label for="pokeid"></label>'+
-							'<input type="checkbox" class="xkit-pokes-sorter" id="reverse-toggle"></input>'+
-							'<label for="reverse-toggle"></label>'+
+              '<input type="radio" name="xkit-pokes-sort" class="xkit-pokes-sorter" id="chronological" title="Order of capture"></input>'+
+              '<label for="chronological"></label>'+
+              '<input type="radio" name="xkit-pokes-sort" class="xkit-pokes-sorter" id="alphabetical" title="Name"></input>'+
+              '<label for="alphabetical"></label>'+
+              '<input type="radio" name="xkit-pokes-sort" class="xkit-pokes-sorter" id="pokeid" title="Pokédex # ordering"></input>'+
+              '<label for="pokeid"></label>'+
+              '<input type="checkbox" class="xkit-pokes-sorter" id="reverse-toggle"></input>'+
+              '<label for="reverse-toggle"></label>'+
 					'</div>' +
 				'<div class="xkit-pokes-pc-info">' +
 					'<div class="gender"></div>' +

--- a/Extensions/pokes.js
+++ b/Extensions/pokes.js
@@ -1,5 +1,5 @@
 //* TITLE Pokés **//
-//* VERSION 0.8.0 **//
+//* VERSION 0.8.1 **//
 //* DESCRIPTION Gotta catch them all! **//
 //* DETAILS Randomly spawns Pokémon on your dash for you to collect. **//
 //* DEVELOPER new-xkit **//
@@ -169,7 +169,7 @@ XKit.extensions.pokes = {
 	},
 
 	pokeGen: function() {
-		return Math.floor(Math.random() * 889);
+		return Math.floor(Math.random() * 889); // TODO: Use a no-hardcoding-required method instead
 	},
 
 	destroy: function() {
@@ -213,6 +213,16 @@ XKit.extensions.pokes = {
 		var m_html =
 			'<div class="xkit-pokes-lightbox" style="opacity: 0">' +
 			'<div class="xkit-pokes-pc">' +
+					'<div class="xkit-pokes-pc-sorter">' +
+							'<input type="radio" name="xkit-pokes-sort" class="xkit-pokes-sorter" id="chronological"></input>'+
+							'<label for="chronological"></label>'+
+							'<input type="radio" name="xkit-pokes-sort" class="xkit-pokes-sorter" id="alphabetical"></input>'+
+							'<label for="alphabetical"></label>'+
+							'<input type="radio" name="xkit-pokes-sort" class="xkit-pokes-sorter" id="pokeid"></input>'+
+							'<label for="pokeid"></label>'+
+							'<input type="checkbox" class="xkit-pokes-sorter" id="reverse-toggle"></input>'+
+							'<label for="reverse-toggle"></label>'+
+					'</div>' +
 				'<div class="xkit-pokes-pc-info">' +
 					'<div class="gender"></div>' +
 					'<div class="nickname"></div>' +
@@ -240,6 +250,30 @@ XKit.extensions.pokes = {
 				}
 			});
 		});
+
+		var sortFunction = function(dataAttr, optData) {
+				var up = $('input.xkit-pokes-sorter#reverse-toggle').is(":checked") ? -1 : 1
+				return function(a, b) {
+						return ($(b).data(dataAttr) || $(b).data(optData)) < ($(a).data(dataAttr) || $(a).data(optData)) ? up : -up;
+				}
+		}
+
+		$('input:radio[name="xkit-pokes-sort"]#pokeid').change(function(e){
+						$("#xkit-loading_pokemon div.caught").sort(sortFunction("pokeid", "pokeid"))
+									.prependTo("#xkit-loading_pokemon");
+		});
+				$('input:radio[name="xkit-pokes-sort"]#alphabetical').change(function(e){
+				$("#xkit-loading_pokemon div.caught").sort(sortFunction("pokenick", "pokespecies"))
+									.prependTo("#xkit-loading_pokemon");
+		});
+		$('input:radio[name="xkit-pokes-sort"]#chronological').change(function(e){
+				$("#xkit-loading_pokemon div.caught").sort(sortFunction('array_index', 'array_index'))
+									.prependTo("#xkit-loading_pokemon");
+		});
+		$('.xkit-pokes-sorter#reverse-toggle').change(function(e){
+				 $("#xkit-loading_pokemon div.caught").sort(function(e) {return 1;}).prependTo("#xkit-loading_pokemon");
+		});
+
 		$(".xkit-pokes-lightbox").animate({
 			opacity: 1
 		});
@@ -302,7 +336,7 @@ XKit.extensions.pokes = {
 				if (value.shiny) {
 					sprite = mdata[value.id].sprite_shiny || mdata[value.id].sprite;
 				}
-				m_html = m_html + "<div class='caught" + (value.shiny ? " pokes_shiny" : "") + "' data-pokegender='" + value.gender + "' data-pokespecies='" + mdata[value.id].name + "' data-pokenick='" + (value.nickname || "") + "' data-array_index=" + index + "><img class='caught poke_sprite' src='" + sprite + "'></div>";
+				m_html = m_html + "<div class='caught" + (value.shiny ? " pokes_shiny" : "") + "' data-pokeid='" + value.id + "' data-pokegender='" + value.gender + "' data-pokespecies='" + mdata[value.id].name + "' data-pokenick='" + (value.nickname || "") + "' data-array_index=" + index + "><img class='caught poke_sprite' src='" + sprite + "' /></div>";
 				if (checklist.indexOf(value.id) === -1) checklist.push(value.id);
 			});
 			header += checklist.length + " out of " + mdata.length + " different species of Pokémon!</p>";

--- a/Extensions/pokes.js
+++ b/Extensions/pokes.js
@@ -1,5 +1,5 @@
 //* TITLE Pokés **//
-//* VERSION 0.8.1 **//
+//* VERSION 0.9.0 **//
 //* DESCRIPTION Gotta catch them all! **//
 //* DETAILS Randomly spawns Pokémon on your dash for you to collect. **//
 //* DEVELOPER new-xkit **//
@@ -169,7 +169,7 @@ XKit.extensions.pokes = {
 	},
 
 	pokeGen: function() {
-		return Math.floor(Math.random() * 889); // TODO: Use a no-hardcoding-required method instead
+		return Math.floor(Math.random() * 889);
 	},
 
 	destroy: function() {

--- a/Extensions/pokes.js
+++ b/Extensions/pokes.js
@@ -252,11 +252,11 @@ XKit.extensions.pokes = {
 		});
 
 		var sortFunction = function(dataAttr, optData) {
-				var up = $('input.xkit-pokes-sorter#reverse-toggle').is(":checked") ? -1 : 1
-				return function(a, b) {
-						return ($(b).data(dataAttr) || $(b).data(optData)) < ($(a).data(dataAttr) || $(a).data(optData)) ? up : -up;
-				}
-		}
+			var up = ($('input.xkit-pokes-sorter#reverse-toggle').is(":checked") ? -1 : 1);
+			return function(a, b) {
+				return ($(b).data(dataAttr) || $(b).data(optData)) < ($(a).data(dataAttr) || $(a).data(optData)) ? up : -up;
+			};
+		};
 
 		$('input:radio[name="xkit-pokes-sort"]#pokeid').change(function(e){
 						$("#xkit-loading_pokemon div.caught").sort(sortFunction("pokeid", "pokeid"))

--- a/Extensions/pokes.js
+++ b/Extensions/pokes.js
@@ -214,7 +214,7 @@ XKit.extensions.pokes = {
 			'<div class="xkit-pokes-lightbox" style="opacity: 0">' +
 			'<div class="xkit-pokes-pc">' +
 					'<div class="xkit-pokes-pc-sorter">' +
-              '<input type="radio" name="xkit-pokes-sort" class="xkit-pokes-sorter" id="chronological" title="Order of capture"></input>'+
+              '<input type="radio" name="xkit-pokes-sort" class="xkit-pokes-sorter" id="chronological" title="Order of capture" checked="checked"></input>'+
               '<label for="chronological"></label>'+
               '<input type="radio" name="xkit-pokes-sort" class="xkit-pokes-sorter" id="alphabetical" title="Name"></input>'+
               '<label for="alphabetical"></label>'+


### PR DESCRIPTION
Gave it a try after seeing Issue #842.

Made it possible to sort by:
- Order of capture
- Alphabetical (Nickname or should it be lacking: kind)
- Pokemon #id

Also put a toggle to switch between regular and inverse order.