### PR TITLE
Fix ER trashing metadata changes made before enabling "edit reblogs"

### DIFF
--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -1,5 +1,5 @@
 //* TITLE Editable Reblogs **//
-//* VERSION 3.3.0 **//
+//* VERSION 3.3.1 **//
 //* DESCRIPTION Restores ability to edit previous reblogs of a post **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -94,6 +94,10 @@ XKit.extensions.editable_reblogs = new Object({
 			return;
 		}
 
+		this.initialize_selected_post_type();
+		this.scheduled_date = "Next Tuesday, 10am";
+		this.load_initial_metadata();
+
 		var element = this.add_edit_button();
 		$(element).one('click', function(){
 			this.edit_the_reblogs();
@@ -138,9 +142,6 @@ XKit.extensions.editable_reblogs = new Object({
 		try {
 			// Prevent Tumblr's event handler from acting on the save button
 			save_button.removeAttr("data-js-clickablesave");
-			this.initialize_selected_post_type();
-			this.scheduled_date = "Next Tuesday, 10am";
-			this.load_initial_metadata();
 			this.process_existing_content();
 			this.state = "success";
 		} catch(e) {


### PR DESCRIPTION
Fix ER trashing metadata changes made before enabling "edit reblogs".

from support chat:

>`Therapardalis` If I save to draft without clicking the opt-in, it saves to draft as normal, and I can then click it when I go to edit the draft.
> `Therapardalis` Oh sorry misread
`Therapardalis` I was already on 'save to draft' when I clicked the opt-in.
`nightpool` hmm, that might be the issue
`Therapardalis` Ahhhh
`nightpool` let me look into it