### PR TITLE
Fix CSS for One-Click Postage reblog tick

### DIFF
--- a/Extensions/one_click_postage.css
+++ b/Extensions/one_click_postage.css
@@ -11,6 +11,15 @@
     line-height: 10px;
 }
 
+.theme_posts_experiment .post, .post:not(.new_post_buttons) * {
+	background-color: inherit;
+}
+
+.themed_posts_experiment .post_wrapper .post_footer .post_controls .post_control.reblog.reblogged:after {
+	color: inherit;
+	background: inherit;
+}
+
 #x1cpostage_quick_tags {
 	max-height: 70px;
 	overflow-y: auto;

--- a/Extensions/one_click_postage.css
+++ b/Extensions/one_click_postage.css
@@ -11,11 +11,15 @@
     line-height: 10px;
 }
 
-.theme_posts_experiment .post, .post:not(.new_post_buttons) * {
+.post.themed_posts_experiment .post_wrapper,
+.post.themed_posts_experiment.post_full .post_footer,
+.post.themed_posts_experiment .post_controls,
+.post.themed_posts_experiment .post_controls_inner,
+.post.themed_posts_experiment .reblogged {
 	background-color: inherit;
 }
 
-.themed_posts_experiment .post_wrapper .post_footer .post_controls .post_control.reblog.reblogged:after {
+.themed_posts_experiment .post_controls .post_control.reblog.reblogged:after {
 	color: inherit;
 	background: inherit;
 }

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.3.1 **//
+//* VERSION 4.3.2 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//


### PR DESCRIPTION
With Tumblr Labs - Themed Posts enabled, the reblog tick for One-Click Postage shows an ugly white background. This PR fixes it for those users with Themed Posts enabled.

Issue:
![ocr_problem-themed](https://cloud.githubusercontent.com/assets/234819/15805354/194cb69e-2b5a-11e6-9df6-f9795a6261bf.png)

Fixed - Themed Posts enabled:
![ocr_fixed-themed](https://cloud.githubusercontent.com/assets/234819/15805353/161ac4a2-2b5a-11e6-9419-b56ff73c7c6c.png)

Original - Themed Posts disabled:
![ocr_fixed-no-theme](https://cloud.githubusercontent.com/assets/234819/15805351/0fd2a5ce-2b5a-11e6-9b71-f1afdec5f877.png)
