### PR TITLE
Two small fixes for the jk scroll fix

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 6.5.0 **//
+//* VERSION 6.5.1 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -475,7 +475,8 @@ XKit.tools.getParameterByName = function(name){
 						wrapped.call(this);
 						this.post_positions = _.pick(this.post_positions,
 							function(scroll_pos, element_id) {
-								return !!document.getElementById(element_id);
+								var element = jQuery("[data-pageable='"+element_id+"']");
+								return element.is(":visible") && element.height() > 0;
 							});
 					});
 			}


### PR DESCRIPTION
Looks like since I made the first fix, tumblr has changed the semantics of ghost list (the thing that pulls posts out of the dom when you scroll away from them) slightly, so I can't rely on their post id being there anymore. This fixes that by checking if the actual element is hidden or not. the current behavior is really broken—in certain situations it will skip past a whole ton of posts when pressing j quickly.

this also fixes the fact that hidden recommended posts weren't being filtered out of the scroll calculations. This didn't have as catastrophic as an effect as when removed elements were being included (it manifested instead as having to click twice to get past something) but it was still annoying
