### PR TITLE
Add support for viewing with sidebar in Go-To-Dash

### DIFF
--- a/Extensions/go_to_dash.js
+++ b/Extensions/go_to_dash.js
@@ -1,8 +1,8 @@
 //* TITLE Go-To-Dash **//
-//* VERSION 1.2.2 **//
-//* DESCRIPTION View a post on a blog on your dashboard. **//
+//* VERSION 1.3.0 **//
+//* DESCRIPTION View a post from a blog on your dashboard or sidebar. **//
 //* DEVELOPER STUDIOXENIX **//
-//* DETAILS This extension adds a 'view' button on peoples blogs that allows you to go back to that post on your dashboard. This feature only works on the blogs you follow. If the post was made before you followed them, you might not see them on your dashboard when you click the view button. **//
+//* DETAILS This extension adds a 'view' button on people's blogs that allows you to go back to that post on your dashboard or sidebar. Viewing on dashboard only works on the blogs you follow, and may fail if the post dates to before you followed them. **//
 //* FRAME true **//
 //* BETA false **//
 
@@ -10,14 +10,25 @@ XKit.extensions.go_to_dash = new Object({
 
 	running: false,
 
+	preferences: {
+		"use_sidebar": {
+			text: "View using sidebar instead of dashboard",
+			default: false,
+			value: false
+		}
+	},
+
 	run: function() {
+		"use strict";
+
 		// Not in a blog post
 		if (!XKit.page.blog_frame) {
 			return;
 		}
 
-		// Not following the user
-		if (XKit.iframe.unfollow_button().hasClass("hidden")) {
+		var use_sidebar = XKit.extensions.go_to_dash.preferences.use_sidebar.value;
+		// Not following the user and not using sidebar - won't work here
+		if (!use_sidebar && XKit.iframe.unfollow_button().hasClass("hidden")) {
 			return;
 		}
 
@@ -28,12 +39,18 @@ XKit.extensions.go_to_dash = new Object({
 
 		XKit.tools.init_css("go_to_dash");
 
+		var go_back_html;
 		var post_id = XKit.iframe.single_post_id();
-		var next_post_id = parseInt(post_id) + 1;
 
-		var go_back_html = '<a href="/dashboard/2/' + next_post_id + '" class="tx-icon-button" target="_top" ' +
-			'id="xkit_gotodash" title="View on dashboard"><span class="button-label">View</span></a>';
-
+		var html_pieces = ['<a href="https://www.tumblr.com/', '" class="tx-icon-button" target="_top" ' +
+			'id="xkit_gotodash" title="View on dashboard"><span class="button-label">View</span></a>'];
+		if (use_sidebar) {
+			var blog = XKit.iframe.get_tumblelog();
+			go_back_html = html_pieces.join('dashboard/blog/' + blog + '/' + post_id);
+		} else {
+			var next_post_id = parseInt(post_id) + 1;
+			go_back_html = html_pieces.join('dashboard/2/' + next_post_id);
+		}
 		// Remove the text from the dashboard button because otherwise the iframe
 		// overflows
 		XKit.iframe.hide_button(XKit.iframe.dashboard_button());


### PR DESCRIPTION
This adds a default-off option for using the sidebar/peepr to view a post instead of using historical dashboard view.

Upsides:
- Works even if you aren't following the user
- Should always work, while historical dashboard view may have the post missing

Downside: Does not allow you to 'time travel' and see what your dashboard looked like 2 days or 9 months ago etc. According to @nightpool many users use this extension for that.
