### PR TITLE
[show-picture-size] Small bug fixes

### DIFF
--- a/Extensions/show_picture_size.css
+++ b/Extensions/show_picture_size.css
@@ -14,7 +14,7 @@
     z-index: 10;
 }
 
-.xkit-show-picture-size .post_media:hover .show-picture-size,
+.xkit-show-picture-size .post_media:hover > .show-picture-size,
 .xkit-show-picture-size .photoset .photoset_photo:hover .show-picture-size {
     display: none;
 }

--- a/Extensions/show_picture_size.js
+++ b/Extensions/show_picture_size.js
@@ -1,5 +1,5 @@
 //* TITLE Show Picture Size **//
-//* VERSION 1.0.2 **//
+//* VERSION 1.0.3 **//
 //* DESCRIPTION Shows the resolution of media post pictures in the upper right corner of the picture **//
 //* DEVELOPER TiMESPLiNTER **//
 //* FRAME false **//

--- a/Extensions/show_picture_size.js
+++ b/Extensions/show_picture_size.js
@@ -61,7 +61,7 @@ XKit.extensions.show_picture_size = new Object({
                     var tmpImg = new Image();
                     tmpImg.src = $(this).attr('href');
                     $(tmpImg).one('load',function() {
-                        photoLink.parent().append($('<div class="show-picture-size">' + tmpImg.width + 'x' + tmpImg.height + '</div>'));
+                        photoLink.append($('<div class="show-picture-size">' + tmpImg.width + 'x' + tmpImg.height + '</div>'));
                     });
                 });
             }


### PR DESCRIPTION
* Fix bug which causes stacking of picture size labels in the upper right corner for photo-sets
* Only hide label for the currently hovered photo instead of all labels in a photo-set post