### PR TITLE
Add function to fix J/K scrolling with hidden elements

### DIFF
--- a/Extensions/xkit_patches.css
+++ b/Extensions/xkit_patches.css
@@ -8,9 +8,7 @@
 
 #xkit-window.xkit-wide-window,
 #xkit-window-old.xkit-wide-window {
-
 	width: 650px;
-
 }
 
 #xkit-window,

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 6.4.2 **//
+//* VERSION 6.5.0 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -496,6 +496,23 @@ XKit.tools.getParameterByName = function(name){
 					}
 				}, true); // uses .parent() and capturing to preempt tumblr's js
 			});
+		}, true, {});
+
+		XKit.tools.add_function(function fix_jk_scrolling() {
+			if (!window._ || !window.jQuery){
+				return;
+			}
+
+			if (_.get(window,"Tumblr.KeyCommands.update_post_positions")) {
+				Tumblr.KeyCommands.update_post_positions = _.wrap(Tumblr.KeyCommands.update_post_positions,
+					function(wrapped, _event) {
+						wrapped.call(this);
+						this.post_positions = _.pick(this.post_positions,
+							function(scroll_pos, element_id) {
+								return !!document.getElementById(element_id);
+							});
+					});
+			}
 		}, true, {});
 
 		setTimeout(function() {


### PR DESCRIPTION
Normally, anti-capitalism breaks tumblrs built-in j/k scrolling. This fixes that.

It does this by wrapping Tumblr.KeyCommands.update_post_positions and removing posts that no longer appear in the document.

Anyway we really should start distributing lodash with XKit.