### PR TITLE
Stop OCP from running on user blogs

### DIFF
--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.3.1 **//
+//* VERSION 4.3.2 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -592,6 +592,9 @@ XKit.extensions.one_click_postage = new Object({
 	},
 
 	run: function() {
+
+		//Bail on user blogs
+		if (!XKit.interface.is_tumblr_page()) { return; }
 
 		XKit.tools.init_css("one_click_postage");
 


### PR DESCRIPTION
Sometimes users have reblog buttons on their Tumblr
blog pages, which causes OCP to completely freak out.
Due to (often) the reblog buttons not being exactly
the same we can't adapt OCP to every single version
of the button, and thus it's better to just disable
it completely than to show a broken interface.