### PR TITLE
Making AlreadyReblogged add a checkmark to reblog icon.

### DIFF
--- a/Extensions/one_click_postage.css
+++ b/Extensions/one_click_postage.css
@@ -1,14 +1,14 @@
-.xkit-checkmark {
-	font-family: arial;
-	position: absolute;
-	right: 0;
-	bottom: 0;
-	color: #56bc8a;
-	background: white;
-	width: 10px;
-	height: 10px;
-	font-size: 15px;
-	line-height: 10px;
+.post_controls .post_control.reblog.reblogged:after {
+    content: '✓';
+    font-size: 18px;
+    color: #56bc8a;
+    opacity: 100;
+    display: block;
+    margin-top: 0px;
+    margin-left: 0px;
+    background: white;
+    height: 10px;
+    line-height: 10px;
 }
 
 #x1cpostage_quick_tags {

--- a/Extensions/one_click_postage.css
+++ b/Extensions/one_click_postage.css
@@ -1,3 +1,16 @@
+.xkit-checkmark {
+	font-family: arial;
+	position: absolute;
+	right: 0;
+	bottom: 0;
+	color: #56bc8a;
+	background: white;
+	width: 10px;
+	height: 10px;
+	font-size: 15px;
+	line-height: 10px;
+}
+
 #x1cpostage_quick_tags {
 	max-height: 70px;
 	overflow-y: auto;

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.2.0 **//
+//* VERSION 4.3.0 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.3.0 **//
+//* VERSION 4.2.0 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -959,13 +959,13 @@ XKit.extensions.one_click_postage = new Object({
 	},
 
 	make_button_reblogged: function(m_button) {
-        m_button.addClass("reblogged");
-        if (XKit.extensions.one_click_postage.preferences.alreadyreblogged_use_checkmark.value) {
-            var checkmark = document.createElement("div");
-    		checkmark.innerHTML = "&#10003;";
-    		checkmark.setAttribute("class", "xkit-checkmark");
-    		m_button.prepend(checkmark);
-        }
+    m_button.addClass("reblogged");
+    if (XKit.extensions.one_click_postage.preferences.alreadyreblogged_use_checkmark.value) {
+			var checkmark = document.createElement("div");
+			checkmark.innerHTML = "&#10003;";
+			checkmark.setAttribute("class", "xkit-checkmark");
+			m_button.prepend(checkmark);
+	  }
 	},
 
 	destroy: function() {

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.2.0 **//
+//* VERSION 4.3.0 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -49,6 +49,11 @@ XKit.extensions.one_click_postage = new Object({
 		},
 		"enable_alreadyreblogged": {
 			text: "Enable AlreadyReblogged for posts I reblog, queue or draft",
+			default: false,
+			value: false
+		},
+		"alreadyreblogged_use_checkmark": {
+			text: "Add a checkmark over the reblog sign of already reblogged posts",
 			default: false,
 			value: false
 		},
@@ -945,12 +950,22 @@ XKit.extensions.one_click_postage = new Object({
 					if (XKit.interface.where().dashboard === true) { $(this).remove(); }
 				}
 
-				$(this).find(".post_control.reblog").addClass("reblogged");
+				XKit.extensions.one_click_postage.make_button_reblogged($(this).find(".post_control.reblog"));
 
 			}
 
 		});
 
+	},
+
+	make_button_reblogged: function(m_button) {
+        m_button.addClass("reblogged");
+        if (XKit.extensions.one_click_postage.preferences.alreadyreblogged_use_checkmark.value) {
+            var checkmark = document.createElement("div");
+    		checkmark.innerHTML = "&#10003;";
+    		checkmark.setAttribute("class", "xkit-checkmark");
+    		m_button.prepend(checkmark);
+        }
 	},
 
 	destroy: function() {
@@ -1538,7 +1553,7 @@ XKit.extensions.one_click_postage = new Object({
 							}
 							if (XKit.extensions.one_click_postage.preferences.enable_alreadyreblogged.value || XKit.extensions.one_click_postage.preferences.dim_posts_after_reblog.value) {
 								if (quick_queue_mode !== true) {
-									$(m_button).addClass("reblogged");
+									XKit.extensions.one_click_postage.make_button_reblogged(m_button);
 								} else {
 									XKit.interface.switch_control_button($(m_button), false);
 									XKit.interface.completed_control_button($(m_button), true);

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -52,11 +52,6 @@ XKit.extensions.one_click_postage = new Object({
 			default: false,
 			value: false
 		},
-		"alreadyreblogged_use_checkmark": {
-			text: "Add a checkmark over the reblog sign of already reblogged posts",
-			default: false,
-			value: false
-		},
 		"already_reblogged_limit": {
 			text: "Remember the last <i>X</i> posts reblogged",
 			default: "a3000",
@@ -960,12 +955,6 @@ XKit.extensions.one_click_postage = new Object({
 
 	make_button_reblogged: function(m_button) {
     m_button.addClass("reblogged");
-    if (XKit.extensions.one_click_postage.preferences.alreadyreblogged_use_checkmark.value) {
-			var checkmark = document.createElement("div");
-			checkmark.innerHTML = "&#10003;";
-			checkmark.setAttribute("class", "xkit-checkmark");
-			m_button.prepend(checkmark);
-	  }
 	},
 
 	destroy: function() {


### PR DESCRIPTION
Following-up on #980 accessibility issue.

Made it possible to check the appropriate setting in One-Click Postage config to make AlreadyReblogged add a checkmark instead of just coloring the reblog button green.