### PR TITLE
Escape special characters using en/decodeURIComponent

### DIFF
--- a/Safari/Info.plist
+++ b/Safari/Info.plist
@@ -5,7 +5,7 @@
 	<key>Author</key>
 	<string>New XKit Team</string>
 	<key>Builder Version</key>
-	<string>11601.2.7.2</string>
+	<string>12602.1.50.0.10</string>
 	<key>CFBundleDisplayName</key>
 	<string>New XKit</string>
 	<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.7.2</string>
+	<string>7.7.3</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>Chrome</key>

--- a/Safari/bridge.js
+++ b/Safari/bridge.js
@@ -226,7 +226,7 @@ if (!String.prototype.startsWith) {
 
 			write: function(name, value) {
 
-				var toWrite = (typeof value)[0] + window.btoa(value);
+				var toWrite = '%' + (typeof value)[0] + window.btoa(encodeURIComponent(value));
 				XBridge.storage_area[name] = toWrite;
 
 				// Send data to background page so it would get saved.
@@ -243,7 +243,13 @@ if (!String.prototype.startsWith) {
 				if (!value) { return defaultValue; }
 
 				var type = value[0];
-				value = window.atob(value.substring(1));
+				// Leading '%' denotes escaped encoding
+				if (type === '%') {
+					type = value[1];
+					value = decodeURIComponent(window.atob(value.substring(2)));
+				} else {
+					value = value.substring(1);
+				}
 
 				switch (type) {
 					case 'b':


### PR DESCRIPTION
Fixes #1178. This change requires a new Safari extension release.