### PR TITLE
Fix rename Icon in PC

### DIFF
--- a/Extensions/pokes.css
+++ b/Extensions/pokes.css
@@ -147,7 +147,7 @@
 	font-size: 28px;
 }
 .nickname::before {
-	content: "\EA25";
+	content: "\EA27";
 	font-family: "tumblr-icons";
 	float: left;
 }

--- a/Extensions/pokes.js
+++ b/Extensions/pokes.js
@@ -1,5 +1,5 @@
 //* TITLE Pokés **//
-//* VERSION 0.10.0 **//
+//* VERSION 0.10.1 **//
 //* DESCRIPTION Gotta catch them all! **//
 //* DETAILS Randomly spawns Pokémon on your dash for you to collect. **//
 //* DEVELOPER new-xkit **//


### PR DESCRIPTION
For some reason, Tumblr decided to change the Pen Symbol (Edit Icon)
from uEA25 to uEA27. This broke the edit icon in the Pokemon list and
showed (at least on chrome) a broken page icon. This PR fixes that


Damn, I did this change ages ago and I completely forgot to push it to
to upstream. I am very embarrased now.