### PR TITLE
Add old sidebar width tweak

### DIFF
--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Tweaks **//
-//* VERSION 5.2.2 **//
+//* VERSION 5.3.0 **//
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -97,6 +97,11 @@ XKit.extensions.tweaks = new Object({
 		"sep1": {
 			text: "User Interface tweaks",
 			type: "separator",
+		},
+		"old_sidebar_width": {
+			text: "Return the sidebar to its original width",
+			default: false,
+			value: false
 		},
 		"old_photo_margins": {
 			text: "Use the old 500/245/160px photo dimensions on posts",
@@ -292,6 +297,12 @@ XKit.extensions.tweaks = new Object({
 
 	run: function() {
 		this.running = true;
+        
+		if (XKit.extensions.tweaks.preferences.old_sidebar_width.value) {
+			XKit.tools.add_css(".right_column{width: 250px !important;} .left_column{padding-left:75px;}" +
+			".toastr .toast-kit{width: 250px !important;} #sidebar_footer_nav{margin-left: -420px !important;}", 
+			"tweaks_old_sidebar_width");
+		}
 
 		if (XKit.extensions.tweaks.preferences.old_photo_margins.value) {
 			XKit.post_listener.add("tweaks_old_photo_margins", XKit.extensions.tweaks.old_photo_margins);
@@ -865,6 +876,7 @@ XKit.extensions.tweaks = new Object({
 
 		this.running = false;
 		XKit.tools.remove_css("xkit_tweaks");
+		XKit.tools.remove_css("tweaks_old_sidebar_width");
 		XKit.tools.remove_css("tweaks_old_photo_margins");
 		XKit.tools.remove_css("tweaks_no_mobile_banner");
 		XKit.tools.remove_css("xkit_tweaks_larger_small_text_on_reblogs");


### PR DESCRIPTION
This has to be the fastest any one of us ever pumped out a tweak.

This patch reverts the Tumblr dashboard layout to its old values, or at least a close approximation.