### PR TITLE
Explicitly set contentType in Firefox's Request

### DIFF
--- a/Firefox/index.js
+++ b/Firefox/index.js
@@ -95,6 +95,9 @@ function onAttach(worker) {
     };
     if (headers) {
       requestSettings.headers = headers;
+      if (headers['Content-Type']) {
+        requestSettings.contentType = headers['Content-Type'];
+      }
     }
     if (data) {
       requestSettings.content = data;


### PR DESCRIPTION
The default value is `"application/x-www-form-urlencoded"`, but we usually want JSON. In some versions of Firefox, passing `{headers: {"Content-Type": "application/json"}}` to the Request constructor works. However in other versions, such as the latest Developer Edition 51.0a2, the actual header sent erroneously becomes `Content-Type: application/x-www-form-urlencoded, application/json`. This breaks XCloud and might break other services as well.

This patch simply ensures that if we ask for `application/json`, we get `application/json`.