### PR TITLE
Stopping quick tags from nuking videos.

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 6.2.7 **//
+//* VERSION 6.2.8 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -1334,7 +1334,7 @@ XKit.tools.getParameterByName = function(name){
 
 				m_object['post[type]'] = tumblr_object.post.type;
 
-				if (tumblr_object.post.type === "regular") {
+				if (typeof tumblr_object.post.one !== "undefined") {
 					m_object['post[one]'] = tumblr_object.post.one;
 				}
 


### PR DESCRIPTION
Fix for issue #1007.

The YouTube URL is stored in the post[one] attribute of the post_model but it wasn't sent through when editing cause post[one] was only sent through for "regular" posts - therefore essentially removing it from the post, "nuking" it.
I admit not really understanding the raison d'être of that post[one] attribute and why things have been done that way, but making it so xkit_patches#edit sends it through when editing a video post seems to have fixed the issue and doesn't seem to have caused any other.

If someone more enlightened on the inner workings of Xkit could review and make sure I'm not hot-glu'ing things that shouldn't be, that'd be A+. 

Also, you'll excuse these dumb commits, a small SublimeText config problem.
