### PR TITLE
Hook into tumblr's JS to fix the metadata problem

### DIFF
--- a/Extensions/vanilla_video.js
+++ b/Extensions/vanilla_video.js
@@ -1,5 +1,5 @@
 //* TITLE Vanilla Videos **//
-//* VERSION 0.0.3 **//
+//* VERSION 0.0.4 **//
 //* DESCRIPTION Make the video player unexciting **//
 //* DETAILS Use the browser-default video player that won't follow you, loop, or autoplay. Only works on Tumblr's player. **//
 //* DEVELOPER new-xkit **//
@@ -11,9 +11,8 @@ XKit.extensions.vanilla_video = {
 	running: false,
 	run: function() {
 		this.running = true;
-		return;
-		// XKit.post_listener.add('vanilla_video', XKit.extensions.vanilla_video.check);
-		// XKit.extensions.vanilla_video.check();
+		XKit.post_listener.add('vanilla_video', XKit.extensions.vanilla_video.check);
+		XKit.extensions.vanilla_video.check();
 	},
 
 	check: function() {

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 6.3.0 **//
+//* VERSION 6.4.0 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -461,21 +461,33 @@ XKit.tools.getParameterByName = function(name){
 
 		// Identify retina screen displays. Unused anywhere else
 		try {
-
 			XKit.retina = window.devicePixelRatio > 1;
-
-			if (XKit.retina === true) {
-				// console.log("Retina screen mode.");
-			}
-
-		} catch(e) {
-
-			// console.log("!!!!!!" + e.message);
-
-		}
+		} catch(e) { }
 
 		setTimeout(function() { XKit.extensions.xkit_patches.check_unfollower_hater(); }, 2000);
 		setTimeout(function() { XKit.extensions.xkit_patches.do_support_links(); }, 3500);
+
+		XKit.tools.add_function(function fix_autoplaying_yanked_videos() {
+			window.Tumblr.Prima.CrtPlayer.prototype.onLoadedMetadata =
+				_.wrap(window.Tumblr.Prima.CrtPlayer.prototype.onLoadedMetadata,
+					function(wrapped, _event) {
+						if (!this.$el.is(":visible") || !jQuery.contains(document, this.$el[0])) {
+							return true;
+						}
+						return wrapped.call(this, _event);
+					});
+
+			// unfortunately we're not fast enought to catch some
+			// CRT instances that are currently instantiated, so handle those differently
+			jQuery('video').parent().each(function() {
+				this.addEventListener('loadedmetadata', function(event) {
+					var $target = jQuery(event.target);
+					if (!$target.is(":visible") || !jQuery.contains(document, event.target)) {
+						event.stopPropagation();
+					}
+				}, true); // uses .parent() and capturing to pre-empty tumblr's js
+			});
+		}, true, {});
 
 		setTimeout(function() {
 

--- a/Extensions/xkit_preferences.css
+++ b/Extensions/xkit_preferences.css
@@ -420,7 +420,7 @@
 #xkit-about-window-text {
 
 	position: absolute;
-	top: 70px; left: 385px;
+	top: 30px; left: 385px;
 	width: 350px;
 
 }

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 7.3.2 **//
+//* VERSION 7.4.0 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER new-xkit **//
 
@@ -2431,17 +2431,18 @@ XKit.extensions.xkit_preferences = new Object({
 					'<div class="title">XKit Version ' + XKit.version + '</div>' +
 					'<div class="subtitle">The Extension Framework for Tumblr.</div>' +
 					'<div class="copyright">&copy; 2011 - 2014 STUDIOXENIX</div>' +
-					'<div class="thanks">STUDIOXENIX would like to thank all the beta testers, bug reporters, and people who support, suggest features, donate to and use XKit.</div>' +
+					'<div class="copyright">&copy; 2015 - 2016 the New XKit Team</div>' +
+					'<div>XKit Patches v. ' + XKit.installed.version('xkit_patches') + '</div>' +
+					'<div class="thanks">The New XKit Team would like to thank all of the myriad users and, '+
+					'contributors who have worked to make this plugin what it is today. '+
+					"Above all we would like to thank Atesh, the original XKit Guy, "+
+					'without whom we all would have been lost to the outer darkness some time ago.</div>' +
 				'</div>' +
 				'<div id="xkit-about-window-links">' +
-					'<a href="http://www.xkit.info/seven">XKit Website</a>' +
+					'<a href="https://new-xkit-extension.tumblr.com">New XKit Tumblr</a>' +
 					'<a href="#" id="xkit-open-credits">Credits</a>' +
-					'<a href="http://new-xkit-extension.tumblr.com">New XKit Blog</a>' +
-					'<a href="http://www.xkit.info/seven/donate">Donate to XKit</a>' +
-					'<a href="http://www.xkit.info/seven/spread">Spread XKit</a>' +
 					'<a href="http://new-xkit-support.tumblr.com/support">Support</a>' +
 					'<a href="https://github.com/new-xkit/XKit/wiki">Documentation</a>' +
-					'<a href="http://www.xkit.info/eula">Legal</a>' +
 				'</div>';
 		$("#xkit-control-panel-inner").html(m_html);
 
@@ -2453,9 +2454,8 @@ XKit.extensions.xkit_preferences = new Object({
 					'<a href="http://code.drewwilson.com/entry/tiptip-jquery-plugin">TipTip</a> by Drew Wilson and '+
 					'<a href="http://jamesflorentino.github.io/nanoScrollerJS/">nanoScroll</a> by James Florentino. '+
 					'<br/><br/>'+
-					'XKit is written by <a href="http://www.studioxenix.com/">STUDIOXENIX</a>, a one-man entity.<br/><br/>'+
-					'All trademarks are the property of their respective owners.<br/>'+
-					'By using this software you are agreeing to <a href="http://www.xkit.info/eula">XKit EULA</a>.',
+					'The original XKit extension was written by <a href="http://www.studioxenix.com/">STUDIOXENIX</a>, a one-man entity.<br/><br/>'+
+					'All trademarks are the property of their respective owners.',
 				"info", '<div class="xkit-button default" id="xkit-close-message">OK</div>');
 
 				return false;


### PR DESCRIPTION
Hook into tumblr's JS to fix the metadata problem

This is ridiculously overengineered, so hopefully it'll stand some chance of working.

First we overwrite the broken function. Basically, inside onMetadataLoaded, tumblr calls a function "shouldAutoplay". This function will always return false if the video is hidden. (b/c we don't want to autoplay invisible videos, ofc..) HOWEVER tumblr then passes that same result to the mute function (because autoplaying videos should be muted, and non-autoplaying videos shouldn't be muted by default). HOWEVER, sometimes chrome fires this event twice. Not sure why, but it happens. So we have an already auto-playing video, and then when we remove it from the dom, it gets unmuted. this patches the function to noop is the video is hidden or removed from the dom.

We then fire off a SECOND strategy to handle already instantiated Crt (tumblr video) objects. This function binds a CAPTURING event listener to the parent of the video element (for more info about capturing vs. bubbling see here: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) this ensures that we always get the event before tumblr does. If we do get the event, and the video is hidden or not in the DOM, then we cancel the event.

okay? okay.