### PR TITLE
Remove nearly all uses of xkit_reset

### DIFF
--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 7.4.1 **//
+//* VERSION 7.4.2 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER new-xkit **//
 
@@ -424,7 +424,7 @@ XKit.extensions.xkit_preferences = new Object({
 			if (m_result === true) {
 				XKit.console.add("News " + id + " pushed successfully.");
 			} else {
-				show_error_reset("Can not push news_object. Storage might be full.");
+				console.error("Can not push news_object. Storage might be full.");
 			}
 
 		},
@@ -519,7 +519,7 @@ XKit.extensions.xkit_preferences = new Object({
 			if (m_result === true) {
 				XKit.console.add("News " + id + " pushed successfully.");
 			} else {
-				show_error_reset("Can not save news_object with read flag. Storage might be full.");
+				console.error("Can not save news_object with read flag. Storage might be full.");
 			}
 
 		},
@@ -1366,9 +1366,9 @@ XKit.extensions.xkit_preferences = new Object({
 
 				XKit.window.show("Can't update",
 					"Update manager returned the following message:<p>" + mdata.error + "</p>"+
-					"Please try again later or if the problem continues, reset XKit.", "error",
+					"Please try again later or if the problem continues, contact New XKit Support.", "error",
 					'<div id="xkit-close-message" class="xkit-button default">OK</div>'+
-					'<a href="http://www.tumblr.com/xkit_reset" class="xkit-button">Reset XKit</a>');
+					'<a href="http://new-xkit-support.tumblr.com/support" class="xkit-button">Support Chat Room</a>');
 				XKit.extensions.xkit_preferences.open_extension_control_panel(XKit.extensions.xkit_preferences.current_open_extension_panel);
 
 			});

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -319,7 +319,8 @@ XKit.extensions.xkit_preferences = new Object({
 							"Please update to the latest version as soon as possible. If you don't, XKit might not work properly, "+
 							"or might not work at all in the future.<br/><br/>All you have to do is to go to the XKit download page, "+
 							"and re-download XKit. XKit will update itself, and all your settings will be preserved.",
-							"warning", '<a class="xkit-button default" href="http://www.xkit.info/download/">Go to Download page</a>'+
+							"warning",
+							'<a class="xkit-button default" href="https://new-xkit-extension.tumblr.com/downloads">Go to Download page</a>'+
 							'<div class="xkit-button" id="xkit-close-message">Not now, remind me later.</div>');
 						});
 				}

--- a/Extensions/xkit_updates.js
+++ b/Extensions/xkit_updates.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Updates **//
-//* VERSION 2.0.2 **//
+//* VERSION 2.0.3 **//
 //* DESCRIPTION Provides automatic updating of extensions **//
 //* DEVELOPER new-xkit **//
 XKit.extensions.xkit_updates = new Object({
@@ -130,9 +130,24 @@ XKit.extensions.xkit_updates = new Object({
 
 	show_update_failure: function() {
 
-		XKit.notifications.add("<b>Could not update XKit:</b><br/>I could not reach the XKit servers to update myself. You might be running an old and buggy version of XKit. Click here for details.", "error", true, function() {
+		XKit.notifications.add("<b>Could not update New XKit:</b><br/>"+
+			"I could not reach the New XKit servers to update myself. "+
+			"You might be running an old and buggy version of New XKit. Click here for details.",
+			"error", true, function() {
 
-			XKit.window.show("Auto-Update failed.","XKit automatically updates itself from time to time in the background to bring you the latest features and bug fixes. Unfortunately, it was unable to contact the servers and download the latest updates. This might be a temporary server error or a problem with your connection.<br/><br/><b>If you have received this message more than twice in the last three days, it is highly recommended that you reset XKit.</b> If you don't, you'll be running an out-of-date XKit which might not work properly and cause problems.","error","<div class=\"xkit-button default\" id=\"xkit-close-message\">OK</div><a href=\"http://www.tumblr.com/xkit_reset\" class=\"xkit-button\">Reset XKit</a>");
+			XKit.window.show("Auto-Update failed.",
+				"New XKit automatically updates itself from time to time in the background "+
+				"to bring you the latest features and bug fixes. Unfortunately, it was "+
+				"unable to contact the servers and download the latest updates. This "+
+				"might be a temporary server error or a problem with your connection."+
+				"<br/><br/>"+
+				"<b>If you have received this message more than twice in the last three days, "+
+				"you should try to get into contact with New XKit support to try to fix the issue.</b> "+
+				"If you don't, you'll be running an out-of-date New XKit which might not work properly and cause problems.",
+				"error",
+				'<div class="xkit-button default" id="xkit-close-message">OK</div>'+
+				'<a href="https://new-xkit-extension.tumblr.com" class="xkit-button">New XKit Blog</a>'+
+				'<a href="https://new-xkit-support.tumblr.com" class="xkit-button">New XKit Support</a>');
 
 		});
 
@@ -154,11 +169,11 @@ XKit.extensions.xkit_updates = new Object({
 
 				if (to_show === "true") {
 					var suffix = "";
-					
+
 					if(XKit.extensions.xkit_updates.updated_list.length !== 1){
 						suffix = "s";
 					}
-					
+
 					XKit.notifications.add("XKit updated " + XKit.extensions.xkit_updates.updated_list.length + " extension" + suffix + ". Click here to view them.", "ok", true, function() {
 						var m_result = "";
 						for (i=0;i<XKit.extensions.xkit_updates.updated_list.length;i++) {
@@ -269,7 +284,7 @@ XKit.extensions.xkit_updates = new Object({
 		}
 		return false;
 	},
-	
+
 	destroy: function() {
 		this.running = false;
 	}


### PR DESCRIPTION
Remove nearly all uses of xkit_reset, esp. ones related to automatic/expected errors. These are replaced with links to the support blog and chat.

Fixes #770 

Additionally, fixes https://github.com/new-xkit/XKit/issues/1170 by blocking the link to xkit.info