### PR TITLE
Fix opening peepr on picture click

### DIFF
--- a/Extensions/show_picture_size.css
+++ b/Extensions/show_picture_size.css
@@ -17,3 +17,7 @@
 .xkit-show-picture-size .photoset .photoset_photo:hover .show-picture-size {
     display: none;
 }
+
+.photoset_row {
+	position: relative;
+}

--- a/Extensions/show_picture_size.js
+++ b/Extensions/show_picture_size.js
@@ -1,5 +1,5 @@
 //* TITLE Show Picture Size **//
-//* VERSION 1.0.0 **//
+//* VERSION 1.0.1 **//
 //* DESCRIPTION Shows the resolution of media post pictures in the upper right corner of the picture **//
 //* DEVELOPER TiMESPLiNTER **//
 //* FRAME false **//
@@ -45,12 +45,12 @@ XKit.extensions.show_picture_size = new Object({
                     if (photoLink.length == 1 && !!photoLink.attr('data-big-photo')) {
                         tmpImg.src = photoLink.attr('data-big-photo');
                         $(tmpImg).one('load', function() {
-                            photo.after($('<div class="show-picture-size">' + tmpImg.width + 'x' + tmpImg.height + '</div>'));
+                            photo.parent().after($('<div class="show-picture-size">' + tmpImg.width + 'x' + tmpImg.height + '</div>'));
                         });
                     } else {
                         tmpImg.src = photo.attr('src');
                         $(tmpImg).one('load', function() {
-                            photo.after($('<div class="show-picture-size">' + tmpImg.width + 'x' + tmpImg.height + '</div>'));
+                            photo.parent().after($('<div class="show-picture-size">' + tmpImg.width + 'x' + tmpImg.height + '</div>'));
                         });
                     }
                 });
@@ -62,7 +62,7 @@ XKit.extensions.show_picture_size = new Object({
                     var tmpImg = new Image();
                     tmpImg.src = $(this).attr('href');
                     $(tmpImg).one('load',function() {
-                        photoLink.append($('<div class="show-picture-size">' + tmpImg.width + 'x' + tmpImg.height + '</div>'));
+                        photoLink.parent().append($('<div class="show-picture-size">' + tmpImg.width + 'x' + tmpImg.height + '</div>'));
                     });
                 });
             }


### PR DESCRIPTION
Before this change, clicking on a picture with an attached image size
would lead to the peepr opening. Moving the image size div outside of
the `a` the image is inside fixes this.

Closes #1069 (probably)