### PR TITLE
Audio auto-play followup

### DIFF
--- a/Extensions/anti_capitalism.js
+++ b/Extensions/anti_capitalism.js
@@ -1,5 +1,5 @@
 //* TITLE Anti-Capitalism **//
-//* VERSION 1.3.0 **//
+//* VERSION 1.3.1 **//
 //* DESCRIPTION	Removes sponsored posts, vendor buttons, and other nonsense that wants your money. **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -61,10 +61,10 @@ XKit.extensions.anti_capitalism = new Object({
 		}
 
 		if (this.preferences.video_ad.value) {
-			var interval_id = setInterval(function (){
-				if ($(".sidebar-ad-content iframe").length) {
-					$(".sidebar-ad-content iframe").remove();
-					clearInterval(interval_id);
+			this.interval_id = setInterval(function (){
+				var videos = $(".sidebar-ad-content iframe, .sponsored_post iframe, .sponsored_post video, .standalone-ad-container video");
+				if (videos.length) {
+					videos.remove();
 				}
 			}, 400);
 		}
@@ -77,6 +77,7 @@ XKit.extensions.anti_capitalism = new Object({
 		XKit.tools.remove_css("anti_capitalism_sponsored_ads");
 		XKit.tools.remove_css("anti_capitalism_sponsored_posts");
 		XKit.tools.remove_css("anti_capitalism_asktime");
+		clearInterval(this.interval_id);
 	}
 
 });

--- a/Extensions/vanilla_video.js
+++ b/Extensions/vanilla_video.js
@@ -1,5 +1,5 @@
 //* TITLE Vanilla Videos **//
-//* VERSION 0.0.2 **//
+//* VERSION 0.0.3 **//
 //* DESCRIPTION Make the video player unexciting **//
 //* DETAILS Use the browser-default video player that won't follow you, loop, or autoplay. Only works on Tumblr's player. **//
 //* DEVELOPER new-xkit **//
@@ -11,8 +11,9 @@ XKit.extensions.vanilla_video = {
 	running: false,
 	run: function() {
 		this.running = true;
-		XKit.post_listener.add('vanilla_video', XKit.extensions.vanilla_video.check);
-		XKit.extensions.vanilla_video.check();
+		return;
+		// XKit.post_listener.add('vanilla_video', XKit.extensions.vanilla_video.check);
+		// XKit.extensions.vanilla_video.check();
 	},
 
 	check: function() {


### PR DESCRIPTION
- hotfix to vanilla videos, which is critically broken by recent changes to tumblr's js that causes some videos to autoplay
- some more selectors to nuke on sight, because they may be related to more phantom videos 