### PR TITLE
Update anti-capitalism for encoded urls

### DIFF
--- a/Extensions/anti_capitalism.js
+++ b/Extensions/anti_capitalism.js
@@ -1,5 +1,5 @@
 //* TITLE Anti-Capitalism **//
-//* VERSION 1.5.0 **//
+//* VERSION 1.5.1 **//
 //* DESCRIPTION	Removes sponsored posts, vendor buttons, and other nonsense that wants your money. **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -71,7 +71,7 @@ XKit.extensions.anti_capitalism = new Object({
 		}
 
 		if (XKit.extensions.anti_capitalism.preferences.yahoo_view.value) {
-			XKit.tools.add_css(' .recommendation-reason-link[href*="//view.yahoo.com"] { display: none; } ', "anti_capitalism_yahoo_view");
+			XKit.tools.add_css(' .recommendation-reason-link[href*="//view.yahoo.com"], .recommendation-reason-link[href*="%2F%2Fview.yahoo.com"]  { display: none; } ', "anti_capitalism_yahoo_view");
 		}
 		
 		if (XKit.extensions.anti_capitalism.preferences.sidebar_ad.value) {


### PR DESCRIPTION
Recently tumblr changed the yahoo view urls to use the t.umblr.com url rewriter. This will detect both non-encoded and encoded yahoo view urls.