### PR TITLE
Make users opt-in to ER, for better UX.

### DIFF
--- a/Extensions/editable_reblogs.css
+++ b/Extensions/editable_reblogs.css
@@ -1,0 +1,74 @@
+.post-form--header .reblog-title {
+	margin: 10px; color: #444;
+}
+
+.xkit-er-edit-button {
+    display: block;
+    position: relative;
+    width: 28px;
+    height: 28px;
+    float: right;
+    margin-right: 21px;
+    margin-top: 21px;
+    border: 3px solid #ddd;
+    border-radius: 50%;
+    color: #ddd;
+}
+
+.xkit-er-edit-button.icon_edit_pencil:before {
+	font-size: 25px;
+	padding-left: 1px;
+	padding-top: 1px;
+}
+
+.xkit-er-edit-button.icon_edit_pencil:not(.disabled):hover {
+	border-color: white;
+	color: white;
+	cursor: pointer;
+}
+
+.xkit-er-edit-button.disabled {
+    border-color: #999;
+    color: #999;
+}
+
+.xkit-er-callout--container {
+    position: relative;
+    left: -86px;
+    width: 135px;
+    background: white;
+    display: none;
+    top: -35px;
+    float: right;
+    line-height: 21px;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+}
+
+.xkit-er-callout--header {
+	display: block;
+	font-size: 14px;
+	font-weight: bold;
+	background: #2E7D32;
+	padding: 9px;
+	color: white;
+}
+
+.xkit-er-callout--body {
+	padding: 9px;
+	display: block;
+	font-size: 13px;
+}
+
+.xkit-er-callout--container:before {
+	display: inline-block;
+	position: absolute;
+	content: '';
+	right: -20px;
+	top: 0px;
+	width: 0;
+	height: 0;
+	border-top: 0px solid transparent;
+	border-bottom: 20px solid transparent;
+	border-left: 20px solid #2E7D32;
+}

--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -1,5 +1,5 @@
 //* TITLE Editable Reblogs **//
-//* VERSION 3.2.0 **//
+//* VERSION 3.3.0 **//
 //* DESCRIPTION Restores ability to edit previous reblogs of a post **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -27,9 +27,8 @@ XKit.extensions.editable_reblogs = new Object({
 
 		XKit.interface.post_window_listener.add("editable_reblogs", this.post_window.bind(this));
 
-		XKit.tools.add_css(".control-reblog-tree {display: none; } .post-form--header .reblog-title {margin: 10px; color: #444} "
-			+ ".xkit-editable-reblogs-button { float: right; margin-left: 20px; }"
-			+ ".control.right.xkit-editable-reblogs-control { display: block; width: 210px; text-align: right }", "editable_reblogs_remove_content_tree");
+
+		XKit.tools.init_css("editable_reblogs");
 
 		var create_post_button_click_handler = this.make_post.bind(this);
 		$("body").on("click", ".create_post_button", create_post_button_click_handler);
@@ -55,7 +54,7 @@ XKit.extensions.editable_reblogs = new Object({
 			$.each(post_setting_keyup_handlers, function(selector, handler){
 				$('body').off("keyup", selector, handler);
 			});
-		}
+		};
 	},
 
 	post_window: function() {
@@ -95,8 +94,47 @@ XKit.extensions.editable_reblogs = new Object({
 			return;
 		}
 
-		var save_button = $('.post-form--save-button [data-js-clickablesave]');
+		var element = this.add_edit_button();
+		$(element).one('click', function(){
+			this.edit_the_reblogs();
+			$(element).addClass('disabled');
+		}.bind(this));
+	},
 
+	add_edit_button: function() {
+		var post_margin = $(".post-form .post-margin");
+		post_margin.append(
+			'<div class="xkit-er-edit-button icon_edit_pencil"></div>'
+		);
+
+		if (!XKit.storage.get('editable_reblogs', 'has_dismissed_button_callout', '')) {
+			post_margin.append(
+				'<div class="xkit-er-callout--container">' +
+				  '<div class="xkit-er-callout--header">Editable Reblogs</div>' +
+				  '<div class="xkit-er-callout--body">click this button to trim or edit this post</div>' +
+				'</div>'
+			);
+
+			$('.xkit-er-callout--container').delay(800).slideDown(800);
+			$('.post-form .editor').one('keyup', function(){
+				$('.xkit-er-callout--container').delay(2000).slideUp(800);
+			});
+
+			$(".xkit-er-edit-button").click(function(){
+				XKit.storage.set('editable_reblogs', 'has_dismissed_button_callout', 'true');
+				$('.xkit-er-callout--container').slideUp(800);
+			});
+			$('.xkit-er-callout--container').click(function(){
+				XKit.storage.set('editable_reblogs', 'has_dismissed_button_callout', 'true');
+				$('.xkit-er-callout--container').slideUp(800);
+			});
+		}
+
+		return $('.xkit-er-edit-button')[0];
+	},
+
+	edit_the_reblogs: function() {
+		var save_button = $('.post-form--save-button [data-js-clickablesave]');
 		try {
 			// Prevent Tumblr's event handler from acting on the save button
 			save_button.removeAttr("data-js-clickablesave");

--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -70,7 +70,7 @@ XKit.extensions.editable_reblogs = new Object({
 		if (post_type.chat || post_type.quote) {
 			return;
 		}
-		var has_displayed_ER_warning = XKit.storage.get('editable_reblogs', 'has_displayed_ER_warning');
+		var has_displayed_ER_warning = XKit.storage.get('editable_reblogs', 'has_displayed_ER_warning', '');
 		if (!has_displayed_ER_warning) {
 			XKit.window.show('Editable Reblogs Warning',
 				"WARNING: Editable Reblogs no longer preserves Tumblr's reblog " +
@@ -81,9 +81,9 @@ XKit.extensions.editable_reblogs = new Object({
 				"and we're working to restore the original functionality, "+
 				"but Tumblr's updates are in this case beyond our control.<br><br>" +
 				"As always, this extension can be disabled at any time from the XKit preferences panel.",
-				'error', '<div id="xkit-close-message" class="xkit-button ER-ack-blockquotes">OK</div>');
-			$(".ER-ack-blockquotes").click(function(){
-				XKit.storage.set('editable_reblogs', 'has_displayed_ER_warning', 1);
+				'error', '<div id="xkit-close-message" class="xkit-button xkit-er-ack-blockquotes">OK</div>');
+			$(".xkit-er-ack-blockquotes").click(function(){
+				XKit.storage.set('editable_reblogs', 'has_displayed_ER_warning', 'true');
 			});
 		}
 		//disable on pages that don't include reblog_key and post_id in the URL

--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -361,6 +361,8 @@ XKit.extensions.editable_reblogs = new Object({
 				this.send_schedule_request(e);
 				break;
 		}
+
+		this.state = "finished";
 	},
 
 	send_post_request: function(e) {


### PR DESCRIPTION
Currently, I see a lot of posts that are "inadvertantly broken". It's really useful to have ER installed for sometimes, but most people don't need it for mosts posts. So instead, we can have everybody install it, and just have people opt-in per post.

I'm guessing this will lead to less broken posts, while no degredation in UX for people who really need and love ER.

![image](https://cloud.githubusercontent.com/assets/233815/20294507/9f95a1ce-aacc-11e6-89b3-70313793791d.png)


Also, fixes handler teardown, which was incidentally broken a while back.

(disabling ER and then reblogging posts would lead to duplicate posts. this *should* be fixed now)