### PR TITLE
Fix hiding of Post IM Share button

### DIFF
--- a/Extensions/messaging_tweaks.js
+++ b/Extensions/messaging_tweaks.js
@@ -36,7 +36,7 @@ XKit.extensions.messaging_tweaks = new Object({
 			value: false
 		},
 		"hide_send_post": {
-			text: "Hide the send post paper plane on posts",
+			text: "Hide the send post through IM in the post share menu",
 			default: false,
 			value: false
 		},
@@ -364,7 +364,7 @@ XKit.extensions.messaging_tweaks = new Object({
 			XKit.tools.add_css(".conversation-message-text .message-bubble-header a {display:none;}", "messaging_tweaks");
 		}
 		if (XKit.extensions.messaging_tweaks.preferences.hide_send_post.value) {
-			XKit.tools.add_css(".post_control.share {display:none;}", "messaging_tweaks");
+			XKit.tools.add_css(".messaging-share-post-search, .messaging-share-post-main {display:none;}", "messaging_tweaks");
 		}
 		if (XKit.extensions.messaging_tweaks.preferences.make_icons_round.value) {
 			XKit.tools.add_css(".avatar > img { border-radius: 30px !important; transition: border-radius 0.5s; }", "messaging_tweaks");

--- a/Extensions/messaging_tweaks.js
+++ b/Extensions/messaging_tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Messaging Tweaks **//
-//* VERSION 1.7.0 **//
+//* VERSION 1.7.1 **//
 //* DESCRIPTION Helpful tweaks for Tumblr IM **//
 //* DETAILS This adds a few helpful tweaks to the Tumblr IM, for example minimising the chat, hiding the IM icon or changing the looks of the chat window. **//
 //* DEVELOPER New-XKit **//
@@ -364,7 +364,7 @@ XKit.extensions.messaging_tweaks = new Object({
 			XKit.tools.add_css(".conversation-message-text .message-bubble-header a {display:none;}", "messaging_tweaks");
 		}
 		if (XKit.extensions.messaging_tweaks.preferences.hide_send_post.value) {
-			XKit.tools.add_css(".post_control.messaging {display:none;}", "messaging_tweaks");
+			XKit.tools.add_css(".post_control.share {display:none;}", "messaging_tweaks");
 		}
 		if (XKit.extensions.messaging_tweaks.preferences.make_icons_round.value) {
 			XKit.tools.add_css(".avatar > img { border-radius: 30px !important; transition: border-radius 0.5s; }", "messaging_tweaks");

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Tweaks **//
-//* VERSION 5.3.1 **//
+//* VERSION 5.3.2 **//
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -494,7 +494,7 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_share.value) {
-			XKit.extensions.tweaks.add_css(".post .post_controls .share_social_button { display: none; } ", "xkit_tweaks_hide_share");
+			XKit.tools.add_css(".post_control.share { display: none; } ", "xkit_tweaks_hide_share");
 			XKit.post_listener.add("tweaks_check_for_share_on_private_posts", XKit.extensions.tweaks.check_for_share_on_private_posts);
 			XKit.extensions.tweaks.check_for_share_on_private_posts();
 		}
@@ -880,6 +880,7 @@ XKit.extensions.tweaks = new Object({
 		XKit.tools.remove_css("tweaks_old_photo_margins");
 		XKit.tools.remove_css("tweaks_no_mobile_banner");
 		XKit.tools.remove_css("xkit_tweaks_larger_small_text_on_reblogs");
+		XKit.tools.remove_css("xkit_tweaks_hide_share");
 		XKit.post_listener.remove("tweaks_check_for_share_on_private_posts");
 		XKit.post_listener.remove("tweaks_fix_hidden_post_height");
 		XKit.post_listener.remove("tweaks_dont_show_liked");

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -495,8 +495,6 @@ XKit.extensions.tweaks = new Object({
 
 		if (XKit.extensions.tweaks.preferences.hide_share.value) {
 			XKit.tools.add_css(".post_control.share { display: none; } ", "xkit_tweaks_hide_share");
-			XKit.post_listener.add("tweaks_check_for_share_on_private_posts", XKit.extensions.tweaks.check_for_share_on_private_posts);
-			XKit.extensions.tweaks.check_for_share_on_private_posts();
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_explore.value) {
@@ -797,23 +795,6 @@ XKit.extensions.tweaks = new Object({
 
 	},
 
-	check_for_share_on_private_posts: function() {
-
-		if (!XKit.browser().mobile) { // mobile stuff
-			$(".post.is_mine").not(".xtweaks-checked-share").each(function() {
-
-				if ($(this).find(".private_label").length > 0) {
-
-					$(this).find(".post_control.share").css("display","inline-block");
-					$(this).addClass("xtweaks-checked-share");
-
-				}
-
-			});
-		}
-
-	},
-
 	upload_photos: function() {
 
 
@@ -881,7 +862,6 @@ XKit.extensions.tweaks = new Object({
 		XKit.tools.remove_css("tweaks_no_mobile_banner");
 		XKit.tools.remove_css("xkit_tweaks_larger_small_text_on_reblogs");
 		XKit.tools.remove_css("xkit_tweaks_hide_share");
-		XKit.post_listener.remove("tweaks_check_for_share_on_private_posts");
 		XKit.post_listener.remove("tweaks_fix_hidden_post_height");
 		XKit.post_listener.remove("tweaks_dont_show_liked");
 		clearInterval(this.run_interval);


### PR DESCRIPTION
Tumblr decided to rename the button share instead of messaging some time
ago, breaking this tweak. Did not notice until now due to not using the
option myself, this commit fixes it though. It also fixes the tweaks Hide share
menu option