### PR TITLE
Blacklist preserve href with comments

### DIFF
--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1,5 +1,5 @@
 //* TITLE Blacklist **//
-//* VERSION 2.7.8 **//
+//* VERSION 2.8.0 **//
 //* DESCRIPTION Clean your dash **//
 //* DETAILS This extension allows you to block posts based on the words you specify. If a post has the text you've written in the post itself or it's tags, it will be replaced by a warning, or won't be shown on your dashboard, depending on your settings. **//
 //* DEVELOPER new-xkit **//
@@ -551,9 +551,9 @@ XKit.extensions.blacklist = new Object({
 
 				m_content = XKit.tools.replace_all(m_content, "&nbsp;", " ");
 				m_content = m_content.toLowerCase();
-				
+
 			    // Preserve href links.
-			    m_content = m_content.replace(/<a\s+(?:[^>]*?\s+)?href="([^"]*)".*?>/gm, "$1" + ' ');
+			    m_content = m_content.replace(/<a\s+(?:[^>]*?\s+)?href="([^"]*)".*?>/gm, ' $1 ');
 				// Strip HTML tags.
 				m_content = m_content.replace(/<(?:.|\n)*?>/gm, ' ');
 

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -551,7 +551,9 @@ XKit.extensions.blacklist = new Object({
 
 				m_content = XKit.tools.replace_all(m_content, "&nbsp;", " ");
 				m_content = m_content.toLowerCase();
-
+				
+			    // Preserve href links.
+			    m_content = m_content.replace(/<a\s+(?:[^>]*?\s+)?href="([^"]*)".*?>/gm, "$1" + ' ');
 				// Strip HTML tags.
 				m_content = m_content.replace(/<(?:.|\n)*?>/gm, ' ');
 


### PR DESCRIPTION
Based on @PalanteJon's great work in #745, this just adds my review comments. It should be re-reviewed by someone else for sanity's sake. Many users have requested this feature because the only constant with spam posts is that they use Google's link shortener.