### PR TITLE
Block new Tumblr ads

### DIFF
--- a/Extensions/anti_capitalism.js
+++ b/Extensions/anti_capitalism.js
@@ -1,5 +1,5 @@
 //* TITLE Anti-Capitalism **//
-//* VERSION 1.2.4 **//
+//* VERSION 1.2.5 **//
 //* DESCRIPTION	Removes sponsored posts, vendor buttons, and other nonsense that wants your money. **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -48,7 +48,8 @@ XKit.extensions.anti_capitalism = new Object({
 		}
 
 	    if (XKit.extensions.anti_capitalism.preferences.sponsored_ads.value) {
-	        XKit.tools.add_css(" .remnant-unit-container, .yamplus-unit-container, .yam-plus-ad-container, .yam-plus-header, .video-ad-container, .video-ad, .standalone-ad-container {display: none;}", "anti_capitalism_sponsored_ads");
+	        XKit.tools.add_css(" .remnant-unit-container, .yamplus-unit-container, .yam-plus-ad-container, .yam-plus-header, .video-ad-container, .video-ad, .standalone-ad-container," +
+				"#sidebar-ad .controls_section, #sidebar-ad .sidebar-ad-content {display: none;}", "anti_capitalism_sponsored_ads");
 	    }
 
 		if (XKit.extensions.anti_capitalism.preferences.asktime.value) {


### PR DESCRIPTION
Tumblr added new ads to the sidebar that haven't been blocked. Now they are.
The reason I'm dancing around specific subclasses of `#sidebar-ad` is because, for some reason, the small links (Mass Post Editor and Blog Settings) ended up in there, and I didn't really want to remove those.