### PR TITLE
Hotfix for link to old Xkit servers.

### DIFF
--- a/Extensions/dist/page/framework_version.json
+++ b/Extensions/dist/page/framework_version.json
@@ -1,1 +1,1 @@
-{"server":"up","frameworks":[{"name":"firefox","version":"7.7.4"},{"name":"chrome","version":"7.7.1"}]}
+{"server":"up","frameworks":[{"name":"firefox","version":"7.7.1"},{"name":"chrome","version":"7.7.1"}]}


### PR DESCRIPTION
It makes the most sense to downgrade the framework version here, so we can disable
the warning immediately, and then make the changes to xkit_preferences which will
stop linking to the old XKit site. Changes to xkit_preferences take longer to
distribute based on how recently the client has checked for updates though, so we
should make this change first, and then the more complicated one.