### PR TITLE
Hermes fixing

### DIFF
--- a/Extensions/lethe.js
+++ b/Extensions/lethe.js
@@ -1,5 +1,5 @@
 //* TITLE Hermes **//
-//* VERSION 1.2.0 **//
+//* VERSION 1.2.1 **//
 //* DESCRIPTION Helps speed up your Tumblr experience **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//

--- a/Extensions/lethe.js
+++ b/Extensions/lethe.js
@@ -113,7 +113,7 @@ Lethe.prototype.showPost = function(hiddenPost) {
   this.hiddenPosts = this.hiddenPosts.filter(function(post) {
     return post !== hiddenPost;
   });
-  hiddenPost.parent.innerHTML = hiddenPost.html;
+  $(hiddenPost.parent).children('.post_media_hidden').replaceWith(hiddenPost.html);
 };
 
 


### PR DESCRIPTION
Should fix #1039 (hopefully).

Problem was caused by `hiddenPost.parent.innerHtml = hiddenPost.html;` because the parent contains both the content and the reblogs (as first-level children).
So I replaced the line by a selection of the `.post_media_hidden` then `.replacedWith` the original content.