### PR TITLE
Get Old Sidebar working again

### DIFF
--- a/Extensions/estufars_sidebar_fix.css
+++ b/Extensions/estufars_sidebar_fix.css
@@ -7,7 +7,7 @@
 }
 
 .right_column .popover_menu {
-	width: 229px!important;
+	width: auto!important;
 	box-shadow: none!important;
 	background: transparent!important;
 	z-index: 0;
@@ -101,6 +101,10 @@
 
 .right_column .popover_menu_item_anchor, .right_column .blog-sub-nav-item-label {
 	font-weight: bold;
+}
+
+.right_column .tx-scrollbar-track {
+	display: none;
 }
 
 /* icon styles are from tumblr, they weren't getting applied when the menu is relocated */

--- a/Extensions/estufars_sidebar_fix.js
+++ b/Extensions/estufars_sidebar_fix.js
@@ -1,5 +1,5 @@
 //* TITLE Old Sidebar **//
-//* VERSION 1.1.7 **//
+//* VERSION 1.2.0 **//
 //* DESCRIPTION Get the sidebar back **//
 //* DEVELOPER estufar **//
 //* FRAME false **//
@@ -54,20 +54,35 @@ XKit.extensions.estufars_sidebar_fix = new Object({
 		
 		XKit.tools.init_css("estufars_sidebar_fix");
 		
-		var account = document.getElementById("account_button");
-		account.click();
-		// wait for the menu to pop up
-		window.setTimeout(function() {
-			var popover = document.getElementsByClassName("popover--account-popover")[0];
+		function movesidebar() {
+			var popover = $(".popover--account-popover")[0];
 			var sidebar = document.getElementById("right_column");
 			popover.childNodes[0].classList.add("estufars_sidebar_fix");
 			sidebar.insertBefore(popover.childNodes[0], sidebar.firstChild);
+			var account = document.getElementById("account_button");
 			account.style.display = "none";
 			// wait and then let tumblr know the menu is no longer active
 			window.setTimeout(function() {
 				document.querySelector(".tab_nav_account.active").click();
-			}, 500);
-		}, 250);
+			}, 250);
+		}
+		
+		if(!$(".popover--account-popover").length) {
+			var observer = new MutationObserver(function(mutations) {
+				mutations.forEach(function(mutation) {
+					var popover = $(".popover--account-popover")[0];
+					if (mutation.addedNodes[0] == popover) {
+						observer.disconnect();
+						movesidebar();
+					}
+				});
+			});
+			observer.observe(document.body, {childList: true});
+			var account = document.getElementById("account_button");
+			account.click();
+		} else {
+			movesidebar();
+		}
 	},
 	
 	destroy: function() {
@@ -77,7 +92,7 @@ XKit.extensions.estufars_sidebar_fix = new Object({
 		var account = document.getElementById("account_button");
 		var sidebar = document.getElementsByClassName("estufars_sidebar_fix")[0];
 		account.style.display = "inline-block";
-		var popover = document.getElementsByClassName("popover--account-popover")[0];
+		var popover = $(".popover--account-popover")[0];
 		popover.insertBefore(sidebar, popover.firstChild);
 		account.click();
 		popover.style.opacity = "0";
@@ -87,5 +102,4 @@ XKit.extensions.estufars_sidebar_fix = new Object({
 			popover.style.opacity = "1";
 		}, 500);
 	}
-	
 });

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Tweaks **//
-//* VERSION 5.2.2 **//
+//* VERSION 5.3.0 **//
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -97,6 +97,11 @@ XKit.extensions.tweaks = new Object({
 		"sep1": {
 			text: "User Interface tweaks",
 			type: "separator",
+		},
+		"old_sidebar_width": {
+			text: "Return the sidebar to its original width",
+			default: false,
+			value: false
 		},
 		"old_photo_margins": {
 			text: "Use the old 500/245/160px photo dimensions on posts",
@@ -292,6 +297,12 @@ XKit.extensions.tweaks = new Object({
 
 	run: function() {
 		this.running = true;
+        
+		if (XKit.extensions.tweaks.preferences.old_sidebar_width.value) {
+			XKit.tools.add_css(".right_column{width: 250px !important;} .left_column{padding-left:75px;}" +
+			".toastr .toast-kit{width: 250px !important;} #sidebar_footer_nav{margin-left: -420px !important;}", 
+			"tweaks_old_sidebar_width");
+		}
 
 		if (XKit.extensions.tweaks.preferences.old_photo_margins.value) {
 			XKit.post_listener.add("tweaks_old_photo_margins", XKit.extensions.tweaks.old_photo_margins);
@@ -865,6 +876,7 @@ XKit.extensions.tweaks = new Object({
 
 		this.running = false;
 		XKit.tools.remove_css("xkit_tweaks");
+		XKit.tools.remove_css("tweaks_old_sidebar_width");
 		XKit.tools.remove_css("tweaks_old_photo_margins");
 		XKit.tools.remove_css("tweaks_no_mobile_banner");
 		XKit.tools.remove_css("xkit_tweaks_larger_small_text_on_reblogs");


### PR DESCRIPTION
Tumblr changing the width of the sidebar reminded me I really needed to get to fixing this, so I did that. This will end up fixing #1034 (finally)

It won't be compatible with the current version of the sidebar width tweak though. This changes the widths of the sidebar and container to the older widths (I think they're accurate at least), whereas the tweak adjusts the padding, which didn't quite work with this. If we do want to change the tweaks version to use the same styles to adjust the width, I think it'll work with the standard sidebar too.
