### PR TITLE
change ER to intentially break posts :(

### DIFF
--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -57,7 +57,14 @@ XKit.extensions.editable_reblogs = new Object({
 		if (post_type.chat || post_type.quote) {
 			return;
 		}
-
+		var has_displayed_ER_warning = XKit.storage.get('editable_reblogs', 'has_displayed_ER_warning');
+		if (!has_displayed_ER_warning) {
+			XKit.window.show('Editable Reblogs Warning', 'WARNING: Editable Reblogs no longer preserves Tumblr\'s reblog structure due to changes on Tumblr\'s side. Any posts reblogged ' +
+					' with Editable Reblogs will display the entire reblog tree as a single blockquoted post. The XKit team deeply apologizes for any inconvenience this causes but Tumblr\'s ' +
+					' updates are in this case beyond our control. As always, this extension can be disabled at any time from the XKit preferences panel.',
+					'error', '<div id="xkit-close-message" class="xkit-button">OK</div>');
+			XKit.storage.set('editable_reblogs', 'has_displayed_ER_warning', 1);
+		}
 		//disable on pages that don't include reblog_key and post_id in the URL
 		//for now until we've refactored more effectively
 		var location_path = window.location.pathname;

--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -59,11 +59,19 @@ XKit.extensions.editable_reblogs = new Object({
 		}
 		var has_displayed_ER_warning = XKit.storage.get('editable_reblogs', 'has_displayed_ER_warning');
 		if (!has_displayed_ER_warning) {
-			XKit.window.show('Editable Reblogs Warning', 'WARNING: Editable Reblogs no longer preserves Tumblr\'s reblog structure due to changes on Tumblr\'s side. Any posts reblogged ' +
-					' with Editable Reblogs will display the entire reblog tree as a single blockquoted post. The XKit team deeply apologizes for any inconvenience this causes but Tumblr\'s ' +
-					' updates are in this case beyond our control. As always, this extension can be disabled at any time from the XKit preferences panel.',
-					'error', '<div id="xkit-close-message" class="xkit-button">OK</div>');
-			XKit.storage.set('editable_reblogs', 'has_displayed_ER_warning', 1);
+			XKit.window.show('Editable Reblogs Warning',
+				"WARNING: Editable Reblogs no longer preserves Tumblr's reblog " +
+				"structure due to changes on Tumblr's side. Any posts reblogged " +
+				"with Editable Reblogs will display the entire reblog tree as a " +
+				"single blockquoted post.<br><br>" +
+				"The XKit team deeply apologizes for any inconvenience this causes, "+
+				"and we're working to restore the original functionality, "+
+				"but Tumblr's updates are in this case beyond our control.<br><br>" +
+				"As always, this extension can be disabled at any time from the XKit preferences panel.",
+				'error', '<div id="xkit-close-message" class="xkit-button ER-ack-blockquotes">OK</div>');
+			$(".ER-ack-blockquotes").click(function(){
+				XKit.storage.set('editable_reblogs', 'has_displayed_ER_warning', 1);
+			});
 		}
 		//disable on pages that don't include reblog_key and post_id in the URL
 		//for now until we've refactored more effectively


### PR DESCRIPTION
ER has been broken for the past few days. This changes ER so that it reblogs posts intentionally in the blockquote format, because we can't figure out how to make the non-blockquote format work quite yet.

This is so that posts made with ER can actually show up on the dash.

This also adds a check to avoid double-adding blockquotes, so that we don't add a new blockquote thing for every person who reblogs it.