### PR TITLE
ext/show-picture-size: Fix element position in dom

### DIFF
--- a/Extensions/show_picture_size.css
+++ b/Extensions/show_picture_size.css
@@ -11,6 +11,7 @@
     background: rgba(0,0,0,.5);
     color: #eee;
     padding: 2px 4px;
+    z-index: 10;
 }
 
 .xkit-show-picture-size .post_media:hover .show-picture-size,

--- a/Extensions/show_picture_size.js
+++ b/Extensions/show_picture_size.js
@@ -22,6 +22,7 @@ XKit.extensions.show_picture_size = new Object({
     },
 
     destroy: function() {
+        $('.post.xkit-show-picture-size .show-picture-size').remove();
         $('.post.xkit-show-picture-size').removeClass('xkit-show-picture-size');
         XKit.tools.remove_css('show_picture_size');
         XKit.post_listener.remove('show_picture_size');
@@ -49,7 +50,7 @@ XKit.extensions.show_picture_size = new Object({
                     }
 
                     $(tmpImg).one('load', function() {
-                        photo.parents('.post_media').append($('<div class="show-picture-size">' + tmpImg.width + 'x' + tmpImg.height + '</div>'));
+                        photo.closest('.post_media').append($('<div class="show-picture-size">' + tmpImg.width + 'x' + tmpImg.height + '</div>'));
                     });
                 });
             } else if (post.type === 'photoset') {

--- a/Extensions/show_picture_size.js
+++ b/Extensions/show_picture_size.js
@@ -1,5 +1,5 @@
 //* TITLE Show Picture Size **//
-//* VERSION 1.0.1 **//
+//* VERSION 1.0.2 **//
 //* DESCRIPTION Shows the resolution of media post pictures in the upper right corner of the picture **//
 //* DEVELOPER TiMESPLiNTER **//
 //* FRAME false **//

--- a/Extensions/show_picture_size.js
+++ b/Extensions/show_picture_size.js
@@ -44,15 +44,13 @@ XKit.extensions.show_picture_size = new Object({
 
                     if (photoLink.length == 1 && !!photoLink.attr('data-big-photo')) {
                         tmpImg.src = photoLink.attr('data-big-photo');
-                        $(tmpImg).one('load', function() {
-                            photo.parent().after($('<div class="show-picture-size">' + tmpImg.width + 'x' + tmpImg.height + '</div>'));
-                        });
                     } else {
                         tmpImg.src = photo.attr('src');
-                        $(tmpImg).one('load', function() {
-                            photo.parent().after($('<div class="show-picture-size">' + tmpImg.width + 'x' + tmpImg.height + '</div>'));
-                        });
                     }
+
+                    $(tmpImg).one('load', function() {
+                        photo.parents('.post_media').append($('<div class="show-picture-size">' + tmpImg.width + 'x' + tmpImg.height + '</div>'));
+                    });
                 });
             } else if (post.type === 'photoset') {
                 // Photo set


### PR DESCRIPTION
Fixes pic size element position in dom for media-posts without link. Now all picture size elements should get displayed in the according picture again.