### PR TITLE
Fix Pokémon sorting

### DIFF
--- a/Extensions/dist/page/pokedex.json
+++ b/Extensions/dist/page/pokedex.json
@@ -1,7114 +1,8003 @@
 [
   {
-    "id": "0",
+    "id": 0,
+    "sortid": 0,
     "identifier": "missingno",
     "name": "Missingno.",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAACVBMVEX///8iIiIiIiLMFIP7AAAAA3RSTlMAf4C/aSLHAAAAVElEQVR4Ae3KMQrAIBQE0Z/c/9BJIQwsrFPaOI1/5c3tcM9KGZkjc2SO9i7vAnOZY3f4/u0hDjkloCQQAOQjAvAIzN1lccBV3l3SlMyROVJHsNvRPjeEAcfzDmAhAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "1"
+    "gender_rate": -1,
+    "rarity": 1
   },
   {
-    "id": "1",
+    "id": 1,
+    "sortid": 1,
     "identifier": "bulbasaur",
     "name": "Bulbasaur",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTFCczljnGMxMjFSU1JimmIyMzJrrVJ7zntSjFIzNDUyMzRSi1JCdDpRUVFlnWVqq1FqrFFRUlF5y3l6zHl6zXpRi1H7+/tSUlK6SUG7vLvkSUFUVFT8/fz+/Pz///9RilEzMzN6zHpim2JqrFJDcjkmREfZAAAAAXRSTlMAQObYZgAAALxJREFUeNrt0kcSgzAMBVAk28I4EHpJ77n/ESNN2ArYJsO3l2++a7Tmt7KJ0mWuiZt4iYOy83YJQ6ywsjDt0tIz4+HR6mXsbi8247T6GSDPsBfqWQYdJolxuyx8YT8FDeLTZWxCEKgXbhFbLuVWhmohdckYx8vXoLn9u+U9CnbEpaQVpg2TbesgfxgJ6rcjMobhWhjjaApSx/B4YYdYkzFWf2UyEkcCD/fJDyEhwQDz32cozqd5NvZGa/4tHyy5Ce9l8xUAAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "2",
+    "id": 2,
+    "sortid": 2,
     "identifier": "ivysaur",
     "name": "Ivysaur",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAtFBMVEX///8xMTFClIQ5azkxMjFSUlJSi1JrvaW9Ulo2NjZSjFI1NTVSU1Mhc2Npu6Nqq1FquqM5bDm7UlkidGTnY2szMzNBkoJBk4NCkoNqrFIxMzJqvKRrrVJElYWcOUJRUlFRi1HkYmrlYmo5ajn7+/sxMjJTUlL8/f00NDRsu6NtvqaaOEFUUlKdOUK6UVlRU1K7u7u7vLy8UVkzMTG9vb1qq1IjcmLmYmpDlIQ4ajhRUVH+/Px8WYr6AAAAAXRSTlMAQObYZgAAAOxJREFUeNrt00eOAjEQBdAu586RnMMEMjMw+f73mrIlWHWh3iLxF149/XKQvUfuKD5AM7eZV6cmbv+1ayT9mRnPqy0A3GbgCo15VoEgVeiFP5PCjN8NQgl0WxapgE8KhFjYE0BDHUkVyALrFpynQ0FDzQ4S85Gnw5xzoF0Zx3EHrepZmop62B5Y2cFVR4pPeZpD/UV/JmWC6DJ/MQ1EPVxZM3Cuy5jVtY1hhq5MIsi0VV3cLHsiD6P7sFwzhkiiRkcdpj+r/kYOwvn7rUW+c5sxN9aWhQCEc/T32HL8OpWmnr8cvbw2/gqP3E3+AR/2EkbemkSxAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "3",
+    "id": 3,
+    "sortid": 3,
     "identifier": "venusaur",
     "name": "Venusaur",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA7VBMVEX///9ClIRSUlLna3NjlFoxMTFKckpKc0pKdEpRUlFRU1IxMjFSU1JUUlJikllCkoNrvaVys1lztVqlQkqmQkrkanHlanI2NjbnbHP+s6T/taVTUVFTUlEwMjEpeWppu6RquqNqu6NqvKRDlIRElYVytFope2uSckoxMjIxMzKmQ0syMzHkanJRUlIzMTI1NTX7+/sqfGtSU1P/xgBBk4OUc0qjQkpik1kzMzM0MzK6urq7u7u7vLwpempRUVHka3MyMTHlbHNTU1Ntvqb7sqNBkoL8s6P8xAH8/f39s6NUU1D+/PxUU1NJcUn///90eHFgAAAAAXRSTlMAQObYZgAAAWFJREFUeNrt08dygzAABNAgIdNMLwbce+/pvffk/z8nC+TiQBhffPNSRsw8VqAZHeyzq5QYw4VbfubMDcIzXP4sl5YeQ5+qhEwohc9xLqVO+WW9fj+2bW+WBx3bixsdLxjZt//+BGSAuVHrUWSWyb4EQWEuRWCdt8irLO3AEIlMAj8Iw1GZPIe+WhCUDCmRQiQJ7CfpVzAoKFmrOW8sp4SYPA/cP6oQrZiodGXDWJmWaIonca/G83x3zIDTEI7vWlYRnyBpvCBEj6I5zioUcRR1mRBMTDSotIQzjBUxRYk0DYPjZJ2TSQHvWaKy6bhWLMHgbqiqc9CgFgrTMOrC4C5xEWVs013riVvWh6wRAR2nDD34s4a1aTOBVfejE3dlw1JtelWP4HDx/RCj3iEnX7QvT1OLeH6vt5awv2W49apZqx1vkicuzgADFG7MmsYI6tuR32YfLjqvnW1gslv32UV+ADYQI9uPwddzAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "4",
+    "id": 4,
+    "sortid": 4,
     "identifier": "charmander",
     "name": "Charmander",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAjVBMVEX////WY0IzMTE0MjDTYkHWY0ExMTHzkin3lCk1NTWtUkI0NDTTYkKrUkJUUlH2kylUVFP355w2NjbWZEOuVES6urpSUlJTUlHVYkIyMTEwMTGrUUHWZUHbuoLbu4PevYQaYmLz5Jrz8yn0kin1kin15JpRUVH29CmtU0OuU0H39Sn39yn7+/v9/Pz+/PyM1BGnAAAAAXRSTlMAQObYZgAAALxJREFUeNrtkscOgzAMQLHJYkPp3nu3//95tWqJm5NzK94JK48XJUrU83sMvIvGdJ8KPZp1GjsRUPKsIzQGxYREIuZBQaVRDuqKkhx0dzCiqN+ZdTGLl8cSxeBtO7caed6TJx8lNgrQcz28UtHeQCD/GMvXqOAL8gYkyuqqhTInk/LkySS7pi6OGlBxV06SeNBlTln0BhfpqanHOUBpIq84uk7WmxYgndEUeGbmXEyDHsvP4SsLa5yNev6PD8AUCWjuIMcQAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "5",
+    "id": 5,
+    "sortid": 5,
     "identifier": "charmeleon",
     "name": "Charmeleon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAXVBMVEX////OSkIxMTFSUlL3a0qlQjkzMTH///80MTE1NTXzakm9vb331pzMSkL3pkHWtXs2Njb2akn3a0nLSUHz8ylTUVHzo0HOS0L3bUn3pEJUUlEYY2P39Cn39Sk0MjFOe7rpAAAAAXRSTlMAQObYZgAAAMhJREFUeNrt0bcOwzAMBNDwSLmn9/r/nxleHHij7CXIYsKQlofjCV7M89upJ7pNU40STIP1flvRXXc5SWFS8HpcLCOBxqyiPz1XmUiYz63veFi98s64mpHnYgz23epGitiJGU8KPqsK85LdSxNR9JAyWKwoRcQFspEumEcphUMJakJdqa5F6Y9LCSBSUgW6jlJFl5FrU0pYOOzUsyijwBbwU9d0hILoR3/3l3T+DS4qgI9jXlZyP533HR983jUFlqkd4GiBef46b4a5BlmXNMOeAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "6",
+    "id": 6,
+    "sortid": 6,
     "identifier": "charizard",
     "name": "Charizard",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAmVBMVEX///8xMTHWY0JSUlL3lCm1QjlUUlHTYkL2kyn31nP///80MjDTYkFUU1EzMTHzkinTY0LWtWNKg3L0kimyQThRUVH3lCq9vb37WTj/Wjn/XDj/5yk2NjYxa1o1NTVTUVE0MzDXZEI1MzFVU1L1kyoyMjL3kymzQjkxaln3lSk0MTFKhHP+Wjj+5SkxMjI0MjL/5CnUY0LWY0H5rO7sAAAAAXRSTlMAQObYZgAAAShJREFUeNrtz8eOhDAQRVFeVZnYOdG5J+f8/x83VYYNuEeyNNt+C0Di6MpOLgu2R6Rbv/wPhm6ziZLH9cObypji1zYW7s7Jm+YvYI/me/y+2wYQAvu3cG6EsVRok89VEFzBGsNH59xpLkp98ioMfiPBdV5h0UijKsOg3NtDM8eFwWGWK11mNOoHhQG5U6hS3dNhQrkMz0EhkVt/5+VcFKqkvC8hfisiwqeIltLZq6dpFkCSkvzE9pOy0onCThIkTlASs0H2TUpnHxh0k9Ae4UDEDlQUBbOXKvYDhf0TepegsLUSg5S70KkDO4PTJsmc2QGpf0SCmtrVIJ6aExYiL7u3BtoXiIhLcyIeti6cl1w20Af+lLopk7qwFmLrRkCjJdWIcM39LovdL79WEqHFVV5zAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "7",
+    "id": 7,
+    "sortid": 7,
     "identifier": "squirtle",
     "name": "Squirtle",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAn1BMVEX///8xMTE2NjZRmppSU1NSmppSnJxSnJ1yxPRSUlIxMjFSU1Q4cWo5c2szMTBUVFJxw/MxMjJyxfVzxveNVCy7u7u8aiG9ayHUiyn354z8/Pw1NTVRUVEyMzSMUilRm5u7aiFTUlFTU1JSUlHLq1kzMzOLUin7/Pw5dG3OrVrTiylRUlKKUSk5cmr25os0NDRUUlH05Ivz5IrMq1n9/f3m9xExAAAAAXRSTlMAQObYZgAAAMxJREFUeNrtktcOAiEQRcWlbV+2F3tZe/f/v80h8WGNAu/qTUiYcHKHy9D766vURwh1CyVnxUkyRM8igr2CgyMQExJtoGBU6MDEnQRIggwfnE9cIzkWw8LbIrBihgkVKsP16iSd2rKYEoqJujPcL2IU12l5BvA9dSfnHoDsnkpLoX7GAaEUOkoy14IWtu3bMeRunY7mSDuZa1WFHF6ozQPDEBebGYfcJrDxdpcqJNjOlgZDz3fA0yYYGf8PZOevQ9aE98d6sPsT//phPQAE+g3z3W4H9wAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "8",
+    "id": 8,
+    "sortid": 8,
     "identifier": "wartortle",
     "name": "Wartortle",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA2FBMVEX///8xMTFSUlJTU1Nje86Upfelxs42NjZCWpxRUlMyMjRSUlMyMzNTU1Q1NTVkfM5tTCySo/QxMjOjxMxBWZqzg0mzs7PT5PT8/PxiectUVFSTpPZTU1KVpvdies2jxM5RUVGysrIzMzRrSinT5PNUVFPW5/f355SMYzn///+MZDuSo/NEXJ0yMTExMTJSUVGjw8tiesxSUlExMTBke80zMjGzg0plfc6ztLXLslHMs1LOtVJqSilTUlHU5fZsSyvz5JL05JIzMzP7+/uLYjj8/P79/PtDW5yRf0vsAAAAAXRSTlMAQObYZgAAAQ9JREFUeNrt0sduAyEUBdDwKNN7dbfHPb33xOn5/z8KaIiyCINm542f2HG40kN3bzfbG6Ol82dVy8A/aCCdOw2eK8m02RKK5AVz6wdIDRlGCAk3sOWDRaWU44hSQuJZMHKlU0qj06N8vCIYYVTDbsFcBTygv1Bc+zyQYUD/nF87O7UShq+vBOxC0hBIevbke+jAY7Y64qsVyl2EJObx+/rGKddh9pRI2LDM/tehaUEZZqvzhDFX7eKOOSTEgYh6ZTg9aYSTy3gMAPf9iJLP8IMnKpwsgvGyXM7LAU/kEGmLcffQP7vFkG+mF9pGpha8zsXJ3/SNTE0L8dDIy5GGyWKJbpC4VdP5N6mgOnc3254fgo4ZdyNLRLcAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "9",
+    "id": 9,
+    "sortid": 9,
     "identifier": "blastoise",
     "name": "Blastoise",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA3lBMVEX///9SUlIxMTFSUlNSe657re82NjZ6q+xSeqtSe61TU1JrSilsSyt5q+xSU1R6rO06ZI2LYji7u7O7u7S9vbXOtVJsSikyMjOzg0lTU1MxMTJqSilRUVFUfa5RUlJ5eXkxMjJ6enlReqxSUVF7e3syMTGKYjhReauMZDr9/f2zg0o0NDQ1NTXLslHMs1LMtFMxMTD355T7+/v8/Py6urI4YoozMjG1hEpTe6tTfK1UVFN9ru9UVFQzMzOMYznMtFQ5Y4zOtVP05JL25pKygklTUlFrSir9/Pu0g0n////MdjkXAAAAAXRSTlMAQObYZgAAATdJREFUeNrt08dywkAMBuBs87p3A6aaanoxIZ30+v4vFC055LLL+MKN//yNNBpJF+ecIBou6TrRvhy8jON9merzTvQn5xjj4md2tPfYWmP8XulvZ7hQyrlTHVm160qt0g8nR6DmMErQ9AOhRjeKJ9BaDSEuZ26jO4jidHp1zEH8dmh3B59WTQ41nHugqo6AsW0F3wqXG5lDvWrR8piLQAZWMJROnBPO/Proq7W6IQih0A4eZVATToSuEhMh3SCi/Vq2vVvCqceeEnBLk1OQtrQ3rFZrLg8sMXWPUSg5HmLpwkEiJCxn1HN1Eqa6kUndrr5IkuTtbnsPBQHGqaLg7rn9utm8mCicPHC/R0K4JKWE1mJsDgvqZeqDxLh5qAlOCf/HX4h5JE5C4b5bRrn/0eATSn/uOSfIL+ZPHxjHF5mQAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "10",
+    "id": 10,
+    "sortid": 10,
     "identifier": "caterpie",
     "name": "Caterpie",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///8zNDWczkoxMTFSUlJ7nEoyMjHnSin15ilSU1F5mkl6mkoyMzR8nEqazEo0MzCyOCnky2JRUVHnzmMzMTBieTFjezFjfDEzMzEyMzF6m0kDAwB8nEkwMDCay0lSUlGbzEmbzUozMjGdzkmdzkozMzC1OSm6o1m7o1m9pVrTuinUvCnWvSnkSSnkSilTUVHkzGLmSSlTU1FUUVHz5ClUVFX35ylN+BlRAAAAAXRSTlMAQObYZgAAAJVJREFUeNrt0MUSwzAMRVFZMoS5DCkz0/9/Wj3TfeV9ctdnnjyGtuYmXF1WgSBygnQ2pmJhlN2N2VyJHZw+Lk8pk4EDlAl6nyUjRaDmiN5o8kq5QbTSS+mwZmBnhr2hOp7GGgQju3WolE/wvvX/y0LaQs1CiPJyhUoXcrfgfigvYx34dtTGXf89k5fbfaytc5BE0NbcvmUiCMc1jyqrAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "11",
+    "id": 11,
+    "sortid": 11,
     "identifier": "metapod",
     "name": "Metapod",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAM1BMVEX///8xMTF7nEozNDV5mkmczkqay0mbzUoyMzEyMjE0NDRTU1EyMzSdzkz8/fz9/vz///9AwQnIAAAAAXRSTlMAQObYZgAAAGlJREFUeNrt0ksSwCAIA9ASrUL/9z9t4wnI2jHrN3FAtpU5U8w01nYXHJnkCh0id9dwIkQXni614zkaIofse7/b80JCBiGMTMl41kg4Ci3d4nDa1HSnCXukBEKBQNf/GqFIq4Ty3a5Mlx+Y8QKuEf91PwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "12",
+    "id": 12,
+    "sortid": 12,
     "identifier": "butterfree",
     "name": "Butterfree",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAqFBMVEX///8xMTFSUlIzNDNSUlNTU1NrY8a7u8S9vcbWY0JqYsNRUVFsY8ODg3KMe877+/v8/Py8vMSEhHNiuqtqZMWCgnEyMjIyMzK+vsZUVFSEhHSLes3/taX///+FhXWLesxjva1lvq6NesuNe80xMzJqYsRBkpJSU1MzMzNtZMXTYkFCk5TTYkLTY0PUZENUUlHWZEP7sqNClJT8s6UxMjL+s6Niu6tju62ReTZvAAAAAXRSTlMAQObYZgAAAO9JREFUeAHt00dzgzAQBWDtqkiADS52cLHTe+/5//8sj3DIxWv24htvxIlvHrvMyBwgfSypISkNKrVSNUHdHDzF8KirtT3ziQqisBOCAc4nLcTU1A3Bqu0xk7h5Qfgy3ttqu0jJ026Xr0t34hhLY6Fx8ry70b5dlGUIa8dE1ZKZo9BY35+X4WNzBzlaJB9TWgmN+cP709fmddBAz1EesTo7fc6ybODghmMfBQdZjJaP2cuVi20fy7+RcsdwCUrY5H/OEIJjFK6Y98LprJHRg8murfyZ/TXemo7UBfP3jeZOXH/S9NIoUhsLqIs1B0qfXzB9DL6+IJLcAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "13",
+    "id": 13,
+    "sortid": 13,
     "identifier": "weedle",
     "name": "Weedle",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAclBMVEX///8zMjG1hDnWrUoxMTGzgzmygjjUq0kzNDWUYzk0NDRRUVG1gzlSUlLTSXHTq0nTq0rWSnNUUVIyMzRTUlG6urq9vb2+vr6UZDuVZDmVZTwyMTHVSnIzMzPWS3LWq0qSYjjscZr7+/v9/fv+/fz////fCsljAAAAAXRSTlMAQObYZgAAAJBJREFUeNrt0UcSwjAMBdCo2E5v9BpI4P5XxBr2+VlD/kqaeWNJ42TNryXVpXDMVZfB9zmQYuenwzEIE4TNKQsiQtCJBcvNI4i88gbB9Nn1rVDRCgNYdyaFzSHZO2bOLtbMSvXRbdXK3W3+nqKqHFN0ewDrQe4loQdN+jjbkSdr0HD33RN/+LUkc1iqJmv+Nx+F1QX2IfzwmQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "14",
+    "id": 14,
+    "sortid": 14,
     "identifier": "kakuna",
     "name": "Kakuna",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAASFBMVEX///+9nDH31ikxMTEzMjGKcTGMczGNdDC6mjG8mzG9nDA0MzD21Sm7mjH11ClSUlJUVFEyMzMyMjHz0yk0NDQzNDRTU1H7+/taLj3wAAAAAXRSTlMAQObYZgAAAIFJREFUeNrt0kcOhTAMBNC4pAcC/ML9b4pBSCyHNWLWT+PYinvzvPxE5Bb7MHMV6IwdqRheErvJ5hdF0IiIJFJYWdev+KzgkXOiIwqXmfpA9O8DlMnUbhtaO44cszl8nxhGwwWPblxaDIvDcO+0Qih9yGSFOLMPp8MH0rs/1715YjayqAVy5kLOlgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "15",
+    "id": 15,
+    "sortid": 15,
     "identifier": "beedrill",
     "name": "Beedrill",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAolBMVEX///8xMTGlrfcyMzMzNDRSUlLDqynGrSn35zH///8yMjT7+/v05DEyMjGmrvczMjBTU1FTU1RUVFGjq/Ojq/SDi5rEqynGUkLGVEGEjJ3z5DE0NDRUUlJRUVH8/PxxcVn35DF0c1mCipozNDPGVESEjJzzYlEyMjL0YlI0MzH2YlH25DH25jD3Y1JSUlOkrPX35zRUVFRTUlH9/f7+/Pxzc1okululAAAAAXRSTlMAQObYZgAAAPRJREFUeNrt0ddOxDAQBVDPuMVOL9srHbbQ+f9fwxOWSEhxzAviZa80fjq6HtnsnL+MgN8RcXlzFxDgMgQ7QUNuAHaLccYH4BeBn5AD+HrbFU4rXkFszMIDYR5VJyji7M0HxbxKKpk8rEatQ0Tbv+LtNoqqxM3oEWr09BGMn6M2upBrY7ISPG51v3VqOtlrXaxfpGz6bxZ1SXD6fj15HeuiwVn/Y/IasUyocHdcOiib2ZPt7UMLoA4El+McNh8pgOev6VRa56DcgMrZQMgD41SnLlIWpMo1OswCMjaLloZdhnaThl2GaMElIPk34R0Nh7Nz/i+fsr4Q5Afxx8EAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "16",
+    "id": 16,
+    "sortid": 16,
     "identifier": "pidgey",
     "name": "Pidgey",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAn1BMVEX///9SUlIxMTGaWTmcWjm9c0HOvWPenCn375zbmilTU1JUU1FUU1NUVFMyMzIzMjC7ckIzMzG9c0LLumLNvGIzNDM0MzLdmykyMTHnpaXz7Jr07JpTUlH27ZrGc3tTUlKaWTi9dEPcmikzMjFUVFTMu2LNu2KllFq9dEL7+/vko6O6urozMjJRUVH17JrDcXn27pvdnCnEcnozMzP+/fxzk+FuAAAAAXRSTlMAQObYZgAAAL9JREFUeNrt0kcOwyAQQFEPxgbce2+pTu/3P1tIHCkrkNeJ//oxCA3K1O8Vj0JIiZk7BhYJIy7370NIDJ3CZsRERcJZhzMkgbOUaDVNUFeplZqJbx6crhtqBSoWQifcpIMDnnigEodXrX4xLyVmmchefSz1xxK8AOMT1X2x2+UW2nKI54RP9iUuzy3gMUK0tWxg0wKUlNqMaEGwkG3w3LSrC7XBkzqeg8I+6iMDPvuTUwNuh3FfaH+Xi69Upv65JzmGDO42CJO7AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "17",
+    "id": 17,
+    "sortid": 17,
     "identifier": "pidgeotto",
     "name": "Pidgeotto",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///8xMTFSUlIzNDO9OSG9c0JTUVG7OSHnpaXMu2JUUlFUU1FUU1MzMTC7ckIzMjIzMTFTUlFTU1LOvWPbminGc3vsYkHsYkLs25LvY0L7+/tRUVHdmynv3pTenCnko6NTUlJUVFPDcXm9c0HGdX26urrEcnruYkFUVFQ0NDQyMzLcmilTU1PmpKQzMjHLumIzMzHNu2KcWjnu3JK6OCG9dEK6cUHryZxEAAAAAXRSTlMAQObYZgAAAN9JREFUeNrt0kcOwyAQBVDPGHCJe7fTe+9O7n+0TBzJO3C2kfLFAmnegg9o//xadvCly2xQUJ3WZ65ndjGVUZoGkJVlQLtaFMNpLod2XtqgNdCKjHWgcLQC0PQ+OeZKXM1ETo4x5iY9lDqCwhAGYwIxmYdURd65b7jLA3p8MOoVw/givbqx6UC1QZJhco+lUB+bpumgFaF324/mVwVMJ4hWHDWO85P8iDBLJ9aD8wG5Birok0To8dYpitPLvdtAh5v5AOcIceV3fUJ46zRtnQpXi6PatY2g2naY1mr//E5ehWAQDnbtW9oAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "18",
+    "id": 18,
+    "sortid": 18,
     "identifier": "pidgeot",
     "name": "Pidgeot",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA/FBMVEX///9SUlIxMTG9OSHOvWOcWjnvY0Lv3hDMu2JRUVHdmynenCnnpaXuYkFTUlFUUlHko6O9pRiaWTlTUVHu3RA0NTa9c0EzMjJTUlK9pRdTU1LDcXnGc3szMzDNu2JUVFLbmincmikzNDUzMzG9c0K6OCHsYkHsYkLs2xC6urru2xDu3IK7ckK9OyDv3oT7+/vno6NUU1M2NjbEcnrFcnlUVFQzMjEzMzKcWjqcWzudWzidXDwzMzO6cUHmo6IzMTEzMTC7OSE0NDS7u7vs2xHs24PtYkFTU1HuZEG9OiMyMTFTU1Pu3YM1NTXvZEHv3BC9dEO9oxhUU1H8/PzPhDA3AAAAAXRSTlMAQObYZgAAAT9JREFUeNrt0kV2w0AMAFBLY+Y4zGSHqczMTPe/S+W4q844u75uoo0X+k8wlrSOv4484uos/nx9++E8XQ00TaujlCflLOyikHUwGmlaOZPJ5OpGX2WOyk6LItdjI2I5bYnv+jF0FgKZ733kysSmjLEsJE5Vz9LcNM6qXtLZISeEVM4hhZHjBcqt2BF8o+HuVQ9o5ygLgaK4KH6bQeIm4e6Je8GyAUFEETSuXz0cPpF0AYAc3Mxme7zz7Q24Op7vAEnT+oSYNYEr+eLbNkldfm7CxCwobWtMTO9yBTf9Wgm2SnGVllUwLYqxLMtd0YiQwHfzsB2zmVwBFP/qaok6k3RbllUIG1Qv9XgMXaao0DrhL8j31xNJrovpbnigPBpLiivPuxOnO9V9pcE35fH8aLvGXaF4o69LcYofQFrH/8c33BsjIrLxv4IAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "19",
+    "id": 19,
+    "sortid": 19,
     "identifier": "rattata",
     "name": "Rattata",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAjVBMVEX///8xMTGEc7WtjMZSUlIyMjOrisMyMzOCcbKDcrNTUlMzNDSri8Ssi8VTU1L355TDunmDcrT7+/vGvXtSUlNRUVEzNDMyMjE0MzKkm1OlnFL15ZQzMzJsWoxUVVRqWYr9/f3+/Pz15ZJtXI1UVFPzYlHz5JI0NDRUVFS6urK+vrZTU1PEu3rEu3vFvHyjtIOmAAAAAXRSTlMAQObYZgAAAMVJREFUeNrt0kcSwjAMBVAkucROgyT03jv3Px5KMgMrGy9hhr9+812kzj9fkxggyC0SsiEyVkQoA6BWZA3DANk3vsYY3jLyOfV6gF72vJBk2+svZIgSGg7sfDBKiaSiR5ZYcCJo3byXTncJexccdGegqIllh+iUupsxqCuxyX3m/uMayuJksDKI46ETqtrt11shACKU4IaYTvNyssnzUUeDb77F5XorMyHEp0U4r4789ujzfvF5modXQdB+HfiGQeHaf34nTz5ACHnArlzcAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "20",
+    "id": 20,
+    "sortid": 20,
     "identifier": "raticate",
     "name": "Raticate",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAsVBMVEX///8xMTEzMjE1NTVRUVFSUlJTU1KchFq1e0LEq2r355Q2NjbDq2pTUlLTo0HTw2rVpELWpULWxmv05JKzekL7+/v8/PzGrWuaglnTo0Kag1kyMjEzMzLWpkRUU1G2fEP15ZL25pO7u7tUVFNUVFRUU1KyeUFTUlE0MzLTxGq1fEJxcXHWpkO6cYK7c4Pk03nm1Xrn1nvz5JJ0dHS9dIT25ZK+dYU0NDQzMzHFrGr///94dtxsAAAAAXRSTlMAQObYZgAAAQtJREFUeNrt0NduwzAMBVBTMm1J8V7ZO0269/7/DyvpIE+mgb4VBXIfBIE4IK7knfOnGfzW7ZWnT3oAsgF2RkGiEnWcPMwkqNNPT/tVllMUHEe9EhJmJssXAGR19CjLlim/mS/GfGGpJPe8XN3mqv6o57lZucu25dNMgD7atXNLk7FjyFKEzQ5L57aI4zd2MmRZf+/setvayqg+qAFumve45I10kJQ7at8Gm5d7hmyNYahH4bQDo/Ar2LwSJFY6rEhCNFRCQ4gU3LXQBmgoh0nICyVKf8kujCuGODwtlHBaXCDagCSEU+h3o/iqKMgyZNYvASAtrqlgh0nYR5x0oCSjwArPkAt45/yX/ADn8xQJoQee/wAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "127"
+    "gender_rate": 4,
+    "rarity": 127
   },
   {
-    "id": "21",
+    "id": 21,
+    "sortid": 21,
     "identifier": "spearow",
     "name": "Spearow",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAjVBMVEX///8xMTGrYjEzNDNSUlJTUlEyMTG9SkrLijHOjDGtYzFTU1JUU1ODUjGsYjEzMjJRUVFSUlHOhHszMjHOvXP3a1L7+/v8s6P/taX0alLMg3rMizEzMzPLunGEUjGFVDTNg3pTUlIzMTE0MzKuZTS6urr7sqO7SkqCUTH+s6P+tKQyMzLLgnnNu3HNizF0RfupAAAAAXRSTlMAQObYZgAAALJJREFUeNrtzkcOwzAMBECTVnXvNb33/z8vjIAcpeRu70VLYEDRmzPV+PAtVF0OxQeD56tScXBCAKVLKhz5WNpdIJTWHAAy5DTY4B1fxNioeZzHObodJeCMEpOzQUVIXBLj2r3VkcxQNOskoJVtV6R2d+oiaA7k+vpaELS74hahcbXcuBZGbNgi/dvXUsqd40R4pLSQ5NnpDMVV8qxCBuB0hi6rcDD3/abHBT1/SW/OpPMGISsK7dlWbfUAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "22",
+    "id": 22,
+    "sortid": 22,
     "identifier": "fearow",
     "name": "Fearow",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAvVBMVEX///8xMTFTUlF7UjGlazG9UkLDsmrGjDFTU1JUVFMyMzJ8UjGcjEKjajGkajG8UUEzMzHDijFRUVHEizHEs2rFizFSUlLGtWvzakH87Jr97Zr/75wzMjIyMTGMMTGmbTQzMjE0MTEzMTEzNDO6UUG7UkJSUlF8UzGKMTFUUlKNMTGci0FUU1PFtGrFxMOdjUPGjDM0MzLTgoLTg4PWhITsq6PvraV5UTH77Jr7+/t6UjH8/PylazL+7pumbTJgzgoRAAAAAXRSTlMAQObYZgAAAR9JREFUeNrt0seOgzAQBuAdF0wNxfSStr33Xt7/sTKGSByMV7ntHvIjLCx9jAfjg33+VQ5hNwWxWO4CY0+KJfxa1IUtVNRI8LYiHINsgAZkRWDZqQ0I6Ywqp7NyhetZBcavHUgQ4tVprZerkq/BOqWpf+3XTdM4KBk6DfJ5SALG2GV9i66Ikvxjhk6DZ+E85CQPGKmaPj+MwIQrL0LOiRQkl8JLv9FlgplWRjfEoyeVSbpHnN/csQ4gyJQlEr2cgsnx+n3RqacYHWMoccO1z3Gfn84/F6wb/ggCM3y5evzqC8IrldikckJB3bWwnQSUzoaCaTTlxnb73SzsypmAWG5st4Wkapwph2ycPbQ4vGHBe9DPl37cbNPZ1l/e5w+zATOGGvUWE960AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "23",
+    "id": 23,
+    "sortid": 23,
     "identifier": "ekans",
     "name": "Ekans",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///+cY4RSUlKbYoMxMTHFg7TGhLUyMzPEg7NTUlKaYoMzNDRRUVEyMTLGY1JzSmuaYoIzMjE0NDBxSWozMjPGrTHGrjCdZYLDgrLz8yn39yl0SmxTUlP19Cr19SmcZIIyMTF0SmqmjTDDYlH29SvFqzJTU1HDqzF1TGnEqzFySmr29SlWNXYqAAAAAXRSTlMAQObYZgAAAMtJREFUeNrt0scOwjAQBNCsWzrpPfQO//9/jAnnDTeElLn48jRrre0s+XlCpb5jrTGlmndgNuWMcwupjSHSM9JtzZAk8vxsNA/DyEPf+rC5SYo5BymEh1ZJHAy73HGPK18ERDy8Zo6Vqz1fiMY+h1TRfctDVFaZ9XWFk4vb9U2MlznVF6F4mfoPLMiMAWYrVkYfhwX5im0ExB7hyA9iBtJbkraOGFhgovAAR4HxO252IoHwjrhlzP8zz0wZ0MdKlWqwaTtz1MZZ8id5AdtlCt2ve90HAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "24",
+    "id": 24,
+    "sortid": 24,
     "identifier": "arbok",
     "name": "Arbok",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAgVBMVEX///+Uc5QyMjIxMTFTUlNxWXFzWnOScpJSUlKsi6ytjK2ri6uTcpMyMzO0WlrFqykzNDRyWXJTUlLzYlH3Y1KVcpK1Wlq1W1mVdZWUcpP0YlJRUVH39Cm2XFm7u7O8vLRTU1PGrSlUUlKUdJSzWVmriqv1Y1OScZL3ZVEyMTL7+/tqEmQnAAAAAXRSTlMAQObYZgAAANlJREFUeNrt0scOwkAMBFC83pqEBFLovcP/fyCTRRzjcEFcGMnay9NoZXnwz3cyYuaP2DlJSHGvA0OI1EcOEKW9kAIhcukQUD1mpL13AVJy293mCNdKEdqMYl8+KVOhcmQysFPp8mI6D4kSt12t1vO82Msw2qpuLqtbQ0FJivHTpV/UB58mSmDG3qP0ohsa62NjqlPs03juhpC8hGodNqW6JWh0egxH3ZKNH9sAh8cKlfGDhFZHGmMzJd4FQqSddgQnyujaEeFrjY4AWXSQfKX3jfdSZPDPT/MEbYEMOGZAIwUAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "25",
+    "id": 25,
+    "sortid": 25,
     "identifier": "pikachu",
     "name": "Pikachu",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA/FBMVEX////31jHGpSnz0zH11DA1NTU3NzU5OTlTUlCehkEzMjDHpinx0TE0MzD01DL21TH31jD21jE2NjbFpCnFpSkyMjJTU1FUVFHz0jBXVVD01DFRUVH10zC3dinCoioxMTHDoynEpCpXVVFXVlCagkAzMjGhaTGiazI3NjG5kSLBoSnCoik3NjTDoig0NDHDoyrEoyjEoyk4ODU4ODY4ODg5ODg0NDTIpyvw0DE1NDDx0jLzYlJSUlLz0jFTUVHz0zL00jL00zE1NDE0MjBUUVE2NTH11DL11TH21DBVVVJWVFD3Y1L3ZFH3ZlD30zH31DH31TBWVU82NjT7+vk45UyqAAAAAXRSTlMAQObYZgAAAPtJREFUeAHtz8Vy7DAQhWEdy5IZ7GGeuTfMzMwMyfu/S9pZJKtWvJ2q+Rf25it1HTFpTFKDkq7zC5VvgNr9gVoGvFTDNf/7X6tFzcCyfB5OaXrronPknpJb3uQOR5Vr+p6j4Y4scppzlQSY8yXkAzn+PSUB2KmX2PV+1eDoJLldmcGbVgtVa58dIu0EwedOk84LhyQ32Qm9hMzVWVpIvc6f/gjvyDw9vgLdlcVV1jnz9f4t0ufDF6D3b/ZSsG0p2mC3W7F8Q7cxsyQMqaH1fnDTitE7yU2uGGv/v48BGRldIUcyA+Dm4o+2VR62s+MNUSJnsEeulMzFpPHpC2dSFXU+ud5RAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "26",
+    "id": 26,
+    "sortid": 26,
     "identifier": "raichu",
     "name": "Raichu",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABIFBMVEX///8xMTEyMzLOhDHzsjH3tTE0MzFSUlJUVFNyUjlzUjmSakKUa0LJgTHMgzEzNDP1szEzNjP/51IyMTEzNTIyNTKSakEzMzE1NTJRUVHLgjEzNDJTUlHPhTBTU1L0szJUU1H2tDEyNDH75FL+5lJVU1H75FHMgzJRUFEyMjJ0Uzl1UzlSUVFSUlGSakOTa0MzMjGrajGubDCubDFTUlDKgjE0NDTLgjLLslFTUlI0NTLMs1LNhDLNs1FUU1DOhTPOtVI1MzHPhTHh2Jnk2pjn3ZvxsDHysjI1NDH0szEyMzH0tDNVVVT1tDJXVFD3tDFXVVD3tjP4tjL4tzT58cL68cFXVlRwUDj85FL89MT95VH+5VBxUDn+/ftxUTj/98aVb7U6AAAAAXRSTlMAQObYZgAAASlJREFUeNrt0sVywzAQBmCLzOwwY5mZOSkz8/u/RdfVdKYHRfElt/wXjTTf7Er2KsMMIDipQwndV5QY/lWGwNLTmRFnGduOYB1RpQVxxt5uAZHAPDSM3VsIIoahUG6cUMaYyp0EYmCQmgWNQxVxKJL4lEPNsktwAXhS/kUEMfXrjBFar2ka+j1Yq2y2BDLdXfQZ+1yp3sUX5XKvggQPD6gPYqcZ/oNZ4U/FThmavzcBkjkus8KvWCid3zN6eQPQRJIZCZylh+/bdrvK/ANCkGTqAm/sVbfoNS0TMiErCeePTzOzx1ejZNJE0kFuLB/p+oVLCJn3ZL3x8/T42WFnl7huTgHZs3XgeZ6SctythX2+g60kjan11UJO6Zv0h2EYqf4ublksKsMMLD/RbhxqQB3b7AAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "27",
+    "id": 27,
+    "sortid": 27,
     "identifier": "sandshrew",
     "name": "Sandshrew",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABL1BMVEX///+1nDHn1lIzMzGymjG0mzExMTG2nTLk01Hm1VEyMzOzmjHk01CDcjHk01JTU1G1nDJTU1AzNDQzNTQ0NjWFdDEzMjG3njLJwpnNxZvi0lBVVFJXVlWAcDHl1FGEczH46LH/77UzMzM0RINVVVNXVlQzNDN4eHkxMDI1NTODcjKDczGDczOEczA1NjOEczOEdDI1NjSFdDKGdDGwmDGxmTKxmTOymTE1RoOymjI2NjKzmzI3NjW0nDRQUFFRUVJSUVC2nzRSUlC3njS6urBSUlHKwpnKwprMxJnMxJtSUlLOxptTUlDj01Dj01Hk0lAyMjE0MzJUU1NUVFLl1FLm1FFUVFPm1VJVVFDn1lQ0NTP46bH4+Pj56rH7+vn87bP8/Pz97bL97rX+7rRVVVLv0B4NAAAAAXRSTlMAQObYZgAAAPpJREFUeNrt0sWOw0AMBuDYGQ4VU6ZlZqYuMzPz+z/DRsp1J8m56n/w6ZPHtsboprOikrrySlAYi4XPlPtMIJoxVFk2IlwxJsCPhhcFkDe/Z6bAUCqNI9xGKN+C52KeBlIJ838okEvXHCIgAcBjjEgNXL1D8JtLywQa9TwN+mpGVc2tna+13gWoOFQieJamYSBfvo9Kpf7j4kydn0Njz9Ltnhs8qLSvP1r3n0/i0aGb+mtmN0bSbz+t6vx71YLIW+Zqzmnx5LAv7aZmFyeMKJmpbe9P2gU+TsJNomimZ85+SI0OJ/lFY3Tq0kiQ7Ov67nSsCt8fMLrptPwBNNcYh9bAC1sAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "28",
+    "id": 28,
+    "sortid": 28,
     "identifier": "sandslash",
     "name": "Sandslash",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABLFBMVEX///8xMTFSUlJUVFL31lJTU1HGpTEyMTEzNDQyMzN6WTF7WjG1hEo0NTQzMjH8/Pw0NjX7+/tSUlHz01H001L21VFQUFFRUVGSajmUaznEozEzMzG6urK7u7O+vrbBoTFTUlHDozPDozHEpDLEpDTFpTXHpjRWVFFWVlb01FJ5WTFUVFT5+fn6+vq4uLFWVFD///81NTOmhTGnhjKzg0pTUlC4uLA1NTW5ubG5ubI1NjVTU1O7u7S8vLS8vLVUU1A1ZVzBoTLCojI2NjNVVFBVVVXEpDE2NjXEpDM3NzbFpDHFpDLFpTFWVVIzNTTGpjJXVlTw0FHz0lAwMDH001F5eXh5enn11FBRUlJ6enr31lT4+PhSUlCRajmSajj7/PwyMzIxMTK9vbVUVFGN1BjqAAAAAXRSTlMAQObYZgAAATpJREFUeNrt0cWShDAQgGEihAADjLu7z6y7u7v77vu/w3a4LmHnNpf5qxIuX3UXoEwad/qIRG9r4kbIx5VtuBKGBuw9pflCIG0zDAycL0QRYoRxlCSLCJLBqUIjSgkWB88GAgFbOnAjSukZHAJMvhzgTIxOxx7AAUsVDQ15O3RLodbFblIwbJimqXlC4eoZFDkeYIzBhTHydBFwpGslnE5afXNHSgZetZ7ZwcLmR+iyoj662yWfJxjvDkOOM2xWT1kDQ2lbIi2M0Sfvr33X1GvK1DRTgXpYPfu0ZMGjv55tHsbooCIsY/ZfOG/p4vfc5VacfE0MLOwzr+1B7u6v/tzvhfLwRuU5i3NFVrCfK6m91V5n+2TwJVWu5Dy+uHzzSsjWji90raKXyvXMf861L53ukTJK5zpXJo23X3T+ITnu9LvyAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "29",
+    "id": 29,
+    "sortid": 29,
     "identifier": "nidoran-f",
     "name": "Nidoran",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAtFBMVEX///+ElMYyMjMyMzRSUlJSU1NTU1SDksQxMTGrw/utxv+CkcKCkcMyMzOEk8arxPysxPysxf5RUVH4+PhUVFeDk8WCksNSUlM0NjVRUVKCksRaa61VVVZWVlZZaquFlcY5kmozNDRaaqyDk8Raa6xTVFaElMQzNDM1NjaGlcZcbKyrw/w2NjZZa6uDksJbbK1bbK45kmu4uLFTU1M3NzdZbKtZbKy6urLzYlGDksP5+vv+/PzbKslRAAAAAXRSTlMAQObYZgAAANFJREFUeNrtkMcWgjAQRTMBkhAERASx9957+///ckC3jmz1+FZZ3DM377F/viRuXi7m+TiF4OulyHuWBJ5httaGIkAAsJRKMYBAG9RJU0K5aA/FyuNjSm4LaflaHHsVyRkJotsXne1pUOBkafyZ1qKzbNU4WdpHbBOllUxOipEzzusKNrLkhAaNy70daJHuSbnrT60psz3fg6URTu4B5gpQdfh7MjyUTMerRwG6ycETluz2TmNul/uFrAzFdrthsRlPM+9HNpzdFixPEtdl//xYHudTDQSkaPxPAAAAAElFTkSuQmCC",
-    "gender_rate": "8",
-    "rarity": "235"
+    "gender_rate": 8,
+    "rarity": 235
   },
   {
-    "id": "30",
+    "id": 30,
+    "sortid": 30,
     "identifier": "nidorina",
     "name": "Nidorina",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAulBMVEX///9znJSUzsY1NDRSUlJUVFRym5Nzm5MxMTF0nZWTzcUyMjJTU1NTVFQzNDRUfXVxmJFxmpIyMzM3NjUzMzNSU1OSy8OSzMSTzMRSenJSe3O8vLS9vbU0MzNympJVVVVKa5y5uLE0NTRym5T8/Pw1NjU1MjJKapoxMjJynJRKa51La5tTVVSRyMFTfHRLbJxRUFBRUlNVfnaVzsaWz8dii9tii9xjjN71ZFT6+vr7+/v8+/tReXH9/v4Tq9hBAAAAAXRSTlMAQObYZgAAAQZJREFUeNrtkzeSxCAQADUjrJD3fu157/3/v3UoUAirbJPtiKBroHoK58QxGZZ6iVrogRLzWQizuE0AQGlJayWmRk/MXpmWaPEcN76aTKGnaXxhe2NCaYVpCQUZPcvILL6dRlVQXKyfRlsAhRpa+W8f1+udTaS1Fit8eD/giQoB62eAm50SlpRCD4vq8+97IOGk/TJlyFNLD/PPHwCKYa6jtpeGq/O7mnOQXKKHUhdSxs2Ej0HAv+iLF0mvNYccYggZo7TvAsQyatFoZhuWpl3fEykxwAhz82rcpi26boXIfUR25phxm4aQv1cvIJxtHRuuhu2JP67m2nZ5w/fL/k/mDs6Jo/IPracRnk0aeiUAAAAASUVORK5CYII=",
-    "gender_rate": "8",
-    "rarity": "120"
+    "gender_rate": 8,
+    "rarity": 120
   },
   {
-    "id": "31",
+    "id": 31,
+    "sortid": 31,
     "identifier": "nidoqueen",
     "name": "Nidoqueen",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///9SjKUxMjJRi6RSUlJSUlNSU1NSi6MxMTFqu8xrvc61c0LOxmtRUVExMzNRiqNquss0MzNqvM01NDRCY4TMxGpCZIX7+/tCYoM0NDQxMTJEZYWzckJTU1JTjKRUVFLv54xUjaZTUlGzc0OzdEQzMzG1dELFm1HLw2pTi6PMxWvNxGrNxWpRUlLs5Iru5YpBYoLzYlFtvs78/Pz8/P38/f3+/PyI09v0AAAAAXRSTlMAQObYZgAAARFJREFUeNrt0sduwzAMAFCT1pb3yl7de7f//2klgSInS8khQC8hIEOCHyiSdnKOk0d9pGtL3G+NOQyZVc4VEQeAhjfEyEWhtAU7JWw0o6T3gLlVfbZuYikrZZ1TVi1vn7JrqjQMoWF45f3jGukYSFqX7BwAXPp7pHMVqJObhWZIQWrAvxsw6IrJgqSg5rm7IBzm7z87HhLPsc2nXYqBXgDgYaWl0I0yuQbo5mMwF32WZeR04xQ9gQJH3GQHaHKh+WKC3NN4jeX3LGlfttvN5wdXGYRJbQjLpX/dCMFJh2eNkf9C9jfeXzAEaSKf+y1Fc5etptYNPJqINIZX2XXpSIGjNRzjeFaLr9n+dKiEc/xr/AKFWhDjIadJ1gAAAABJRU5ErkJggg==",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "32",
+    "id": 32,
+    "sortid": 32,
     "identifier": "nidoran-m",
     "name": "Nidoran",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAaVBMVEX///8xMTEzNDRTUlOca5QyMTJ7UnOaapJSUlLLirLMi7POjLWbapN8UnQyMzOaa5NSpXu6urI5g1l5UXE5hFpSo3ozMjMzMzOcbJQ0NDS9vbV9VHVRpHrNi7RTU1P1YlL7+/v+/Pz///9USl8cAAAAAXRSTlMAQObYZgAAAL1JREFUeAHt0bfOwzAMBGBTpLrcy99L8v4PmdMQeAqRIYsB3+Dpw5G0mjPHiHnWeftyKPa+gCHSIYSvn5jz9sh1XkRsZM9gcFqhCCcOKWcOaFdkRZzA1qW32jWRU3XrMGjOUN0NdPoetEIDJT8ZdFqWnr0i5+JSbosgrN4S25S38V044GYFdpjd/l2+CoOJs6RtCcGoA3VFmT3+BqJaZ4k+37T/ODuL3vp6RI0Giarb71Dx//VDF3ttc+Y4uQF7IAdXko1u8AAAAABJRU5ErkJggg==",
-    "gender_rate": "0",
-    "rarity": "235"
+    "gender_rate": 0,
+    "rarity": 235
   },
   {
-    "id": "33",
+    "id": 33,
+    "sortid": 33,
     "identifier": "nidorino",
     "name": "Nidorino",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAbFBMVEX///8xMTGaapLOjLUzMjNSUlJTUlN7UnMyMTKbapOca5QzNDQ7hFsyMzPLirLLi7PMi7N5UXG6urI5hFpRpHozMzNRUVH7+/vMjLS7u7OdbZV8U3R8WkNSpXs0NDQyMTHNi7QxMjF8UnT///81YDZSAAAAAXRSTlMAQObYZgAAANNJREFUeNrt0rkOgzAQBNDsrvHFTRJy3///jxmjiM4rujRMAS6exlrbmzX/TLnUsZ+XtAyWjYFVYPQzJNhMao4JlsmJCJwKUZZg1QKqWwMZuN0RUK38ue1LH9sSP01T7W4aLGksOokT3LaGsq4RKJF3V7UYhZ3Pyj7AISil6QTynWg0fYiICy74rMO2ZrgEy4laVqBcH4cziCsYnwys4SQ1FexCtETDPlM4djKxaLGwyuupcY7FaU/px169mN55mp+bBol+Q81Q94fPfbMoGGPNv/MFPLoKlOemYGAAAAAASUVORK5CYII=",
-    "gender_rate": "0",
-    "rarity": "120"
+    "gender_rate": 0,
+    "rarity": 120
   },
   {
-    "id": "34",
+    "id": 34,
+    "sortid": 34,
     "identifier": "nidoking",
     "name": "Nidoking",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAmVBMVEX///8xMTEyMTIzNDRTUlN7UnOaapKca5TMi7POjLVSUlIzMjMyMzNUVFQ5hFr////Duqt6UnJRUVF8UnSMjHtRpHqaa5ObapM1NTV5UXHGva3LirLLi7M4gln7+/v+/f05g1n8/PzEu6uKinnGvq5TU1MxMjJSo3rNi7Q6g1rOjbYxMjEzMzL9/P39/fydbZV8U3NSpXs0NTS6SgGOAAAAAXRSTlMAQObYZgAAAU9JREFUeNrt09duwzAMBVBR1vTObnbSPdL5/x/XSxYtDNsJ8tK38EEwoINrirLVpc6qhM6FTv8953QqUGAubpmdCnyaapWAJLSMButRuZ56PQwZWIxYs35FpL7WUxO8NyGa3Sr2O7wSIYCOoXn4LFeAx2Q0KZwETn4kEfVI9xhRHLgry0nJJPEetCs96ChEgfdyA7kHbcN8HqIUyxeVy1xzZyE7XSIyAzdpGrKh84CK2pGYMr83qz9kQtwsJKnEIrLpHG9GQ5t3I4/GaYcGebENeIV9hh5p+yIdBBNYwtkZdAPKAD2aS68P9eJuIJnC7IxUE74WRASuqV5sqwJwWzg9Z6hbdy0r2Pjt10mHmje6o7T6ZjxO98+RTw5E1H/hc2v1pqoQBgeojlXOknAaHDyOZq1Zt3olWZzFibuw7wtB6XP+yU11ezgpmgO71D/UN3a0E1yOL8o6AAAAAElFTkSuQmCC",
-    "gender_rate": "0",
-    "rarity": "45"
+    "gender_rate": 0,
+    "rarity": 45
   },
   {
-    "id": "35",
+    "id": 35,
+    "sortid": 35,
     "identifier": "clefairy",
     "name": "Clefairy",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAASFBMVEX///8xMTFSUlLWjIT/vaX///+1c2uzcmpUU1OjcTGlczGmdDIzNDPTi4P8u6P+vKQyMjFUUlIzMjE0MzK9vb1TUlEzMjL7uqO+2zN7AAAAAXRSTlMAQObYZgAAAKBJREFUeNrtz8sOgzAMRFHGdsK7QJ///6cdI7GMw7YVV8ruaJI0V7/RdNb1azMBdYh+WD9mjzo0uZlRwouhLt3NdLFxWENoIvNibHwFk9BkR53M+i4PgiT5zR2Xy06NEau7Nt+LMPkTjY5na3NRIhPweKqbCIJPe3mH0nIwfKQkOsKMpiZldwHEk8SLBxkAOZw4DO3uALpKSInqTGRXf9gX3bwEhq3h2REAAAAASUVORK5CYII=",
-    "gender_rate": "6",
-    "rarity": "150"
+    "gender_rate": 6,
+    "rarity": 150
   },
   {
-    "id": "36",
+    "id": 36,
+    "sortid": 36,
     "identifier": "clefable",
     "name": "Clefable",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAb1BMVEX/////tZTOjGsxMTFSUlKta1I0MzJTUlIzMjEzMjL8s5IzNDP////7spL9s5L+tJPPjWznhHOralJUU1PLimoyMTHkg3LMi2rmg3JZUTFaUjG9vb38/Pz/tpWvbVRcUzJ5YjHNi2p7YzH/t5Y1NDMxEMzVAAAAAXRSTlMAQObYZgAAAM9JREFUeAHt0bluwzAQhGHOzqxu306c+37/Z8wKgpOKDJvAjf/6w2gFpmv/0MhK93ZTCz/q5Hh/6n4/P5JZeDTrVmgWVprnsR3MNg3J1esDUx5au18fBpivAesKcPspDVhq8iz1mHDucNsz48CXLYGnZ9sgbvC7XZ85UIADXwgYgzvP/TWFkA5DFJO5xZD4yaydbyxDAR5Qpy4LbXEKZ9q/ByxNCjYnD1icNGl25qUnpJ2TWwEmSlUu8dGDRGK4oiTlHi79nabJK9yymi7dtW9Ynwda8M/V4QAAAABJRU5ErkJggg==",
-    "gender_rate": "6",
-    "rarity": "25"
+    "gender_rate": 6,
+    "rarity": 25
   },
   {
-    "id": "37",
+    "id": 37,
+    "sortid": 37,
     "identifier": "vulpix",
     "name": "Vulpix",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///+cWjlSUlJTUlExMTG1c0LbkmrelGt8SzEyMzNUUlF6SjGycUGaWTgyMTGzckK0ckHMakHMakLNakEzMjHckmr1izn3jDl8SjFRUVFSUVF7SjH2izlUU1Ldk2ozMTH0izkzNDR5STHLakE0NDSaWTnzijg0MjGdWjn9/PzOa0GbWTguVypzAAAAAXRSTlMAQObYZgAAANNJREFUeNrtk8cOxCAMREMJpPfey/b9//9bHGWPQK6RMhJw4GkGW8a4dCrNVOgI5hevonxSHVffgQNUE7oiAQKKAmVosKK0itGWLjN7bE5OUsVAyhxnjyQoRWnnYDcGtJO80fZMMn0ExngP5AhVSyyLsnTCgVsNxjgZDTlIJodxbn2J2DNVb1iPmdVGbc45NzMVKO7fN4/AaQIpix5EIl0iE6QCmZXvDAnFoopq/lBGfei2VDatsRtBqK0EwdRHJATG1g7Z0ri7l3YaUXD0GxiXTqQfqI4QR8Qu1P0AAAAASUVORK5CYII=",
-    "gender_rate": "6",
-    "rarity": "190"
+    "gender_rate": 6,
+    "rarity": 190
   },
   {
-    "id": "38",
+    "id": 38,
+    "sortid": 38,
     "identifier": "ninetales",
     "name": "Ninetales",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAeFBMVEX///8xMTHWxlr354xUVFKllEqmlUvVxVn15Yr25otSUlL05IvTxFlRUVHTw1lUU1I0MzIzMzHenErz5IpTU1GjkkozNDWjkknbmkoyMzQzMjHVxFnnTCqtSinnTCzWxFnWxVkyMjH25YrbmklUU1H35437+/v+/vzxIWnCAAAAAXRSTlMAQObYZgAAAQxJREFUeNrtk8duwzAQRLPLXiSq23GK0/P/f5hRCXIhFV8C5OCBBCygh8Folry56m800YVY31zC3X68N9tEtGsnmnWgg8VYsutlwFdwB6utENxSAYSLNu3CKYyqYDpVQTAnoio6Gd3KPufAfuaCHIfIaXmUspIyYM2srB5+wBSEaLIZlXHazpYLmHxA5Oxf8+fj2QnpAa6epYzi/uGOv0kPzrR5TvBs47SZqeRHcLl24DAAgJThBaXCAqF64xhkwG6K264dOxjP8VBOvp0tqbaIuDXpdsBqNDAb1RCERN62fCIrH1dOyONTmcPRGVChP3YveE+7HNp77d6IuhPt3pkqJoJ+v2QToKv+gb4AkjAQAaQoB+gAAAAASUVORK5CYII=",
-    "gender_rate": "6",
-    "rarity": "75"
+    "gender_rate": 6,
+    "rarity": 75
   },
   {
-    "id": "39",
+    "id": 39,
+    "sortid": 39,
     "identifier": "jigglypuff",
     "name": "Jigglypuff",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAeFBMVEX////ejIwxMTFUUlJUU1O9Y1pSUlL/va38/f0zMjIzNDNZrKRaraVcrqa6YllChIS+ZFvbiorbi4vdi4v+vKxTUlL/vq7//f3///8yMzJEhYXejY37+/v8u6v8vKxZq6MzMTH+/f37uqtRUVFEhIRUVFQ0MzJcraU1pn4vAAAAAXRSTlMAQObYZgAAALtJREFUeNrt08cOwyAQBFADpsV23HtJT/7/DzNIuWbhaslzflpggOjIXnLiPMyVTHDYAChWrZn1wweckxyh5R2MMVk3Wr89EwtZM7Ci5dS8/lUxobB+rBQBx0u+xY75Bi6T6fQvMSfKXrJ8g3km8IxZosO+c85MiZkB/08smxgb/ORJSkKUUzU4S5+lZpjhyKt2uQ1wJMRIOInGaTeeZYu+V+1x7jhIKVQlryFv8oy1beDrtaH/ITqyl3wBLJcKghZj2esAAAAASUVORK5CYII=",
-    "gender_rate": "6",
-    "rarity": "170"
+    "gender_rate": 6,
+    "rarity": 170
   },
   {
-    "id": "40",
+    "id": 40,
+    "sortid": 40,
     "identifier": "wigglytuff",
     "name": "Wigglytuff",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAkFBMVEX/////xrUxMTEzNDNSUlJUU1PTmpLWnJT8xLMzMjL/xrb////7w7L8/PzDw7q6cWK+dGTVm5P7+/tUVFRTU1NRUVFTUlL8/fw0MzMyMzIzMzM0NDT8/v1yxKy7cmL//v1xw6vVnJR1xq1ChXNEhXRTVVP8xrREhXUzMjHExLv+xbT+/v3Gxr3Gxr69c2NSVFL9a6GzAAAAAXRSTlMAQObYZgAAANZJREFUeAHtzzdywzAQhWHuLjKYlZ1zDve/nd/IVsmFXKjjz4Yz/PgwqOaOTvhY2J5N/KZA4fF8Gjof/4ZkzHka7rrBx5q2eKttAzctnQ1E/Usl3TpsNYjv/dcQubZXQ1TvvXIexcIgjn6zkDbgYRXWRNaYQKQ7uXmi36yLGnxsEtHd/SW41+B3IPSwed4k8pqUcdHkhMWL5AswL0yTrnOiIkRg1A+qlPb9X/JzGcrwY9/SON1169c9vPWaQzvm9gDh1AQULnJVTFaGywzOFY89SOzNnawfsiMPHnZmUg4AAAAASUVORK5CYII=",
-    "gender_rate": "6",
-    "rarity": "50"
+    "gender_rate": 6,
+    "rarity": 50
   },
   {
-    "id": "41",
+    "id": 41,
+    "sortid": 41,
     "identifier": "zubat",
     "name": "Zubat",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAb1BMVEX///8xMTFKhJQxMjJJgpIyMzNSUlJrtcbGpc4zNDRLg5RLhJRRUVFRUlM0NDRSU1NqssMzMjNKg5Kze5u1e5xqs8T7+/vFpM1TUlOyeZpTU1Oze5xMhZTEo8zEpM3Epc0xMzMzMzPLy8PLzMVqtMW1ykUaAAAAAXRSTlMAQObYZgAAALRJREFUeNrt0McOgzAQBFBmsbFNCb2k1///xqw5kEsW+ZhIjMTtaWZxtOX3oxEInYoD4T5dpAOCoKuMuUGWeYK5DHlPHOkSX2MA9TKm7KlNGcquTHpztQd23ZgJ0nGVz7GbeLgdrc2+Qz3s/CwVSeN3L7aGEiqBYaeI5rp51yESJEfxeVNytvXaiz/uQEVUNBQvq8KP0/PEjOLPqjiee7eodQvfF0L50yFQC1A4IFiGwy1/kjeWLgdSPjq76QAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "42",
+    "id": 42,
+    "sortid": 42,
     "identifier": "golbat",
     "name": "Golbat",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAflBMVEX///8xMTFKe5QzMjIzNDQ0NDQxMjJjrca9hK0yMzMxMjNRUVFiq8Niq8QxYnFJeZL7+/tSU1NKepJSUlJRUlNJepO6urIzMzMxY3NirMVLe5RkrcVlrsaSY4QxZHQxMTIxYnL8/Pz8/f4yMTK7g6y8g6yTZIWUY4S6gqu6g6w5qPCMAAAAAXRSTlMAQObYZgAAANBJREFUeNrt0skWgyAMBVATFXCe7TzP//+DDcSupMqum771JQ9y8P75aQJXVwg3GH1gBAAuE4NUShl/s4GGKBgi4oqtbRokx26A95tSak1cjGGeSVk1wAOvD5IU3zKQquT+5Q9QkbS6fiNNYuN2pEiOHb/zHJZbFMDFWvq2FZYhUDtim3GvlhfrdgDKsMBlR457eTd2CoVmo1oLTGqSPjzVlOsXZmQL5ow3IdPqFKao5UwCfnZTi1kJibmmmP+Q+YE/5bzUV409hzB0lN4/v88bLbYMPZIWA80AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "43",
+    "id": 43,
+    "sortid": 43,
     "identifier": "oddish",
     "name": "Oddish",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAb1BMVEX///8xMTFjnEo1NDVKe0JSU1FTU1Fac5QxMjF7lL2bzUqczkpZcZJSUlIyMzE0MzQxMjJJeUFimklim0lKekJ5krp6k7wyMjOay0mazElRUVFRUlGazEpSUlNjm0tZcpJLfEJ8krrlSys2NjZimkrc6JhAAAAAAXRSTlMAQObYZgAAAK9JREFUeNrt0kkOwyAMQFFsIBBImnlO59z/jHVaqUt73SpfgtUTGAl19DMV8N6AV1rpyisNY4wn1tW+MguMiB5YN6JtlzVioOMEGJItYIgJALDwNiWbmWLSGuP5Gc3SNmhzCkCENl8RMbDvLmrTmGZX8QSc69I0vdgcKHbE7nFPqUHxPbOeFFlXStD1A13uRDhf3Z4Ilc4+7gzyF8uI5bLLXAkzOTENtEhL7quP/rEXN94I4x2uRb8AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "44",
+    "id": 44,
+    "sortid": 44,
     "identifier": "gloom",
     "name": "Gloom",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAq1BMVEX///+MSjExMTFKhJRSUlJrrcb3ezFRUVFJgpK9Y0IyMTEzMTFTUlFUUlFqq8M1NTWLSjE2NjarajGtazGubDO6YkG8YkFSUVH2ejExMjJRUlOKSTFLg5K7YkKLSzO9Y0HFs5Lt1LrzeTH1ejGMSzKNSjGKSjI0MjFKg5I2NjUxMTJMhZVCa3NqrMVrrMWScZLs07uTc5SUc5T0ejGVdZUxMjOsajH8/f38/f49yUYvAAAAAXRSTlMAQObYZgAAAPBJREFUeNrt00dyxCAQBVA1IJIiyprgyc4e53D/k7l7LyHtXK6av2Hz+ISC4JI/j2OYOUrlsD3aCZeplyp+l4mY6HSqiAWlKMF61122+VcJbbGrUI6zOhbodhXKEkZhVhsDbQ7YiMP26GtcHhISBMcLSe6lTOhu2jUeaR3R3CF3V3cnWC0EGmMMNCZi+5vhTUa6Z5pzft2YbgNNJwcdrePSMOR9Gl4dpDxZz6W757dzGH6yFCW1jUP99EoUKzdgJ+TPxxlhA6ve55i6/X6g04Bl3j7OF0wjBDv9ZoOMKUF108k072dBpx/v5/6a4JJ/k19fABEEAnPJHQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "45",
+    "id": 45,
+    "sortid": 45,
     "identifier": "vileplume",
     "name": "Vileplume",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAqFBMVEX///8zNDOcY1KdY1LeY1L/lITbYlFSUlJTUlJZcaNac6VqistrjM6aYlIxMTIxMjO9jEIyMzLcY1IzMTHeZVP9k4P+k4P+5MwxMTH/lYX/5cz/585BWYJCWoRccqNSUlNqi833rTFTUlGaYlEyMTFCWoVZcqO7i0JZcqQ2NjZRUVFUUlL0qzH1qzH2rDFUU1H75MudZFFqi8y9jEExMjI1NTXbYlLbY1P6F+31AAAAAXRSTlMAQObYZgAAAQVJREFUeNrt0sdyhDAQBFCvNELknNmcnbP9/3/mlly+CXHa8mX7AEXx6EGCm2sulFmrM42cmrOK+B52nDnN0HH3YfMcVX1HRTvidpUQAu6VPUKKfigLk/t0iDhj7il92ryn24ixnMgkbx3O8qaje3lKt/KrFgLXhXH0S1kLBBSsHzpzIRqJSANeCRVqSvPoXY5boHC6DuF742hIFa5O4w7J2haWu5GS9i3Hnt/J40oiUNZkztLX+Zj42EHi+f73EnDinwjCRB3slbP5Ig5CFcBFbG3EbA0Pb+EB0ma9NfpQeF6Hia3SW8mjekH7T555f2YeT+wizO8ThkWb1382QfP6r/nf/AAqwBZFDB1EQgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "46",
+    "id": 46,
+    "sortid": 46,
     "identifier": "paras",
     "name": "Paras",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAt1BMVEX///8xMTH3lCk2NjZRUVFSUlJTUlJUU1HEclLGc1L2kyn3e60zMjHDcVEyMTHGc1FUVFT0kimUSmOrWTmtWjn7+/u9Y3vGdVS7o0Lzkin31Evzeau9pUK9u7s1NTX21UmuWjj3fKvFclHFdFOSSWL8/Pw0MjKSSmI0MzGUS2JTUVJTUlE0NDS6o0FTU1H0equ7u7v1kym8Ynq8u7pTU1O9ZHq9o0IzMzM0MjC9vb39/Pv9/f3///+BIQtKAAAAAXRSTlMAQObYZgAAAOdJREFUeAHt0sdug0AQBuDMbC90sI2Lkzi99573f64wkaJcdu29WvJ/Quhj+Wdgb5ctCgNIcsuZm56nnHezf+jcaQI8fhy9XuQJkJ/V9SXA5qqMT24rxPfZdO7Xj9xjYay6c26NXEJmUYkKCzmZv4zqPOq6sUVERfK3aoTx+6PBFYuPZ20LKSLTsMxIbdp2tfi67kottYw6Y2TzgAdPb9CVolKiyYOQa+NJiObzu6SSWgYly+hVDPjJuL0a3HD6ykMQ+r9Fcm0H6IHuhOT/VU+Ontn0uXsltE/5I3lkNZG+CaFyW5JdfgDE6g38M9J2AgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "47",
+    "id": 47,
+    "sortid": 47,
     "identifier": "parasect",
     "name": "Parasect",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///8xMTEzNTQzMTG6YmK9Y2Pve4RSUlL3lCkyNDM0MjC9pULTYkHueoNTU1Pzkin2rGNUUlH3rWJTUlL33kL0kimlpZTve4PseYLWY0HWY0L33ULvfIL2kylUU1H8/Py+vr6tWjm9o0K9ZGKmSkq7YmLz20FRUVH23EP23EK9ZGO9g1K9hFHteoMzMjGjSUm6uroyMTG7u7u9Y2KlSkq9pEKrWTkxqNEMAAAAAXRSTlMAQObYZgAAAOhJREFUeNrt0jcWwjAQBFBLsuSEA9kEk3PO9z8aIxMq1qaDwtOo+W92pSejyD+EM8a+cvutmhzznRMrJFc6LI46laaSIseZvlJRp1ZZXY6Zt4jVMzKrkps+yjB3UetKSVfyGQwkaOR5YynowiXMazJdyZkp/feGtOSlxDWl1Ft2U7a+eruPDxO22mVrCjHCgpptzoJy/UFgwVZTTzwQBxSHRqBt3e5BVpnxecW2wH3mp0ZQt+1W2bJuQ+Iu4vnDQhtQlJIeJV+nhq7haAlIBxCF6QiW5QASuBTm/cjQfZyZiqgipFHk57kDN7YRvKD8tF0AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "48",
+    "id": 48,
+    "sortid": 48,
     "identifier": "venonat",
     "name": "Venonat",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAwFBMVEX///9qYqtrY61KQoRUVFQxMTE0NTOLg90yMjOMhN69pVrOUnP2eov7+/ttY6yLg9v8/PxMQoMxMTKKgtz///9qYqwzNDKlSmO6o1lSUlPLUXM2NjZSUlL8/P1LQoNTUlLNUXL+/Pz0eozm3ZMzMjE0NDRKQoPLUXHk25L0mppRUVFTU1JLQ4OmSmMzMzK7o1pMQ4TMUnPOU3PMUnLk25P9/f7n3pTzeYr3fY33m5tsYqxsZKtsZKxSUlT0eos1NTXU9onqAAAAAXRSTlMAQObYZgAAAN5JREFUeNrt08UOg0AUhWFG8RpSo+7ubu//Vr20Xd8Z9j0JK778yZDB+C/jpK7zB5ouTKHUDKqz9Z8LNaDQCQLkeUv4hhS4i31OzEeBJ3kLhxKC9gEecEqYOlrShaaFu1GHFz7Oti3UeTkzDcJweMpBikIPl3WyuVKTdt1igMsXqU62xafrgVQUG+fLuuYt2iiEScIafFdul5sBHBz5lrJyqybDmtsiwChAJAnvGYsoRR3AKWF7Z55CFgFUyOMdmgx1ccWZkW9OdR+FEISyVR9nPzx2eku9P1YI479sewO1NxEHtpHrCAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "49",
+    "id": 49,
+    "sortid": 49,
     "identifier": "venomoth",
     "name": "Venomoth",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAqFBMVEX///9SUlIxMTFTU1RUVFSro/Oro/Stpfc1NDJRUVGSgsuSg8yUe1oyMjIzMzNTU1OUhM6zmnK1nHO9rcbk0+Tm1ebn1uf7+/v8/PxTUlMzMjOspPa0m3IyMjO7q8RTU1LT7PwzMjI2NTOLcouMc4yVhc4yMjSSelm2zt66urIzMzS7u7OKcYq9vbXT7PtTUlLW7/+upveymnHm1eeyy9s2NTKzzNv///+h2ZxBAAAAAXRSTlMAQObYZgAAAQpJREFUeNrt08dywyAQgGEtXQ0VqxG5yo6d3sv7v1lWJOOTMDkkN/8XXb5ZYEDBuT9Okd+5Idym9kt88G4HaBTf++EuDVTUI/RKhDxf+CFsU+9ATIWCgpBHqAg2LTmN+3yBwioupaSTcuBUSAqEU6teG0w7obXCKhccol7+uJHNxi6mXMuExKxDUzsXfqNiZOiscsxDGI6uu6KwrJ37s71zST80eWBQzZwbxFT7TGF9gzA2ULkHogy7S7N+YnFulhkAcV/hdYYGYvM9EVd2Sx3luelYkTyOB9JuiVfcfrLbrFjheWoLT4y9z4pkvqoaVumTMIRDMi83hFSNZ+RLWZYbz195fLDBuf/qC0pRFjnkdEdiAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "50",
+    "id": 50,
+    "sortid": 50,
     "identifier": "diglett",
     "name": "Diglett",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAaVBMVEX///8xMTFSUlJra1KMYzkzNDSLYjkyMzO0g1mCgnEyMTFsbFO1hFqDg3KEhHNSUlEzMjGzg1lTU1NqalG6sqO7s6O9taWNYzmyglkyMjKKYjhTUlJRUVEzNDONZDvMYnLOY3PzeYr+zNRT9B4gAAAAAXRSTlMAQObYZgAAAIBJREFUeNrtzkcWwzAIRVF/kGW595LqJPtfZMjJXLAAvQmTe4AslTKUAzC5o2lcZXMmmV/DIHbQ3OP9eVYWWNzP1x4Eqm680aj/WCyTD8Kc64GYK5mJvPtBJkTgzLRuk3c9rczRlVi2Wmzd/l30esfcdpdSLisSMwMyMjUxqZSlL9ElBXyH0Wh3AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "51",
+    "id": 51,
+    "sortid": 51,
     "identifier": "dugtrio",
     "name": "Dugtrio",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAjVBMVEX///9SUlI2NjYxMTFTU1N6enq0g1m1hFq7u7RTUlF7SjkyMjKaakKca0Kda0Oyglmzg1l7e3s1NTW9vbX3e4S7u7N5eXkyMTH2eoNRUVEzMjF8Sjl8Sjp6Sjn3fYX7+/uaakFTUlKbakHMWWLOWmPOXGX0eoPLWWJ5STgzMTG2g1q6urJ8fHv8/Pz+/P1ooWZjAAAAAXRSTlMAQObYZgAAAN5JREFUeNrt00kWwiAQBFAbAoQMJjGTxnmevf/xLHThRoRdNtb6v+ru8DL4p/+MOOc+jmVKpa2X6zIPySaJBFSdc8HlorooH3gc76bSDTH7FEmPaxifJCnigmwlUw2pibucUpA6x+yfL/L6hmvKlYLktrqG7othm6Eyf3kRf+9rCtqOqxmWPDz2ZwOL+DskQfNog0vghxIb2CvDIMHBiZ5HEgvAWWBYBkR1CY1oURQ2eQ1IhOWN3rAOhFVyHIQiSBRiEQFop+gEJzOZ25yhDQA4bOz8Ywz/1Ln44J9e8wRXjQ8tjEte2AAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "50"
+    "gender_rate": 4,
+    "rarity": 50
   },
   {
-    "id": "52",
+    "id": 52,
+    "sortid": 52,
     "identifier": "meowth",
     "name": "Meowth",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAilBMVEX///8xMTG1nErWxmtSUlJUU1LTxGozMzHTw2rz5Kv3560zMjE0MzK9ezHVxWqzmkrWxmwzNDVRUVGSWTFUVFNTU1GUWjGymkk0NDS6eTH05Kv15avWxm0yMzS2nUv25qu7ejH7+/v+/vz///+2nUy8ejHUxGt0c3L35ylTUlEyMTH15Sn+/v22nUnc0SmWAAAAAXRSTlMAQObYZgAAANhJREFUeNrt0tcOwjAMBVBsZzXdAVr23uP/fw+34jUJbwiJ+2b16DpRM/jnq6k/dUn2Ea7B6A4DRODSKQ2QZE5ASAHDEs8nkptrCNZGQ3u/POejTc4wKAk5DCMOnCi5saD1CHgCL2wxTVZY7PYL0pDYzF/p+LN9TLb7w9z2pd57s6t2k+2CcMxumqdeadZ2hVhIRaSneXNMfU4KRVJJ6OKH3FfhWHSuH4fsAj+QW2c24yl0ROjXz6putyEdfha8WogSMYWgGzY3Xq50/KHB+3TReJyv9Z8fygt9IA3qel9S8QAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "53",
+    "id": 53,
+    "sortid": 53,
     "identifier": "persian",
     "name": "Persian",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAh1BMVEX///8xMTHWvWP33pRSUlJUU1J7a0qtlEozNDUyMzQzMzHTu2L13JLTumJSUlHVvGJRUVEyMjH23ZN5akmrkkk0MzJTU1HkSjGulUsyMTF8bEurkkqsk0rUu2J8bErWvmV6akrnTDTz25L025KulUz2kvP225KlSzH33JVUVFP8/Pz9/Pv+/Pv+hqt2AAAAAXRSTlMAQObYZgAAAO1JREFUeNrt00eOwzAMBdAhVSNbrnHa9F6S+58vXwK8CGAC2mUW4YYQ8PBBSvbdrf5HrYiKnH9TaqIit3M1h6JAtaunghER2cdhkha4WAZ6WnZjk6WfvRegH+1+bvkchW1899IQ0WgtJHLXLZwQWSt1sA/O7onSRQqMur/XL3WAa6pBoTgsushm+/mjmN2mYoZkYcRVp99xyxtdGQ2ZKyy5aOB+t6ePGq0SIWSan7+Pz0anRJOsIeHdcsyQAgNR5KfHIL1hZORpuHRat7kLG9330AAYWgrMIa6HgJs/clES3MW2Mo2uDcW/1a2uX2dqhQwjHsHAwwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "54",
+    "id": 54,
+    "sortid": 54,
     "identifier": "psyduck",
     "name": "Psyduck",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAk1BMVEX///9SUlIyMzQxMTFTU1K9pVr000r21Ur35639/fy6o1kzNDW9pVk0MzHWxmtUVFH31kq7o1mrmln////z00k0NDTVxWqtnFr05KtUVFNUVFRRUVGagkH31kwzMjGchELz5Ku8pFmdhUQyMjH25av25qu9plu+plzTw2pUU1JTUlH8/Pyag0L7+/szMzH+/vzWxmxGMHaBAAAAAXRSTlMAQObYZgAAAM5JREFUeNrt0ccOgzAQBFAWjOm9Q3rvyf9/XYZw4MTCLYqUkY9PO2tb+efrcXAmQkfDGUEawASnpmHoaYgy6gKSYYt5Z+sCDAFlF7SX1hzI1Q1IFlpZCmclRyOQASdnVk3ymd2TWrqGx40UpVnRNdlcsCsHm9I87MzqtsaWjFRPexN5+edISBauOkZEEUbCDY/0fYzTP1mwT94QodRtoWB+UtXs9hKdFBGGDjWj1+BdL3GPlhF1xYPdcbHFnhTnD4Z1VFHjvOgdj1H7z6/kDavyDdR4R7tLAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "55",
+    "id": 55,
+    "sortid": 55,
     "identifier": "golduck",
     "name": "Golduck",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABaFBMVEX///9Zesxzrfc1NDQ1NTY3NjVSUlNSU1RZeMkxMjNae81ae85xq/Nyq/Ryq/U0MzM3NjQyMjRRUFFRUVEzMzUzNDdSU1VSVFdTU1FUVFVYeMkxMTJZecs0NDVaesxae8wxMTExMzRafM9xqvM2NTRCYqNCY6VyrPRyrPZzrPVzrPZzrPdBYqN0rPZ0rfR0rfXMtEPy44T05IP05YP15YL354RUVFJUVFQzNDVVU1VVVldXVlMzNDZYeclYecsxMTNZecpCYaFZecxZespCYqJZe84xMzZaes1CY6Q0NDNDY6YyMTNbfNBdfc9xqfI0NTZRUlJxq/RyqfByqfNRUlNRUlRRUlVRU1ZSUVE0NjVSUlQxMjJ0q/J0q/Q1NTRSU1ZSVFZ1rPZ1rfWlTDylTT3MtEIyNTfPtkTxY1Tx4IHx44QxMDHzYVH05IJTU1RTU1X1lLxTVFX25oNTVFf5+fn6+vv7+fn+/PvXD/v3AAAAAXRSTlMAQObYZgAAAUFJREFUeNrt0VVvwzAUBWDbScNQZmbmjpmZqWNmxr+/epvUh2Re36ZJO5byYH1WdM8F//nVqMEWnWRqBasei8zyQYx/gN69hD2QRCagXhGhgcsdzKSRcmpdDgFiJl/vc0gSkmiI/rqp67G61XJ+tCN1tsuKrTmcjpORfSmV6rp+K4S9Y5//9i2a9ByCLmfb8/HLrMjAtG0aT6eEtA3mMwpbPnvsdvYKwrqMpHAP8EGR18C5y3zAVanVqidO5tavyE8JZONG+2htNTTHlLEzUty4V3AkEJLuIA80iQKDuVK9KRrxo/0H7Bwbblq/8IuikfoYbDuDnd/+3dajKv52BCOlw3yGhaLIEzeeXR1mI6VCA8J+4sYHJzYX3MzAGhRj84AozSMru2YmFo97ACBLimpMPpWNb5Fds1gatCQb5z9/IO+ZICiFOeUrtAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "56",
+    "id": 56,
+    "sortid": 56,
     "identifier": "mankey",
     "name": "Mankey",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA+VBMVEX///8xMTHOtXszNDVSUlIyMzT25qQ0NTczMzJUVFOKYjGMYzGrg0qsg0quhUvLsnnMs3rNtHoyMjH05KP15aM0MzL356XIsXgzMjGthEpTUlGuhUxTU1KLYjBTUlKNZDKogUnz5KOqgkmrgklRUVGsg0mMZDFRUVI0NDSpgUowMTE1NDM1NDU1NTRUVFRVVFJWU1JWVFOuh06vhkxWVVPJgWnJsHjJsXlWV1bMs3lXVFPMtHvNs3mIYTHNtHvOs3mKYTHPhWzkTCznSinw4qLyqZny4qE2NTX0q5o2NTb1rJuLYjGLYzH3rZwyMTH6+fj7/Pv8+/r++vnDJOUIAAAAAXRSTlMAQObYZgAAARxJREFUeNrtksVyxDAQRD0jMDMseXk3zMzMnPz/x0RKNjfL8TGp2r7M5U33VEvaVH9dDCpyw0Ykx++cPRYk66fSu2RBPx40mobGfJ5C3wT4XgAoIMmCZUfpMMnMGLnpRF8h9ktRujWzeuUlGXLMYy9JQYBNKLyzFmzFmZQpQY2NKKgaujnkWSJRRDTAEskK0l+LRXS254Qo1B1HKvD14jTGDXhrhZhT8NFQlVRbp53598uPloyWhTLVldfP5x3Xk8EUJu9VbLl993AQoNAmRQNKyJXZfDf0gyNR0QkGBsDIKQTnHus7S8E96XGOlJAaYrEhs86eFjUiTnD3XTkIgOJrLJOJdbuulUn/sW4PupU+st67FdGVSHHpVP9Dn59CF10JHrr2AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "57",
+    "id": 57,
+    "sortid": 57,
     "identifier": "primeape",
     "name": "Primeape",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABKVBMVEX///8yMzRTU1LOtXv15aP356UxMTFUVFOMYzGte0qtlFrIsXjLsnnNtHozMzL25qT3rZxSUlI0MzIzMzQzNDVwSTGKYjGKYjKLYjGLYzFSUlGNZDKreUmsekk0NDQ0NTeulVw1NDXJsXlRUFDMs3pRUVHOhWtSUVDxqpnz46Lz5KP05KMyMTH25aQyMjFTUlH35qRTUlIyMTCMYzKNYzEwMTFTUlCrekqrklk2NDWsk1o2NTZQUVGtlFuufEuulVtUU1JUU1M0NDLKgmrKsXnLgmrLsnhUVFRVU1JVU1PNtHvOhGpVVFJVVFTPhWxXV1bzq5o0NDNxSTFySjH05aT1rJqIYTH2rJpRUVIxMTL3rJtSUVFSUVKMYjD4+vn7+/v8/Pw0NDU0NDb6gymZAAAAAXRSTlMAQObYZgAAAUtJREFUeNrt0sVuxDAQBuCYwrjMmGUuMzMz8/s/RJ24Pa2z2kOlXva3ZMnSJ8+MbGGSPw4Qx2QZpTuOi2UVxZOAHYNhRvEhaIaoYnvwjT1RALudkG42CTKpDZByyvHhmqFgBFvVTog/IFihLtyoUmiRHwi4A4JKortxQwhBFpFatt1HZsbrm1u8QX5j94k0rwTBkyOLGswogh6UUyKndgPTuhhZDHrSn3BYaipVyGqSdRV7UKw4DoUcqatL+io+F98LGNGYFb4TiiW4eTpw3vY/CgZKy9leIpVoc1xeg9O39tnM84JqINaiTB0nuVr96eL+GLrIjynGKOQ/41z9cDt94ENDLwb90fxdMtmDklQydENP721xEZOz5cGO6y5qyxqMv8amRsjodTscEb4EUH6I1z6FETISYe1elV8eeWD46stoThhL0jXJf+Ybeq8jRlIOIaMAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "58",
+    "id": 58,
+    "sortid": 58,
     "identifier": "growlithe",
     "name": "Growlithe",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABUFBMVEX////vzoTOpXPsy4JUU1H0mkL3nEIxMTGufFLMo3LNpHIyMzIzMjLtzIPuzYQzNDPzmkE1NjJSUlJRUVHMpHI0MjHOpXJTUlHPpnTUeknpyILqyoI1NTNUU1JWVVNXVVOufFP0m0L1m0K2Y0L3nUT4+Pk0NDJXU1IzNjM0NTJXVVSDg3KEg3CEhHOFg3Kte1I1NDMyMjG1ZEEzNTK2ZEG3ZELJoXDKonHMo3E2MzE2NzVQUVHNpHNRUFEzNTPOp3TPpnNSUVHReEnReUrTeEnTeUnTekrTe0tSUlHUfEzVe0rWeknWe0kzNjJSVFLryoLsyoIyMzHsy4PszILszINUUlHuzYMzMzLuzoTvzoM0MzHxmEHxmEJUVFP0mkFVU1FVU1L0nERVVFL1nEP2m0L2nEP2nUT3m0L3nEFWU1FWVFH3nkVWVFT7+vn7+/v8/PwrFlhAAAAAAXRSTlMAQObYZgAAARRJREFUeNrt0bV2AzEQBdAVLqOZOczMDthhZmbG/++ixLW02yWFX6XintGA1MwfR5cDMnQUyCGg9MuBHDwEAUpu7gMQwLVM/jgIDb9/6+MpgEBG9hu8bX6tx3y9IhQTGpGYlvnyvrTudDDpkYiMBN3qhFL8Vcad3UX8267Bcc5DGfd9vtGuhlM0HpxOHQNw90xbPZWtE/ZqvJKutwWsWYILpZgKWQzOPHoyms9rUCk+UXo9CgULdcNTEEat7BnFsTmVDzeSZjUetwDKErKaGQm381fOpjFP0MVi4uUgNGOLrr28N7abCy0MDdfSwmsvDWznbp3TnfOCK752ZeX98jGRlgZ1oWPSrtx8TDTevtSWmvkX+QYn8CGGrYTtiwAAAABJRU5ErkJggg==",
-    "gender_rate": "2",
-    "rarity": "190"
+    "gender_rate": 2,
+    "rarity": 190
   },
   {
-    "id": "59",
+    "id": 59,
+    "sortid": 59,
     "identifier": "arcanine",
     "name": "Arcanine",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABMlBMVEX///8xMTE1MzRSUlLOpXPvzoQzMzIzMjLLo3HMo3LszIPuzYNTU1L3nEJUU1I5NjhVU1K2ZURTUlHNpHJUU1HTeUnUe0tUVFTzmkH0mkJRUVFXU1KzY0I5NzbtzINUVFM2NDXpyIHuzIPsy4I1NDXWe0ozMjHryoL8/Pz7+/vuzYTVe0o3NjVXVFLtzYTJonHvzYKte1K0YkK1Y0LOpXI0NDNSUVFVUlHSeUnSekk4NzXJo3HzmUI5NTfUekrUe0lUU1P3m0JUVFLMpHLReUnXfEpVVFOzYkL0m0LpyYHUeknWeknWe0nuzIJSUVDxl0GxYEE4NjXTekrRd0nvzYOufFLwmkLWfErMo3FUUlFWVVP+/PxWU1LszII0MjHqyoLryoFWU1GrelI2NTT2m0Lry4L60wgnAAAAAXRSTlMAQObYZgAAAYFJREFUeNrt09Vuw0AQBVAvmCEOM3OKKTMzMzP8/y90RlWq1N5I6XtH8oN1j2YWbOm/fhclpD9WlmWlDwfMIT3TboclHE4hVdB2QXmL+J2mkjJXDaXLXea46nMp3TJk3pIVHNdp2A57JEa8ncMmYQ4Z1Ux0HCDxHcYPxB4oOZTlgTQ6fihzEx2EhABEhlCVPPLWwGEQsaRtPyUiTEfIuG926htaSXtUdhBHUKpc9cJm3EDXCL4M3+VH0jt2wtVxW75TNBWNmw5pBkNM19LQ0WUARXd7fR+HiQfVEqwTJ4dmahW/w+NwmMEHqiVcwNWqbS+JvwlKgGI5b2Fs+bH5OqVMiiRuh7FGnOngdOssFnt4/MyKnGZBL3w47sti+fW6yHXuAhhX8QW9JKyKZvIJk+stzGlqvi6LIT1iBu5n7VmBq07YkV6/1vv29G62eHGzwkJEChwvL8yJXeAkkxmUAsUh1904laRFWhAylAWMaHRvvyYGHn4+NgsN+5GUSv/19/oCiiUkBY/T6S4AAAAASUVORK5CYII=",
-    "gender_rate": "2",
-    "rarity": "75"
+    "gender_rate": 2,
+    "rarity": 75
   },
   {
-    "id": "60",
+    "id": 60,
+    "sortid": 60,
     "identifier": "poliwag",
     "name": "Poliwag",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAzFBMVEX///9SUloxMTEzNDMyMzJaeqxae61zlP5TU1xUVFxVVV0zMzVae6wyMjRcfa5dfq8xMjKEhHO7u7u8vLy9vb39/f39/f7+/v3///8yMzMzMzN2lf5SUltzlP91lf8zNDS7u7w0NDQ1NTX7+/v8/f/9tKRbfK9SU1z/taWGhnZ4lfyBgXEzMzJYeapbe6u6urpbfK00NTUyNTK8vL0zMzTHhXT5+fhxkvv8/Pxyk/xyk/39/fxzk/5Zeav9/v/+tKT+tqZZeqszNTMzNjMEeNliAAAAAXRSTlMAQObYZgAAANFJREFUeNrt0ccOgzAMgGFsSAKUQoEyuvfee+/3f6dGvXBK2nv5JUs5fPLBUdL+Ng0Rk6eQYaHCy+LHtWIDRS7TZYd9Y9fDj4vjhgBmSqVzE4stOyeHGuv3h2FzENrHLIfVtgjWnPvm5oTXboX1cBZU26KF08jvdCKHMUZp2ZvX80UB3LqmabqRTXnwoHWBU5YjMwpOhpvnzgJSE1+xELicAYcT0DTJp1g6eIZvrCyyGCuSXkBA9cC39LUiT1VVPqDTS06iEk5I+fnFJIvT0n7oDZ90D/dDqB/5AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "61",
+    "id": 61,
+    "sortid": 61,
     "identifier": "poliwhirl",
     "name": "Poliwhirl",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAkFBMVEX///8xMTH///80NTSFhXX8/f79/fxjlPdTU1NSe7VikvNUfbZikvRik/U5Y5RllfeEhHNRUVG7u7u8vLu9vb2+vr77+/v8/PxSUlP9/f0zMzM0NDRUVFRRebI5Y5W6uro8ZZUxMTI4YpJTfLUxMjNUVlSCgnExMjSDg3L7/P1SerP8/P2EhHRRUlNSe7YzNDP+J88JAAAAAXRSTlMAQObYZgAAANBJREFUeNrt0tcOwjAMBdDaWd2L0kLpYO/x/3+Hoz7X8ArqVZSnoytbiTPlRyIAvnO+Madv3PaSkPzcK3q3WscbsL0sffW1bygKE9NtOHkIu4hcA2ViTuwuCnEdqRUPBfhKpqnG4Ibk2E3kbIky1UFE24y7wj3PlsTmd1aKLK+PWhLVUgeLkKkER5RSI0riO07a0sK1x80JKlyNuTZ+5MXgvEWFOCbFNqbnywYHJTISwF7ZlRzN21Tzmv0Zred5ezuwwzoS4ZMah35eApEpf5c3i9AOJj7PDJYAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "62",
+    "id": 62,
+    "sortid": 62,
     "identifier": "poliwrath",
     "name": "Poliwrath",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAn1BMVEX///8xMTFSc7Vii/VjjPeEhHS+vr7///9RcbJSUlJSUlMxMjRSc7ZTU1NUdbZii/QzMzM0MzKEhHM1NDOFhXW7u7u8vLu9vb1CWpT7+/v8/Pz9/fxRUVH8/P1CWpU0NDRRUlNiivMxMjNRcrQ2Nja6urqCgnH9/f1BWZJDWpNSUlQyMjJkjPZTdLWDg3JDW5RScrP8/f5EXJUxMTJji/T5zVS+AAAAAXRSTlMAQObYZgAAARpJREFUeAHtkNluwjAQRTN2bJMlBEL2BSgLofvS/v+39dp9ZIL6VlXixnEk6+jcib1b/jYr+iV250fuS9exPvV9PyLg4Ke5WdjOJchYrms5TS5nwoHIWmJFU7XH5zCFS1pjLIa5jIjTHVVZJem7foIrHjaNgZtpP1iuSlqTZ1n25ceD4xjy4CWFKu07Gq2ybi7kQ8qB3spVv5QjlJ1WHYSWjHeX5KlcUO+UuSOhxC/pBV2QZL1Jm2ddjudjL3aNMRjkkb2kvqjsBOp+LwBq6MsFg9F5GxQKy3HU6Gpkur3lua7rbRAUr7XlvOUJI5gNJwT5iQ1YGJA9AIoRGZLoZ+/fhGu0B1ezmtluJgzIXDYHojvkW7lx/0Vu+QazmRYazYCczgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "63",
+    "id": 63,
+    "sortid": 63,
     "identifier": "abra",
     "name": "Abra",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAb1BMVEX///8xMTHEqzHGrTFSUlJTU1FUVFE0MzH020L23UH33kLDqzGcczmchDgyMjEzNDT13EEyMzNRUVHFrDFTUlEzMjF5UTiacTgzMjJSUlGagjjGpXKchDnGrjTz20GddDmdhTmccziacjn8/Pz///89NeMsAAAAAXRSTlMAQObYZgAAANFJREFUeNrtkskOgzAMRIlNVtaydN/b///GDlCJCyHcqkqMIMjSU+wZE636sQqxkKuoFWIJmGTn0mkBBcBj6SBFVgfAqxt02neVl9uMXF9pv+cvydyiAuj3Ujp4SQJgsT2QdfcamEC1S/PIT77eF5ax6I3dcm84tYw7PXEXAtCTEDKuSIJp8KZpnlhuJ22wNE7FxI+OLBVh0MkEKwLJVhmWlDU0zOlrjRCByRiPwR7F3AIVJjXKYNls9SzXf0L/D9p3p8fvVALLuHHHYTJa9Tf6ACb4C5JSjwfhAAAAAElFTkSuQmCC",
-    "gender_rate": "2",
-    "rarity": "200"
+    "gender_rate": 2,
+    "rarity": 200
   },
   {
-    "id": "64",
+    "id": 64,
+    "sortid": 64,
     "identifier": "kadabra",
     "name": "Kadabra",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAtFBMVEX///8xMTHGrTFSUlJTU1EzMjH33jnEqzEzNDT02zmLakqMa0qagjGagzGchDGdhTHDqzHFrDHFqzEyMjFTUlHz2zhUVFH23Tj7+/syMzO6urK9vbU0MzJRUVFSUlEzMzMyMjL13Dg0MzH3Y1L3ZFGzg1n77Iq1hFr87ItTUlKchDNUVFR5eXl6enp7e3udhTR8fHu0g1l9fX1TU1O7u7P33Dm7u7T33jo0NDS+vrZUVFL8/PzCU09NAAAAAXRSTlMAQObYZgAAAUlJREFUeAHt08duwzAMBuCQGvLew9l7pHuP9v3fqyRS9OC4qQ49hofEBj78kkmwdy7LcgDs3NXnw8wG9pv34fTnBU4kDobDR/i+RLk4dfTL3SzIiTpJHecn4PhamFrrBZQ6TtXvVyx1JdzVs6YiKAGguzVBFBXuarlkiSgNIio4dol0OVBzIuUdINFjiFKIMC85ToYpRoUwnbI/fppCIsM5fcvgIqWz13svY9hv9+Zm1nOCtEbV3JKLCoK+n6FKVKvbU/op43kcRSlfY73dkszosi0I7FC6lanjwpt4/v1ecGQbsuVGGinCeeX5EyHomSOxE8KYjKtZGkSGx47kZkRzpKhDS8nx0dAJDx3dvVau1hUdnSnoHDc5nuTuw9Sah8OsuxxqtoLNqLk07P7aG4f+iKIEmw1KeNIWrnmDILdaXba2e977/zrXF71bFrNOHk+EAAAAAElFTkSuQmCC",
-    "gender_rate": "2",
-    "rarity": "100"
+    "gender_rate": 2,
+    "rarity": 100
   },
   {
-    "id": "65",
+    "id": 65,
+    "sortid": 65,
     "identifier": "alakazam",
     "name": "Alakazam",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAq1BMVEX///9SUlIxMTHGrTGchDEzNDT33jnz2zhSUlGKakmLakqMa0o0MzGdhTG1hFrEqzFTUlEzMjH02zn23ThTU1H7+/uagzEyMjGdhTSzg1k0MzJUVFHFrDF5eXl6enpRUVEzMzMyMzOagjH8/Pz/74xTUlLDqzH77IpTU1MyMTHGrjSNbEl8fHv13Di6urK7u7T33jq9vbW+vrb87It9fX1UVFL////9/fv+7oo2yKGcAAAAAXRSTlMAQObYZgAAAVlJREFUeAHt0meS6jAMB3AkuaT30OFR4LG9l73/yVZ2lqGYzOQA6Es8k5+l/9juXUtiV6ijrpDyQ3e8OFLa7/8yaoREraILcDfejc1iyb+1UhEz61y42WzGppeOH5Utdm3wE30vLZXjHPly7xX0B+NphVwXoJ4AV9EMnvSnRNUoSXJ05Wz9AYGXCpbx95ChlVt0YP32etPAeFDfsRPZKAlDDxFdaIZzPOKqAAJm8G6P46iWs+cH4GglQ5EBzG2S4sdxvgeQUo6aSqqC0FubAcadSul7hZoA8h1Srs1cAwulzjsyBID+oLl1raiacxKzF3j3yWjkVrjf9s8SrlGyTfP2N8sSgC2fowvl0+KwXgmRNf0guO21QYnsRJbyzeR+GJ5BTrn/1sMM+rYlmgxHo52w9VAMEM0IPi1i2E6xySJXU3Klw21DQYTt5vBQFqsW50SQXww7VTd3rV8nMRyrJfu+mQAAAABJRU5ErkJggg==",
-    "gender_rate": "2",
-    "rarity": "50"
+    "gender_rate": 2,
+    "rarity": 50
   },
   {
-    "id": "66",
+    "id": 66,
+    "sortid": 66,
     "identifier": "machop",
     "name": "Machop",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAZlBMVEX///+tzsZSUlIxMTGMpaVze3uszcWNpqZUVFMzNDMyMjJTU1KrzMRSU1MyMzO9pVL05JI0MzJTU1NTVFSsOTkzMzOtOTkzMjG7o1K7pFKLo6O9plOMpKT9/v7+/Pz////WY0Lz5JJZcpIZAAAAAXRSTlMAQObYZgAAAJ9JREFUeNrt0EkSgzAMRNG0WgbCnHme7n/JyMmCnewtVfzCu1eyxWppNq1p5bhPNVbjJtPdhlPC8e8aYWrgRcbq3LTYpiRlaKQF0LusPggEeJSFD7m7G8P+/SwL926qwOLxVXbXovdhANTqWu+ZFBX9JervQ6oYDcEOtHb3ISyNJf8kEETJtLOmad4+cSKTTpUaS0vaN8GMd2ZKG7w0k76rRwVaZ17Z0QAAAABJRU5ErkJggg==",
-    "gender_rate": "2",
-    "rarity": "180"
+    "gender_rate": 2,
+    "rarity": 180
   },
   {
-    "id": "67",
+    "id": 67,
+    "sortid": 67,
     "identifier": "machoke",
     "name": "Machoke",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAilBMVEX///8xMTGMhJxSUlpTU1qKgpqLg5ozNDS7s8y8tM29tc7Ms2rOtWtTU1tSUltra3szMzO6sstUVFoyMjIzMzH05JNRUVkxMTIyMzNsbHz25pOLg5u9s8yNhZ3Lsmo0MTHMtGu6urLzYlHz5JL0YlJUVFz2ZFNqanr3Y1L3ZVP35JL355T8/Pz+/PypNG2sAAAAAXRSTlMAQObYZgAAAQFJREFUeAHtk8eOgzAQhnfGNi4G08km23t//9fbf7gCMrdc8h8iRfr0TfFwde5cYoloB3ZNUyx1nrQv3diNP+Wwi4ORcuC9HruoXWiypaeolQuB+4zUthWwShWpqA/bqKU2IM0TM8AbaNcpMskJ9/x3xwjI+rCyQOOloqsKMBAKqV5vm4XPePbVh1JCJFUATeDgX0zBnpMYlfp9c7PUh/D++bBiRD00eXQYXEDHfikUkpHe+KMLM0fSDPdrUxvuwWNa6TIO1G7sB+j8iPFU6lgO8//NWJPi6eu71Ioy54hOH2HEmvrMURRyD5OsM0MSya+pa3m+fKysqdn5icF9vlzyD41WDWjGA/elAAAAAElFTkSuQmCC",
-    "gender_rate": "2",
-    "rarity": "90"
+    "gender_rate": 2,
+    "rarity": 90
   },
   {
-    "id": "68",
+    "id": 68,
+    "sortid": 68,
     "identifier": "machamp",
     "name": "Machamp",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAolBMVEX///9SUlIxMTFSU1Nac4SEnK21xtZRUVE0NTNTU1JTU1RZcYJZcoODmquDm6yzxNO0xdXGrVv001L05Jr355xUVFJUVFMyMjKCmqsxMjLEq1k1NjRTU1GFna6yw9MzMzOzxNT15ZxbdIXGrVpbc4PMq0rOrUrTYkHTYkLVZELdg2rz01E0MzJcdIT05ZtcdYX21FEzMjH8/Pz+/Pz+/fz///9arSiyAAAAAXRSTlMAQObYZgAAASNJREFUeNrtksduAzEMRE21rdpe3Ft67///axk65SIpyM0Xj4AVoH0ckhInJx1JCwF97X9y8VRaaUchonb4RmNEegwBYs2Tdmi7Qfyc+MiIiECBq89efkNHF8yUooNhnRAJTo1QgB6S2A6eVms9ikmcKQQEQKz7q7eVKoBGuVJq5ms84szzm9v3p8cHkFrmfhD9oEh6/Vjt6vNCFX4yFtBUEurbdXWCTalt6oKLdVpiUdt1wBiXtjImzcH5QCsJKg0XSCVA4X+ZnH/utwZikkj4hyJDRWuzLyqDjyw5xyY0QOjcKghuYRAC1/TN5ZLoYnnoSIS4DF7Xz33Toz5WcCq5zDs4OuPgWKKjGaaX8zqk2xEuSwee2b3WSlebf5HcyUlH1Ce94hR/Mpm/gQAAAABJRU5ErkJggg==",
-    "gender_rate": "2",
-    "rarity": "45"
+    "gender_rate": 2,
+    "rarity": 45
   },
   {
-    "id": "69",
+    "id": 69,
+    "sortid": 69,
     "identifier": "bellsprout",
     "name": "Bellsprout",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAXVBMVEX///8xMTGMznszNDVRUVFjrUoxMjHOxmv370oyMzTMxGpCe0IzMzFSUlI0MzHz7En3tbU2NjbTi5pDfEKKzHqKy3lTU1IzMjKLzHpUU1PWjJzzsrJiq0rOxmoyMzLpudovAAAAAXRSTlMAQObYZgAAAIVJREFUeAHt0TcWwyAQBFDtioAyztn3P6aHZ0oeu72YAprPEOha9pqeiFRuCyGsshvgkhRb+wxxAo37+OvbiXDdMqxdCzAXWkcXttZVIJyfydxP03Rm/hbdwSzL6OGwBIWM2q4MXzE+xpnghJcfzPF5wwQjfyCGf6WchIARXa22Ut69peUH+VQFO/lh1GoAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "70",
+    "id": 70,
+    "sortid": 70,
     "identifier": "weepinbell",
     "name": "Weepinbell",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///8xMTH351ozNDVSUlJzvVoyMzJJmklRUVEyMzRUVFJyu1kzMjGK23GM3nOmlVK9e4TMu1LOvVLz5Fn15Vn25ln3nK1KnEr////zmqszMzFyvFkxMjG1hEq6eYK7eoNUU1MzMjJUVFTOvlQyMzFxuln05FmLYkKL3XI0MzGKYkH7+/v+/fz+/vxRU1GMY0I2NjZSUlE1NTWllFJTU1Kygkm0g0nVp/9/AAAAAXRSTlMAQObYZgAAANRJREFUeNrt08kOgjAUhWFvCzIIZaYioKg4z+P7P5q3dmurWxLPgtWXP7lJ6f3XqVGA39z2WXta4Uj3qD19ki5a2cOc3pkIqb06XfQ9qxQOEteIRvogr/CbBCkJ0o3aXa2S8woSQoJbSiR04AM8Wxx3XBI5lBT8/lfoAoDPWP/zMRLGcUbcgblmTECFFMHDcH4fmCZKhUMJNgZHu+FMD1HizfFeFlGqnR1lKHFCtqB+E0UTZW9nGNpXQYu8McQm4VStZDLHhaHeybvHgsFvfwH0/uvQXro1EKeUBKlcAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "71",
+    "id": 71,
+    "sortid": 71,
     "identifier": "victreebel",
     "name": "Victreebel",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAwFBMVEX///8xMTFSUlJzvVqM3nOL23IzNDUyMzRxulnOvVJJmklSVFJUVFIyMzGK3HJKnEpRU1H351pyu1m1pTnLulFUU1M2NjaL3XJKmkqN3nKcc0q7eoMzMzHMu1JTU1L0mqv15lr3nK1LnUozMjIyMzJUVFQxMjG2pjy6eYJSU1K9e4Q0MjLLvFHLy8uK23HMzMzNvFFTUlLOvVPOzs7zmqvz5FlMnEr05Fn15VlTU1P25llRUVE0NDT7+/v8/Pz9/fvnqwMSAAAAAXRSTlMAQObYZgAAARlJREFUeNrtk9duhDAQRZmx6cXAQtje03vvyf//VWa82khZgtmXKC97HixsHa4tX9na8Uc4ALCFBtDvI7a6LgRJiLaI6cu4a6ASOU+kJNOBFk9UklhaJtN5RVsyHElTy2DmlBfS0BZ5dG1LJPJqyVOjGKIGDKIDdyV2U/zYx8HCahRd8I4nsxKZwclCr/zqeUKpdDJbcWoI9BSRIqsljoarzuuZe14MgVIH58+IeHl74w/hQl88bIrAxVDkqPP59n54NbalEKLSN1+DRTY7nafInlObrIEXbySuIx8zIuom30XCT7Hw9fkDFnvTyF57NVwyKdW9zxh/nAvatqEXPRYvvWnm+/qvZlgk6eGMztGGW+i4bR/hjv/nCwGDE9JFlIDPAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "72",
+    "id": 72,
+    "sortid": 72,
     "identifier": "tentacool",
     "name": "Tentacool",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAsVBMVEX///8xMTFajM5SUlI1NDNyvPZzvfe9UlIyMjFCa600MzJSU1RZistyu/QzMjJRUVGKeVmMe1pSUlO9pXv2YmIzMTFCbK5yu/Vci8y8pHq6o3nzYmK7UlK9U1NZi8z3Y2Ncjc5xuvO7UlMyMzQxMTJZi83zurI0MTFCaqtTUlK+VFR1vvdbi8z0YmJcjM0xMjOLellTU1L2u7NUUlL3u7P3vrb7+/v8/f79/Pz+/f3///85AabvAAAAAXRSTlMAQObYZgAAAORJREFUeAHt0sdSw0AQBFB6NqxkycrYGAeTc87w/x9GU7ouq73BQXMZHZ6mW1XaGecfzASIYRpLdxlB9dn6RozNhqhebveMtdnKud0B+Dz9cU+fV4RBmYsh/HhdD558uTNy5JzrzoOuXHUsyY7dNgQnuTQbY8Vkt0HHgtLwYyyXAoKQTswsTU+bjdyHKio1naUnbwd04pUa6Feezt+/rhnuh7patEV/82JuM6V+O0hZ1wmAqk4Oj1Ep5L3zZtMSl+BbSQkEf0T0D+VD4ieeItFyUQCIkdhv20dEHaUs4uIZPc4fzTepmw421a0zAwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "73",
+    "id": 73,
+    "sortid": 73,
     "identifier": "tentacruel",
     "name": "Tentacruel",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAqFBMVEX///8xMTFCbK5SUlJSU1Ryu/S6o3lTU1JajM5xuvNzvfeLelm9pXu9UlIyMzT2Uln3UlqMe1ozNDS7UlK7o3p0u/RCa61UUlIxMjNci8xRUVEzMjJyu/XzUVlyvPYyMzP3U1v3u7P8/PxTU1O8pHpCaqu9U1NUVFS+VFTLy8PLzMXOzsZZi83zurL0UltSUlMzMzNTUlL3VFxRUlP3vbW7UlP+/f3///89Sq/hAAAAAXRSTlMAQObYZgAAAQxJREFUeNrt0sduw0AMBNBwm3px3HtJnO6S/v9/lqEW0CVLJzdfPFhAOjxxJEJXl5w714RD/2DzISVpPKI/3G41tKna1/V4dNLNa+/WX29jeeiSJt1XmzbwY4VHSgqPS0y3AFSfRVUjfF9KkAcCQq7vin68gAy41ENciiZ93AchiDXaqneGFd5RgBMLuXnAUIz0zlB411xeNUBrLbj2NQHalNIeUa5m3vBQ4tWGml2EL5mpweBlAZd1NJGb/nYuj3p5pLdPx8fnG41kt3kuO+xn833P4xAKFaO3x8fGBxBIULgAnFJjsUWMy6RmSMZo99J/Csm/NzlIo+F9r5yliygx8G2vPNUf9F5yzvwAdg4Uy7B29z0AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "74",
+    "id": 74,
+    "sortid": 74,
     "identifier": "geodude",
     "name": "Geodude",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAY1BMVEX///+UjGsxMTFRUVFSUlJza0qSi2oyMjG6soq9tYwzNDWSimpTU1KTi2oyMzS7s4q7s4tTUlL8/Pxxakl0bEszMzIyMTE2NjaVjW00NDNSUlF1bUy8tIs0NDS+to37+/s1NTXrcKDTAAAAAXRSTlMAQObYZgAAALZJREFUeNrtkskOwyAMRGOzZylZu2///5Ud6KVV3Kb3ZoRkkB+jsaBY9Zcq+Sdsw6qd3q6xeHHHPtQvZOnrtmYJRGMG4jzTPTs8M+SltAjCQmlLDtEqMjFMyVJrmayIHHsy4EImUURwaIi6NiTROYEosqNpuv4U0c4kDxFRCtES4MWPQDtrjjZFlUFlnbJkYHS7jshhtp/f8ICJyKl+Tw7ju28vmcgEY8sLXwPTO4GRUC5WrVrWA+ycCLAUF3wMAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "75",
+    "id": 75,
+    "sortid": 75,
     "identifier": "graveler",
     "name": "Graveler",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAZlBMVEX///8xMTF7c1pTUlJTU1N6cllSUlKTi3KUjHO6spK7s5K9tZS8tJNRUVGSinF5cVkyMzQzMzIyMjK7s5N8dFqSi3IzNDUyMjEzMzN9dVz7+/v8/PyVjXU2NjY0NDRUVFQ1NTX9/f1zqwRrAAAAAXRSTlMAQObYZgAAAQtJREFUeNrtksduxDAMRJfq3U3OttT//8kMHSQIYMnXveyAgC3hYYakfXrqUXqh/U2T83Eiov8YblpgDrFaN/+eRz6bvedncdJo8UeOXmlhwt7zjaiIBZ4zMmnrRIFTjTYvGfcalj6i22xCXRidWmNncLCNzqVqMAuEVhoai9TMJdR0upSfZ3tHKijDxfHepbYhVsIMF0AnA6ynNnh7TVuyMoDXPue/3hEXWewZwXU65HEXRbcrmsQLPkyPjLGK+8f9alO1cp17XIbRJidXYYXtgkUaKGAW3jxz/WjMKsE6x8F9cBBmlYiv9hiEJccKsYCT+nxAjjSIM9PQIQhTQtFg9G6JHRx/71OP1DdhjA85A310+AAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "76",
+    "id": 76,
+    "sortid": 76,
     "identifier": "golem",
     "name": "Golem",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAllBMVEX///+chGsyMjFSUlJTUlJUU1MxMTGlpYTWtZRxcVlycllzc1p5YlF7Y1Kagmqag2qbg2ozNDWdhW2jo4MyMzRaWkL8/PxZWUIyMjJbW0Ojo4J8ZFN9ZVTTs5LVtJP7+/szMzJTU1I0NDSkpIM2NjbLy8vMzMzTspJRUVHUs5JUVFRZWUHWtpXkSSlSUlEzMzP9/fz+/PtR74TSAAAAAXRSTlMAQObYZgAAAQBJREFUeNrt08luwyAQBmAP2APed6fZ06T73vd/uf6AlEuh7q09ZCTAh8//iLEcXervq2U226wbVkpd8Qpr3qnrXinwn5pyenIOlYuQq4jiTKIsXGYiEFeUIDYNG5yEDMQ5Z2SW5xJLeNzHpol7m2XTJJwH3uw3ZUNxjxzXtUco7Mi+zoLTXNooOLTf6mTB3+e3P0ZDKrda6wTOQb1kz22itjDOSefIO6AzJDK3wjPtDn74YF0ydRj79AKnAf2Rj1ofXj+7eDG+mcAk+LHv9bohMm7qdjqpRQgWJcYp+HmEfJI1hWA0VGA4mKu4JgpDkPMrzs1Xe7u+e//1v3Opf19f0iQSP4iho+sAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "77",
+    "id": 77,
+    "sortid": 77,
     "identifier": "ponyta",
     "name": "Ponyta",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAqFBMVEX////394QyMzIzMTEzNDPWY0L3lCkxMTH/987/zjFUVFLTYkLWY0EzMzHWZEHWZUPzkinz84L2kyk0MjA0NDL394X7yzH+zTBRUVFSUlJUUlH09IP19YP29YPTYkE0MzEyMjK9tmP8zDH+zDE2Njb+98y6smK9tWP29IK+tmSEhHOFhXP3lSqUjFI0NDO7s2L788tUU1H0kilTU1L+9MtUVFOCgnGDg3Kja6dgAAAAAXRSTlMAQObYZgAAARlJREFUeAHt08du8zAMB3BTW7bjvbOTL8nXvdv3f7OSRtCTZORS9JL/iQJ+IUVDCa75/Qh9KWzWUz3OjQRBu/awJuFaj31YVuqsdUPWqFap1qqSDitZUOm+klVtIouS6qxN9n5nEymH/nzAWjrW/qe7nVWxlP+hCgQesMbeDnh8i4oYWcoDsdqrl0hy7V4ZJbnhtcwU/iL0fm3x/NHPASDc2eTdmJpuoN3QmJtZDpBKdKaGyvO9GcJHnW+XBzM6uFelb3Z9t4DtEg7EIC1i7oVAjhLOgfb3QByL4AdW/mfV9aNDHw1Pp1ngl8eHBc5OCxXz7mszBU8znePgiAds6nmzrtd4VQgRTYfasNyxhivi83Zz8Z/vz3PNN8IoE28wd7SkAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "78",
+    "id": 78,
+    "sortid": 78,
     "identifier": "rapidash",
     "name": "Rapidash",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAw1BMVEX///8xMTE0MjDWY0L3lCn09IM0NDJUUlG6smK9tmO+tmTTYkLWY0EzMTHzkin394T2kyn29YMyMzI0MzH7yzH+zTD/zjH/987788tSUlLTYkFTU1LVYkEyMjJUU1HWZEHWZUNUVFLz84L0kilUVFP19YOCgnGEhHO1UjH394W2UzC2VDL99MszMzH+98y8tGIzNDO9tWOUjFK7s2KVjVL29IKDg3K1UzE2Njb8zDGSilH99cz+zDH1kim2VDM1NTX2lCkANHUbAAAAAXRSTlMAQObYZgAAAVZJREFUeAHt0/dygkAQBnCWO3pHCvbei2h6z/s/VfY2k5mEgOL/fjMqM/7uW1xG6ZJckwO+akFXhqhRT8ZJQjKHyqlibIv5McE8Eh95iYuwCaKkz14bP9UNcOWiC9FxG9u4zRxRH/WZT9e/8whS6MZ9xrTmE2qZ6lExtH8qP0Yq3pvt95Th2HaA+jlHWXA4aTS0sE8ZaBbNdRGJ4KEi9IaKh1gDwWzNEqhFN1gmB9qYy+6qwxYOQPlusuUuTZeet37jq837YmNuK5adpan5MlFQLjapOKJKldLcZksjwGKqNqorJ9adZwTeDpmISs+0mDCjGvw9lNspXoN4hv8LzQC/uznguzB6YLQtX4bS9ajwvD/ug++p+ie3HaksIaDWD8cpOdAfOgxhRVC2FYQQJb37Lp48LQd+zGVAdg6uaejphLN5U8HR0nkoXL2/9WzerQNpTddcni8lPiGYO3E7GQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "79",
+    "id": 79,
+    "sortid": 79,
     "identifier": "slowpoke",
     "name": "Slowpoke",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///8xMTHWhIQ1NTXVg4P0q5r3rZyUhFL374z///+tY2OuZGPGrWvTgoLTg4MzMjJSUlLWhYVUUlJUU1P3rp00NDT7+/uVhVLDq2r9/fz+/f31q5vzq5rUhINRUVE0MjL17Yvz7IqrYmJVVlSSglFTUlIyMTEzMjH27YvGrmv2rJuuZWVgQvlyAAAAAXRSTlMAQObYZgAAAMVJREFUeNrt0UkOwjAMBVCcNknTeZ4ZWma4//1wIiRWScMOpP71k+0vb9b8QhwAsIMjY3uwGymp1dDqC2kPSWLjIkKWoAMYdAi14l0YU6Sx3kUkARjRpFTS2ADJA9U8BGfKTFWOVC2lwVBQZqhSqePU0pxiFf+icXWJ+3pRMpLH0rmJBp443/ZVLTIzdNqb5zW8EyLzXVS5rrQzeTJNVxKiDgRtl8lrDveQb/N44XsVtGF4hd3su2YoKcj2T/fjzBz9mn/JC8FuC7a/DIs1AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "80",
+    "id": 80,
+    "sortid": 80,
     "identifier": "slowbro",
     "name": "Slowbro",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAyVBMVEX///8xMTE0NTNSUlKta2vWhIRTUlJTU1JUU1NUVFSDg3KEhHOjklKllFKramo1NjSubGvLy8vMzMzOvXPOzs7Tg4MyMjLWhYX355z8q6P8/Pz9q6T+rKT/raX///8zMjKFhXOFhXTTgoKjklFTU1NUUlL25ptRUVEzMzOCgnHLunH9/fw0NDTMu3L//f0yMTH15Zr15ZtUVFM0MjL7q6P7+/utbGymlVPVg4P9rKP9rKT9/PzVhIPNvHL+/fzNzMz/rqbz5Jr05JoSRRXuAAAAAXRSTlMAQObYZgAAAVFJREFUeNrt0bduwzAUBVBRJNV773KRbbmn9/7/H5VHeghgxoaHDBl8BwkiDu4jKemcv46L0GnOeaDtKd4dUUK2CDmlt90tHJQ3NUTLaXXNP/3+mNuklRa3knsEymPbftysbj9gp7LfIz/qf3efWZbdL5sm5bALOhyAlNG+W4TTbHAZvqUUoCTPjCAaJpI8T/bhrNCtiywL7ReA7jzoDBMbydxMhLOMVYwt+1WNGfSjqMOcClscTSyQhR7TirZscBQNTfMXR4li2baa87ssdByA440iLDWM89ojZa0ZYCAwXID+XVmzeOzFhLlc+eJsfh9P/AeyR61xChEbHeVrAOu4SCuAXkMUoMyJcD2FX3PlPOs412JCGlaKkQiJsg4hKpyH0gnF4BLEnTibNcIeAbboZ6wgEVpAYVwxJ0lo13bQollMORQjXuh7f4LjtdI5/yDfpiQfRH4sHc0AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "81",
+    "id": 81,
+    "sortid": 81,
     "identifier": "magnemite",
     "name": "Magnemite",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAkFBMVEX///8xMTFSUlIyMjJzpZyEhHOlxv/OzsaFhXRTU1Ryo5ozMzOCgnE5a5w2NjY1NTWmxv+tUlLMzMRSU1P7+/v8/Pz///9RUVFzpZ11pp04apqCg3ODg3KEg3IyMzQ6a5ujw/ujxPzLy8MxMjOrUVGsUlI0MTFSe9Y0NDRTfNX2ZDP3YzFxo5oyMTH9/v8xMTLtOqszAAAAAXRSTlMAQObYZgAAAKtJREFUeAHt0UcOg0AMheHYU4YeOumF9H7/28UmuygzYh9+id2nBxajoX8uAejnSmNCNxkDAO01iOB2+2ypxEb7iNuVEzZIRH9yyIQdVnWd6mdKErhfe7N4rtix1NrPjTGX087yYqzOJcNJkRtPqXX8stwMZU1NpSQYAmW/p2JHcJGb6+1oda2HgewSkTpkDyuMlIC7LDAQ3Ze4/g0/rSds4Hu3H+TdoaEevQG8VQnsShgBvAAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "190"
+    "gender_rate": -1,
+    "rarity": 190
   },
   {
-    "id": "82",
+    "id": 82,
+    "sortid": 82,
     "identifier": "magneton",
     "name": "Magneton",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAilBMVEX///8xMTFSUlJRUVEyMjKlxv////8yMzIzNDOEhHNyo5pzpZyCgnEyMTE2NjarUVH7+/v9/v9SU1PLy8P8/PyDg3JSetOjw/ujxPykxf1Se9ZTU1RUVFQxMjM0NDT8/f11pp0zMzOmxv+FhXSEg3KrUlKsUlIyMzTMzMRzpZ1RedNxo5pTU1ODg3QuPBoJAAAAAXRSTlMAQObYZgAAAQRJREFUeNrtksdywzAMRLVgE9WLe3eKnWL//+8F4ORIMbklB++JM3pYAVhkD/25cvzue/6xT3LNeAbDwHjOHBK+DRSwNGb7dkNbZ/n4rCd/rVaGwbn3mj3VdKdu2Vv7ZLYEfnLJFcwjBnaWdSoH4HNtTG9PurrUEU7NAji8vngq1j2/d4RYj2p26IIj0ZyKoz10O4qQTVuLZeACKI6LzT6yHvYkAGqxuVNRlkfuMTqLRIJMaGKaSY1UhjkjQ4gonbgTKyHTFEKI74zqJFd5T6ueJxfPRIJtjYq+ly6BT4JgT93xngXUckKTKJ+sC+HoSkthwlPmJiDU/CAXLjbiF/N96B/oC7veDkjc5NXeAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "60"
+    "gender_rate": -1,
+    "rarity": 60
   },
   {
-    "id": "83",
+    "id": 83,
+    "sortid": 83,
     "identifier": "farfetchd",
     "name": "Farfetch'd",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAqFBMVEX///8xMTFSUlKcc1K7knL3961TU1IyMjE0NDIyMzSllEKmlUGmlUPz0zH31jE0MzH9/fz////7+/tTU1EzMjKddVS8k3J7nEo0NDRUVFNUVFRRUVG9lHO+lXXOxnuU90r00zH09KszNDWU9kqczkqV90yazEqbzUr8/Pybzkrz86tTUlKcc1G6knE2Njb11DH19av29awzMzJ5mkmjkkHLw3nMxXpTVFF6g1F7AAAAAXRSTlMAQObYZgAAAPZJREFUeNrt0UeOwzAMBdB8Su7d6b1NTZle7n+zIeVFgLETeZdNvg3BgJ8oierccuVs0NIdZ71WbqpnLtrUcxlqe82AoRq0WTyY6lPBALhwFImRGxz5C+ec2msjqznvjuPXEMxZSOf9apOGObH3z72Uxch0Jx+Vc+XxHHFxF50mKL/zydPcBcTF4VttZTYskaRRmPdln+xM/KbOrFJJdFBqYBiX9JpamKRSrygmtBZ1Wrkuo9cMZXG//KXK+jhzLYAMn4/b5XOXAFy+xN2YHu6Gw58P622vnTERwea+Qu97sXBpldkk+JVOVdCmkywx0C75ueWq+QPDhRS0wWwVlAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "84",
+    "id": 84,
+    "sortid": 84,
     "identifier": "doduo",
     "name": "Doduo",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAXVBMVEX///8xMTEzMzK1hFrbs3pTUlKyglmzg1kzMjHetXsyMzMzNDRUU1LbsnmSYkncs3rdtHpSUlLz05oyMTFTUlG0g1k0MzI1NTVUVFNUVFRRUVGSYkqVZEr31pz+/fy2AgtLAAAAAXRSTlMAQObYZgAAAK5JREFUeAHt0MkOgzAMBFC8JMHs0Jbu/f/PrC1x6KGxckaMIsLhaaRJdWRvaUpdj1DmhCbUn9Z3bZxEhGqAWPuwF0vHNAkCuPBz5y5pL1FghCwcxtcpBt56BR13sSrR4mQXZjejzoDhzFpMgR1nL94s71uyYqK/26/bW5tjCnOiHFS2uefYGTOXi8EVeowh1TFA5Uo9j5lRvz9rnPl2+dAkmFvWqiDmymQDdo7sJ1+trwe75aSLfwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "85",
+    "id": 85,
+    "sortid": 85,
     "identifier": "dodrio",
     "name": "Dodrio",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABuVBMVEX///8zNDQ1NjRSUlIyMzMzNDMxMTE0MzMyMjJRUVEzMjFWVVN5eXl6enqzg1rbs3rcs3netXv005qyglk0NTNTUlJTU1NUVFM1MzI1NDN7e3uUZEuyglj/zrWzg1k1NTS1hFm1hFq2hVswMDE2NjTcs3o2NzXz0pn3hHM0NDPx0ZmuWkpVVFPdtHrdtHtTUlFUU1LygnHZsXlQUFHasXlSUVGWZky2hl3YsHg0NTTasnjbsnmxglmxkHGygVnxgnE0MzLy0pmzglnz05k1NDT7qpH9zLM0NjX9/Pr+zbSSYkk0MjI0MzHasnlQUFCUY0rw0JiuXEz0g3JUU1M2NTSyglpVU1FVU1JVU1OzhFqzk3K0g1i0g1m0hFtVVFEzNTS1hV02NjZ4eHgzMzLYsXl6eXmwgVg3ODeXZkw2NzauW0vcsnmUZEo1NDLds3qVZEqVZUzdtXvetHqWZUszMzMyMTHx0JiXZ0yrWUqsW0s1NTMzMjI1NTVTU1L01Jv1g3L11Jr2g3L21JqwgVn4ybD5+fn6+fmxgVr7qpL7y7L7y7P7+fn9yrE0NDSxkHBUUlL/zLP/zbQ2NDNklQv6AAAAAXRSTlMAQObYZgAAAb5JREFUeAHtzsWX01AUx/H7JJIXT929TcfdpeM4xd3d3d1d4C/mcYBN0klhwW6+52T3ub88WOsfouKvr12CIgLV5D835dVOqEJEUUvKIHD/LiO9z0irQREEPSnf1MaBvvy27WMmIy22/PMWPqgRnTv+iqV7b7+eX+ajLQcpd0nuqE5mv5DtncvrfVBg2T1ZppwiuswdH47qe+8+cZc2eueGdxXy6bipZr//vNKiukb6O5+5Xgc0tOFqKG5att0TB+F4VEvGJtV+10344Pym158m7ezEyIUiY4oWGzaL3ersTvB237xxgI1dVxc/jIYumWpXRR26ZlsPWrjNla2JxFD3utFCxLR51g7TvnLL505WyqUTjnNnPl9Ic2j1WNxbReZxD8fKFLDjXJxLhYxG78Dl1MDIwchEMZ3zwHMIAN9+nMohhEqnjcTMbunV0cNGgYE/2qwiBLwV/oSzM0ak902eD/o7guB32Hm6UJeVqb4pBkHVF2qHcoOPFEKIGOSoUcMlCE+HB2OKEAibVQhL0xiEWgOCGkeAP+/HgPs6qhAcbdYFwB3PG9CmFYQ47trHgNcev5irwl915his9R/6Ac5bQFaKdCIfAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "86",
+    "id": 86,
+    "sortid": 86,
     "identifier": "seel",
     "name": "Seel",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABO1BMVEX////////O1vf7+/tUVFT8/Pyltc42NjYxMTE1NTWmts6nt88yMzM0NDT9/f7+/v8zNDSjsstSUlI0NjWcc1qbc1rI0PHM1PTN1PUzMzPx0Znz05r00pmedFugsMn9/f00NDP+/v5VVVWbcllVVVdXV1eaclmac1ozMzI1NDObdFk1NDSddFqddVyedFowMDE1NTagscmhsMk1NjWkssmks8yktM2ltMyltM02NTYzMzSmts+nts02NzU2NzjL0vLL0vPM0vM3NTQ3NjPN1vbO1vY3NjfP1/fP1/jQ1/bWrXTXrXPwkHk3Nzfy0ZhRUVH0knn0k3pSUVH1knn2k3r21Jv21Zv21pv31pz3+fj4+Pj6+fn6+fv6+/s0NDX7+/xTU1P8/P78/fz9/PxTVFI0NTRUVVU0NTVVVVZSfyWFAAAAAXRSTlMAQObYZgAAAR9JREFUeAHtz7V6wzAUBWBfgZntMCdlZmZmZub2/Z+g8uAtcrX0y5Izafi/o3Ol/0w7pnos5jwbiIjDoNtgqaoqUAiEAoD150TMlC6zWoHfI2qLQMJqLZF7LLYgAeRiB7qZ2PQ8Ht+C5hKc4tnGSMQiKJsJfXoNEHT6lDnEr6zi3RoABkd/oQlQU7tXXwEqW3IFfEA8qLmjs/mBaft94aEHbyMfoeYbNU82MUnd9/ftrTWWNxHJcgoXyzPft+RoPby8KeyHK1MdJCtrTRcG5cncWVi8ui7U84MTX5n5+hPn5MAd7joplYofQMZ+2EJnZ0ni0YOhi/NG9Y58pjeQYbw5Fl+epnpZtRSkMwDG4yEPMuPGD0opcwJRFEVqYdr5BQTLHVhPTAh/AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "87",
+    "id": 87,
+    "sortid": 87,
     "identifier": "dewgong",
     "name": "Dewgong",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA81BMVEX///////80NDT7+/v9/f0xMTHG1vc2NzbD0/PE1PQyMzM1NTX8/PwzNDT+/v7A0PH///79/f74+vmMnLWMnLaNnbaNnbeOnLc2NjXB0fHB0vHC0fE2NjY0NjXF1fbF1vbG1fdSUlJXVlf6+/1TVFRUVFRXV1dVVVWFbURUVVVVVlePnraPn7eQn7dUVVQzMzRUVVc3NzfC0vPD0vNVVlbE1PM3ODfF1fVWVlZQUFFRUVE1NjXH1/jI1/f4+Pj4+fmKmrL5+fn6+/tSUlP7+vtTU1P7/P78/PuNnbX9/PwyMjNTVFb9/v41NTT+/v+OnbaOnrdJddU/AAAAAXRSTlMAQObYZgAAASZJREFUeNrt0cdug0AQBmBmCwuh2bj33tJ7770n7/80Gdgg+TAgX6Jc/J/Q7qf5tYOxzF9mRcrFHAdgi7jrgkCZSZKBJaQsq5JphykJllEpmG4uHPlg+iztpe469kn8ssxiRIHR4/IQV75GEFMUKZADIM0Bi9coraGLI2kH5pb1jrfJAQmb0fn0hfE5SEmHj3ouTD9OdR+WcyChugQu8EKPkZqR3S1+PAtB9J9gLvRrat23zbsDvSOeDs929+uVwVrbzOdwR+OeK2jnWOXydr3SxkXfPn8NfBhPJjcUVEHH3Bs2ughXZ+HG9yNufnRP/ZlWYCvvxEaINBQX55+8X1MGJb1Id7TEBcBDI3H03F965e54tEnmBnYchSw7h47jNKtVY5n/zQ9hOBaND9jvmQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "88",
+    "id": 88,
+    "sortid": 88,
     "identifier": "grimer",
     "name": "Grimer",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABI1BMVEX///+Ue869pc68pM6TesxzWpQ1NTU1NTZSUlJTUlNTU1ZUU1M0NDV0W5WQeMmSeswxMTGTes0yMTK6o8u8pM0yMzMzNDQyMjNTUlR1XJVTU1SRecqRectRUVIzMjNUU1aUes1UVFSVfM66oslyWZK6o8y7o8y7o827o840NjV0WpV0W5TVxff9/P57jJM2NjaReck2NzZUUlOSecmSecqSecuSecw3NzeTestUU1Q3ODc0MzSUe8uUe8xVVFVVVFaVfc64ocm5osm5o8tWVVa6ostxWZJRUlG6o827o8tyWpIzNDNzWpVSUlM0NTW8pc+9pM29pM41NjW9pc/SwvLTw/TTw/XUw/XVxfZTU1P7+/v8/P15ipH+/v////9UUlWTe8yRGiTwAAAAAXRSTlMAQObYZgAAAQFJREFUeNrtz1Vyw0AQRdHpnpHFLMvMKEOYyWFm5mT/q4i8gI797fL9PtWvmk2bxJLOmMzHojOG818xrvifud50mNGI1Qh572PXW+MxAuCQIl3iEdEfNLG9Df3vjMvJk/N7wPUmIlx+rL5nWpAiH4oc66eGd1jtf+1y7EouvR5ZqlILAjx7syXJBRoy42opqyi2Vo+Zakse6XJwrirZgoDh32qdGk8uS62dk8+Zyn5pPbht6zY1Hlmdo4fDhUpDF889vqWJY49RJ82n3g1W0wfw8quJvEx/XYZ8eQXM9OJpaU7EjpZCtjqm6RaUnBzSLpbhEAthhBdsZBuziQSbNnn9Af1qGmNW3bWKAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "89",
+    "id": 89,
+    "sortid": 89,
     "identifier": "muk",
     "name": "Muk",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA2FBMVEX///+Ue869pc6TesxTUlNrUoRsU4ZsU4WSecwxMTGTes2Ue80yMzO7o8y8pM4zMjO6o8s0NjUyMjN5Yqx7Y617Y658ZK2QeMmRecqRecuSecqSecs1NTWSesw1NTZSUlKTes4zNDRTU1OVfM66osxUU1U0MzW8pM1rUoU0NDXVxfZqUoM1NjZRUVFrU4RsUoYzMzRSUlMxMTKUes16Yqt6YqyVfM16i5OVfc64ocm6osswMDE0NDR7jJS7o827o867pMxZanJ8ZK5aa3PMzMxoUIH7+/v///8mNEwEAAAAAXRSTlMAQObYZgAAAT9JREFUeAHtkMd6gzAQBvlXEkIUYdx7L3Z6770k7/9GEZAbYDuH3DwHnebT7qy148/4SqmtrBIRhWqT19G0RzHhBrFUfyLaziR6kSLYRgzvS2T+DTfk+srIa0f7ae5vEQBVODPJDVVsAtCqyEsByukpCeWC+xE0YcmgAW6qUSBCywDLj7qnnyfglerV5O4gdzCwFGdf3zeaMOzwnhkQFk1OAb9weYVhCF68Ix/0ED8zVqsyNmPzkxzzcJAQjI1sqL3ZLuCUs0uan16vH097fBDA4A7heC3xkI0Zx967sXTSdenBbvb9vBXHZnAcS8kxY+Z5MftTogWRtKcEOIAnWc6GRrw9EmK6kAy2EaQQog2IrpUlGjWYtJ0OO3c8KdxWf2Swcok+20x0R41j226ylbWGKPkjajC2ytQW+NaOf+IH9mAZ0owDam4AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "90",
+    "id": 90,
+    "sortid": 90,
     "identifier": "shellder",
     "name": "Shellder",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAxlBMVEX///9SUlJ7e86cnPdTU1NTU1R7e80zNDQxMTH/rc4yMjNVVFRjY2NrY6xrY614eMl6esx6es0yMzObm/VSUlP9/f0zMzT///80NjVVVVViYmI1NTVqYqo2NjZRUVHHfK78rMz8/PwzMzV5ecp5ectrZK9sZK5sZK8wMDFTU1ZUVFRUVFU2NjUyMjRgYWGamvQyMjKbm/acnPYzNDXBwcnDw8vEeqzGe61mZWX4qMn5+fn7q8s0NDRqYqv9rM1SUlQzMzNrY666+HPCAAAAAXRSTlMAQObYZgAAAPRJREFUeNrtj8dywzAMBQ2ARVTvcu/pvffE+f+fCuTJ5Abl7vGeeNjZB/b27BJ39e8j9zyvw7NJVntbb42IfofaTzJz3eamkGKc+bKZJ/ps+VEQYglpV3Opj4huv+OCiDRc0YXg1RQRFQfEbGUtJD1ca2NghRwt8IZ0Klxp01IBwNjgITf5TBYF8/gBmEGExHR9Jr9n73QxMGyakj2J9ymLi1HDJp/ry8HhMFDw2jQVmBOEWDT7l4F7DqCqlII0hehLHD93M/eplApDWG1yGEvJ/O3JOQhbRpYHrJWmX2bu0Vobhn+bkjmftxHLqX+YTHp7dpYfDowQLMJ/61MAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "91",
+    "id": 91,
+    "sortid": 91,
     "identifier": "cloyster",
     "name": "Cloyster",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///8xMTFSUlNSUlJrWpwyMjOEe86lnPczNDRjY3NqWZoyMzOCecuDesyDes2Dg5JRUVGjmvOjmvSkm/ZTU1SFhZUxMTK8xMW9xsb8/Pz9/f3///+EhZRUVFRrW51kZHRlZXUyMjSDg5M0NDS+xsb7+/tiYnI2NjaCgpJOGXCQAAAAAXRSTlMAQObYZgAAAPhJREFUeAHt08eOwzAMBFAPJdO9O317//8v3BGyQbCAGPjgY+bgg/FAUoSU3LN6Kixzeem3yyX+/YAJvQBXNmSvlpRxdsCZ1VOm6S04PnGAqtZJ4y4HekdH2GraNxp3hD+7/YM4JkiVJu6Yqu92e1pCH6Qz5kPpxZEGqb6llZj75mp8OEonl+aERkW6w0vBuDGbG/a29t0Tbujejo8sKSPXiCgcZvdVFIf3z1OAqlNGakLWO22E0LcsyIpxScj8bRLmfbyUPHdO7VsmPG13/HgOJdk6tS/ZFrU45jYEwG+t5ANbX0c0fZITpuWSd0EdBln7qSFZP/f8AqVRD/3Z9RA9AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "92",
+    "id": 92,
+    "sortid": 92,
     "identifier": "gastly",
     "name": "Gastly",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAbFBMVEX///9SUlJ7Y7U0NDQxMTFTUlEyMjOce9b////7+/vEUjGbetVUVFRRUVEzMzO6urIyMTNTUlNTU1M1NTX8/Pz9/f27u7OaedO+vrathJyuhJzGVDTzq8P3rcZ5YrKrgpqrg5r+/PvFUzN9fX3geyc6AAAAAXRSTlMAQObYZgAAAMFJREFUeNrt09kKg0AMBVATZ9PRWnftvvz/P/aqUJ8mUCiUgvf5EO6ETLTl9+GvQuYVs8C8tTxZb1mCYEYp1VtkkmFoVE5EoCKMewM2BzLs6mIH95bhjnXyJGQdiQcF4PDQC+sqEmrukyzVqQZrXQYYcIBF1VWpbhxy1IChlt4kGVETJ84NDwlGvM8pvQNioLzJOCdIh4YkQ2+u41gS3UrRAVqjTudDG2Pdi5OPotj1PJ+bKJm9uchovdcPv8OWP8kLclgI0RUO+XEAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "93",
+    "id": 93,
+    "sortid": 93,
     "identifier": "haunter",
     "name": "Haunter",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAh1BMVEX///8xMTEyMTMyMjM1MzNSUlJSUlN7Y7V5YrKaedM0MjJ6YrNRUVFiSYqbetX3rcace9aaetN9Zbarg5q7q7O7q7ViSov7+/v9/f3///9TUlSce9U2NjYxMTJjSoyrgppSUVKthJyuhJw0MzU0NDS+rrb0q8T1rMV8ZLVTUlP8/PwzMjNUU1PKQ/eMAAAAAXRSTlMAQObYZgAAAQ1JREFUeNrt09luwyAQBVAGDBjjLXvSfd////s6d4oitcQllfqYKyxL9jHjQaBO+WOqY10w/wubMHpdnIz4AiSi32GtiR3COH1LdAh6N0uwHw1x0o/kkuFeIl5cDtvluUAoYVONNZs5TFJTDqVX7yExF9m5if4b6UaYhROs80WUvns00C638/0y/WBhNICY5+1hs9sBOktZTZQ0xFLKrbaPLy7mZS/gEKOq69foLA/LDjKDaIOfQy5uMeLh0ppqL65dPA/DHdwVcknfIan7Gg7SPg3DxxqmE6ryWb/u3Y21a2a8Dh3c5GGpCO+DNFfamNhfZzNIVQg2HGgJoqfodd2XIc6FXEj5qDXqlKPyCePmEognvnuPAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "94",
+    "id": 94,
+    "sortid": 94,
     "identifier": "gengar",
     "name": "Gengar",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///8xMTFrUpRSUlM1MzN7Y7Wce9aaedMyMTMyMjNSUlKbetV5YrK+rrb9/f1qUZJ7Y7QzMjI0MjJ8Y7NTU1OaetN6YrQxMTJRUVHsenLve3N6YrOyapK0apS1a5O1a5S6q7K7q7U2NjbseXFtVJXtenTuenNTUlT7+/v8/PxqUpL////TIlw1AAAAAXRSTlMAQObYZgAAAPJJREFUeNrt07dyxDAMBFABFKkcLgeHc47//39ewsfCY+2MCru7LcjmCUMAo+ySP08uc2FbzoW+lB+VRYRJX2Z5UZnFUQQKIYtQidkQ8BmFbhNCZRYOkMg9WMxrvaHOYGEsmsYjQttukkNowaVcj75JDHEfO5kqN7jD6kxuTiNOVZ2AD4O6w6I19nJcWUHdZdPwKrLnxePxdvRc5iL7bxmdbqkEvVvXoFGkW8h43rp1HfP+tD23zeZ43392fdfDWVG6mSUkmD0QtBa6QrSjxtLEGRxSGx4cUIVKddKCwaUVsoULJgqLlL8Y+ynmJEflS/4hX85wDrf709YWAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "95",
+    "id": 95,
+    "sortid": 95,
     "identifier": "onix",
     "name": "Onix",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAARVBMVEX///97e3tSUlJjY2MxMTG9vbV6enozMzO7u7NkZGQyMjJ8fHszNDS7u7RTU1P///9iYmJ5eXm6urI2NjYyMzM1NTVRUVEXIUzuAAAAAXRSTlMAQObYZgAAAQ9JREFUeNrt0utuhCAQBeAOMwOoRXe3l/d/1J5DalBxN23SpD/aiTpGvhwg+PTX6/mr7pZ+Hb6aPXTXkmq3m3sy9Dse47MhDsx9Kok9nUIMq9mnc58z+tinmrr4kDFOKMXnWGpuOuYRamYS2URZc0+gKsKGEAubashOuI98wTcVR0nIdFFCVM2cX8YNfHNW1ZCDRjRY3HqINGTRLZRgMto7Gdw0bqcWBRRbFgGk4wnw/aK2X6MwThgohqpndFG4EyiqeEgbgOzO0ZwGjxCsnT4WCruHq2uBdZGhg0IooUGza4jNNUm1ddwyd9P/FdWt0PCqaoe9tAxbnWrA1dRekq3wTlq/jIp+CLIw6399qz4A5oUKOFnLOHUAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "96",
+    "id": 96,
+    "sortid": 96,
     "identifier": "drowzee",
     "name": "Drowzee",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAY1BMVEX////33kJSUlJrWlLGrTExMTGMezE0MzGMc2P23UEyMjGNfDE2NjbHrjI1NDJUVFH13EGLcmIzMjHFrDH23UJUVFLGrjRqWVLz20H03EI0NDT13EOMezJtXFHDqzH7+/v9/PuBvYaNAAAAAXRSTlMAQObYZgAAAM9JREFUeAHtzslygzAQhGH1LCMBAS9Z4ux5/6dMW5XrqLj54r+gT18NlJt278F9n/s2OzvbISOOAKqPj1Ne0FvmC3nuKv7dEV+nOUHbtrmt6wSLGDkHPgQsft9/XqaDp84gZitgZhPnnML1TYAngIPl0aaaSveIhS4+n/vV6onkYyxEugPSz1OSijH0UMuQkgnY4dXLQIJM0OGpzbkThQoMMGmNMHeirQlE6EZQtQPqa+plIIn6jJ2ZqlMrX/KBZH3LlfMfd+SAl1053Y269wcltAdLNjCG6wAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "97",
+    "id": 97,
+    "sortid": 97,
     "identifier": "hypno",
     "name": "Hypno",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///+9pVoxMTE2NjaMe0K7o1m8pFkzMjH82zH93TH/3jG+pVmKeUE0NDS6o1m6uro0MzFSUlJUVFS+plxTU1L8/Pz93DFTU1P9/fxUVFH///+7u7v72zFRUVGNfEFSUlE1NTUyMjG+vr79/f0zMzP7+/sCAgKMfENWVlZQUFC9vb2LekKUG/qoAAAAAXRSTlMAQObYZgAAARhJREFUeNrt0kduw0AMBdCQmq7eq3tJu//9wtEECOBEo2jvb2j38E1SenlmW4L/ukRugAHimjsmABInY7JVyNhBmVCvyCDRxvQq1KHOvG4yNj3X+yaU/kIn808mpM915bfkXQnSB+P5z8OKQ1fKRRcJYA2xbih8MEhfhXPxbZbx4g3TltOIewGgew7ytlCI6f1dGYKNXWa+eIz4myVQja2iyyjapS6UyXBXn1t83BeYqMaPNrdPTkBlNPQV0+sjZAKAJOUyDAMVLkCMhKQh09mdLw7uqP6PIe2zG9u6qIucdrESEZdOfuAV/YCc7zs7RsyOCu79+D4KguyUkHOFXnmyk03G3+hWorypn0ovn0JNhetxd3lmQ74ANvsUEBJNKm4AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "98",
+    "id": 98,
+    "sortid": 98,
     "identifier": "krabby",
     "name": "Krabby",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAgVBMVEX///9SUlIxMTEzNDQ0MjEzMjLEWULzgln3hFr3zpzGWkJRUVH0g1mzknq1lHsyMzM0MzJTUlFTU1L0zJpUU1OEa1L+/fz///+yknkzMTFUUlL1zZv2g1m2lHv3hVzDWUE0NDQ2Njbzy5q0k3rGXEQyMTGFbFNVVFP7+/uCalH1zJoHhnMlAAAAAXRSTlMAQObYZgAAAQBJREFUeNrtksduw0AMREVuV++Su9PL/39gyNUhgGkFPgRIDh5gIWr1NENKm9z1V6oQb+LUae/1TaDzW/xF7sGlDcgmFQrwRCDk+jIm3UiQyNzri3a8GFCRZe7JQH1vRVJ4VplNN5hUTlNN91xlkAtL9XhoATlO84rfdQtXwRBCnaj3o9cutsDj2T2XguwL48az8ywdSZsKjsi5bLs+H49+PLNv8gYLJ8kMipbCxmmanhtEilh+gXQ09MymrKajRnahvsoNL3F22wBA1xMJgGvHsSJL6EJ4/eRL/UHvrkjNuxDCoRyeSpMVZviBxLlkGYxNc8w6ylrszRokj+Nd/15ftYYPsFL+/jkAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "225"
+    "gender_rate": 4,
+    "rarity": 225
   },
   {
-    "id": "99",
+    "id": 99,
+    "sortid": 99,
     "identifier": "kingler",
     "name": "Kingler",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAclBMVEX///8xMTHGWkI2NjZSUlJTUlFUUlI0MjH0g1n2g1n3hFr3zpyyknm2lHvEWUJRUVHzy5ozMTE1NTUzMjJUU1P///9TU1L0zJr1zZs0MzK1lHvGXET7+/v+/PzzglnDWUGEa1IyMTGzknr9/fw0NDRUVFSmuT5LAAAAAXRSTlMAQObYZgAAARJJREFUeAHt00mPgzAMBWBsDAkJC2Xp3s7+///iPHyZETIzOfTYp0r08OnZoCR7Jik5ESW5lyoElwCHeygppfCXy/90XIjCHP+drryxIRct77JFdd7pcwty4YPTakC8GuCGVAjBXDm6oz4nU3Y6GpWliA9aHpzh+mYvpA6qFO/IdNnQx3jC43qpAoI9oO3RqCSqPxaILcF0viWp3h/i5OFun9cLKhG38T6AbcW3eZ6/4BjlJZHReB77SVpegkI4wEMzrlx9fn3DppCFiHhenMp4WjdSBhgneT/qqgha15U/xceIKCylrYLbOs4DgTZj5+EU/nMncHqoMz6lwfHrrEaDYjzv0m4HJqc5R4kXPXt4nvkGddUPEFSG6XoAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "100",
+    "id": 100,
+    "sortid": 100,
     "identifier": "voltorb",
     "name": "Voltorb",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAWlBMVEX///8xMTE2NjatUlLWY0JRUVFSUlJTUlK7u7u9vb3TYkHTYkIzMTH7+/v///++vr6tUlE0NDStU1O6urpUUlGuVFSrUlIzMzOrUVHVYkJTU1MyMTH+/Pw1NTUukbpPAAAAAXRSTlMAQObYZgAAAH1JREFUeNrt0scBwyAMQNEIiWrAuCRO3X/NyB5AaAD++V1UbqORIgMACvaDRES5Sw2zq9x3KmmeLxU028qwnbjhR4JlSbRPtLsHyjBlhmDDiuhBgnYi+i6l3tGHQ9yidUwbesdOhGV+Oy7EKEMep9Y5ckf/0tvJQPsUo1G/P3LOBURCzOxMAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "190"
+    "gender_rate": -1,
+    "rarity": 190
   },
   {
-    "id": "101",
+    "id": 101,
+    "sortid": 101,
     "identifier": "electrode",
     "name": "Electrode",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAWlBMVEX///++vr7////7+/sxMTE1NTXEUlLGUlLGjIxUVFT8/Pw2NjY0NDTkUTEzMTG9vb39/f3+s5r/tZxSUlIzMzPkUjH7spo0MzJRUVEzMjLFjIxTU1P//f1UUlGRD4aVAAAAAXRSTlMAQObYZgAAAIlJREFUeAHt0kcSwzAIhWEhrIIk9/Ry/2uGkMlkFTiA/a+/YcNzW26v45xd6NB73yxahXmbhq9jqR78OFvWS7Hh7yCtwuGgwIZUqHhiCaMCT2cU9A5u1/+wnx9MGopLgzMkQxhV50L/PM7LknNOSYWuIq1cFGe8ECaYKKahs0cB98jMrsrMttveC75uBY0V8/AhAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "60"
+    "gender_rate": -1,
+    "rarity": 60
   },
   {
-    "id": "102",
+    "id": 102,
+    "sortid": 102,
     "identifier": "exeggcute",
     "name": "Exeggcute",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAb1BMVEX///8xMTH/nJRUU1M1NTXGc2vGdGz7mpL8mpL+m5NSUlL/zsb+zMRTUlL7y8MzMjH8zMTDcWrEcmpRUVH/zcU0MjL39yn/nZX+zsM2Njb7+/s0MzP8/Pz+/Pz29Cr39So0NDRUVFH//f3//v7///9w8j+qAAAAAXRSTlMAQObYZgAAANlJREFUeNrtkskOwyAMRGMTCIHsS5eke/v/39ixlKPT9lxlDgjE04wNTjb9pY5E3xFZMpuPnzkgdZJmgyt4/Mxdd4e5D010thb7VbC97O5NjKZxua2pirOKIZNtCQ6kZzbY8agb9t6cImILgKYrsJlVwyqaQJU7v8QShs/btB+1TgapDnFThF8ZJJo1sEJo6UHj3oQO+TrXFq487cXKSyMOR29rLZlFYsMCgjRE6hvmJsCCsoWza/+YtjlLVErU+4Ef0vLqzEjUMhWsdLJaRvILySqnl7Hpv/QGxesMHPSkW5oAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "103",
+    "id": 103,
+    "sortid": 103,
     "identifier": "exeggutor",
     "name": "Exeggutor",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAwFBMVEX///9SUlIxMTFRUlJKhFpTU1KMa0rOtXP374xRUVFSUlFStXOLakoxMzK1lGMyMTHvc3P07IsyMzG2lWNKg1lJglmNbEqNbUuNbUyzkmI1NTXMs3LNtHJSs3LscXFRsnHvdHNRtHL17Ir27os0NDT7+/v+/v21k2NUVFI2NjZSU1L9/PzLsnF502J61GLOs3N61WN71mOKakkzMzLvdXXz7Io0MzIxMjH17Yv27YszMjFUVFSykmIzMjL+/Py0k2L96shLAAAAAXRSTlMAQObYZgAAAPxJREFUeNrt00dywzAQBEDvIjIH5ZxlSc7ZloP+/ysPH0CAF900h+WlaxZEFa4uOVv23IAwxl3phx3BFfSWQsqPWYLPfenZHLTFJOFZdCCuLx12pJSCQKVoLx6fyvpGFMJATyIp2LkcsnJYTew5JOSiWh1FSb37GSsChMNmdjljFBGBkfuEt0YNPm1LUWHNixPCtdKxKoxZ9bL6e0RhYbfrTX+5Xb/Zd9flFLZKb4kx/3VezzT/e/3ajVbz/ProgFg/zR+6IY1MN3O7gJBYZ8xOt38OB2ma6hDMB2OtNUbmgUGMSoVWnxwyEqD1dGzyCjf9m29u9l7x05ecJf9Z/hSy9FPowwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "104",
+    "id": 104,
+    "sortid": 104,
     "identifier": "cubone",
     "name": "Cubone",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAflBMVEX///8xMTG9vb00NDRSUlJTU1JTU1Oaelm7klm7u7szMzO+vr79/f1RUVGce1q6uroyMjFTUlK9lFq9lFu9vLs1NTU2NjbbzKP7+/tUVFT/573///+be1pUU1O+lVwzMjF6eoPezqV8fIT85Lv8/Py7u7x9fYU2NjVUVFO6klnFXiGeAAAAAXRSTlMAQObYZgAAAMVJREFUeNrtklkPgjAQhN2llF7cN6iIt///D7powlsprxomafrydTKz292mH1IJ67gqRgWk3QNcIJem1xxi4znIpv9KK4ejIQYNcW5DjZxJXAPyIEqlcie875PmWCxalp8m7dVr2tNNLRtqFSMXBZ4ZLHcmK0TkjjJEThRjwnctJpSc1XlGGmwITOfls0vXjbkviLSl84ASBimBT5H5TAz2wWgFYZDW44H8osQ+Qg/oAgiJDCIrWDVazXGBXrm+9lxt01/pDajqDnhFpfU1AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "105",
+    "id": 105,
+    "sortid": 105,
     "identifier": "marowak",
     "name": "Marowak",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAjVBMVEX///8xMTEzMzM1NTU2NjZTU1JTU1O9lFq9vb2+vr78/Py6urrWvYRSUlI0NDS7u7u7u7y8k1lRUVF9fYWScVH7+/u7kln9/f3///+Uc1JTUlKSclL85Lu6kllUVFR5eYL9/PwyMjH/570zMjF8fIQyMjK+lVtUVFPTuoKTc1JUU1L8/P3Tu4N6eoP75Lp/w+Y7AAAAAXRSTlMAQObYZgAAAOVJREFUeNrtk8cOwjAQRFknLum9EHrv/P/nMXI4Yic3hMQcfHp6u6uRJ/98NS6N5FYpozGsEygl/HiMMhBJExPR0BYA/aXfth6jqrWYnVUqgPWJrTtico9BauHyBMJhzi0zHmljESWCcA4ZwIWUHKDHqiJVjBZyujGNrrkP32XtKcXK9bLemXoRj1sLm3r7TKMDhVsg2x+AyR0wI8iCpkDdzyM4SytNrOFzGIYSJBF95Cpdhkt5NN9uT7XkMxxtADVZdvfwWkPJDUs6VHkMYD7r5hBatgTav0iZaeFwXNhH/55/fiIvssgP378824MAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "106",
+    "id": 106,
+    "sortid": 106,
     "identifier": "hitmonlee",
     "name": "Hitmonlee",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///8xMTGle2s1NTVTUlJ7Y1oyMjG9tZT25qzOrYykemp6YlkyMTGjeWqjemozMzOmfGy6spK7s5I2Njbz5Kv15at5Yln7+/vLy8vNrIszMjI0MzLLq4pSUlI0NDT3561TU1L05KszMzJ8ZVt8ZFpUVFPMq4tRUVFUVFTGp1SPAAAAAXRSTlMAQObYZgAAAMtJREFUeAHtkUdygDAMRSO508H0Qnq5/wkjwJOVidkmw2MGNo+vb+vhL3HDAK5oFmZjRghr6WCItyTgfcYRkokof2/XLhk6ZECkRBQL+RJOhtJDb4rk0H3F0YAi8Xrd2q17yQw5xYroZDhL91oM6Eu46b7ETeBQ6gIP+MdTpSef2BjERmnlPOr6rF58kfVjgc0E0FI9ytsHeE8z60LCcfBKoYT07CYtwE/2O2x/jqF1l2orZ0kOmfUrXXYY1gpxSbR93udhza3933HzDSyrCus7Ms7PAAAAAElFTkSuQmCC",
-    "gender_rate": "0",
-    "rarity": "45"
+    "gender_rate": 0,
+    "rarity": 45
   },
   {
-    "id": "107",
+    "id": 107,
+    "sortid": 107,
     "identifier": "hitmonchan",
     "name": "Hitmonchan",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAilBMVEX///+1hGMxMTFSUlKzg2IzMjHOrYz3Y1IzMjJTUVJTUlJTU1KMWkqrQlmtQlquQlk1NTW0g2I2NjbLq4rNrItRUVHzYlFSUlMyMTGrQVmNW0syMjJxeZpyepqygmJze5y0gmJ0e5uKWUm2hWXMq4qNXEzNq4uMjMaKisNDY3L1YlJSUlH7+/v8/PwQXHkMAAAAAXRSTlMAQObYZgAAAMRJREFUeNrtkscOwjAQBVnX9N7pEDr8/+/hhYNPjn0EKe+QKNJoMo6ymPdnK4gbl5XCc9IdRuDEzpXDKIa88lxAgEp49j4hlBOibrqvZpXADTlwE0PURZ1XKUPKwKQsGpl26AtZQJ6n3MRljZQyPX9dt9fRmJj1d5kmO06UFHABMRT2SeJTrLy2Sho9GHCT0o/V25C8tBQDJk+N95rGys40aOBX2zb+ZOhIoxl710t8sLM1Zdztl9zAXjstqbZI/RHm/f7efjALWonTTD8AAAAASUVORK5CYII=",
-    "gender_rate": "0",
-    "rarity": "45"
+    "gender_rate": 0,
+    "rarity": 45
   },
   {
-    "id": "108",
+    "id": 108,
+    "sortid": 108,
     "identifier": "lickitung",
     "name": "Lickitung",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAk1BMVEX///8xMTG9a3Pskpruk5vvlJxTUlJSUlJTUVK1SlpUUlJUU1NUVFQzMTK7anIzMjK9bHLEu2rGvWvmYlrnY1ozMzPukpo1NTU2NjbvlZzvtb325pv355yzSllRUVEzMTGySVnLw8PkYlm6anH05JpTU1K+bXX7+/v8/Py1S1v25ZzFu2rssrrvtLzDumr+/f3///+zOMkZAAAAAXRSTlMAQObYZgAAANVJREFUeNrt0tcOgyAUBmAPiNbZ5R7V7j3e/+n6Y+OdaK+Nf4Ro+Mg5ELUpo0tC9B97ZFlIgz4BQ0C5YB6pi274M8veLhcOF4Ixr9vtmcHFNRLzOmqg43sKxwxfF79gDz47ZQwoJTNMTHhrRqfchvQ6mjJAuoNZcZwEz6acldZsuWC6sseG1msLua8WTa9zpdsF1jqwl6s8dUwOOODyIpXHvrikhHCB7TPjUKRoUOXitvCR34pU1lVDxKa9vGu9ByYSWpUWE50/J9xMr6wG/8l2fcp48wXP2A+qaEBpKwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "109",
+    "id": 109,
+    "sortid": 109,
     "identifier": "koffing",
     "name": "Koffing",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAnFBMVEX///+1rVpqcbpqcrtrc72cnP8xMTHV1XLW1nObm/02NjZrc741NTVRWXlSUlO2rlrGY3syMjQxMTL19ZP////UzNWamvszMzLTy9OcnP5SWnzWztadnf9TU1T29pP395T9/f9SUlJUXH0zMzPEYnvEY3wzMjE2NjVSWXrVzdZsdL1tdb5SWnuamvwxMjNTUlL7+/tRUVH+/PxUU1RDce7lAAAAAXRSTlMAQObYZgAAAQ1JREFUeAHtk+eO7CAMRjGFQEomfXqZe7f38v7vtlgoE2nZWDzAnB+BfDoxVmTYlVgApu0UhLTH4+KyxV1ycEsAxmhOIrQ+CERzmHLw76GIQGIA11QHH/7Ge4OqSROtXLP8U8hS+8S1CoGH5+Z80wwqk1bVWs/9HxTTQljlySyeP9tgulqr0Xxj86TDaTeKNSNF73w8W7XHJtvF3x4vX5136rpul8lNM1+Q999nVNVeSCmJJu+Lm+r97BASCxLk/Laqqq9/gqzH4K4Q/fZJIpSYmCUvhVWP6JYPDSGapdar7Tpz9YqXhvAM4Fzw/r92i0+Jcbw4QN6tBB/jjLEI8L4YiBNNlMjC6SbmM5orP4ZiEftxVZKSAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "110",
+    "id": 110,
+    "sortid": 110,
     "identifier": "weezing",
     "name": "Weezing",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAn1BMVEX///9rc70xMjNSWnxqcrsxMTFrc761rVpSUlJTU1RqcboxMTJSUlOcnP/Oxsabm/2amvz9/f////8yMjTLw8P395Q1NTWdnf+amvu2rlqtQlqyq1kzMjFSWnvGY3s0NDT19ZNRWXlscrtsdL1UVFQ2NjacnP7MxMTMxMXNxcTNxcarQllRUVHEYnr7+/v8/Pz8/P3FYnr+/Pz+/v6tRFveJToDAAAAAXRSTlMAQObYZgAAAUZJREFUeNrtlNeugzAMhnEmlNEFbemi6+w93v/Zzp9EcJMUcV0dgxxL/vTbGEx086YHcoeq7kV1x8Hqq9q6qjR8B7bagXoo6BL26AFr69qKd1K6INyiBoADfpUrBjZoYAwwt4eica7G8yA34ulK2fQIFAyiIXBxFC6dJzZQcNMmSK5cGuRkOmvel4i82tpxpjOnOJ0t8ySezP3hOPCzQX/JBLoGUyww7W15hhyUnFSefCzV2BcE+fS7PhFRJsCrzKCxRE8+uH19WX/t99+XtxPxXRzHgtme/B5HlCH98HMRxEWGywddhUVZ3CvAgohTBk8s+LYh+VgUeKLnMxFo4Gl07c0oYEaWW1nU9k1DkKdlYTB2FEwSuY8nNHGJWx53qYmiDvNH7hoAuNG9q+dAqG361xApbw37TQ8ED+02DgCH/VQA/Vtrf0l4HB2/EcuqAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "111",
+    "id": 111,
+    "sortid": 111,
     "identifier": "rhyhorn",
     "name": "Rhyhorn",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAQlBMVEX///9zhIwxMTE1NTVSUlJTU1Nxgopyg4syMzOrsrqrs7ustLyttb00NDR1hY37+/s2NjYyMjLMSil0g4r8/Pz8/f3VvybNAAAAAXRSTlMAQObYZgAAAL1JREFUeNrt0csSgyAMBdASCG+1z///1d5Ixw3GsnXGLGDh4SbC7apTlaVBl8xjJG0UpuiLGZD3ZOAg6S+EcqigU0viqriMBVSbrkaiJHG5VnYBUoMGhLNscOqcgBzQsHBjxpHWmoORTCTKARyJB4FZ1raVvdu0RInlu3SVHYtM2cPGalxmTNdGRFEPfal4Evd8mR/cArvILSi0d0mc93/GN/eeyK9ZlrTrWQGRjAGo15Zhl/kzKaQ/cNVJ6gvhOwbXIaHb+wAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "112",
+    "id": 112,
+    "sortid": 112,
     "identifier": "rhydon",
     "name": "Rhydon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAolBMVEX///9SUlJ7hIw1NTU2NjYxMTFTU1N6g4syMjKrs7ustLyttb2rsrp5gooyMzOtSlJRUVHWvYz357V8hIx8hYytS1Ots7t8hY29pXPGa3PT09NUVFTz5LL25rT8/Pyutr42NjW6o3E0NDTFanJUU1LTuorTu4tUVFPUvIxTUVLW1tbkSSlTU1L05LP15bR9hY2rSlL7+/uuTFT9/Pz9/f3+/PsdbZ+LAAAAAXRSTlMAQObYZgAAARFJREFUeNrtkzdyxDAMRRfggllxc/Q652zf/2oGJbuSSKvwjJv9hQrNG3zyCRod8/cZ01Aw00NBIOKpgug30juHmrzLkwck8lJZJw1i6ghiW10wxkEEpSlBXu6qyTeJltsFRbq3dbWbWgnGOal0VMKYshvm8vvPE+YQNYOoe9WY0NhGNoIOJXW59QJDp0MAMLIFDuy1A5YKNZVMvby/3YLJf971aRwJPztfrYq55NE5URY09QvyblYUc8cgAihQCNTLlcoi2ka45ZvHBopQ9VRPAysblwnwqgqZWAY/Ns13jJGPdV1fGyf3zxDdNbG+W6A+XS4fQi+ktoKImkdmsbNpkTMMBV83+7MBXPvTHPO/+QLkDQ50IA1nHwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "113",
+    "id": 113,
+    "sortid": 113,
     "identifier": "chansey",
     "name": "Chansey",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAeFBMVEX///+1Y2P/xr1UU1MxMTG2ZGTkkpLne2vnlJT7w7r9xLs1NTVSUlI0MzNRUVGyYmL8xLtUUlIzMjH////keWr+xbwzMjKzYmLNeoMzMTHkemr9/Pz+xLs2NjZTUlL/xr7//v22ZWXOe4T+/Pzmk5NUVFT7+/vnfGx2iWjvAAAAAXRSTlMAQObYZgAAAL9JREFUeNrt0kcOgzAURVH83Qs9QEhCetn/DvODkRjZZIrEHR89W5aTrfU0MMb+UhoA0gVqWVaAL40yoRqARWl3kpjrZXLchOWA56Ya0CKjQlZhqUE1aEdWHlCGHLKPPIFnJYsMcgO/KDIn2iDMDT8XwIkB6gqlgtBqTo6vzo+qMET5rusbOm7iDl/ygZKQJzKELAKllKVQY2R/b2NydrgYhpnzjsa/ms0J6ZFkruuXvhmbfBzON63iYh5OtlbTF8QbCsTtEvdhAAAAAElFTkSuQmCC",
-    "gender_rate": "8",
-    "rarity": "30"
+    "gender_rate": 8,
+    "rarity": 30
   },
   {
-    "id": "114",
+    "id": 114,
+    "sortid": 114,
     "identifier": "tangela",
     "name": "Tangela",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAeFBMVEX///9SUlIxMTFSertSU1RSUlNZq/wxMjMxMjQ1NTVRUVFSe71Se75UVFRZq/tRebpZrP1arf+7u7v8/Pz9/f0zMTFTUlFTfL2Dg4OEhISFhYW6uro2Nja7u73DUUHEUkLGUkHGUkLzcSn3cylUfb78/P0zMzP////8RWP7AAAAAXRSTlMAQObYZgAAALdJREFUeNrt0kcOhTAMBFDGTkLo9ffe73/D70RsSfYIA7N6GqNAss7CJvNBcVdbkuis4AhUnOYwneLWhuC5LrVjgAk7alplFNglBZ0G+0qhnIb2slym1H47Bd5QDRXgMJyfrcyaywEY3r6QJe3c2ZSfCv33tJskzR8igH78VbIaXAQ2tyL34xFAoM/JnAvtkI903l0fWwid7jTQSL7SKJeRn6LR5D4PbpvYf0byPF/3yUU1Jessb/4U7QgqVqt7KAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "115",
+    "id": 115,
+    "sortid": 115,
     "identifier": "kangaskhan",
     "name": "Kangaskhan",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABmFBMVEVzc3NSUlI1NTU5OTmyeWo2NjYxMTGzemqEY1JTUlKFY1JycnKzemtVU1JRUVHOnHtxcXHNmnqMjIxUU1KLi4uxeWmDY1JUVFOBYlEzMjIzMzG0emqFZFOCYVBTU1E1NDO0e2s2NTY3NzbCsWqxeWrNnHrMmnrKmXlUU1NUUlHDsmqyemo2NTW1e2q1e2u1fGu2fGw3NjfMm3rGtWv5+fk2NjUzMjFVVVW0e2rDsmm1emvBsmpRUVKzeWt0dHSkpNyGY1KGZVX3763x6ak0MzI1MzI0NDWGZFPPnnxUVFS0fGwyMjG1fG00NDKhodn6+vkzMzOEYlKCYVH6+flTU1RxcnHjSipTUVE3ODfFtGuEZFTy6qo0MjJSUlGFZVTHtmzFtGz8/PzOm3v07Kq2fG3GtGr++vrz66lTU1I4ODiBYlLLmXn37qxTUlM4Nzf4+fmCYlFzc3SFY1P7+vlVVFOiotlzcnLPnX2CYlL17ayDYlKyeWlUUlJWVlYyMjJUUVH7+vq0fG1VVFS2fW3z6qpUVFI0NDP////wkzM8AAAAiHRSTlP///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////8AGLfWDwAAAU1JREFUeNrt1MVuAzEUBVB7xhnKQJiZ03AaKDMzMzMzM+e3m12kRk6z6aJSvD66vnrPMsiVeSrwTyDRP1gmrKo24WCxHKFyuRnK/gsU5U0APFEfbesdJa+Wa1QaAOD2cu0RNtH5ZaQUGpUKAMVh/aYJ29FJn7+q5QDkXfYkyGdwkEA0B6/yMCA+ry6ZURgLtRwDfRd6fdI+tdWKhJcwBpIGnQ7615ReSRlDEbYvSndiOpIyA4R+h++adwiIHX9nzJmfsEBFaNMfZ22NTNAT4dACfo7paffsp3oldhYSQvyDzmjEQGIMqWFv+0FPlLNY4B3DWF0YiFgoTz3O38bjdbSwN2pNYxJJLTt52jU0wSYlc4tl8caF7Uga4GXzW8O+V+I89wlZiUdBEoTo3uGVUneAwu26MCSZdqBmg07gYcGm5oZ3MbsuSq18Kf8FfgNahOYw1zVdxwAAAABJRU5ErkJggg==",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "116",
+    "id": 116,
+    "sortid": 116,
     "identifier": "horsea",
     "name": "Horsea",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA7VBMVEX///9zzv82NjZanP9yzPxyzf81NTU5OTlCa6VCbKZZm/xam/wxMTFxyflxy/sxMTJyzP82ODg4ODjOvXNHbqRRUlNTVFVUVFNUVFRYmfwyMjJZnf4yMjRanP4yMzRbnf9cnf4xMjQ1Njdxy/1yyvs1NzdDbaVDbadzzf1zzf9EbaV0zv6r5ves5vfJuXPMu3JFbaXZUkzbUUneVU7rrn/uqnnx463z46r3561SUlJSUlNSVVZTU1I0NDVenv7KunHLu3I2NjUzMzI2ODdYmvtZmflZmvtyzf4zNDVRU1Zzzf78+/v8/f3+/Pz+/fwMVUxpAAAAAXRSTlMAQObYZgAAAMRJREFUeNrtkcUSwjAUAPPa1KACLRR31+Lu7v//OWQYriE9A3vIaWdf8oL+fCOi6lLTIam68HQg8BlWVzwIlxoxFYN0GcHGbfGOfhQxtPsPXgBFNuizs+oJA8w7d74CBOpscScA+KDXvUIOQJYNWtDUplj3CMd6pVw881CmP0bSsJ/j9l5vOOgZz0LWhmqa4utQV4GIvbQc5tqjw1ErNXE4llewm1aVXIL9iT5lkI4jJpIWKyXyfsTG1DDeIjdI3Br9+V2eDpEPYWq+eAYAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "225"
+    "gender_rate": 4,
+    "rarity": 225
   },
   {
-    "id": "117",
+    "id": 117,
+    "sortid": 117,
     "identifier": "seadra",
     "name": "Seadra",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABKVBMVEX///97zv81NTVCfNZKnPd6zPwxMTF5y/tSUlI5OTkyMzR6zP56zf5KmvSllGPOvYT05Ks4ODhRUlNBetNCe9RSU1RSVFdTU1JTVFVUVFNVV1d5yfl5zP15zP4yMjFJmfN7zf9JmvRKmvPMu4NRU1Tx4ak0MzL3561LnPVJmvNCe9ZLnPZLnPdLnvdQUVMxMzRRUlRBe9dBfNdCedFSU1dSVFVCetRSVVY0NTcxMjM1NjhVVlZDe9RYWFh4yfp4yvtDfdd5yfp5yvxImPJJmPA1Nzd6y/s2NjY2NzhJmvV6zf97zf1JmvZJm/Z8zPt9zv99z/82ODimlWTJuoTLuoLLu4PLvIUxMjRKm/TPvYVKnPYzMzL05a725qxLnPT6/f/7+/v8/Pz8/f8KHVzLAAAAAXRSTlMAQObYZgAAARFJREFUeNrt0cWSg0AUhWFuK8GJu5LJuLu7u7u9/0PMZbYhwDZV+ddfH6obZVD/REQ8RKQWw408CQmaEFFub1QHoBcGRIwur+tA0dIVPBQyS1IG0FcDME3IkFW3BFSHMjAjw4F5ovfsgaRbnE5z5BmV4+z9x1Cg4/43v3+vAMNJ1ekEOaKhg6/iz7V/7392a1VFwBPungGU63WoIFowmed0sO7JhFzKc5lePIRhz2RoVfPdtqpdDmWJ8xuRyxUKJjtpMPb5aKELyiVEcdsvD87lxExW3b9rtWz7TenVRnstn9wZZ5NHfmH/vMgr20mzdqxERDZPxxrzzSklqsTc+Wy2mVpVYsjacxpdDEnw9oP6pz8zGRxZaBRBCgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "118",
+    "id": 118,
+    "sortid": 118,
     "identifier": "goldeen",
     "name": "Goldeen",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABIFBMVEX///8xMTE1NTU2Nja6urq9QkK9vb38/Pz+/v7///9UVFQ0NDS7u7s3Nzc4ODjsclLuclH7+/tRUVH9/f1SUlL/taVUUlK5ublTU1PudFTvc1LvdVTwdVT5kZH5+fn6+vq7Q0P8+vk2NjX9+/szMzP+s6P+/PyOjo6+vr7//v6/REK+vLu+vb00MTFVUFC/RkW/vb3RwnnscFJVU1Lsc1LsdFTtcVHtdVVVVFTuc1Luc1TudFNWVVRXV1fvdFPvdVNbs6PvdVWJiYnz4qrz5Kv05az25qz35qz3562NjY05OTk3NTT7tKW6QUD7/f38k5P8+Pk3NjT8+/q7QkI3NjX9/PwICAi8urq8vLxUU1O9RUX/tqb/t6f//f1UVFO+u7tIyNGkAAAAAXRSTlMAQObYZgAAAQBJREFUeNrtkUWSxDAMRW3HGOZm5h5mZmZmuv8txgfoONnOVL+ytXqlr5LAmD8Gyup5RlZRpJoIyo8D0W+rvXNM29BnpW5qS4QpzTvE7ephqAiVVQ9NukHcmAmhJ4iHjwBYvtdfDR/c2Ol8JZlo7vgOehOtUrQdO4TIdDF6ULR/dPrd2Fvu8I/ozSnKjgZMyD442Sm4Q3IrxJYPJSMtzZjyF8vl+5n54vBJ8MTl2LnX9+nLz8HZylV9vUGxptgfrrcC3qs9715vLkDFSXKWVp2cDXqMm4W1C6Qw5avc/FCK80vRQFjqS2uVF9OCVe4xZoMUVZNT1OxmE2TARmDMv+MXTTgaefOkzo0AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "225"
+    "gender_rate": 4,
+    "rarity": 225
   },
   {
-    "id": "119",
+    "id": 119,
+    "sortid": 119,
     "identifier": "seaking",
     "name": "Seaking",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA5FBMVEX///9SUlIxMTE1NTWMjIy7u7u9vb3WY0L8/Pz///9UVFQ2Nja5ubk3Nze+vr6/v79TU1P3hFr7+/v9/f3+/v5UUlJUUlHzglnTYkIzMzNRUVFVVVVRUVLbg5rehJytUjn1g1mtUjr5+fk0NDQ0MzK9u7v+/Pz+/fw4ODg5OTmPj4/3hVvTY0PTw4LUY0LVYkHVY0HVZEPVZUWpUTnWZUTZgpmrUjndg5pUUlNSUlHz5KOuUjn25qRTUVG6urn3hVz356X4+Pi6urr6+vpWUlG8u7r9s7q8vLxWVFNXV1eLi4tTUlHxYxXcAAAAAXRSTlMAQObYZgAAARRJREFUeNrt0kWOw0AQBdBmMDOEGYaZmeH+95m2PcvuKNtI+atavP5lqQy22ZxgtKZ7YeX/iNCKNtSi5LNsZinHRhhJC/7UEEtJyCrpxRakZfXEIyRG+r0NVBTVgzTsxjcTANqw40SsjVThTmzYjPfvJigPUwihEwhTYVP5tBuqpB0IR57wEuVWwLl8TOH9NWWJdE0wD5WzUGTB4u0h0a/GCKH8tj8I5+Ma8l8RR2KhOxwLLj56wwGfybOs4NPglbq29sQEdq9gd3jIeVZM1TNa6r/PoSw4v+xVkB9/0YAyPQRLuwWWp/33kyM+86szskaatEP3DjLh+8m3Q10Ta6jKKImEWNhr/LzPLtYwTS0G22xK/gBnwhglMbJYlwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "120",
+    "id": 120,
+    "sortid": 120,
     "identifier": "staryu",
     "name": "Staryu",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAt1BMVEX///9SUlI2NjYxMTE1NTVUVFJVVVKVZEOspFKzg1rvxoz350r15UtUUlKxgVlUU1K0hFq1hFrsw4rtxYw0NDMzMjL25ks5OTk0MzK0g1mTY0OUY0KTY0KtpVKvU0PuxIvuxYuVZELz40r05EqsUkNUU1P+zLv+zbz//f0yMjG0g1qvVESvp1L1Y1KxgViWZUTpwYkzMzIyMTH2Y1KygllWVVKzg1m2hlu3hVzqwYkzMjGRYkKTYkIQ3KbgAAAAAXRSTlMAQObYZgAAAL5JREFUeNrt0bcOwjAUhWFf9xJIJaHXhN57e//ngoUxDgMT8EvePl3pyOjfF0bJmy4Q249CcuqI2rUARZMKIkHD9wsguZxXUXVd95+SPMuFuBzo0Dtwz4v2Ha31Jn/HMuRsEHMe6q4WjfxNyQ2M7EsTQ1fYF1HulLKSM+f1msLIBg3Mhm0wBo7276k6MBrvIHZcO6Q+sHSRshaIewF0JTAmZaZ6FRtMmk2MpcRYqamwnsT49cqKordKKPr3qz0ATvMM0pMN25AAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "121",
+    "id": 121,
+    "sortid": 121,
     "identifier": "starmie",
     "name": "Starmie",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///9SUlJSUlNrY702NjZUVFFiWZIxMTF6esx7e86lnM709ClTU1JjWpQyMjM1NTV6es1RUVGjmsykm85TU1PEu1LGvVExMTL29in39ylTUlFqYrrGvVK9Wkqjmsu7WUpqYrsxMTN5ecv8/Pz0q5r3ZVS+XExUUlLDulH2YlH+/f3////0xTv+AAAAAXRSTlMAQObYZgAAAM1JREFUeNrtkskWgjAMRU1SOjIICDI5z/r//2dw46rFtYe3aRe3ryf3ZDHnDyPUb5DY0mGak8lafcAsXJvJBDUtTar4RagwB4kFgyiTECi2hhAAtDF8KOUHj6W1q2qINYLma+r/WZcrcG0EhbWWvMOLHvfo6qZu2qggWvoLe0JwEYCrY9AGVWDoqonOz2vnWkb9gjKJDJ5el9sIsiAfKdg2wO6x6aoY9iGVQh2RGRgFEYZFmjRnbFROh6nluQ+xXCt+8ssGfbdnonbOP+YNnJYLxt45ZsYAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "60"
+    "gender_rate": -1,
+    "rarity": 60
   },
   {
-    "id": "122",
+    "id": 122,
+    "sortid": 122,
     "identifier": "mr-mime",
     "name": "Mr. Mime",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAtFBMVEX///8xMTE2NjZTU1O7u7vWWlrvrZz/zr1SUlL///8zMjI1NTVUU1OKioqjSkq9vb2+vr7TWVnsq5pCYotClLVRUVG8vLwzMzPDgoJUUlLVW1tCY4zvrp26urrEg4PGhIRBYooxMTK9u7vWW1syMTGjSUlBkrL7y7r7+/v8zLtEZIz//v2lSkrurJtTUVFTUlLVWVlCkrNCk7T8/PwzMTH9/f3+zLz+zbz+/Pw0MzPWXFxUVFTZGKIBAAAAAXRSTlMAQObYZgAAAMtJREFUeNrt0kkSgjAQBVBDRpBZQEFFEcV5nvX+97KzcGnC2uJvksWrX13V3WryVzFQTTfuFwi05PJRyn4x5/yJEKrg+xO2oTK8c87tYxRBu2rI3o1L2DlBn8LNdlC4Ngd2B5wGMmYtBswWwUUp43wL8EXTsKQKafT2AiQr04BSBTScBBMsZNwD3Ux/w6GHSUbpw/Sxq3CttpN0Y5JNPCwIzkeWctdGTDx8Nt9LhvTrdq6m30X6A5Kzfp1WhytUx1URnE69RjjGJv+WD4XwDvydmskHAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "123",
+    "id": 123,
+    "sortid": 123,
     "identifier": "scyther",
     "name": "Scyther",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///8xMTFZkkpalEpSUlJSU1FZkkk2NjaDxXKExnM1NTVKbDkxMjFZk0lKazmCw3EyMzIzMzP7+/uDxHJSU1JTU1LDw8PEs3rExcRTU1P9/vxUVFTGtXvGxsbk1Jo0NDQzMzL8/PtJajiFxnVKajlblEvn1pxclUxRUVH8/fxRUlH///9tt3GcAAAAAXRSTlMAQObYZgAAANFJREFUeAHt0rd2xCAQhWHPDLCAsjZn52C///v5QuNqkFrv2XskVd/5UcHDP9l9C8JDM5yryfl+hmsbH0JPORpJdc9NuwyhwtvjD1ytwej+XOzk8qif7ENa1X4T3EmDi058do2I5cs7XAlWNH74lWE9mCTc03V8WbHYbcFRF9A8HA2cId253Z49yHbNln3oS9AY1AR4efi5ajBuzgO5VDytCw7FzYAb8ckTvQxxvNjXxvLXeU+6jAm/SU1E45HrqftI6QsokNNDeTfMgbl8323tFwSNDC/uIBfaAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "124",
+    "id": 124,
+    "sortid": 124,
     "identifier": "jynx",
     "name": "Jynx",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAtFBMVEX///8xMTH3Y1JSUlJTU1JUUlKUe87GvWs2Njb/95SSesxTUlO1UkLEo8zEu2r1YlEzMjP3ZFL785L89JL9/P7+3GL/3mNUVFPGps62UkL7+/szMzHzYlGVe82yUUGzUkIzMTG7u7vDumpUVFT+9pPEo81TU1M1NTVxWZLki6Pli6XnjKVyWZL0YlKSecs0MTHDo8v722JUVFI0NDKVfc6clEr9/f3FpM7Fu2zFvGo0NDT///9O5kS9AAAAAXRSTlMAQObYZgAAAOxJREFUeNrt08WOwzAYBOD9zQ6noeKWYZn5/d9rx+rZTq+VOlKUy6eZ2FKuLjmjGCI6iQ2s1RPqdWBW642e9LmOV3DAQblfiUyLTPDK2rcgHHSRUnH0LapgpYGrhwqJAcmnyMG0GL+rerjzN5rDtqBj41cxXuNEHmme3WDHo9u7mWvUHz8eSI+QODC/meG98ULXWdBKPEiOYFlkXkh4XkrWlExWWix3FLjHKWvatpT41uXn36/XmeucsVHetK+pUvWa/HDKHBzl8n6r4vkiNA3HAFO4JAlIQ1iHlXyeLNx0D2XsieiUXwHqkjPJP8xbEihIa/slAAAAAElFTkSuQmCC",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "125",
+    "id": 125,
+    "sortid": 125,
     "identifier": "electabuzz",
     "name": "Electabuzz",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAP1BMVEX///8xMTGtnFpSUlKEhGP33koyMjE0MzH///+rmllUVFGunVm9vb3020r13Erz20mEhGKsm1o2NjaDg2KFhWLpyJpUAAAAAXRSTlMAQObYZgAAAL1JREFUeAHt0ruWgzAMhOGdGQ0QLiR7ef9nXYnUttOlyX+OVH2Ixl/v7tPPq+4+v4BwQWDgcN+mhNs5jyAfT7jiOt+Ruk3pvB5zfTB1ZPDMg4c94/ZoQ1DONvJcbxPazpYc0m+5JitYKm02lFLkHP77Zl+GjYXlOhAALdsSu45iCe27KLSdgoCk0CLRTYkQUl+RDqNBQaK2FA6ppiXLRbmcy3d+v0cAIBmg2zAlUFtJYI9f8MIl5dA9D396b/9PEwWNIL6noAAAAABJRU5ErkJggg==",
-    "gender_rate": "2",
-    "rarity": "45"
+    "gender_rate": 2,
+    "rarity": 45
   },
   {
-    "id": "126",
+    "id": 126,
+    "sortid": 126,
     "identifier": "magmar",
     "name": "Magmar",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTFSUlLWY0LGrVKtSkL39yn/xq3///82NjbvnJz//f32kynWY0E0NDBUUlEzMTHzkim9vb1RUVHGrlH39Sk1NTXWZUTXZEQ1NDM0MjDz8ynTYkH0kin09ClUVFH29Cn3lSnTYkLUY0LUY0MzMjE0NDSHuY0NAAAAAXRSTlMAQObYZgAAAOBJREFUeNrt0clyAjEMBNBpyeuwJYQtGySB5P8/Ma1AFReE50LlQk9Zvryy5VF3z42ywjBXX9OUFRjmWBsOJG1nIqXFN+t1iDcdL3db4oase9XZ13j5Ofk4ugpH4kColodjJ965VcQk1wz8o3ReoDr6eZL3iZ1ZH18895yzbkalrP8cn+ZIZKY/9UjI7bJDRu57SmGHJh1HQCaWBH+O0BKVxlZICfDmiKIAgiTlyUHEZuk8BVyBQMSsXe8GUQI/6yHgmuviPAKIhdqcLxnbxG5H1w5UB0HMY4ln12rhnn/NL7TUCYyEbx0mAAAAAElFTkSuQmCC",
-    "gender_rate": "2",
-    "rarity": "45"
+    "gender_rate": 2,
+    "rarity": 45
   },
   {
-    "id": "127",
+    "id": 127,
+    "sortid": 127,
     "identifier": "pinsir",
     "name": "Pinsir",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///8xMTFSUlIzMzNSUlEyMTFTUlJTU1Ojg2KlhGO6urK7u7O9vbWDYkKFZUSMhHQ0NDSCYkE2NjaEY0K+vrbLspLOtZT7+/v8/Pz9/f01NTXNtJOkg2KFZEP9/Pz///9RUVGmhWUyMjLMs5IyMjGKgnFUVFSNhXW8vLP9/fyjgmKEZEPyDuRRAAAAAXRSTlMAQObYZgAAAOlJREFUeNrt0kduxDAMBdB8SVaz3Pv0ZCb9/vcLbWUXh94mwBCGtXn4pAg93OsP1A6bpI7/ocSG8zIeUys3YYw8k+RcKJ6+4bnkYZB0AARbyUKS6HqTTm3g4PNbkF3fu0alwYBboJ/dMRlyJeyNvXZ17d17O+UH5xwn684IIazbO6cFOHgZX8ZXQbHa7o8JK8VcWaPsRm9v0lBQc50dGFijUksixWmKTdYRUDW0QZMWZJTIlF3L3A20kibBJQbq5VuF8BKYN6loOk2RY34qfxkwXjtTAD5oSIB/k0uu/zw9/ui7zsnf6z/UFw4YDnwxiLNpAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "128",
+    "id": 128,
+    "sortid": 128,
     "identifier": "tauros",
     "name": "Tauros",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAllBMVEX///9TUlJSUlIxMTGchGu1jFK9vbU1NTU2Nja+vrZ7Y1Kag2ozMjGyilGzi1JTU1JRUVF5YlHcvHP8/PwzMzJUU1IzMzOSkooyMTG2jVR5eYrevXP7+/s0NDTbu3JTU1OSkouUlIy7u7Obg2p7e4wyMjLbunFzc2uVlIsyMjHcu3K0i1LdvHKVlY16YlK6urL9/fz///8kKfb5AAAAAXRSTlMAQObYZgAAAOpJREFUeNrt0tcKwjAUBuCeLNO93Fbr3vP9X86TQK70xFsFf2ho4esZkOCfr0iHu/ND9HhjD6/h3J7m8bJydbBtA00Ax4QQVmqiUjPlgS4Yi4WAemohDsHfwFD1i3k16cUIwz5H9n6dzk21swmmx+pQtVniJnqBg3y2r9AtlTK/yITctzAFJdSPcJHjazcgZXOp5H0E80XO/HCwO3abkQQWA7aOhpTbms5SAq6dSUxCwfSMDtg1iliW8NSzTRmdAJlx+EVKnQIz5RwcrzfEFUwlOOe/jKZGaRw9nZMc5xy6NT5hYjii8D8/lCcLDhBZHY8VtQAAAABJRU5ErkJggg==",
-    "gender_rate": "0",
-    "rarity": "45"
+    "gender_rate": 0,
+    "rarity": 45
   },
   {
-    "id": "129",
+    "id": 129,
+    "sortid": 129,
     "identifier": "magikarp",
     "name": "Magikarp",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAyVBMVEX///9SUlIxMTFUUlLGUkL09Cn2clH3c1L///80NDRUVFHGvr7zcVH0clI2NjZTU1H39yn8/Pz+/Pz+/f26o0FRUVHGvb0zMzPEu7vFUkIzMTHGu7s0NDA1NTVUVFTz8ymEhHOaQTicQjn29Sn3dVRTUlH8s6O7o0K+e3PDUUH/taXEUkK7enIzMjGdQjn9s6O9pUK9pkH1clFTUVH2c1L2dFODg3IyMjJTUlLFUUH7sqP7+/s0MjHFu7pTU1PGU0OdQzq6eXEyMTGQmNzQAAAAAXRSTlMAQObYZgAAAQlJREFUeNrt08VyxDAMBuBK5jBslpmhzEzv/1BVttNb7eSyt9Xkkpkvv2SPcnKsw1RU1zXO6sHBqI9YI69YzTzRrwFHV7Mk2cOoSia/MApeK84SAyCWMDNuGSguz78xUJk2bqcU51yykKDb9fI5lyRTv+W4RYKZeZlzav+Wa+NsnGlNkQwgdcANlyT9OwahUqzdbFnc5GK7vlVEQsod3o/HDxb49QjLD6kYdfWb77seJVpkAacdyUTitXOtzYbz7v8OCygjGQgvHSK9o20VJzew/LymIYW361rvkFZ28Lxdd6bTp4Xw0L3b1I0mW0AJ3XI/6eoyFuWyOZr/fdGIKbEaIj0Vv+qxDl0/S0sU65hBiGIAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "130",
+    "id": 130,
+    "sortid": 130,
     "identifier": "gyarados",
     "name": "Gyarados",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA+VBMVEX///8xMTFKa8ZKkuRKlOdRU1RSUlJJasNJkuQxMjMzMzNKk+ZRUVFRUlM1NTU2NjZyxPyMe0r///9RUlK+vr78/Pw0NDQyMjFKasQyMzRTU1JUVFNUVFQzMjFyxf5zxv+KeUm6urq7u7u9vb1CenLEq2rFrGrGrWvs25IxMTP8/f79/f1MbcbDq2r7+/uLekpBeXExMjKKe0xLbMVSUlGNfEtLk+RSU1S7vL1LlOZTU1NUUlFUUlLEq2xMbMVKbMbTYkHTYkLTY0Rxw/vs3JXt3JLu3ZPv3pTzior2i4pMledyxP78/P4zMzL8/v9Ce3P+/Pz+/f10xfzu2VYyAAAAAXRSTlMAQObYZgAAAXFJREFUeNrt01dyg0AMBmBrG53Q3Hs3tmM7vffey/0PE7Hxk8GEA0QPDGi++VerGXL/tawNyOhmgQ5Z4sx8MCn8hWTexAv0dLfYkid7XiF9UDuCNkhot3XZgjWJAKbz/swa5XZXx1BQNUiYbvHhO80D4TSbjHd0bLR3DPJaWA2TUIieLxzGIonwiB3iAlaliaaHoYxTlFpOwnGgr0IfkXSEWJRxiJpqLFBOiOVHYVwIAbKn4IQxaGKcKBmMWPjgVIsCSZi0RVPAbGowRGOvRjmAQs7qCUtUG+z6c2oQK++hQ04wPYy7ze+LFyaLd7rHlI+qNDmwdfcwdPd/b5LHyNvq6NzQ4k4JTTEfVCgX/eGwIoQ8O36wrYRg5mt9hCVr7roDxHR7UE+CuJ+rk34FVGJhZmTdYi4ZXj6djt7w9hpAK2IQd1LC41cNoX1Txk8AWPsXtHYFOnxDmVa4yfu9YhaIoRBzaVzVMkLFyCpxgv9a1g88tyfSe4MNLQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "131",
+    "id": 131,
+    "sortid": 131,
     "identifier": "lapras",
     "name": "Lapras",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAnFBMVEX///8xMTFKjN5Ka71SUlJjvf+EhIS9vbXv55xRUlRKi90zMzNMbLtRUlPOvXM1NTVSU1Riuvtiu/02NjZJarq7u7MxMjNKbL7u5ptKi9sxMTNTU1OdvbxUVFO8vLQxMzTLunHLu3TMu3JivP7s5Jpjvf1RUVFMjdxlvf1LjN1JittKarsyMjJlvv+Dg4Niu/yau7tMjNy6urL7+/vWkjD1AAAAAXRSTlMAQObYZgAAAPVJREFUeAHt0sduAyEYBGD/9O29rB13x+n9/d8ts0hRLgGOkSWPtHv6GPgRi2v+LwX9/PxpWr4kquQ25KjNxFMtZUA2FYve5FAPdQBCgkl8rA8dEUwyxoPToFJuv15sYUPkdSVVQ9yDfWqduGgBKAe+TzMwtdFaPbvn5vs8T3n2CgaauG+SaJencdTNhZ5Ki3f5B7NSqU3igydzdyw7BaZX5Ic3t7LstF6JqSfPzqMx97gnISaG9A5G55MxqJwNX7axQxZtHB1GyPXEIkF4mkR/9j2ihbD3+v2BsWPpOeBcgJrzYcRAvnf5u8LObmWQzllccwH5BuVtELBgvfUHAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "132",
+    "id": 132,
+    "sortid": 132,
     "identifier": "ditto",
     "name": "Ditto",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAOVBMVEX///97Wq2Ue84yMjM1NTU2NjZSUlNTUlN5Wat6WasxMTGSecuSesyTes1SUlIyMTJRUVHDo8vEo81MGsDmAAAAAXRSTlMAQObYZgAAAGxJREFUeNrt0DkOwCAMRFFsMDvZ7n/YDEIpg1Ok5BeunlyMWa30XP7m5GRrJCsaojCzjRf01JVQLSiaS3lQ0WHYKqsvJTZmUFQVSI0aj4j29wmPRNQlDgHO1gEdDahSn7y+OSQUmJbrarX6sRt6ggNAQYlaqAAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "35"
+    "gender_rate": -1,
+    "rarity": 35
   },
   {
-    "id": "133",
+    "id": 133,
+    "sortid": 133,
     "identifier": "eevee",
     "name": "Eevee",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAilBMVEX///8xMTF0W0I2Njbcs1netVrnznO7gzl0WkHnznT+9tRxWUEzMjEzMzJ1XES6gjg0NDO9hDnbslk1NTXdtFkyMTHkzHLmzHJRUVFSUlL789NUU1L/99blzHLmzXJzWkLetlzky3EzMzHbs1lSUlH7+/tyWUL+/fw0NDT99dPOnErLmklTUlH89NP4pTIDAAAAAXRSTlMAQObYZgAAALpJREFUeNrt0McOgzAQBFDW2LjQe4eE9Pb/vxebQ6QcWHFGzPlptDvWno3FBljnEjatc4ROv2IbhdwDzY6OD9BEy9A914UPYUloyx8dAqvTwAZCyahhqaLlQspMZhfHpb8E08thhnHWXjX0kBETrQRl2okc0BXZ83ZPSE+46UPkK2MkD0Xv6Jkw1wSjvk18pGMqMdjpSNVJ8wxeaZSSJAeX40dWhaMCY2yw0KThu/7rwrY0162j1p5N5gs6pwrpfjOn7gAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "134",
+    "id": 134,
+    "sortid": 134,
     "identifier": "vaporeon",
     "name": "Vaporeon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAt1BMVEX///+E3u9iq+RjredRUlM5jK0xMjIxMTFSUlJRUVE6ja42NjZSU1RScppSc504iqs5i6uC2+yD2+yD3O2D3e4xMjO6urq9pUL9/f3///81NTWC3O1SdJ1TU1FTU1NUVFK6pENUVFS7u7xUdZ2+vr7u5YLv54T7+/v8/PxSUlM7jawyMzM7jKtSVFS8pURTdJy9pkO9vb0zMzLs5ILs5IPt5oVSc5wzMzM0NDSF3u/8/P26o0FirOU3lPmJAAAAAXRSTlMAQObYZgAAAQdJREFUeNrt0mdvg0AMBuD4fAM4CHtn76R7z///u3pAVFUK7udWyvsBCfmRfYYbnPNHopWii9VPGGKqCFz5snl21SqEqwgu+qcZqJUvhGwlSwDTXvdxyQ2bre+P/TkxWT8cePDttF+buQScBoI/bg6yebEDGtpWINpIs65fY0p8m+wldEQNDm89ZyS0d2+YAIAjZnk+pl02USEAutF1vt5MGQ4lccLtPAIYvb+y5Ol27MVUQyOzmxhGkqFrWbtl3PwUsqX3iTh8XtwVxhlIy9XEsrxFUS73LEFMaam25aoo56y5N93WNGWu1x1PMxq2Zfd4t7T6zVVsuI9OZvbPDk/WJengnH+VLwPjExTLxQhGAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "135",
+    "id": 135,
+    "sortid": 135,
     "identifier": "jolteon",
     "name": "Jolteon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAjVBMVEX///8xMTH/70pSUlJTU1G7mjm9nDnbw0H97Ur+/v40MzFUVFGFdHo2NjZRUVG+nTkzMjHGxs41NTXexkL77En97UnExMxUVFSEc3vbxEL7+/vdxUEzMzFUU1E0NDT87Er8/PyFhXL+7kmFhXSFhXX///+Dg3LDw8tTU1P9/fyEhHMyMjKCgnH/70zcxEL1vpTwAAAAAXRSTlMAQObYZgAAAOFJREFUeNrt0sduwzAMBmCTsqZ3vDKcPdukff/HK90E6ImqbkGA/CcJ+ERqRe88N1mgmzQu0GEYzAgGFkwgyuCxCjxwaxw0bsQAeuDhzRQtFi1hRKeXAHzrMVuD6dQksx06HySXTsnJlnfzLxxzd4t6YLeYrxGLeJ1+10tBjdHxt4jJZqWJyZZWAOfmB4MJkOtsL5Uq+Xc5X2hnKu72QioalGzFY7UX4vRR2cPnVdceCXlnK3vsO7uiieaPTUV7sellCb8T7YG5jIVcDP9+Cq1iMfN0/JMATb0L/LsA0TuvlB/VRw4Ix4WhigAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "136",
+    "id": 136,
+    "sortid": 136,
     "identifier": "flareon",
     "name": "Flareon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAn1BMVEX///82NjbWY0Lv74xUU1IxMTFSUlL3lFI0MjGlUkLGrUrTYkHVYkI1NTXzklH0klL2k1EzMzL7+/vt7Iru7Iru7YrGrks0NDTTYkLEq0rs7Ir+/v0zMTGjUUFUVFJUVFSEa3OFa3LWZUMzMjHs7IujUkJTUlGmU0KmVEPv742mVETDq0n1k1JTU1HFq0n3lVRUUlH9/Pz+/fxRUVH///+5YfcLAAAAAXRSTlMAQObYZgAAAPBJREFUeAHt0sdOxEAMBuDYjmfSS7bv0mHpHd7/2bAZIXHwRHtDSPmv88mJSzLlLwOHuvLoMFj/gjXzSEHEICGB4fOuj8KPdYDQZAlsd1EJw30lELjxGW+Jdiu23cO71oDGn589pldEywVZNfVb1LOUS10rTmI6gfJy0aVt6n7g8tLuZC7O+++Cm2IhrrBgPbwgqsNO6KaQWC706m+uW8zz2W2VPwuL9KzubdWgOhk8c3wvnYyvzGdEIuNLh+HU7Suca7NPa4xLXS6F9FwqHJdhePVxFYfyKr934jgc2eg1vrq90YY5SuyyMWGc9b/JlC+jrA/5OVLiawAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "137",
+    "id": 137,
+    "sortid": 137,
     "identifier": "porygon",
     "name": "Porygon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAn1BMVEX///9ClM5BkssxMTFRU1N7xv+9Wkr/taVSUlJzredUUlJRUVEzMTHmalnna1o1NTV5w/t6xPx6xf42NjY5c7Xkalnka1tCkswyMzQxMjP////7sqNBk81yrOZSU1S6uro4cbK+W0v8tab9/PwyMjPmbFt5xP29vb1xq+S+vr40MzI6dLZRUlP//f0zMzO7W0z+s6P+/PznbVw0NDRTUlHNeh3DAAAAAXRSTlMAQObYZgAAAM1JREFUeNrt0kcOwjAQBVDscU3vIaGG3vv9z8aARNnYsEb8lUd6+hrZbv3zc0kBvmMdKVfPwezyg5QPmUZto+vcWCN87zYMZ3a4revTHUZ6YnDYMZLN+DyYejgsEnNhxPnePy7nOzxT0jMVhuh0VgSBk3vgloRUxkJ0XaZULvxAXEp0xh2zjcImUgjhOwC266Ys1ggDR4H9YdyYc04KJ8YNbY6ysqcT3ke+ziobJAwoIQyhvTIEwEUhwsLuw9k4Tfhbn3XXj+71E//5uVwBmRANDJmRZBkAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "45"
+    "gender_rate": -1,
+    "rarity": 45
   },
   {
-    "id": "138",
+    "id": 138,
+    "sortid": 138,
     "identifier": "omanyte",
     "name": "Omanyte",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTFSnNYzMjF7xv+1nFL355wxMjNSUkpSU0xSmtOEc0JUVEx6xPw1NTU2NjazmlG0m1FEhb62nVPz5Jr05Jr15ZpRUUn8/Pz8/f7///9RmtNWVk55w/tRm9V6xf40MzJTU0r7+/uFdEP8/f2ymlFUVEse32J5AAAAAXRSTlMAQObYZgAAAKdJREFUeNrt0jcOwzAMBVCTKu6We0tx+v2PGEYJko3MbPiD0PTwqYHBllXGAcAfrIDWNkaJ1N2N6a1t+pPgWkuKKEkZEiWppMVU51sV5+C7Oa0YWRD7bL5WaaWYDz6i7i1TFgb7cc5Kc446AbpLFo00L+0dC+sbPSQNU3jAaa6Pk68tOafjBBftNYbcOQy5jnOtETFOeAngW8MdhiDf4pBI7NcbbFlfnngRCs2U8+B0AAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "139",
+    "id": 139,
+    "sortid": 139,
     "identifier": "omastar",
     "name": "Omastar",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAclBMVEX///9CQkKMzv/355RjY1pjZFxlZVr05JNKpediZFz25pJEREO9rVJKo+SKy/xDQ0K7q1K9rVP05JJFRUVGRkZkZFm7q1G8rFH15pWLzPxCQ0RLpediYllJo+SMzfybi0KcjEKKzf5LpeSNzv1GRkX05ZVEbst/AAAAAXRSTlMAQObYZgAAAOJJREFUeNrt0scSgkAQBFBnNpKzksz6/79or5Y3WLjpga6pPb3qgYXdln9ITWvhPltZOObZGlYKoReXVzQancehiBZcKbTBFAuyxlZAjF8CamkwQkBGPocyDebg5ZB57i9ujHi/SxHPwppoH36fMIa7TMMqHQK3VMvPeQYkmpKPVBk0hcK5jtX50CT9dCUrE5VFCH1ilTcSbhIer9xGuB/oOyuZWAs4J11awCGQc4VOUsotPt+JWaEvkDQrjxZNsmMUelY7Z59ovKEtsQH5CnsiAn/L3vczfk7QHn3LqaC2/DYvAOoN1ur8negAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "140",
+    "id": 140,
+    "sortid": 140,
     "identifier": "kabuto",
     "name": "Kabuto",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAaVBMVEX///8xMTFSUlJTUlKthFKjWVJRUVHevXM1NTUyMjGrglE0MzG7oynbunHbu3LdvHKMa0L1YlL33kKmXFE2Njarg1Ksg1FTU1FUVFG9pSkzMzKNbEI2NjWlWlLz20H020KlW1H3Y1KmWlKI2k44AAAAAXRSTlMAQObYZgAAAINJREFUeNrtzTcSwzAMRFEjkFTOztn3P6TXlkclqMIl/6B8s9ikUvEmIlrFijaEE0VdHb5pbtNLre1Pam7BrJBmht0O0nJOGhWGPndkQO/6l7C7ylZVDZndRkDXP6FBLXh8CM+QGdCQJfnP62rPDGdIHJG/D4dqcdbuUBJcHEKlUn/sDRFEBdc3bDtaAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "141",
+    "id": 141,
+    "sortid": 141,
     "identifier": "kabutops",
     "name": "Kabutops",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///8xMTFSUlJTUlKMjJS1hFr7+/v8/PwzMzP9/f1UVFSLako1NTWNbUyyglmzg1m0g1k2Nja6urK7u7O+vrbWtWNSUlEyMTE0NDQzMjGLi5K1hFu2hVyMa0qMbEu8u7O8vLS9vbVSUlPTsmLTs2LVtGKNbEpTU1NRUVH9/fyKakn///9IwvROAAAAAXRSTlMAQObYZgAAALtJREFUeNrt0dcKwzAMBdDIM6Np0kyne8///79Kwa8RfiuFXLDBcLgWKJrz66wg0C2HQKeD4GKp9QAQ4qQoyNIDgIESGYZqcQjGXUfme5nCW9uODhkLLy0G67zj4b03eekd97V+pXZLQwLjTCqKXamJZV0dT7sm+aSCUmhZJ24SVomD6lGr42kjbcNA4/B6d2ul1Nk2MTMjnWfWY61goP9+3+OSceXWsRCR36WHfEgOYc7khzhMAkRz/iNf6UQLIj63HwQAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "142",
+    "id": 142,
+    "sortid": 142,
     "identifier": "aerodactyl",
     "name": "Aerodactyl",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAkFBMVEX///8xMTGcjIy9vb2Mc7Wai4u6urpTUlIyMjI1NTVSUlKEa2tTU1Oaioq7u7ubi/2lUjkzMzO8vLxzWpw2NjZ0W5yLcrRRUVGdjY2jUjlzWpsyMTEyMjPWY0L7+/tSo3IyMjSbi4uMdLWCamqmVDxTUlGKcbK8u7ybi4yLcrPTYkHVYkEyMTKcjP/8/fz9/PvTLozEAAAAAXRSTlMAQObYZgAAAPhJREFUeNrtz8eSwjAMANBIriROp9ddyi5sgf//O6RMZrgowAwHOKCLPdazSvSOV4n+vS71D0DRIfq74Mg4uJLvXW5drXsAbZavrZQYz8RJoK5Z2TQHcfRpXe89WIXeqsbZkJWChC+t6z+rOKh0n15SdAAinbfOxWBLKomVUqVIORUMuoyBXWutv+kmbMRjLcdIMmRqkP9zfEhOqbA6MjTVoB7mzEB2iKRigzgdUt+cywkwrYIhFhtHx2EOtJ3kWDrjJsWOYJLM+AGiTjn5LU5jv0k+vQQuEn4Wi2JGP5DgVbncUkH6MDK3SnKtZgiIbkgGzR7veG6cAXLaDoWTv22GAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "143",
+    "id": 143,
+    "sortid": 143,
     "identifier": "snorlax",
     "name": "Snorlax",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAk1BMVEX///8xMTFCa4xCaotSUlJShJzOvZT/78ZTU1NBaoo1NTU2NjZUVFNUVFScc0Kyilm2jVv87MT97cT77MNRgpoxMTJRUVHLu5NUhZxRUlJSUlP8/f0xMjL+7sXLupKddUQzMjGzi1m1jFpTUlJEbIxRg5vNu5JEbYwzMzJWVlb8/PyacUH97cOackL9/PxSg5qddETRxQ0BAAAAAXRSTlMAQObYZgAAAQNJREFUeNrt08eOwkAQBFC6xxNsnMFEw+YAG+D/v45qebUX3OALN0oOl6fqUUszuue2SWigi5shckwxcyN/oouuqL1f2JZm5q3VDCrGk7TyCKy1reKmFkXFc+3T6KmG5KbXJVO7zqStBC1fqgWcAtdZBCi0xucDUJm8Eoe5SAWnwZ0wuINFVoZ5Sf2FEy9xQaBIuCGQMfncEN7txv/JCJQFnneVj0RbB9nRV+ZemBRYseG5AwWD0yDKXDCADnMjwxoUCSiVYf/wmxnNAXbz5qFC9yY1GhT5GTNW3K3caA6S8MSAx/xbjvHvFD37yfP8HfDaVUi+BAYSdlXCDbuoqLvnRjkBdQgRnAvCZjUAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "25"
+    "gender_rate": 1,
+    "rarity": 25
   },
   {
-    "id": "144",
+    "id": 144,
+    "sortid": 144,
     "identifier": "articuno",
     "name": "Articuno",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAXVBMVEX///8xMTFanPcxMjRBectCe85SUlJSU1RZmvNZmvQ1NTU5Y61RUlNZm/ZBes1cnff7+/sxMjNDe804Yqs0NDRRUVE2NjYxMTKKgoKro6OspKStpaXTY0RCesz+/PzPH/CuAAAAAXRSTlMAQObYZgAAAMxJREFUeNrt0tkKgzAQBdDexKzudl///zM7E0LBJqZ9bMH7ICLHOxl0s+YvcwC+c1Xdjcm7GbfNOCtkQn2l6uP7M2uckLMnQOoYCmGcBF4nobGKJ6ejVSsoMp6OVF133JhKjtGI61KhGnMbWkLOuDAfFRmAWU6yUo0LxSh+haq5q0brQGVB+j252GlQhtHxReJTpYjr01bLUGPohWFbWsmfLtPt0dNQGzsXVvLn69SGfT1LDvJw2IESbmFDpwaycv7z2LQ0H48wYM2P5wnJHAinO6x62wAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "145",
+    "id": 145,
+    "sortid": 145,
     "identifier": "zapdos",
     "name": "Zapdos",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABL1BMVEX///8xMTE1NTViYln05Ck2NjY3NjA3ODU5OTlRUVFSUlFSUlJUVFBVVVJXVlBjY1rBqUnx4Snx4irz5CkyMjL05Sr15Sr25ir25yn35yk0MzBVVFE0NDE4NjVXV1BhYlliYlo1NDGMhEk1NTLErEnErErFrUrliypRUlFRUlLz4yjz4yozMjHz5CoxMDD05SlTUlFTU1H15ilTU1NUU1D35ig0MzLFrUk5NzbCqUrCqkrDqkk3NzVUVFHFrEkzMzNVVVHHr0zgiSjhiSnjiijkiyk2NTHnjCnw4SlVVVNWVFLy4ivz4ilWVVFWV1E4OTZXVlFTUlA2NjVTU1D15Sk5ODgwMDD25SkyMjCPh0iPh0z35yhUU1LDq0jDq0nEq0lSUVE6OjpSUU/8+/j8/Ps917VkAAAAAXRSTlMAQObYZgAAAVZJREFUeNrt0dVyxCAUBuAAycbdNll3d6u7u7u37/8MJZ32ZkPb205n/wuGYb4DHKAm+duBV8Ng+B0+a6MMAA918FXY/EF2eBGJ4IMB06dYQJZw5g4JPdUKpmaSjoA9n8Tmhu0y3lBVEcDw3vU8L18nOE4rjGIpATupAii4NcBQyTVJEmqFpRRCUk1CQ5+nMazaLAFiymgdJNn5HalYU2zTqR4yRBdQcGp7StE1Y4Yj9Szq+7D4RJoeKLJcQaq4aFnWBdEFPdA3Au2ZjqTi4DcA5KN54zL7tt06OyojhJkg9nMZokwcT2+8LrsLj/sVhMR+WtgdeJEMwa1vvjRuaff6yTiQ0yKtpMVaq2rHw26tlNC62dkGC/VuUjYcRS62IYTjbqU0xVCcPs8wwU81ogpvRL1IuOVVzHDOmc/n16M+1O1oSHLM+IIeD3j4ihSxlIMn1CT/JO/DEyRBwpHm/wAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "146",
+    "id": 146,
+    "sortid": 146,
     "identifier": "moltres",
     "name": "Moltres",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABI1BMVEX////3azn/3kI1NTU2NjYxMTH83EL/pTk0MTH52UL720GuQjn+pDk5OTn/3UL3bDn1azn2ajn2azkyMTFTU1L3bjn4bTr42kI3Njb7oziuQznEk2v9ozn920HEpEr+3kHzajj/pjn/pjr1aTn1ajmvRTivRjmwQjnBkGnBkWnCokrDkWnDoknEkmozMjHEo0rEpEk0MjHFo0rFpEzGlGvGpkzyaDg3NzQ3NzU4Nzc4ODX1bDk4ODg0NDT2bDj3ajlTUlE1NDFVVFL4bDiFhFH42EGFhVGGhVL62kGHhVSpQjn7+vmsQzn8/Pz9ojitQjn92EGtQzj93EL+ojmtRDn+pzj+20L+3EL+3UEzMjI2NTX/pTquRDiuRDn/3UGuRTivQzlsxffcAAAAAXRSTlMAQObYZgAAAShJREFUeAHtkNVuw0AQRXdmdw1e22FmKDNzU2Zmbv//KzqxFLWqt1Wfo5zHmaN7pcu6hh78v15uSiNzqRHBkiR/r+B0CHlOCtR11PrKoQrHBOun6NmVGsQHYlZbq1pBg/tmUmA4EiPPQPWPueDNq+BCOzAciYipFqhYy6JQWQXQeQS3DcSVfMlsvksH96IULpmWVeGsK1Us9pWQeE38teXRWQQ+Lh46HpfyN3M+Do2XO/TRbDfTtEzPwk0DLqev9g98gLQqmvnzhDaT7/r9J4eTo+WtDN4igGq6miWJ7Ebmfud0bnxtKMltrMM26LuzY7PJic3jGc48wTwD637EzSekxhspJIfL5UUWIAyjUktrVueDhSVBPHUOQtiGsSxCE3lCMP2pR5fwCclrGpJ1nwhOAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "147",
+    "id": 147,
+    "sortid": 147,
     "identifier": "dratini",
     "name": "Dratini",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAzFBMVEX///81NTWMtf83NzdjjL0xMTG7u7v8/Pz///9ljb1ji700NDQyMzRljb5nj7+KsvuLs/w2Nja5ubm6urq9vb37+/s5OTlSU1RiirqKs/2+vr75+fliiblkjLxji7uLtP2LtP6Mtf5kjb5ljr4zMzNTU1Nac538/P3+/v5mjr5RUVEyMzUzNDX9/f04ODgxMjKLs/4yMzZTVFVacpsxMjONtf9cdZ25urphiro2NjVmjr8yMjKCgnL5+vuEhHSJsflRUlNji7w2NjeLs/2H/nToAAAAAXRSTlMAQObYZgAAANdJREFUeNrt0NcOgjAYhuG2dIGIbNyLuvfe+/7vSTQknv3x2Pid9smbtui/3xpmXzpPfQcdrj5tMOi1mPkWOMgAcOy2RLZOzJcrKvCOeVpfEWKyQGYQNC3XIKf1g0TcV6AT2X1hyHKRkBJK4iA5t9oTO+Ln4wEIhqWulJ241iCRq/oMenVJdGJK6RLhq01mDJC4XNENOkB3mxSadAD+uW8Z1LzUps1t9QbI0B1Jy2jPF5W85pSrGpBMXtTTdX2TmNBBUFJ0i77H0xYoOefaDjSpxBij/35wT9CvD/L38tDmAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "148",
+    "id": 148,
+    "sortid": 148,
     "identifier": "dragonair",
     "name": "Dragonair",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA81BMVEX///8xMTE1NTVKhM5Mhc57rf+7u7v8/Pz///85OTlKg80yMzRLhM0zMzNRUVFRUlM0NDS5ubkxMjO+vr77+/syMjRKg8xJgclJgstJg81CWqxVVVd5qfm5ubt5q/u9vb1Nhc35+fk2NjZ6rP79/f3+/v5RU1U3NzY3NzdNhc5Ohs45OTgzNDdBW65SUlJSU1RTU1NUVVZVVVUxMzV4qfpDW64xMTJ6rPw1Njd7rf1Jgsx9rv+CgnGFhXWaQVE1NjhJhM66urpKgsq7vL28vLu8vLw1Nzc2NjX4+fozNDVLgsxLg838/f/9/fw2NzhMhMxMhcySH+4QAAAAAXRSTlMAQObYZgAAARVJREFUeNrtz7V2AzEQBVCxtF4mL5gxzIwOM/3/10SWU2b2uHPj18wU90hv0DKLDsHzwlv3b5kXoqDyXw07RpJEBTBrp4hcPrgYV0LyshbNOOcpTlTsYgDelROErCR2BpzvSHX1GfzvPI/Myl3w1JMqHgIuYZFZnt4HH4GGSgEwL4/NnDa8fvNl7EK3+K9mNDnnbepjjCB4yNPptJonfK8eITBWdsY3bb2cetvCiTCGZY+x4sC2s4a8361TGmFQhuKHsbwhh9++hppCcoOEQuxLZR48v6mQyOrjRCk2zmp0q2YgGNIbqfViXB7VqJN/QcoUlaO4W1DqsNYqzIwUj50uYy1R6UzPUOisPFczQwkhfbTMIvML0qMVu7FwWNQAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "149",
+    "id": 149,
+    "sortid": 149,
     "identifier": "dragonite",
     "name": "Dragonite",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABCFBMVEX///8xMTH3tWNTUlI1NTVRUVFSUlI0MzFUU1Kzg1m1hFq2hFrWxnvzsmL0s2L05Lv1tGI2NjZUVFNRvKSygliyglk0MzOzg1pKlIRMlIM1NDLxsWIzMjE2NjX0tGM0MzI5OTn3573+/fz3tmU3NTLxsmKwgVixgVmxglo4ODg2NjRJkoJKkoOzhFq0hFw0NDS1hFu1hVozMzK2hVu2hVy6urLRwnnTw3nTxHpMlYTxsWA2NzhRuaDx4bnzsmFRuqLz5LoxMzI3Njb0tGT0tWRSu6RSvaX2tGL2tGP2tWP2tWT2tWX25rw3Nzb3tWQ3ODb357w4Nzf5+fn6+vn7+/n7+/v8/PxWVVRhF2pnAAAAAXRSTlMAQObYZgAAAS9JREFUeNrt0sVywzAUBVC9JzPEcZipKTNzU2bG//+TXsfTbhLV3WWTu5Asz5kry7YYZ1TRfmZKcMeFeLYl9XkC1KYcpybEE1Z/SMKoLyxKIjh1qbbtrZHPlhG025Hz2VRJnXzXkUGGSESw1FB2+sxWkEmZ8XW51DCHMtJTzOymOYblUvbcHMbyEq6zjFbI08nd7Hzv4swccJsrcCD0MYGxslfOXu4T+YMw7/ShKz8BmbuVgxPcbgkxKAHxfL/pKo+MjaJKeCsVydumEHWV1Q0jWE/H8v2r0LRryneOz/LIkJ0NWXSc3IPC5eWO53k3btoyDBuuriqcLsrg/hmbo3Qmh/9IlZZuyy1vFRAyJKWDDMPwMFO9Zj56EUkBrt5dzSWx2L4uvc3+T2qaGGeU+QY1mhiFYf7hvQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "150",
+    "id": 150,
+    "sortid": 150,
     "identifier": "mewtwo",
     "name": "Mewtwo",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAq1BMVEX///82NjZSUlLn3u8zMzMxMTHFtM3Gtc7l3O01NTVVVVVxYnmaiqObi6SbjKScjKWdjaa1c6XEs8wyMTJTU1PHts/k2+xUU1Tm3e5UVFQ5OTlRUVGKWYqLWouMWozi2epTUlOai6MyMjIzMjI1NjWLWYuejaeejqeycaOzcqM5ODnDscvDsss0MzPFs800NDTFtM7GtM6ZiaE2NTVTUlJyYnpzY3t0ZHw1NDVSvpHyAAAAAXRSTlMAQObYZgAAAQJJREFUeNrt0MduhEAQRdGuqo7Q5Dx5xjnn8P9f5jZ46QY2ljdzF0hIh1cS7NhfZMRMd8t7PfmVse+FEDXx/uUyO/G5UBN9aFJ8cH5Yk0o0TQ4616f4uGMLd7Slbi8H6JwvQ1XL61SWYhwarKi7ulfc7sYl5ERSuTljDw6uCu/kqcw7qyRf7r/h8qzwuTeEPFGof/7PavO7FGHI2UOcdoN0ix4IYRnfPT3KKkAiLpzzQGYsZtlNQITUXuz8ji2em032SkSBPtflcNgzmTRrlEQtbnFtjN81SSIApYoAXvzMnY6iCBhgytlEAOCeXKWfbEYirqQ6zICAGrfXbI50sWP/3RfhCRE4uT0ekwAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "151",
+    "id": 151,
+    "sortid": 151,
     "identifier": "mew",
     "name": "Mew",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAWlBMVEX///8xMTEzMjLejJQ2Nja1Y3v/vcYzMTJUUlOyYnmzYno1NTW2ZHzbipLbi5Ldi5M0MzPejZX7usP8/P/9u8T+vMVRUVFTUlL8u8RcfP5cff/9/Pz7+/tSUlLOVNAXAAAAAXRSTlMAQObYZgAAAMhJREFUeNrtk0kWhCAMRE0iIM6zPd7/mp2IWwkuemet4PFfBSohu3VRObBSON8RGae7NaRzlVCCgeLmOwSRUnUtDyedSwvFO6meAm4Aa4vAtEaarTWz7f3cqxmOVkSola+axdqaTZWI8pEWW79f01CUHDpEQMuGDj4DAodPCFHyOQ14dL2AM1DuSGSkk/sWs1OSkMPkqxIqJOy2xEXjoBwWD0koLCGSZQAlS+biY/TlTtIeZcJ0lPxy/ReG5ydOZxghXRVkt/6hH0AgB9+POKrFAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "152",
+    "id": 152,
+    "sortid": 152,
     "identifier": "chikorita",
     "name": "Chikorita",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///+MxlKt/3M6lTlSU1IxMTGr/XI2NjZSUlI1NTVaxlpqo1FrpVJsplJtplSLxFGLxVIxMjGr+3Gr/HI4kjis/nIyMzGu/3X7+/v+/P2Kw1GKxVFWVlaLxFJZw1lZxFmNxlRZxVlahUI5lDlbhESt+3ExMzGt/3Su/HNRUVG6usvDIRDFIxHFJBHd/7vsWYLuWYLvXIUyNDL9//z++/s0NDT////ChcSAAAAAAXRSTlMAQObYZgAAAKpJREFUeNrt0kUSwzAMQNFIpjBDU2Zmuv/RGvsAUbft5K/fWKORra5fSgkhvmJj13XXgnQN0y0SwuUzo6jhzm7CbVvQc9OAZ1DSe/QL1N0p16vOGwx8ScLLFhGOz5CS6rBCfNzqaUHBFAo8XesKWSKopWOzDvBR2+pOLtHEBsBbnxxmTCKToGuFypOoEQ33y6gxfgz8/aJ+ohfDPCr1tcnzhIlRtBRW1z/2AWMRCgFsKTWUAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "153",
+    "id": 153,
+    "sortid": 153,
     "identifier": "bayleef",
     "name": "Bayleef",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAq1BMVEX///8xMTHOtVr/72NSUlLLslnMtFkzMzH87GI2NjZUVFKNfDma00mc1koyMzE1NTVSU1FTU1L+7mJTVFHezm1rnEqNezk0MzHdzWpqmkr77GL7+/syMjGa00r+7mP++/ub1UrTMTHWNDTby2rbzGrczGqNfTzezmoxMjHezmtrm0n3a2v3bWpUU1KKeTi+vr797WL+7GOLejnMs1kzMzNqmkn/72X//vz///9wsiQcAAAAAXRSTlMAQObYZgAAAPBJREFUeAHtkjd3wzAMhA2AlEQVW6J7d3rvJfn/vyy8ZMhkYMrL4luk4Xt39w7sHfRnGhCRTQWiummaPhkYKEhHB8DA/Hz7e+3qZty6NQD8Xu7nxu1zxp0jcFpyeNsNTzcinKeu+i71sBCebabWfn7yKB/H25FFhoWITI+272KCHOX25inRZFpyYkWq6+9tgnY/xMvFHa4dTnKjaOlckeL9TAEDLcqinO/STlJlubJ51s3bonQvMRXI1S27NdxQlFnt6DtwCDbA+wwLceTJ2ZUChuXDq09gtSJajlRHIvIRodYTguvn+UpHfl17/6yDvgCc9w65FXC+GQAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "154",
+    "id": 154,
+    "sortid": 154,
     "identifier": "meganium",
     "name": "Meganium",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA6lBMVEX///+194SUvYS09oQxMTH///82NjZrlEpslUqSuoKSu4M0NDSy84Kz9IOz9YMyMzJTVFLvc5z7+/v8o9v8/Pz//f5UVFTucpv8xQE1NTVtlUy+vr7sc5pqkkpTU1LvdJn7wwCTvIM0MzBUUlP9xgL+pNxSU1GzQ2rb+7ozNDLvdZ22RG229oG294W6urq8rhG9vb2+rQ9UU1BUU1Tc/bze/71TU1CUvIJqkknvc52VvYGVvoX7o9tSUlJTU1NskkoxMjFtlEj9wwG1Qmv9/v219IH+xAL+/P3/pd7/pt7/xgBTUVL//vu2RGlw4oCAAAAAAXRSTlMAQObYZgAAAShJREFUeNrt0cViwzAMBuDKEGZOuzKNmalj3vu/zuRst8Rpdq8OPn2W9cutVSmsoRt8jBA3cCNW4AawwA1dq9HLg0PWZMT77OCMandL4fnz5JICwMaS5IqFjqgOEDfgZp2DybaWfbUd8MK32JTDdSD0KYmuKKCMTZGKMVYFTwD2TqMdANDWxmHMTWYRtwxz/RiEcYpznk7jxAaEVUMSCp4NULT0EaoOYZVTipFu7T/4ig21oSuNdH1kF09/docUVyp1webYoKBl/SleqIcv3wt1/tD/zUJcKeRbqe8/pr6ABKH8w2fhBQaJOE+MOphbXvQe87Y6uzFIz6iBOvWipOsA7prt7suhWHsP8wooFit1edDBVjoVrr6KLopOS1CypU4Jyvuu6j/1AwVbGXP0qkdKAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "155",
+    "id": 155,
+    "sortid": 155,
     "identifier": "cyndaquil",
     "name": "Cyndaquil",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAARVBMVEX///9SUlIxMTFSa3vnzmv354RjjJzsWSnvWinvWymljDn/nCkzMTD+1ClUUlFSUlM2Njb80yn+milRUVExMjL/1in///8PEmRLAAAAAXRSTlMAQObYZgAAAJtJREFUeNrtzzcOAzEMRFEPg9IGZ9//qB6p2UpSv9hPsHsgwNvVaXtI27mJa9tewiqQmNp2XWCfd0x7TGzoVMM9vvKWJ1DdLeCZN84uMnKU+LJ2cgQFFpYql9x3gY4XVZfqdulCr1nhR1plWjvQRVCKsaBIkO4zchODO2j1UD3scIMZ2TgpDtgcys8KZ+ooGVAOODk7g8f/V6frD35DBiarEKvHAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "156",
+    "id": 156,
+    "sortid": 156,
     "identifier": "quilava",
     "name": "Quilava",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAY1BMVEX////vWikxMTFSa3v/1inWvWNSUlLvWyljjJz354T/nCmdIQgzMTD81CrsWSmcIQg0MjEyMDD+min+1CntWSj////8myo2NjYzMzFUbHk1NTUxMTJRanmtlEr/1SnwXClii5sVPeDEAAAAAXRSTlMAQObYZgAAAM5JREFUeNrtzkduAzEQRFFWNeNEZWfL9z+luzmAV6SlrQB9gFw9FNo9e7Be7nXLpB9vMoP1tePub27BuF/QhaAjDY4naOO670Kz7n3BMR3SuJ4wtR12GOri4dunY4K6NrwCXiE/57fZJz2zyUgMGHwkmeVHLkNnkSA8fJRMyTnLnDCxcyG89zGvMVsS6drRoI6tssEP14fmtkRCeO1BgZFzdaWE8MUOzLaHcxDZXOgeqY4otUCW8h9UE6MSNfZ6si6ZczciqbpxW0e7Z4/UL7tZCFD0OPQbAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "157",
+    "id": 157,
+    "sortid": 157,
     "identifier": "typhlosion",
     "name": "Typhlosion",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAvVBMVEX///8xMTFSa3tjjJzWvWPvWinvWyn354Q2NjZiipoxMjKdIQitlErTumLsWSntWSg0MzI1NTXz5IIxMTL81Cr+min/nClUbHsyMDAyMjFii5szMTBljZucIQj8myozMzFRannvXCo0MjCaIQj9+/vUvGPVvGJUU1JUannsWipUbHqbIgpSUlNSUlKdIgj05IP05YT144L15YP25IL25oP25oWdJAmrkklii5qulUzO1NP+1ClTU1H/1Sn/1imvyZagAAAAAXRSTlMAQObYZgAAAQlJREFUeNrt0Uduw0AMBVBzqrqs6l7Se+/1/scKKQQwsiCVAFn6A6PVw58hNdjmzwl+67IZfqCXEaTTX5fZeJxZGRYAe7ltnLXxYgz8nRBqrVXdOnQ51xmEEbKIbO3enG12ucL1FF14/qz18sM1LToGYhUqhVzXn+3lQoKUaz/XS5zGziQXpffe+/lJg+PwhWp6tv9yi3DHxvmxqpgN0sjZ6wM6lHePN6OKv/rAmKOLK/8dRgYhshWkyTtJQ08dMpUAQP+wRIKo3EjGkyAE5RAEV5R0K8Ws1qoSYGpIdnqkJBk8HRoMQXNagdCYTCDtJC1BGgbodDaZDPpT0EY3hfKefuxRfsQ2/54v6eoTJw8UphcAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "158",
+    "id": 158,
+    "sortid": 158,
     "identifier": "totodile",
     "name": "Totodile",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAqFBMVEX///9Kpc4xMTE2NjZKe5xSU1R7zvd6zfYxMjNSUlJJo8tRUVFKepo0MTF5y/NKo8xKpM18y/R9zve7KULzYlH3Y1I1NTVRUlN6zPX+/PxRU1N6zPRLps5MfJtMfZ1MpcxUVFS7K0S9KULLsmJLo8v0Y1P05Gr2YlH25mozMDH8/Pz8/f79+/xTVFT///+07v617/+6KUFMpswxMjKy7PtKfJ3Ms2LOtWO0eCLTAAAAAXRSTlMAQObYZgAAAL5JREFUeNrtkbUSA0EMQ9e+xeQgzMzM8P9/FqdISjt15jRbap7klcr1b4qQHv7gS8GnoK+ysaBbsK0YRJFo7Xh3GMwToSD5DNbaArJxO/UcGc9leyckl2u69i1w4PlLiBc2o7hFRdcq4joWq8v6pPxmUtUEGWut3q5Ykzk6qjrz/PeYsOhT+HGfecWmP1YX6ISuifl9oulzSOvoZiAgp0YBNAWDLnlh7E6mS86CvDYiFmPd/PgE7HcZGaty/Zte1n4Ki20TkWEAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "159",
+    "id": 159,
+    "sortid": 159,
     "identifier": "croconaw",
     "name": "Croconaw",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAulBMVEX///9Kpc57zvcxMTF6zfZSU1T352t6zPQ2NjZKo8xSUlIyMzR5y/O9KUIzMDE1NTV8zfRJo8tKe5zzYlH3Y1LOtWN8zvQxMjNRU1O17/+6KUExMjLLsmLLtGQ0MTFMpcz05Wz15m32YlH25mpUVFJRUVH8/v5KpM1Kepq7KUK7K0RTU1JLo8vLtGNUVFRJeZpMpszz5Gr05Gr05WtMps5KfJ18y/RRUlM0NDR9zvey7Pv9+/z+/Pz+/fxFIYHkAAAAAXRSTlMAQObYZgAAAQRJREFUeNrt0ceOxCAMBuDYtDRSSEim99nee33/11rIbaQNYQ97m19CXD4Z2wTH/DGhr6sWXswPWlXVMiODMK/kppabhUfF2kRmHlBeUYR2GE5eENFI4makpIhJinjhbDP/GI+N+XxL8XkauKGpV33dCHMRFywpE3jyNP9+d7+d33N+B/Mt1wUo19vh/oF30UuwGwr7XAmj2NJdBEBNl5Psd5cCgKFx3DlEdt4DCUkTcnu9tFwgAmWE9O07CGd6yxtY7QQTLI7aoLdNuuYNrnXBopHDGbjiFjaIoE5b18rVo11PYWexDTpKqulMX0Z04Lft6Pbsz9TrQUHHUImP6wof8y/5AcUCEaeo0w2UAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "160",
+    "id": 160,
+    "sortid": 160,
     "identifier": "feraligatr",
     "name": "Feraligatr",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAwFBMVEX///9Ke5wxMTFKtda9KUL3Y2NKtNVRUlNRU1RMtdRKs9NKeppSUlJUUlJ6zPV7zvf0YmL2YmL352szMDExMjI2NjZKfJ3zYmJ6zPRRUVE0MTG6urK7KUK7K0S6KUHMs2JJeZozMzP25moxMzNUVFT8/Pz8/f5SU1T05Ws1NTVMe5tMfJu7u7NTUVHLsmLLtWRTU1POtWPOtmVMfZ3z5GpUVFJMs9T05mx5y/M0NDRMttYyMzT7+/tJstNLfJz9+/x7K5DRAAAAAXRSTlMAQObYZgAAAVJJREFUeNrt09dygzAQBdDsSqKJjuOCG+5O7739/1/lAi/BEzF8gHcG0MOZlXQlTo7VvU67ukEO2wnKDLa9ew1VEOe1Qncj41miZJLXa5glRng2kDJRKuByGMQqb5kYMPDECq0xyrlFlk4Ix4+VkjIzwlEM54DimbbBL0eHu80akiwxbXGCQjH9Wc9dSNtnk3vtUxh9DJ5f0juXKOzbXOX5D4yiSIjt/RIQzhLl9rNZdhAiF/Zw523fb5Zp6mLfHpFF9gRb4sahFES2h0nB0qcqomHUt5yJvNK9P258qwmSH0vmV06jIxr7mgCbssfoPIIq06kbQjccJDNX38LWFsFtHvDyG7DhC6xUVIe4WSN5R8O1QdpjpQ6Os5zHKOcu7dMLS6BWxis5/ibIJRz6wZnvz+VivODrczhE47VIRFRlUOe0fevwR/In9s1mcJDtsbrVL+z5G6On6SfXAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "161",
+    "id": 161,
+    "sortid": 161,
     "identifier": "sentret",
     "name": "Sentret",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAbFBMVEX///8xMTHGjHvWnIx7Wkp8WkqrcVnDinnEi3oyMTE2NjZ5WUkyMjGsclmtc1pRUVFSUlLFi3o1NTXTw6vUmoozMjLWxq3+9eX/9+fEcnpUU1PVm4vVxKutdFtTUlLzcXn3c3v99OTGjXzTmoqT0iS4AAAAAXRSTlMAQObYZgAAAL9JREFUeNrt0skOhCAMBmBbiiwqrqizb+//jtPRzNXi3R6akHyh/A3ZUbvKQ6IrHCRxeJL7cRBl99BuaeJsNmsTZQ3ATozsPwrvpyhFrspaKZYgwJyGRqloEKNwo0XUlqEmB5vS4DS/EXHxW0vMX/PMUoSZ7/F/ZxTihBYnhqHkkyDDdbwt+xEk9OO5YSfLurHrA+XhJaR9XXIprjNLYjlKQWRl6YtBoaZKhuaiEHUCzFvEQC5pN4nL6QCyo/bXF3CKCRZvw608AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "162",
+    "id": 162,
+    "sortid": 162,
     "identifier": "furret",
     "name": "Furret",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAeFBMVEX///+EWjn/563WvXuFWzqmdFPTunkxMTH85KszMzL75KsyMjEyMTGjcVE1NTU2NjbUu3nVu3r+5qxTUlJUVFOCWTijclJSUlLTu3o0MzJSUlH95Kv95aukclGlc1I0NDRTUVIkZTKDWTnTu3mFXDpUU1L+/fy6SVltvs1XAAAAAXRSTlMAQObYZgAAAN1JREFUeAHt08mOgzAMBmBsJ3EClJ0u7XT25f3fcEwUzSkJ3EaV+G+RPv2WjCn2/Gca3uZa47a5GeqllXnVXU/MB7jhJQ8PzyFV3pW6H1D/uZaZ4w4RL2bQwS1vcglI3y+lXhrDk2KyKSeLbx8y3MNmvvcR5+XPq0VhT7ryGwDoFpcY/gk3X9kaInWviqT00SPPIJNVXazI6R0kHbnkxkcbKs+kIDlZJJsBJzsde9WJrPOfcTyOAqFTOSfb1CJ7Ekgue5BfFolWnUhmQ+p6Ojve8DtwGTnIRG+x52HyCxdDDJJGLlkmAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "163",
+    "id": 163,
+    "sortid": 163,
     "identifier": "hoothoot",
     "name": "Hoothoot",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAflBMVEX///9SUlIxMTFRUVFTU1JUUlJUVFPEkln0YlL3Y1I2NjbenM6aalKca1LDklk1NTXGlFrWrYT/3pzzYlEzMjFUU1P725r7+/syMTE0NDTVrINTUlLbmsvbmszcm8wyMTLenc7vxOScbFKda42dbY0zMjM0MTH825r+/f7Fk1kQsZYxAAAAAXRSTlMAQObYZgAAAKNJREFUeAHt0scOgzAQBFBm3emhp/eS///BBPnu9RWJEeL0PHuZZM1SUkVDioQpUcQDD/2f+Eoflon8W0veCatMLWHqjoGtU0YCIenvUqsA6xRMAFZlJ+w1661zTgUrUxr0sYd9tR4G5NDot/anJSVh2TQaQL5nK+dsbkUxUXgTw+z+cGLXU+5456UAQBFufJyy7H6O2ON4eR4+26jpzt9SsuYHRO4IzVBmZ3oAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "164",
+    "id": 164,
+    "sortid": 164,
     "identifier": "noctowl",
     "name": "Noctowl",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAt1BMVEX///8xMTE2NjZSQilSUlKEWjm1jFrbmsv352s0MzFSUlFTUlJUU1NUVFKDWTg1NTWzi1kxMTDMs2LOtWNRQSnz5Gr05GozMzH8/PyCWTiDWTlTU1KNLDS0i1kyMTG2jVqNdAmyillUU1QzMjP15GozMjH7+/uEWzq0srJTQylTQyu2trbLsmJSUVGEWThSUlDenM7sw+TvxudTU1P05GmFWzmFXDz15Wn25mqLKTFRUVGNcwv9+/uye/+LAAAAAXRSTlMAQObYZgAAAOJJREFUeNrt0cduAkEQBNDtnbQ5B3LGBucADuD//y73CIlj9x6QuFDS3N5UaTTOLZeP67jQydX+U9sNemXbpThFOASA2q99Ds5eMx02nudz03ETZxbGwEgk0rpsTTrns/HKH9yXmaakezd6RjmUhdYcfAnk7+ZhN6Uhyo9Fb/T3tZpqNSFh9f4W9R7vEWIhldRExV6hC4H7xbm2CQd2mncqECJnoBqrMRaKhJZu/wzZbStPEChnooGFuCzy/oSAYCI4yGIrkgCqhJApAJjjd9lWeXV6DtNqlniHdlYCHueW6+YfqtURFlr9tEUAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "165",
+    "id": 165,
+    "sortid": 165,
     "identifier": "ledyba",
     "name": "Ledyba",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAq1BMVEX///8xMTFSUlLv73v/lEJUUlH8/Pw1NTU2NjZRUVFSUVEyMTBTVFQ0MjFiauR6ajGMOyONOSG609O9pkK+1tbUY0HWY0Ls7Hru7XozMTH7kkH7+/v8k0E0NDT8/P7/lUQzMzPTYkHTYkLUYkFTU1HVZER7azHWZUTs7Hl8bTLt7HlUU1FUVFKNPCS6o0FSUlRkbOa91tb9/v7+k0L+/Py+1NNla+T//fz///94rOOGAAAAAXRSTlMAQObYZgAAALRJREFUeNrt0rcOhDAQBFDWNjnnDJdzzv//ZWeEdHR71IiR3D3PuLAwZnBRoLfrMO74gT6FTXotZ8zsQZXpnTEzi1wdp7Iq1Yyx53XpaoBCyGvubqXnzKMUW24ce5eQHzUyS7EnivYqjB6ftSgFjo5VbijdcipaVWCglWpMKT0Qu9gTAoBA73Im9o7XFq8qmGDboMZ+wmEoSijk9CdBQCN7BpwSf2G10+h6+zXyDv69MGZQ+QKuAAxK9T14QgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "166",
+    "id": 166,
+    "sortid": 166,
     "identifier": "ledian",
     "name": "Ledian",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA21BMVEX///8xMTH/e3M1NTU2NjZSUlLeUmP7eXFRUVHO7+cyMTG9pUI0MjLM7ue9pkLbUWJTU1OrMTmtMjnr7Hv8enL8/Py6urq7o0K7u7s4gvMzMTEwMTJTU1EqU50pUZpUUlJUVFTv73tTUVF8tPz///84g/V5ajG+vr7L7OTM7OR6ajHN7OTO7eUpUp3s7Hns7Hq9vb29o0L7enN7tf8zMzLbUmJ8tf7eVGNSUlGtMTkzMzPt7Hnu7Xrv7XqtMzuuMjkxMjT7e3X7+/ssUpssVJ3+fHQzMjH//PxUVFJ6OEDIAAAAAXRSTlMAQObYZgAAAONJREFUeAHt08duwzAMgOGQ2rIjO7tp0uzuvfce7fs/UVm4PcrMrQiQ/8LLBwECpcqy/0zO66CYgnHizwF3HvxOFhaKHAsFmJSHJA1iCubRc9CqZmqbiIyULyOC3SeDerX0RnLrHfFz9tYzegiZJh1JdJ8R9y7Wepkenh8nSd1HoBycIL6u7zcuf9z0tOpuYtLg/dmgEeoT1ZlWnYtBkgfjcegr1ZqNtl0JJAlWdZJ+azOv7ZY5ku38MNx9qZWHCQCznY3b8NE+yomx+9m5ArA1z0GRXfuK4GHx3CTpuX/FYrTsGwNgEGMLj+PtAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "167",
+    "id": 167,
+    "sortid": 167,
     "identifier": "spinarak",
     "name": "Spinarak",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAolBMVEX///8xMTExMTIzMjBRUVFSUlJZaopaa4xjxlGU90qS9Eo2Njb7+/tTVFExMzE1NTVabYpcbIozMTCS80lRmimS9UmT9EtSU1HLihjMixjnSin7wylSU1LkSSlUVFQxMjBSmimV9Em1KRC7u7u+vr5ba4pSnCk0NDTkSilixFI0MzBZaov8xCn8xSkzMDAyNDFUnSxjxlJTU1PMixnOjBj9/f0dTGlgAAAAAXRSTlMAQObYZgAAALNJREFUeAHt0UVyBiEQhuG/cWGccYm7S+5/tcBssoLJAXjXT31F0afU/0ppgCNSgGeMcwQHS+bOsU7KkqPI3IDBXH8quVcGpWbIbFc/77etH+xEHoQDJuc9VTJTHmYQfiKBRrrEosTHMt6gkFunC8feoMnow0KfeBjWjXNmA9vT54qOOPw7thU5oWBfvjH7whD7b3Jfgz2bKwTzY/Qy63T5CqeCIX+kqNzPrP/m4mk4JKnUL8GTCqXiqe1UAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "168",
+    "id": 168,
+    "sortid": 168,
     "identifier": "ariados",
     "name": "Ariados",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAt1BMVEX///8xMTFSUlI2NjZUUVJUU1H0zCn3QlL3zilSUlRTUVE0NDQ1NTWCavuDavyEa//zyyn0QlIzMjD1zCxRUVE0MzD8cmr/c2v////OjSllQsRUUlL0QlMyMTSDav72zCliQcOFbPv7cWr7+/u2MUL8/PzLiin/dW3MiynzQVEzMTExMTNUVFRTU1P1QVGFavxjQsayMUGzMUJkQ8O9vb2+vr78cmw0MjH9/P/+cmplRMPMiyxlRMa+cvVsAAAAAXRSTlMAQObYZgAAAQJJREFUeNrtkkeOwzAMRU11d8s9xel1eu/3P9fQMbIaWZhFgGzyAQkE9MQvUnQuOrvof7mkODEYhN/pMQSwZQzjpgsgUYUddKFVmFk4CmiY8LKqRlEcN1ZbBBUnRMxtXFKg5WJEyG6KcPneb7xAT1LiEjxy9eqqj9t/VpVkREvcotjVDEz9g2Vd35QSIY3byosyTnbp33SIvb7c6gPYJmVCDdJNajLOCZ4PH8YItg/0hPq6NlU8eH6T8v7jB8HhJONPHmCzTJ3J11u0hdmYQS6U4mAGwQmW/uMdI22pdDOdN/2DRB2ar2sfui+ygA4mrf3uzmzSWIc9gGNw8jlH14vOql81xhHpFFE+KQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "169",
+    "id": 169,
+    "sortid": 169,
     "identifier": "crobat",
     "name": "Crobat",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTEyMTM1NTVRUVFrzt56Yrt7Y72ritOtjNY2NjZ5YroyMjNSUlNqzNw2NjVCjJwxMzOsi9VDjJyujdZTUlT19Sv8/PwxMjJCjZ3///97ZLp9Zb6ujdOmpqaurhDOVFlCi5z29Cmri9P9/f39/f6rjNV66EA5AAAAAXRSTlMAQObYZgAAANlJREFUeNrt0ckOgkAQBFBmYRaGfVHBff3/T3QqmKgBtA8mXqiEwOFNkekO5vw8EWOMxIzVmn93YCSnSU64RJGcaRQKKTdx3uH9dn5sDMJ5GJn4VRlrbTygkZfGehihJmPybKs8z282HkipykZx5jWGUFZ5GoYFTg0kfqVL7/BdpW0aFhMjRzTvna9rV8FYsh6iUMBNQmGu9eJw2mrO4ArMZowxuey6erFf60QdV080Mka53F02WFCvpiAHRhKwDxIPc+hzfIK+b/exTUroUkhFrqRBXG3On3MHPxUJX1x8ICsAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "170",
+    "id": 170,
+    "sortid": 170,
     "identifier": "chinchou",
     "name": "Chinchou",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAilBMVEX////39yljhN4xMTGMrffz8ylSUlI2NjZSUlRUVFFigttig9s0NDCLrPY1NTWNrvO6utO9vdbsxAHvxgAxMjP19Sz29ihRUVH////swwCNq/RSU1RTU1RUU1DW1v82NjXtxQMzMzMzMzT09Cn1ZFRlhduKq/MyMjT39yz7+/vV1f4zMzD+/vs0NDQz5qjtAAAAAXRSTlMAQObYZgAAALlJREFUeNrt0kcOwyAQBdAMY8C9xi3F6T25//UycRbIi8HrRP4bQHoCzRezKb8SjX3GWIxmM8LMweLax+DIu2IAN9wUbQVfqftpNHells/mGn7Y2aFc0A5pSZw+S7aj+Na80p0EgiXAyQ3mfDuYrlAm5EJZrANBkrXkRFSGtQJPELRIPzouSvAOSgmFaJeOs63Ay5Xqur1Noi+EcPNCZdmdoJVinVP75mmLpVKBZXbIt2/c2Bee8l95A0XxCjo59V5XAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "171",
+    "id": 171,
+    "sortid": 171,
     "identifier": "lanturn",
     "name": "Lanturn",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAtFBMVEX///8xMTFjhN4xMjOMrff39yn///81NTVigts2NjZCY61DZK6Kq/MxMTIyMjSNrvO6o0Hz8yn29Sk0NDCl1v9ig91BYqtSUlQ0NDRRUVGKq/X+/vuLq/SFdTAzMzSj0/yLrPZTVFQzMjGj1P42NjVig9u7pES8pEG9pUK9pkG+pkTTOFHT5PPV5vfWOVLW5/dSUlL19Cn19SxUVFH3dYqMrPT39yz7+/v9/Pv++/xkhNuFcjHWx1uaAAAAAXRSTlMAQObYZgAAAPBJREFUeAHt0sduxCAQxnEPBlyM+/ZN7733vP975QMOHDLr7DEr7f9gC+lnjZEm+gdtS2gtllHT9eu4NG6Xs7+H0qQMo5OVzEhZlOFsKt4ZWVF6IKtwZmFmKrJPCe5mnxgRc25O7jVZyGIBaz/hYNYq1Xtng5nvCEDOQZKB8VBMAc+OfsOl1m89XJD5mIFJgE9K1Q4KxkG+az1zbve8g/TwgpNE3n3oq662LqaGg6DNK+DL3aeH8co1StoaP9hffz/WssjHgIiHynX5JcTx6JCiQfn8cCrQdH90uze4ZZQKW17e3Ds4iFM45iKsjTalbT+UDRADq/f3dwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "172",
+    "id": 172,
+    "sortid": 172,
     "identifier": "pichu",
     "name": "Pichu",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTH//2s1NTVSUlJUVFLDmkHGnEL7+2r+/WrGnUI0NDEzMjEyMjE2NjbkxErnxkqEczGFczH+/mqFdTFUU1E0NDTkw0mCcTHmxUlRUVH7eaNSUlH7+/v9/Gr+/Go0MjJTU1H/e6X/faTEmkL//23///wuuEH1AAAAAXRSTlMAQObYZgAAAJdJREFUeNrtkUcOwzAMBLVUtRXHNb04/f9PjAToLOqawHMecJekWPgF1igU5RGlokKZaCqNItER+dQWjDg1QNC4DnJ/JapXpqrv4LIDU7B1Pvrypkicmh8IlzQwy8/dSJ+tI190H5weN/41r8NIz+BJbmutlAKCB8bcbVRrK49IPrvt7HAGn22Gvm8geCSMTcfmVbHwl3wBqqMFj5s+fPgAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "173",
+    "id": 173,
+    "sortid": 173,
     "identifier": "cleffa",
     "name": "Cleffa",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX////njIz/xqUxMTG9e0I0MzL7w6P8xKP9xKMzMjK2ZGT+xaS7ekEzMjHki4tUU1N6UjF9UzJ8UjG7ekLli4o1NTU2NjbkiooyMTHWZEN5UTFRUVF7UjHmi4tSUlFSUlKyYmJTUlH+xKO6eUFUUlL/xqb//v2p/xd6AAAAAXRSTlMAQObYZgAAAJNJREFUeNrtz0cOwzAMRFGJVLXc03vP/Y+YiYEsQ3lv//XDEFRzU27NYwxyZLPuYUy/TESWs7A/e+o86cgi3Jc33x2x2bRlxZI8eBpqFsaY6j9cufdrHNxER7CDlNw1wFj3he1WSZeLoBPt7qTlt3E6EdLoWUcRasgiFKcByhJjlxpOy5AZFEVmhXL2t5a3am7CfQBcJQfTZE2cbQAAAABJRU5ErkJggg==",
-    "gender_rate": "6",
-    "rarity": "150"
+    "gender_rate": 6,
+    "rarity": 150
   },
   {
-    "id": "174",
+    "id": 174,
+    "sortid": 174,
     "identifier": "igglybuff",
     "name": "Igglybuff",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAjVBMVEX///8xMTEzMTI1NTW2ZIXGhJz33vf+rcb/rcb12/T9q8QzMjLkSSnz2/P7q8P23PVRUVFUU1OyMVH+q8P+rMU0MjPFg5v02/TGhZ00MzQ0NDTmSirnSinnSyvnTCxUVFRTUlMzMTD13PX22/OyYoL33fazYoO1MVL7+/u2MlP9+/y2M1S2NFQ2NjbDgppvUgxyAAAAAXRSTlMAQObYZgAAAJ9JREFUeNrt0ccOwkAMBFCMt6cXEnroHf7/8/AicV3nHGXOT6OxPBkzxCBAP5YoPePdO+lagtADzusz2QUL81ZRdMEXZh6KKefEQfnQTA46+asMj8Tby4om4ysRSqvU82rJmSCMj+Qey9JqE4KY+oXbPcSVMcG7EVJzd5t1JWsZMZ/+rHybK9gfYn5ppNyxjiojgBPt46U/6n8xj8cML183+QlS0TApEAAAAABJRU5ErkJggg==",
-    "gender_rate": "6",
-    "rarity": "170"
+    "gender_rate": 6,
+    "rarity": 170
   },
   {
-    "id": "175",
+    "id": 175,
+    "sortid": 175,
     "identifier": "togepi",
     "name": "Togepi",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABdFBMVEX////u7pLv75T8/Pz///92ZTLZuVnevlvt7ZLu7ZI1NTU5OTm7u7vevl36+vk2NjR3ZjPhSSk0NDTs65Lu75Q2NzXZuljaulgxMTB2ZzTr65H+/v40NDPs7JJXV1VXV1czNDI4ODb8/fz9/f2jkkF9t/2CgpqEhJuGhZuGhp6Gh5+hkUI3NjU4NzYzMzA4ODi5ubm6ubm6uro1NDGmlELv75W1Zob6+vr7+/s6hPV8tP78/f7auVj9/v98tv7+/v+llUO7uLi7uLk5OTe7vL69u7q9vb29vr2+vr6/ubkzMzHZuVozMzI7g/M7hPbbulnbu1rcvFrdvVrevVrevVxRUVFSUlJTUlHjSyzr6ZLr6pDr6pHr6pJTU1NUU1JUVFTs7JPs7ZJVVVXt7ZPu7JFWVlRWVlbu7pM1NDPv7JQzMzNxYjH4+/5yYzByYzF0YzH7/f90YzJ0ZDF1ZjP8/f8xMTE2NjX+fKT++/s2NjY2NzQ0MjJk7a8VAAAAAXRSTlMAQObYZgAAAO9JREFUeAFjGIZgFCjKEKeOK0o2gwjFihL5Kqy5elKMCgSMk5UUE+BgVTERN/bBrzBahDWRib1IXMAhRQGvQhtGXkYmTsliDqZgL3wKubUZ+UyZeBlFmDgDq/HbLVUVycQXks7JnieKR5lOaTwbR3kmf4BwkD8/PovZ4pjT1M1ikhPk2FKZhfCpDDX3kGaRV0tilme2EMLrREcl6RJbLWUWFmY5Gby+FvRUsrIrsGdR1vQWdsZrpKCrX46qdYW7URYX/uAJN/S1dHGLcIqtBPLwerxQ1ICHRyOsklDy0edi4C7LFtMlLk1yVw6//DgKADaxIkFFSXWnAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "190"
+    "gender_rate": 1,
+    "rarity": 190
   },
   {
-    "id": "176",
+    "id": 176,
+    "sortid": 176,
     "identifier": "togetic",
     "name": "Togetic",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAwFBMVEX///8xMTE1NTX///9UVFTe3t77+/v9/f00NDQ5OTmEhJy1tbW2trYzMzM2NjaBgZlSUlKysrLZ2dmFhZ2zs7O0tbfb29s3NzdSUlMyMjKFhZza2Nc5ODhTU1OwsLCxsbEzMzKysrM6g/JXVlfLMxuGhp7d29rd3d3e29vc3N3d2to4gvMzMzTc3NyDg5vf39/mSSiEhJuztLZWVla0tLQ7hfbmSyv5UZH5+fn6+vtRUVH8/Pz8/P22s7T+/P1RUVK5PptRAAAAAXRSTlMAQObYZgAAAM5JREFUeAHtjsduhjAQBrfYxgZ+/kIhvffee3n/t8oGRbnh5RZFYrSHPYxGH/wpIySHQzzn0flBonllL1HUvDJhNuhYqRaOBYkqIm0kfJlJk/NJXJxIq8NDdCc5af0E5be92SBi6zhpsPP6RaAn/uC3fP1bLO9iO0Px+H69cozLzlTixaCXWXVo06UUIU5ozLmdmUWGoJm4erD7fGtz1aS9q6P9tK715OLhxN7cnxagsXaxPd/JtkCHPpGmZ6ATpi3QHIeYcpu/G3V55F/wBeReC26z+PYbAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "75"
+    "gender_rate": 1,
+    "rarity": 75
   },
   {
-    "id": "177",
+    "id": 177,
+    "sortid": 177,
     "identifier": "natu",
     "name": "Natu",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA+VBMVEX///8xMTE1NTU2NjaUzlpKpRA4NzU5OTlJoxBKpBEyMzFLpRFRUVFSUlJUUlFUU1FUVFQzMTH8xCL+xCDRYkJVVlA6axEzMzBKohJKoxFKpBAzNDI0NDA1MzFMpBRNphRRUVAyMDFRU1BRVE81NjQyMjI2NzU3NTU3NzSQyVg3NzWSzFkxMjCq5HGs5nKt53OSzFjTYkHTYkLUY0LWY0LhiSnkiynljCr4+Pj4+vf5wSL5+vj7wyH7+/v8xCE4ODj823gxMzD/xiKUzVo1NDE3Nzc2MzE7axGRyViSy1mxOUKzOUK1OULQYUFTU1NJohCSzViTzFqTzll0glB/AAAAAXRSTlMAQObYZgAAALxJREFUeNrt0MUOg0AUhWEGhqKlxeruXuru7vL+D1OaNN0xzJrwr7/ck1zCzZmRANO1ujKeu2I6CWu5EAU4juSrEEIe2LqAAb8JNTtYb8KfBEh3apjwbULd25ZRsPzaGMKDfuqKz4s6WYlvj8lMfuafqz7UxdJyrQZHOX7inw4k0RoyY0Xpx8I0TWd7kra/pK0lRYmhiAnZlQxuHQ+BiBETLMcdUuciRdl8crgAd83zV4h50+4IrBiScHNgH3HbEKgbGRs8AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "178",
+    "id": 178,
+    "sortid": 178,
     "identifier": "xatu",
     "name": "Xatu",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABUFBMVEX///81NTWUzloxMTE2NjY5OTlarSGSy1kxMjDe3u////9TUlKSzFk3NjYyMzHe3e1ZqyFcrCHc3O3RYWGSzVjRYmLUY2NTU1JUVFRRUVH4+Pj5xSFRUlAzNTE0MjA0MjJdjCNdjSFdrSFdriEyNDBVVFRcrSTUZGRcriQxMTBVVVWTzVmTzFpUUlJajCFaqyKTzVoxMzCbmpqcnZ2dnZ2r5nGs5nJejidfryeRyliRyllSUlJSU1FSVVA0MzAxNC81NzSUy1mUzVpUU1EzMTEzMzE3NzVZqiI3Nzet53OyOEG1OULMfDQ3Nzg4NzfTYmLTY2RarCFarCLVZmTWY2Pa2ena2urb2+zc2uo4ODhbjiJbqiBbqyFbriL7wyH7xCD7xCL72nj7+/v7+/z7/fv8xSH82nj8/fv9xiH9xif+/f3/xiH/xiL//vv///xcjCEtHFFzAAAAAXRSTlMAQObYZgAAAPBJREFUeAHtzjVvxEAQxfGZ2bXX9jHfhZmZmZmZmTnfv0usFOlm0kUn+V//pPcg6J9Dpf7GDFFUphjvXyYi2xGhGfAhRSU3TH6yxLOa1hnKjYYluPDw9pmuUzf5OH8Sr69eZ9tOypXJKRZaFxOFESIytrMyx0oELAt30bgCFCREOsfqW/yHuMlK3Jq2H72hjuZvuMfJ9YPB3RfvrmkSeImHfbfe+0dD+twBK7PKwqT7fF+9negGOEbm4n5v0nWrErWlFcBmZXqOYrG1y6fTKeBbCqWy2fbFnXnBYUnjhtaFfChVKUxr/cMjyMNfXjwFfQGrAx4MQe8l/wAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "179",
+    "id": 179,
+    "sortid": 179,
     "identifier": "mareep",
     "name": "Mareep",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABCFBMVEX/////7601NTVSUlLexlrexlv97asxMTGUvfe9lFK+lVPcxFo2NjZRgsv77Kv87KszMzH+7qtSUlPZwVndxVnaw1jbw1nbxFlQgclSg8xUU1JUVFNUVFR6enpRUVI4ODY5OTlUU1BUU1E1NjdUVFI2NTMzMTB5eXk2Nzh9fHl9fHqSuvOSvPY3NzS4kVG5klK6klG8k1K9QiE3NzY4ODW/llQzMTEzMjEyMjJRUVHcxFk0MjE0MzHdxlk0MzI0NDTkajjnbDnsmgH4wTj6wjn7wzj723EyMzT7+/v8xDr83HNShM797apTU1L9/f7+i2r+xTlThM3+7qz/jWv/3nP/3nX/76xThM6V2VSLAAAAAXRSTlMAQObYZgAAAQhJREFUeAHt0seugzAQBVDGxjadQHrP67333nvv//8nb4iVHWNlGylXCfLicAcNWOOMXphSw7n7n4vdoeDt99eRaZwaHM/fNmdJV0nA29NPh9cDRbkIMKKA/DSz7OY4f2wEnisBmuh3PmHGWsmtZHP7kSdB/3Tz9SQFhSs92eQ8BvmLzWvv+aPXX2IQDd5+XOSxeM7k1Tax4hbn9bT9sICVIgE5HVBLXHIc5y+9nIghg5UutR10r2dhyqsJCBtXRK47XHbuVJhW7X7cUoGSvfCp/qHdCf7LXcOr7qyWbPvQbvgIsZCWtfmiX97YCop+y/g19gKLdRTDg6pNmaAu7d/CjEqXjjNK+QfTVRbG06bP0AAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "235"
+    "gender_rate": 4,
+    "rarity": 235
   },
   {
-    "id": "180",
+    "id": 180,
+    "sortid": 180,
     "identifier": "flaaffy",
     "name": "Flaaffy",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABHVBMVEX///////81NTU2NjZSUlJVVFSVpqb3nKX9/f0xMTG21tbccpPec5T0m6QzMzMyMjL+////taWkSmv7+/ulSmulTGymS2yz1NS319e01dU5OTm31tY1MzPZcZHbcpJUUlPcc5NUVFRUVVX1m6T2m6UzMjL4naX5+fm01NT8/PyUpaX9/v7+/v40MzOWp6c4Njc1NDNTUVJTUlKnTGyx0dGy09Oz09NTVFRUUlI0MjO11dU2NTUyMjRVU1Q2NzfacZFVVVVXVldXV1fdcpKKefvfdJXxmaHzmKLzmqLzmqONff+TpKQ0NDSVpaU4NziWpaX7+vuWpqX7/Pz8s6SWpqb9sqMyMzSXpqb+tKShSWmiSmr/tKVRUVH/t6ekxP/IbJyHAAAAAXRSTlMAQObYZgAAASRJREFUeAHt0rVuNDEQwHEzLMMxM8MHYWZm5vd/jDhKkcq+dNfcX1v+NLMaGUy1WUhK+SsWQ2h5Ey2KYbULVcw3Oj+2+kywnoDwzOQkaWd6ggmoPsszLSZ/r6BSVh+yrGcc+Xx+MwhYtl8lC0aI3tp31/n8IiGlJjAmC63w3d0vl8pEmiF/CoU89O0JsCCL96/rzc0q8uS84SdzbpIWK5VkcgRH3/dBmrn4VOzUttgKhMEgjZWLT9Y0si0yMNMNgs7ln6+Bex8Pmu3bZSHEY6dD67cXCmofBzrepZQeUdqiQzD0He01cwcJznmChyF3lh0SjYGujZTt8v8NBStLEcH6A83ZGLtuVG84/15WEdCXU0MwlrVUNMZgcjht/zCzxGDqzfoEOgoanpTgHXcAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "181",
+    "id": 181,
+    "sortid": 181,
     "identifier": "ampharos",
     "name": "Ampharos",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAolBMVEX///8xMTHnvUIzMzHnvUGdfEL/////7zk2NjZRUVHWY0HkukHku0Llu0JUU1HnvkT77Dj7+/v97Tn+7DlSUlJUVFH8/Pz9/Pw1NTV6enr/7zwyMjKdfEE0MzH3lSz+7jn87Dn87Tr9/f3WY0KdfUT3lCm9vbu9vb3TYkE0MjB9fHnWZUGaeUGcfENTUlEzMTE0NDT+/fy6urrzkin//vv2kykxq5nUAAAAAXRSTlMAQObYZgAAAPZJREFUeNrtk8duwzAQRD27LFGXJbnFjp3ETu/t/38tJAXEJ5ZLbp4DAQGPO+QDNTklOWdI5LLVOglcFlQDSJk43+a94Dh4/3OT91owEAHbp32v9Wx19bgOctNzbWLBGcJyWssJ+VpypFnr7/dWEGMSBS9gFUU17kzz5q94Cb/HwaSsB4x32z74wIKotii7r6/8LcDNVUNEDFcArx88L5RqZKcFu53sd64MSPWluX9wZPGhRnKAOwp7wdtrB+42FSMbSn+1PaM6dEZnRc68d6RcHEHiwPsRjM+7l07IanTkF2SXrJRVCDvyrbWTAk4bTv7BT/mf/AJpQA4Wy003IwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "182",
+    "id": 182,
+    "sortid": 182,
     "identifier": "bellossom",
     "name": "Bellossom",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA7VBMVEX///8xMTGU90pSUlJS71JTVFExhSFRUVFR7FExgyFSU1EzMjE0MzCDszmT9Uk2NjbWrTHnSinvhGPz5Cnz5Sj35ynkSilUUVFKxjGS80mS9EsyNDFRUlGV90y9KSm9KikzMTBJxDDmSSlR7VHsg2Lug2JR7lH25ikxMzH9/vw6VKM7UqMzhCHkSSkxgiExMjCafEGdfEG6KSlKxDExhCG9KynTqzHTrDDWqzDWrTBTUVFLxDE0hSFUUlJUU1HnTCnsgmJUVFHthWLugmKCtDg1NTXvhWKEtjlRU1H05Cn15Sn25CmS9EozMDCS9Uk2lM2IAAAAAXRSTlMAQObYZgAAAO1JREFUeAHt0cVyhEAQBuB0jyAwwCDr7ht3d/f3f5zM7iW3nr2lUsVfcPvq76ZZ++OUiQFWY/sPureC2zqdHp2DvTd23m7GaQDgjNKAhLfdga4qf5R2B+OAhLrKVCQqnY+za3L4k6MixBffyGfL8Pq8jYhiMbxHb7nRwHlbVHTni/7u7W/E9QY2rXePF1veX9mYaXz0GfN2rK6OwjtsqagJtMvu2IFsfaI4nobkGbPLIZf9V+blRRGSG/YnXJq3JvMCCLcsPNkcci7zBKhGcGu773sXE8MT+g+6M8hCcPkMEos0z9Kbdsr9+v+SMj/2bxWTRCP7LwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "183",
+    "id": 183,
+    "sortid": 183,
     "identifier": "marill",
     "name": "Marill",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAllBMVEX///97xvcxMjM2NjZSU1QxMTHGKSFKhc5LgstRUlM1NTVio+Rjped5w/N6xPR6xPYyMzS6urLEKyRKhM7zYlH3Y1L7+/v///9RUVF6xfZ7xPVKg8x8w/N8xfZ9xvesbIWs3f6ta4Su3v9SUlK9vbW+vrYzMDA0MTHclMZJgsv1ZFT2YlFlpudLhM38/Pz8/v79/f1Mhc7gtzrOAAAAAXRSTlMAQObYZgAAAMNJREFUeNrt0kcSgzAMBVDkQu89vUB6v//lImWyxIZ1wvfCmzeS7JEx5rfC5TDnBj77cNnjcnMeEweL6Rvnpu1IGUBq2j3yFIHlhOmlMPdaVy6Bci70kHvMm8DjFaE8aN7EcbjVZhpje0GCBwBxZz0RAhwXQPEZujUopEyeVVVtAYSXEQQFNFyEXzljhosjqP6TlxXlKhqE+FcOXt2wvqPb3TLsrH41lchY0rbkJDGDq3eHqtSNJENHG6o7aOGIjPnvvAFpgQuqNyfK9AAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "184",
+    "id": 184,
+    "sortid": 184,
     "identifier": "azumarill",
     "name": "Azumarill",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAkFBMVEX///9ChM5jvfc2NjZBgssxMTFivPYxMzS9vbX8/f4xMjNiuvNEhc5SU1T///9Ro+S+vrb7+/tlu/Riu/REg8w1NTVku/RlvvfzallTU1NUVFRVVVWrbIU0MTFku/VkvPYyMjIzMzPclMarkqv0aln0bFyr3f5SpedCg8y6urJkvff1a1uta4T8/Pyuk6uzQ1T9J1hzAAAAAXRSTlMAQObYZgAAAO1JREFUeAHt0cdywjAQxnFppVVxMRBwDOm9l/d/u+izJ+OLSg7h5v8BNMOPtWYt/r0lxfMh62qyAvW1rPJSGzv/Iyv3Jxbu+7QIv24AH+EzgVyGz/v3XSXy9XtAXKAIdxUXBwJqQ+3DHwbWhGRpoNoMRM8mUJt3tQ0TfVOQgHTxcWVXM1QcY4wL3l3TlE29SrVqPwc/0G8W7ulNchRC+A5fLQOSjCxAsTYBAUpppkfr+KLOX3zXBCP92ZYmyYk1NhLUr91hO0LRi4TsQmvn3C3jjsmJutqMzB14VNDR8NPr6HAGzgQc23MCi2O19AOIRgvxyhIASAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "185",
+    "id": 185,
+    "sortid": 185,
     "identifier": "sudowoodo",
     "name": "Sudowoodo",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAbFBMVEX///8xMTHGhFqEWkL3rXNSUlI2NjZKxjExayn3a5wyMTGCWUEzMjGS80k0MjL///9JwzHEg1lLxjExMzGDW0FJxDCFWkIxaimU90rDglkxMTA1NTVRUVHzq3H2rHIyailUU1L3rnX/xjkxbCnZn8f2AAAAAXRSTlMAQObYZgAAAL9JREFUeAHt0EduxTAMhGHOkCr263Z6L/e/YyTbmwCho2UC+F9/oAaSrb9QbHXPx0Z4f9MD4gbMDDu98MU/iruE6V17u+yf1g6mCnF6NzvuelkJOUMQrMT9PMKZmMvjNDstMB6G8eeJISV0ZmGCEbfXaXQmEsGKNEIeD8NnfvB+B4RZ11WIc7p6naCDWQ8ygNqjbvTCB+cAiee0AslCNWAZ44cK+V34bzdIKNtOgkUqg/4ua6qEtAQ2QgHkn7T1BVSxBkVKDuLxAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "65"
+    "gender_rate": 4,
+    "rarity": 65
   },
   {
-    "id": "186",
+    "id": 186,
+    "sortid": 186,
     "identifier": "politoed",
     "name": "Politoed",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///9zxjmM5zFanEIxMTFSUlLexinn/5RzxjgxMjOM5zKL5jHk/JJiq+xjre9yxTkzNDI2NjYxMjFSU1HexipanEH3a5z7+/syMzGN5zSSOCm8vbpcm0Nxwzjfxyt1xDoxc6b0a5pRUVFRUlNzxTpcnEFcnUS87nm873rdxipVVVR1xjx1xzuK5DHl/pLn/5OL5TE0NTP2bZszNDEzMzP8/vv9+/sUBirKAAAAAXRSTlMAQObYZgAAANpJREFUeNrt0MduAzEMBNAdFmmLu2M7vTq91///tDALBL6RyiE3z4G6PJADVdv8LVORMjccjZoid3ohw6ZoYWOjREpVBk3KuUgBO+qI6sUscqs96lPv+vD98bqtP++7SArdEB18rK5eiDwory1M7H8Z9FaKPq+JqK0XZ8uTzoP59g7Aw3F+Wx6O4dwWZE0558Q8xly8ksyqygxgroNJINFHBzuXM0/2tw0S0dPEa6mmTDKCn2RNyMhMrOK5pD/SJhEhkEksjABWhvqHAf6FQYXIbSpsYFRhm3/IN/86CvnnoAcwAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "187",
+    "id": 187,
+    "sortid": 187,
     "identifier": "hoppip",
     "name": "Hoppip",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAgVBMVEX/////WoQyNDE0MTI2NjZRUVExMTFrxjlSUlL/lL1UUlJTVFExMjFClDGS9EqS9UmU90qlMUqmMkv7WYL7krr8WYP8krv9WYNDlTE1NTX/lbsxMzFUU1MyMTGT9kmS80n9krumMUr//UNBkjE0MjOjMUpqxTj/k7yjMUlCkjFqwzh0HLHFAAAAAXRSTlMAQObYZgAAANZJREFUeNrtk8kSgjAQREmAyQSRRVkEFPf1/z/QCUh5msBRq+hbqt5096QSZ9bPywPSJPDVJnISuFetNJ7fBA5MFHkOlDlLYDoaz2FK0pxSDee5uTVgZs4xYWxnz8eIyL6FWoZ7drcKfENShWVMqRW/eLaNkk1IVRcYSdsNrQPEZ7xAvKY7+11mWgSEHbS+2LlTrTttc3fE8MMhjCSvDvpUU3ruAlg4v9CrlPoJIYJc8OHVOiiEuPcggv1JZrrjjuXgx7KPtBQu+MPW1oV2xnvKj3Bm/ZPeh3kMlQMPyFkAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "188",
+    "id": 188,
+    "sortid": 188,
     "identifier": "skiploom",
     "name": "Skiploom",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAmVBMVEX///+U90r35ykxMTFSUlJrxjkxMzG2nUHvtQj15Sk2NjZqwzhqxDlqxThCkjFzc6WT9klClDGV9EqymkH05ClTVFFRU1H25iizm0NDlTF0c6NRUVHtswpBkjFUU1C1nEJSU1F0dKJ1daaS80mS9EqS9UkzMzDz5Ck0MzDutAgyNDG1nEE1NTUxMjEzMjH7WYL8/P39XIP///9ND8ZOAAAAAXRSTlMAQObYZgAAAMZJREFUeNrt0skWgjAMQFHStJQCUkBQxAGc5/H/P84W1gTX6lt0dU/IKXX+fV8+2j5gQ8UYkzfscUPlnUtdKENJt2eyKh+vVVEpb9fJLjjNpPKWWuvZWKpD57g1QJ4xeRybHRUzjoCTEecZY96Cc3QIOdm2lkcD4TqEvKcAIGwxwIn6dpsdDIT05wY8UwMHMQX9wJ0n7ax805zYeY8YJJYKUYcx5NGV+tWBaKo5D92eVzGNkhEiCkFCu6pw7XKI/S/N+ffTvQFmewuHOodz/wAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "189",
+    "id": 189,
+    "sortid": 189,
     "identifier": "jumpluff",
     "name": "Jumpluff",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAk1BMVEX////exntSUlJ7hM6UtfcxMTFRUVEyMjNSUlNTU1RUU1J6g8wzMzKLm+aMnOeTtPY1NTWVsvS1nELbxHo2Njb29qz3961CkjFSU1SSsvOSs/RTU1FDlDEzMjGVtPSVtfazm0FUVFO2nUPUe3Xbw3l5gsvdxXpRU1HsGFntGlzz86v09Ks0NDJ9hM38i638u9P9vNaYy3y0AAAAAXRSTlMAQObYZgAAANVJREFUeNrtkkkSgjAQRe0MgIAy44iKivN0/9PZHUtd0XHHxleV3auf7p/0/nRNrrX+QYv1CYryYlXzbVESENrEU/ni8qMHENpE+NxtHxFlPjHXjsgKyrR4WEydpTsAPIwYm2trQaqvbRsD+GK0mu8DlxNpOH8qPSECOXA10rIxeUGkhlIOItWntcIWE9LZfakM/XOJrKu2f+McEqUeKFMg11I+wbRjooZjk8iITbRZ0JReVvDvEze3q0TQxOIrrs7m5QlTDyc6gmAa/+5uYt+i3f7TLU+79xGnfSXq4gAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "190",
+    "id": 190,
+    "sortid": 190,
     "identifier": "aipom",
     "name": "Aipom",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAArlBMVEX///8xMTEyMjMzMjObg8WchMbFpM3Gpc7exlPz86v3960yMTN0W7UzMzGdhcSdhcXDo8vEo8w1NTU2NjbexlJRUVHexlRSUlJxWbL7+/u6urLbw1FTUlNTU1NUU1JUVFM0NDJzWrX09Kv09K00NDT3966agsP9/f3+/v3///9SUlN0W7OdhUqdhUvGpcwyMjH19a329qvGps3Gps5yWbP8/PzbxFL+/vzcxFHdxVMsULzVAAAAAXRSTlMAQObYZgAAAPdJREFUeNrtksdyxCAQRBkyKGsVN+fonP3/P2YwPgpZR5drmxPFm+kuZtBVf18jQCiHAVwqCEBKhoCzzBz4jdvz8JwxLohL0QOuKBdCME6+U/SA00w4kZQx7G+bt7snB4b0IcEASi89v9M+i8/3U3UXbnSC1VLp23voAsvXnT6etm112cgYK3nzMV/LqANUWuvjFtoqXlGMRpNHLYsi6mo5PtiWhgvgp24BnpTjQ1XEU/vqOka+2czqugbDOdL6eshyrRPOMIC9NAHyKjd+i0wQy+R77J/OZP5mMhr3JoCG4r6VhLJ+CawvZY7zs0pGrmTAol/1L/UFxs0R1A+Mk1cAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "191",
+    "id": 191,
+    "sortid": 191,
     "identifier": "sunkern",
     "name": "Sunkern",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///8xMTE2NjY5nDlUVFFjxlJ0WyGM73O9nTDz5ClRUVFSUlI0MzA0NDRxWSE1NTV1XCGK7HExMzG6mjG9nDEyMTDdxSnexik6nTn05Cj05Cn25Sn35yn7+/u7mjCK7XIhUiH25im7mjFSU1JTU1HbwyncxCghUyFiSRAwMTAyMjI4mjgyMzIzMjEzMzCL7HI7nDhiw1FycnKL7nJzWiFixFJixVEmkpY5AAAAAXRSTlMAQObYZgAAAKtJREFUeNrt0kUOw1AMBND4c5iZmpSZe/+jNb1AnXWUWT+NZcvanKmFAIxzvpQwymWU8gDvJcZVcrrd+5IHiIQ7Xy6OlLaY1Fyjv32eMmtPSKXOzH5lvnkAGFQlMwsG2Nph0lUq6VhhIdDJq19U+R+S2tYrL/fy9ILdEQYYg4NJshsmW7UNOlbphlFpGY8DCslaNNEZdCViDVt7k4pXg7phOISRiGHs786ZYL60yQuzT9WahQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "235"
+    "gender_rate": 4,
+    "rarity": 235
   },
   {
-    "id": "192",
+    "id": 192,
+    "sortid": 192,
     "identifier": "sunflora",
     "name": "Sunflora",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA4VBMVEX///9jxlL35yn3960xMTH15Ck2NjY5nDk6nTlSUlJSU1JUVFFixFFixFKFXCmEWimFWykzMjCL7nKM73PToyHUoyHWpiH05Ck1NTX19az25Sg0MzA0NDLnxmO2pntiw1GEWyqFWyjlxGLnSnsxMzHnxmTz5Cnz86uFXCv19KpBazmCWSmcMVKdNFPnTHsxMjG1o3u1pXpCbDlRUVFRUlFSUlHlSXoyMzLmxWMyMTBUU1HnxGNBajiK7HGK7HKK7XI4mjj09KtCajn186ubMVFCazlixVH29ar29quyo3m0o3onXsQvAAAAAXRSTlMAQObYZgAAAQBJREFUeNrtksVyxEAMRKMBs8fMXmYKMye7wf//oMiXHOVjKlXbpzm86lZrdLDXnysXopXRkNHiMg1awSmr4pIxW4g2Lh14npcMJKsEBa6Sj27BJ36CrhXBxaW6eOGcd/uS2XFABKtFPeO1+CrmmB8QI6rhJ69nmD6XZPN8tdtyvvkuJr5kKem42KzXl8fXyDVtyCEPR6O7kz5u6Ibeoxp2Or4nmUoCgrs/NzOFfUsqGKs8RGBlyNhmRn5iLnoA42l664Jlvj5GVy3Hc+YCWG5o6E8NSdmGAKcOhJHxPiY8ew2kL98cgNA4ok/3WV86YAl8IEinI9PEajT3W2uv/6EfkWYW3a2+MWcAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "193",
+    "id": 193,
+    "sortid": 193,
     "identifier": "yanma",
     "name": "Yanma",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAolBMVEX///8xMTHnYyk0NDRUUlGU90rkYikzMTD///81NTVUVFRiq1mS80mS9EoyMTGrODGtOTCtOTFRUVHlZSnmYilSUlL7+/s2NjbnZSxTU1P7imJTUVH8/Pz+/PusOzGV9EmrOjFCUppDVJpVVVW7u7u8urq9vb00MjHkZCljrlkxMTJSU1KS9EsyNDExMjH8i2KV90z9+/v9/vxTVFH/jWWrOTEo6ELlAAAAAXRSTlMAQObYZgAAAO5JREFUeNrtkMduxDAMRE2qund7+6b3Xv7/1zJSDkFiGch9d0gJPDwNRUZHHajGn4oIZ5ZbXXvGXZrNICiIwkSbbxqKm2fmrZhQMdFgE9jQio1/pau6q+qC/rgN1iYXS80SrMPKGlhBZcfmt+GwYDbpjXQoXHED840mH9Ry89Iy75VqgVfr+ZGb04cWHLRbf77ahIhmSMoAvYlM7S6vlv3GLtgE2TG973N1dpfdnhRutr7XvLUiRGKS9KnJ38lt4YNZwlYEm5edzNVjQ3757Pxmv0kECulK9BdhLkZE0TlFMXKyxIm84T80Io46aH0BxaQN3bNmSNkAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "194",
+    "id": 194,
+    "sortid": 194,
     "identifier": "wooper",
     "name": "Wooper",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAflBMVEX///9rreeUzv9qq+RSU1QxMTExMjMzMjPkq9M2NjYyMzRTUlNae85CZJ1qq+WSzPxSUlK6ebq9e71SUlPnrdZDZJ1ZesxBYppCYpo1NTU2NjWSy/tRUlOSzP2Tzf4xMTKr2/us3f+t3v84UVm7eru7e705Ulo5UlvmrNVZecsyYzIDAAAAAXRSTlMAQObYZgAAAKlJREFUeNrt0UcSwyAMBVBLdGMbt/Ti9HL/C0ZkPJOdyDrxX7B6oA9kU34r7ltnTeZUTMIpa5TYIyJojq5s3/pwPGGU5cCd2PiQHwim5JogjgFpDTNcLXaE8g3ibEt9meFC1gGJVddHb6zhJMi6XlYgLy1R9okEAN1ENZ4oSa4oJe5oqCQLz0JHN/4nP1vTohNOlPfbvBNQRMhXfBbdu2Yy7jM3TbMpf5wXlZkH48gNSSoAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "195",
+    "id": 195,
+    "sortid": 195,
     "identifier": "quagsire",
     "name": "Quagsire",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAYFBMVEX///9qq+SUzv9rrec2NjZSU1SSy/tSUlIxMTFSUlMxMjJScqMxMjNTU1RTdKYyMzRqrOVrbM5Sc6ZRUVGSzPySzP2Tzf4xMTM4UVk5Ulo5Uls1NTVra85RcaOs3f+t3v9Tf0W7AAAAAXRSTlMAQObYZgAAALtJREFUeNrt0kkShCAMBVATEBTnuee+/y37CwtXkN5a5V9YWLxKDJJdOUWeBfIPM8ysaolqw58veyq4zgTIrRMKqpVDuiR8L7vsjAgpt7NvvPCwJYc23FhrKxQGTEpa/dBInQlShQgltWn7A2r8pJhTIyAeYz+8ttu9oDoCG/JuReHhUVD0U/WEvZzgwB0pvMSOvCSVz9x4n5hdg9FYWph94aK3yA8KhcYlVvLdnaoeXeXoY1xJou2V0+QHWLcIdGA5ypgAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "196",
+    "id": 196,
+    "sortid": 196,
     "identifier": "espeon",
     "name": "Espeon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTG9jK0zMzPnvd41NTU2NjZTUlNUU1SSapKVbJW6iqvkutszMjK8i6zku9syMTJSUlLmvN1Ke5S7i6vlu9yUa5RRUVG7i6yFXLZLepQyMTNJeZLlu9uaQkpKepLnRETnu9sxMjLnvt78/Pz9/f3+/f6gTqo1AAAAAXRSTlMAQObYZgAAAOtJREFUeAHtksduwzAMhktKtobkYWWke7fv/4j9mfhQKKqqW1EgBJRD8OEfJq8u82fTt3JhaAO7wDnZUVHx/vob2BNe1KoM8rBCRFGBs6B/kKSTkBapXmAqgYdJCIpslu0goJ/Pc8PO7T6fX4Dap83m9fhf5IFyLrB5f7OPD1r725UT73NbCoYiqP1O22UhOkUple6E44+bu5C03cKTQlLl0iD8TNGPICfej3m+rLU3E7wntK9smw5uZPk4SRd2kpVPjHxBfmucMxBT0syNdXBGTvXr0XVuPm5jvZ4KSHhRtV2vCDYNLC/zv+YLY4kKHWyy600AAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "197",
+    "id": 197,
+    "sortid": 197,
     "identifier": "umbreon",
     "name": "Umbreon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAflBMVEX///9zhIQxMTEyMjJSUlJSa3MxMTJ1hYLz00E1NTU2Njb01ENxgoL31kJyg4MzMjBRUVH01EJRanE0MzHErCpUbHLDqynGrSk0NDRSanJTU1GCkpr31kT7+/vEqyoyMTA0MTFzgoL000L8/PyaMSr21UHzYlFUVFFTbHGaMSkJJbwEAAAAAXRSTlMAQObYZgAAANNJREFUeNrt0tcOgzAMBVBiMiDssEr3Hv//g3VIpT458FZV4j4fXcdWgiU/jQaY51IWznFxlCkLYwCYKEyyGsenjIW+d+gR6O6mGEeijZAU5BzA5EnWotBR/6RgeVaM8Vzsi8AWZ31BwEglKAVOHAdXNeF2WwelXcNYT8DXKVHiskpDVHyQQF6xzHHr+xFXGj519HXE9eBc1frkhiFFZh1u4pFQWubgA3zSWCM4QLfmE7BSTYEkNkJ6oYxU6G5AF7qatClo8IVy5s/V4OAsGiz5r7wB07oKA26mPcEAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "198",
+    "id": 198,
+    "sortid": 198,
     "identifier": "murkrow",
     "name": "Murkrow",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAgVBMVEX///8xMTFCUoQ2NjYxMTJZcbJac7X7+/tZcrQxMjMzMjFRUVFUU1E0NDRZcrNBUYI1NTW1hFnWrUrWrUvWrkxCUoP33qZcdbZDUoO1hFq2hVy7MSG7MSLTq0pUVFNEVIRDUYLz26P3dVT33qVSUlJSUlP9+/v+/Pz+/fzVrEpEVIWotvV7AAAAAXRSTlMAQObYZgAAALlJREFUeNrt0UcOwzAMBECTqu5xTY/T2/8fGEo+K/QtCODVdUBoyWjO7yNgmhEq5uFCxaA0C/00pTkoACAttNaIEr5PI3S7FoiWmSlgpB1K9ouldRT4LqcB7VhG0As7018O2/uSpKsfQ2iJpm/q5/nxpjLKlw/Ctq7WKwmU0pIL/7BJPELpHEnm0gpxd5yydXQIgNl5aT3k9mjarOMd9QazSSDdZxDx1G2peiWs9GNzk0eTJN15zr/kA0VsB9ZIMgfCAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "30"
+    "gender_rate": 4,
+    "rarity": 30
   },
   {
-    "id": "199",
+    "id": 199,
+    "sortid": 199,
     "identifier": "slowking",
     "name": "Slowking",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA2FBMVEX///8xMTFSUlKUra3/nJw1NTVTUlJTU1NUVFRze3uSq6szMzO6UVHD09PE1NTG1tbOc3vWxmvv3pT7+/v8mpoyMjL////LcXk0MjLE09N0fHzG09NUU1MzMjJTVFTOdHu1nEJxeXn2SkL3SkK9UVG9UlL8/Pz9mpr+m5v/nZ2+VFTNcnq9U1L3S0O1nUM0NDTTw2rVxGrVxWq8U1Hs25Lu3JIzMTHzSUH0SkJyenr2TERTU1G9VFQ2NjV1e3s2NjaTrKz9/PxUU1L+/Py1mkJRUVH//f3McnrVi5rXAAAAAXRSTlMAQObYZgAAAQxJREFUeNrt0tVuAzEQheGdsbPMGNowl5mbct//jTqW9jbj5j7Ht59+WZaNw/ZbS53/OLcIPLcAPRyHUdQNPT38zk96kcZtgVzncdobAO/cwmgFkZrHO2HB2HFCgqIADloPCnWdUAirw0TpfuQUVVmCjEREwoKc5prZWr46b4IPKljFq5/SdoVT8O46TYd1tu4jGDp4epMOV1K2eRcMKJmSbPu3PHw2kaJPuNjMWfniT2Ym4v3svbQBuF/ZuiOzmUw/7Vy2oap3Ot/ERVnaiLns/8ZxvctV84vkA5GIiYxT8OsySZLjpeopyMnR6GopJUnGkQQ4p6CCAIxrrH8UN8+os1l5pkVN1Thsv/0ByIcbfxc2XGUAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "70"
+    "gender_rate": 4,
+    "rarity": 70
   },
   {
-    "id": "200",
+    "id": 200,
+    "sortid": 200,
     "identifier": "misdreavus",
     "name": "Misdreavus",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAArlBMVEX///8xMTExMjIzMjM1NTVSUlJSkrNSlLVac5TOc7VZcZJTUlPLcbJSk7RSU1NZc5RypNVzpdbMc7VRkrJSUlPMcrNbcpNZcpJUUVLTQXH2k91SU1RTk7U0MjClWoxUU1Q2NjZac5WjWowyMTLTQnLVQXLWRHTs27Lzkilxo9Nyo9NTUlLNcrQzMDGjWYpRUVE0MjMxMjOyIVGzIlO2JFTzktv0ktv2kio2NjX9+/ygTBhtAAAAAXRSTlMAQObYZgAAAMpJREFUeNrtkUcOwkAQBDcH5wQGg8k5m8z/P8ba4squryCX5ljq1syAhl9iVI4JAgFxMHSwSbudoDWZHnYYEF2nk0lppy6P+pOpg3WitCnjFZHE370191ScwmMeK4BGDHus8lr2fQg1YhyEY5XoJ61M2trIIwuURjeRHGx14nOVWyoxCENKdR4g3U4qEjWUc4G0B7eEQMvFIxdI7WI0VS6q8etShRYyeefXdQ+7bZcbqy/zzqzt+i6sUV1+sQBGSMz9z87GUAga/o83U8wNhzkIwAAAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "201",
+    "id": 201,
+    "sortid": 201,
     "identifier": "unown-a",
     "name": "Unown (A)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAATlBMVEX///8xMTE1NTUyMjJRUVFSUlJUVFRqamqDg4Ojo6P////Ly8v7+/s2NjaCgoJra2vMzMz+/v78/PyEhITOzs79/f02NjWmpqY0NDRTU1Ml7xgiAAAAAXRSTlMAQObYZgAAAIBJREFUeNrt0MsOhSAMBFCHUiz41vv8/x+VmNzFXXV2xsQJoZsTpqG5c34CODfkCRwclYOBhCGaAkzxppo38WE7L49vFsaV4ssK12TPkhj4lr4k87v7T1wZ+OqOHUH8Y7dwblQgmhBQjot+0XcT2npMiOaAOgj4G55s/qHv71wkOxjkBMxYXWKhAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "202",
+    "id": 202,
+    "sortid": 202,
     "identifier": "wobbuffet",
     "name": "Wobbuffet",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAVFBMVEX///8xMTFajM5rvedSUlJZi8xSUlNSU1RqvOaU3v9RUVFZistTVFQxMjNquuRqu+QyMzQ1NTWS2/uS2/wxMzNTU1M2NjU2NjaT3f4yMjOrq7Krq7O+ThDKAAAAAXRSTlMAQObYZgAAALJJREFUeNrt0bkOxCAMBNCMzZmQO3v//3+uEUWqmHSrlTISiOJpEKa58uM8IDnDlhgjb6i5zLLkTXXzMp2Tc4sd1i+e0K4sUoPJrDEmWRU4PJMRmqSQggqZMxXHflShH7mEHJo6lJ16fY6DtyFDb/vmDqiQyI3s0czvm8HxwI0lZ4MU5vPndVzZlULr0BpA+0NpNMY6kVAfQyXOVl7dUQ+gC3mMukQp3j+6Wlwhe/GVv8kXt2cI1yTcPZsAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "203",
+    "id": 203,
+    "sortid": 203,
     "identifier": "girafarig",
     "name": "Girafarig",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAyVBMVEX///8xMTEzMjFTU1NrQinWjEH/vTH///82NjYxMTBsQyltQymlUimmUym+xsbTi0JUUlHWjEL7gpr7+/v8uzD/hJz/uzFUVFRqQSn7UVE0NDT7ujHTikH8uzH+vDH/UlL/U1HUikHVi0E0MzG7xMQzMzM1NTU0MTFRUVFSUlKVlJKVlZWaYjH7ssOcYzGjUSn8g5o0MjKmUir8/Pz9uzD9vTP9/f39/v4yMTH+/fy6w8P/UlO7w8NUUlO9xsZUU1H/vjT//f0yMTBCl9FRAAAAAXRSTlMAQObYZgAAAPxJREFUeNrt0bV2AzEQBVCPcJnJDOvYATvMnPz/R1m7KtysJDc5afy6OboawfSO+YNYcKBL+QAOaQdpeccHZjj8WuIW7nd2w35xjpc4RACyviJZ3SlXo5cAjxljtSyr98+TbphyHjyw2XQty1OAbvf6xAMcTmaNs3pWZas/h188lmOKxDOSG7Xb5j/fdVqGcSRYkn+ACib5W8EYjUIESX7reQukkv1pQaMz0fFasHvm/2pGA5uFQ+YOyXwNlF8ZC+WSjPkesfVwwppQh+jhkLaQIqiMsunp2mKCBujOnYyidtb6S14+wyg2QbkqdAtBqeSqhOYoDlW1Pea/swOQQBUQqtHEfgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "204",
+    "id": 204,
+    "sortid": 204,
     "identifier": "pineco",
     "name": "Pineco",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAaVBMVEX///9Ci4NCjIRRUlJSUlJrraUxMjIxYlkxY1pSU1MxMTGUxr1RUVE2NjZBioJBi4NTU1Nqq6NqrKQyMzOSw7o1NTX+/PxDjIVUVFSSxLuSxbxEi4K6usu+vs7TYkHTY0PWZUT7+/tDjITahxHOAAAAAXRSTlMAQObYZgAAAL9JREFUeNrtkscSgzAMRJFly5WATUlv/P9HRkwmxwiuybDnN7urUm36JdUruaHvVkAhrAGZiRNloygEsVtIGorPSlEfOwnsY2xBIbisUPKsbVOMB+cc6mOUPOvLviimtOaeTrJ8Ps6o4TQ3IIEbkg7WNffxoDWQtBvjszF0G68tFEPfQet4BGM8N/Sc3wlnSTzthO+SSgpPgFwPQcl7ZJJDmWLaitzsaZF3iDz0ArhDO/s1tOLPdp/nWWarTX+oF+t/CQJf4em6AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "205",
+    "id": 205,
+    "sortid": 205,
     "identifier": "forretress",
     "name": "Forretress",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABX1BMVEX///9UVFSzm8znxu82NjZVUlJVVFVWVVaLQjlSUlK1nM7SUULkw+zkxOzlxO3lxe3mxe41NTVTU1PiwuqxmcmEe4yEfI2HfI+HfY85OTmMQjlRUVGymcuzmsxSUVFSUlG2nc62nc/RUkIxMTHUUUHUUkJTUlE0NDTUUkNTU1TkxO02NTYzMjI3Nzfmxu7nxe83NzjuioH6+vvhwenVUkI1NDSJQTiKQTiKQjkzMjFSUVKOQjmPQzukpKyloqqlpa2np682NDM2NDRTUVGzm8syMjK0m8y0m81TUlM2NjUzMzPRUUHRUUJUUVDSUEFUUVHTUkLTUkRUUlE2Njc3MzNVUlTVU0LWVEPWVUfZ2Nnb2NhVU1PiwelVU1Tiwuviw+riw+vjw+zkwek0MjJWVFRWVFflxOwzMTGDeow4Nzg4ODiFe42FfI7sjIKGfI3vjIM1MTL7+vr7+/o3NTVUVFPzqW6IAAAAAXRSTlMAQObYZgAAATFJREFUeAHt0MWSg0AQgGFmeoDgxN3dJVl3d3d3d3n/2qH2CjxAKv+hT1+NNNNl9XrKp+lI02nfzrkO5bwCAOU5O+eMel80qmRNq8332UG333DKHbd46Z9dtnTTxUcVQIWApojvpYDTilUcpwkdIJnUIeBdEHU5b35tf2jg5KJmPLD2r/nhoRsTGAwPrh0hBWQkuKmkqbfZzIOZJKtTYbeGBOSikn48sbUe+jHf9vGvkIuPtSZd1MdmrouEmL9SPtwQUuxXtYUEIebYH/20+PZzu85znDT+PeHKsY5M8+Ng12rfbR2Al1g2nuqMbBY6zbeKOQyGcfS+zkuFM04q7KGV7DZhLKTH93pF71dVHuFIg1BnKbGvBLIqihHcYOwKOj0YV4kHN4zT7ClZMgbTdfX6AxRQJqmiljEdAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "206",
+    "id": 206,
+    "sortid": 206,
     "identifier": "dunsparce",
     "name": "Dunsparce",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABO1BMVEX///8xMTE1NTU2NjZSnOf//3NSUlJSmeI0NDJUU1HTvCvWvSnWvir8/XT9/f3/7704Nzb////56rnUuyozMzA5OTlVVFJRUVFVVlFQmOFVVVYpaanRuixSm+X9/nVTU1BTU1H//3U1Nji1tca2tsS2tsbQuSnQuSvRuSo0NDRSU1RUm+JUnOLTuinTuyk2Nzk3ODZSm+ZRmuTWvilRm+YxMjRVVVXVvShVneDXvytVneVRVFZVnORVnOZUVFTRuy7RvC/46rvSuy356735+fn5+3ZRmeFSUk9TmuFTm+FVneZVnudXVlX67L/77Lr7+3H7+/v7/HP8/G/8/HL8/HX8/PxXV1P8/XX8/Xb8/f397r397r6Eu/GEu/P+/XH+/nH+/v7+/v//7rz/7r2Fu/L//nKFvfaGvvSzs8T3WwoWAAAAAXRSTlMAQObYZgAAAPRJREFUeAFjGHpgFDARq86fgzKFmOpYeUQIKGFkBJG63HEc+NUFCApqggxk5eEWwaswlE/QjpFRPBivOiYORhc+VTYbFl4eTjZG3MpMY+RYwxTY+ZPSWFi4cJtn4GcbwcrKainB4szPz4bbQCZHKZ1IRaBKHjF2VzZBoJdwKfSwCmdl5Q2RM+bmZFdOSMStUD0wPpU3xcvbwZxTno9PJQOX3UpuhvZB6WZCySxcnHpi4sLMuAyU1DJi4YqN8hFi4XLXEBbApY5BlJlZ2sTJwjdaylNGgBmiDKdaaWs1bVlZGQHCSUZSn5mJCU+KRVg/fDPsKAAAm+saMBjHWF4AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "207",
+    "id": 207,
+    "sortid": 207,
     "identifier": "gligar",
     "name": "Gligar",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABHVBMVEX///9SUlIxMTFTUlOEUnu9a63OjMa7aqszMjM1NTXepda8aqw2NTXMi8Tbo9PdpNVUU1QzMTKCUXk2NjaBUXmCUHlahPeDUns2NjeFVH25aam6aqs0NDS7a6w5Y71RUlPKisIxMjTNi8XNjMUyMTI5OTnco9RVUlRZg/TxemL3e2NQUVJQU1SDUXqDUnpRUVGEUXs4ODiFUnmFUnyFU3xSUVGGU32uUkI4Ybi5aqlSU1Q4YrpTUlVTU1O8bKxUUlK+ba7JicLKicNUUlPLisM0MjNUVFY5YrlXVFTXa1LaotNZgvHbo9U5Yrpag/Q3NjbeptY7Y7v0emL1emL1e2P2e2OBUnn7+fn7+/v8/Pz9/P3+/f7///+6aqo4Y7yt9ZLuAAAAAXRSTlMAQObYZgAAATRJREFUeNrtkcVywzAQhi20DLHjgMMch8rMTZmZ+f0fo5ImM71ESi+55TusLt/sv6s1JowJ67+ex+QDNQqEcCCKqvYSDsFNrthMFqVXIIIg0dKKMlmoCHhxAD2bBHIWZVNk+raEiTn5M1w0C22PS+Rjz5fxHDa0Yelw17f9z+Lb150dByqRm1Ob7zl8wcOXW2JY4qvE63LlYW0RY+xwD5gEt0gwNPr+h4uPvdecg0CML4YU3x5Zp5Xu+XPvjHerU4oAVN4x2pruPvVjlNITADphTXPv9e14rEHpzmUYlq8058mumOZ8lS4BBDo3NXX0Qj7znXHh3MZqHcGioSFKJpOGm2ofNI6YMQp3Bu3jKrNGaSyF065orCV7nMDopTkyNcqXME6DQap+mdTsrd77u6MxYYz8AkITHCTN46v7AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "208",
+    "id": 208,
+    "sortid": 208,
     "identifier": "steelix",
     "name": "Steelix",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAHlBMVEUAAAD///8xMTFSUlJqc5SDg6S0vb3NzdXVKSD///+j3FxbAAAAAnRSTlMAAHaTzTgAAAEISURBVHgB3dHbittAEIThSR1q4/d/4aRaCoxZMfg2++OLbvgsiZn168P+F7j+BWA99w6RCOVniDobiHGAZW5McoCIYyuTsADgCdZlmB3Zs98S2OHtSNbaHAkswMEGx5GvkbIGMkESvcOI+H3BWSJ5uLZXw04jc0+h7IHjbojky3aR058kjsu4Hfr19RrUasa1Ha5KO5NkgyFpfYMLvlGZ0X926P4OF4BBZfi7cmbZDHbYcNfR5gUZGzvcqwNgm1SSR7hd72X1/dUPVbLyDAFfN4ozhC0rsY6wsjROiA++MVISnCFMOwTOT7xPEut4PAAkWtIZgqLEcScIlUhA3fGJJaN2+Fk/Cv4Bs+wKrY0z2eMAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "25"
+    "gender_rate": 4,
+    "rarity": 25
   },
   {
-    "id": "209",
+    "id": 209,
+    "sortid": 209,
     "identifier": "snubbull",
     "name": "Snubbull",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABF1BMVEX///9SUlIxMTGtWnNUUlPkgprkg5rnhJz/rcb+rMVZkvw2NjYzMjJSU1RTUlLnhZ01NTVUU1Ocve80NDT8q8RRUVH+/f1blP5UVFZVVFJWVFVXU1NZkvg5OTlbk/xQUFBdk/tdlP5elPuDg3KMazGbuu2cu+0yMTKeuuueu+yqWXKrWXGsWXKsWnCsWnOsW3SsW3VSUVKtW3SuW3SvW3TGxM3Gxs7hgZnhgpvhsTHigpnig5nig53jgpnjgprjg5kxMjTkgps0MzLkhJ3khZ7ksjHlgprlg5vlhJvlhJzlszHmg5vng5vng5w3NTVTU1P7+/tUUlL8/Pz9qsP9q8T9rMT9/Pw3NzX+rcY5Njb+/v5UU1T///9DbT7bAAAAAXRSTlMAQObYZgAAAQNJREFUeNrtkUWOAzEQRbtMZbcb0sFhZmZmZuaZ+59jygdwnG2kPHlj6fmXfjnq0BaUGGvNq4FKWsuTyCcZY6E8JcAdxIS5V8znVbUuQBmtkVRpdMF8IooqOs8hFBoyPZNfKpKcNZPfra70wMyy9XSR9Y3H0Sv+RqEXRuMz87WhOOrCPypP+dzrl/4F5hXrOc/U+s9fLnbfsQBv5GymyEWCZzsFDFpfIg12dR1JDcD6Vx6nEKdkCrdx8ryjOZ8oN1KA+Cjwi31nnA+NlxcP9pOm3vn8VOP0eonfdp3Ipma/3by8nx7YGxneWnige0Dt7T48/i7RJaRu34x9Ro6waqMObcM/Vt8XkUZz5rgAAAAASUVORK5CYII=",
-    "gender_rate": "6",
-    "rarity": "190"
+    "gender_rate": 6,
+    "rarity": 190
   },
   {
-    "id": "210",
+    "id": 210,
+    "sortid": 210,
     "identifier": "granbull",
     "name": "Granbull",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA1VBMVEX////WnM5SUlIxMTFVVFSse7yte73Um8zUm83vvd42NjY1NTVUU1OufL5UU1QzMjPVm82servVnM6GZKbTmszWnc7TmsuEY6VSUlOrertTUlNTU1RVVFWufL2DYqOEY6Q5OTmFZKWFZaZSUVKoebipeLipebmqebmreboyMTIzMzSse7s0NDQyMjKtfL02NDU2NTa8vLzRmcnSmcvTmctUU1VUVFTUms0yMjM3NTaCYqE3NjeDY6SEYqPsutvtu93uvN2EYqX7+/v8+v38/Pz9/P3+/f67s0SSAAAAAXRSTlMAQObYZgAAAQtJREFUeAHt0sWShEAQBFCy2nsQGPd1d3eX//+krZ17Nxw2Yi+TXB8ZCVHJMn+elhDN3LNDIZpBBxS1TgB4/ZWiZoEHLoB0/rLAPDj4gjAn98PPHqBLprsl1xcB2U9R9KG/GPMKh5REAF6ZCXWL917aZcouCGcfndyy6PIzt6HCxBtkyPLva2Kox5GvF6YEsg64czTYi/3Kw03Lqq0U98Wcc6eklFonTgx6U1rinE2nlOvbmNx+kkRDck4qvR+9iw1IOcotLO3oIyHCcAvALMt5wVhPqrsgfOAyjpJSGj0IF66eV2QMNDG+0Y8+CUvPqSqy7fbxSu2xs6XO2xq1kvp4c3DZxC1ak2X+NT/pVRFAoYribQAAAABJRU5ErkJggg==",
-    "gender_rate": "6",
-    "rarity": "75"
+    "gender_rate": 6,
+    "rarity": 75
   },
   {
-    "id": "211",
+    "id": 211,
+    "sortid": 211,
     "identifier": "qwilfish",
     "name": "Qwilfish",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAllBMVEX///8xMTG9zmMyMzNCi3JCjHN5urq6y2JBinE2NjY1NTVCjHRRUlJSU1NUUlN6u7t6vLt7vb0xMjK7zGK7zGMzMzHvc5z394R0fDn29oNSUlJDjXLscZrucpsyMjFEjXV1fDp0ejo0NDRRUVHLQXHOQnNTU1Lscpo0NDJxeTj09YL09YNyezlzezn7+/v8/Pz8/fz////VzLyMAAAAAXRSTlMAQObYZgAAAN5JREFUeNrtktkOgjAQRZ0uUPYdFFTc9/X/f84pGF6k1VeNt5n0oSfnJpMO/vm+WACgB56X4JzHOs6gTzAlpIp7q1CG763GFmmV9oO2QQ0KRhRFFFoQT9ZnFG7gBZGME4PgqmYkpa1FnZCahGQwUIIeShulSJUYXOoQVYiWZeCx19ZubS7joWxFL+MuKPe33OY+uy3Qi5xu1dZqkvvXe81lTlNQgvZ4PfGZpI7FLBkVO7VynM8PhQwhQ43RMjcJISPEJPfmX+GWJXZuOD1rDqf7JNMgXX/WzAdkM//8YB54Mw6UGqrOQQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "212",
+    "id": 212,
+    "sortid": 212,
     "identifier": "scizor",
     "name": "Scizor",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAn1BMVEX///8xMTEzMTFSUlJTUVFUUlG6QTHWY0LvjHM1NTW7QjG9QjHTYkHTYkIzMzPsi3Lui3KcnLX7sqP7+/v+tKT///+9QzK9vb00MzI0NDRUU1HWZEHsinF6enruinF8enozMjKdnbY2NjZRUVH+xCn+xSr/taUyMjNUUlJTU1NUU1O+vr40MzD7wym6urr8s6PUY0LVYkF7e3u7u7u8vLxy0XZ+AAAAAXRSTlMAQObYZgAAATJJREFUeNrtkllvgzAQhLs+sLnCHWggVyHpfff//7aOW6RIMVAe+pgVko38aXdm7KtLmbqZy2XX/w4+LmbNdw3optXfHV/uX6tU72aBD5G+IyLzRzSA9Gep1nrpb9DUpawozr0BOOolw9porWKtGHwV+yS5tTgNQDECZ3aSKNsnX2W5OAcbYN3KExH6HWolQ7X9LG0O4I4cwT0Rxoen51p6Yg0Og+0A8Tm+IApUV8sQHSXnnAaTCXxGWKjloc/QPoz1YKBAfhdHePDcht0qyk+kTUMC+xkgeZQfq1EwYK3HyGwU8szHQSjcwgVcSagcHQ2B6w8O08yYE9EYh0OAbwo59bc/XG6jEMwGV+n4bPKROe/MuGBmR5OvcdHnCVBNkEBOai3DY7YslRMy5hV0XGpufQPHyRcAUR2eQgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "25"
+    "gender_rate": 4,
+    "rarity": 25
   },
   {
-    "id": "213",
+    "id": 213,
+    "sortid": 213,
     "identifier": "shuckle",
     "name": "Shuckle",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAn1BMVEX///8xMTE2NjZ8RDq1QkrWpVLeSlr15LP357V5QTijYkG0Qkk0MzG2REvTo1HVxIo1NTXdSVkyMTHeTFtSUlL25LNUU1L/3jk0MzNUVFPTw4rTxIumZEHWpVEzMTGlZEIzMjH+3TnTo1L72zj82zn93DnUw4rVo1G1REv05LMzMzKlY0JTU1J8QjncSVlRUVGVlWTbSVl7QjndS1pSUVFIdxMAAAAAAXRSTlMAQObYZgAAANFJREFUeNrtk8cagkAMhA1bAZUONlCx9/r+z2bWMyU3Lswhp/9LsrOTQa9uZQEAiRuvs3xF4DYZqp30H9tsiOywFUSIBjo7M1m0L+mDczmIZUh6tjANSSQZxNEANNA7BgW0cbO0FOn8k0yhmbPV8xqfRkGiJ83giyutR4HkKiqafJyxO+cc+0XypiYAUBMwx2MqkkhK/lbTUlR5b5nvW3jMRUSbuj9DpfmYsHwFYLvYKp4z1/jj143+V/uL/sQAhGPAVOIWIeVuxmsMJfnEenWqH4i5DyOwQKiwAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "214",
+    "id": 214,
+    "sortid": 214,
     "identifier": "heracross",
     "name": "Heracross",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAbFBMVEX///8xMTFjjNZiitM2NjZBapoxMTJSUlRCa5xii9UxMjNCapo1NTVRUVFii9NRUlNSUlJljdPbuyncvCtljdaKs+WLtObT09MzMzDz8yn09Cn09Cr7+/tkjNMzMzNUU1EyMzP8/f5DbJ3////KD4cHAAAAAXRSTlMAQObYZgAAAOlJREFUeNrtk8cOhDAMRLEDaXTYwvb2//+4Q9BqL4Tkwg1LIT48PPZYSbZYIdLxUASXyaQQNgasSXAcmBuOIYvMKCKKAMsK5cITpUIBdMnhGQLZEiFhCknzyAoFLgQyaxPgUiq7B8j+po1ddFHX3SCY1blluOQHy9z53Q+nVuX7t/TpZloSPkZfUBAdWJ+ulrgERmGoNxX6pDnweKfJyglDk3DAzin/Bm8aYAwG/3j3U2QYB+KoSa669YK6rgCqHJ6jb0MLXkrBoJ32lT4essBI6BMuGecBcu8W/68nJlLx2tk4EqveYo34AojfCNQCfRe8AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "215",
+    "id": 215,
+    "sortid": 215,
     "identifier": "sneasel",
     "name": "Sneasel",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///8xMTFSUlJCa5RjjK3////WWlL31imtWlJ7tb0xMjK1tb3TWVFiiqt8tbo2NjZkjK15srp6tLwzMjJRUlOMQjmrWVGrWlMyMTFSUlO2tr41NTXGpSFUVFTTWVLVWlIzMTHskqvuk6vvlK311Stii6v7+/v+/PxBapLEKszKAAAAAXRSTlMAQObYZgAAAMBJREFUeAHt0cluwzAMhGHNcCTLdhJ33/f9/Z+wRNoeQx6LAPkvvnyAMVT53w7d/n4XIHTLevphz6+nMfw6A8qyai+JW5+Mo6ZVf2xPIcTx28blZerGYdjIu0aJoQb/8cf9u6YMSrV93hw5zKWXOpfmzOCHB0IHmplQlot+FVCYcRAldPIhOBFm6k4uxd5iB3lUZTsnsRtiu4a1VrK13dAdjeZyrj2cjdkM3MLsEYECh0RJQ5Wc5wGoufsbdWh/+gZu8gbH/1YVFAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "216",
+    "id": 216,
+    "sortid": 216,
     "identifier": "teddiursa",
     "name": "Teddiursa",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAY1BMVEX///+9ezn3nCkxMTFSUlLejDE2Njb//1L/////vXPvznvzmin2myn2nCpUU1H3nCq7ejm9ezgzMjH+vHE0MjCEhHP0mim9pULejDA0MzLuzHn3nSv3nSzvzXlUU1Lwznrwz3ss9cXHAAAAAXRSTlMAQObYZgAAAKlJREFUeNrtz0cOwzAMRFHPkLLkEtf0fv9TRg6CLEVtDfivH8RRsbWOSpE818zVJcNJw9g+A/adHjsVsTaUw1OHa70bJzE2lGC9Izm2c5/eIKG+8fG1aBNQVPh+MdbpgCkB6Q+eEu4LnFKX/ZIKz/E/CbdIVe/pEO+moVaVngBIYUCSCqjpEB0JQgzoECkdSFM6F6VaUAIUDjkjY6A58f9s+EH72WJrNX0AsOoFfuvopS4AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "217",
+    "id": 217,
+    "sortid": 217,
     "identifier": "ursaring",
     "name": "Ursaring",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAkFBMVEX///8xMTG1e0rOlGNTUlGEWkI2NjZSUlL7+/uzekpUVFSDWUI1NTWFWkIyMTG0eklSUlEzMjHOlWPexko0NDT8/Pz/73PMkmJTU1KyeUnOlWXdxErLkmKCWUH87HLMk2L97XL+7XL+7nJRUVGFXETdxUo0MzL77HHNk2LOlGK1fEq2fEr9/Px5eXnbw0nbxEpNv465AAAAAXRSTlMAQObYZgAAAPJJREFUeNrt08luxCAMBuDYhkD2kHW2zt52ur//29XQWyUgl6qX+SXn9MnxfyC550+SwkK3IwNLdHmZiQzr+EKbxxcTcR9qxhvLFUTg53manvSGMLbxeeJ0RBGZrsXX2TmqZA0BeMmEmi072DH+heickytV1B5X7ghR7N2RVasy75mpzjO+saMTS5QHqmqfBJ3vbZVThyK7EZlA7SNDPL6hsLeG2mz7Vzti3BD/GrxQNtu+ZyvUmI95oM9Dgy6yEUVbNGgCK38cT1tI6eld6uv7AGvkzmglgP8ZpPYLwCf8Wuc9dpFjqAc9JItkUib3/Gu+AZLuDp+O2O7oAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "218",
+    "id": 218,
+    "sortid": 218,
     "identifier": "slugma",
     "name": "Slugma",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX////WWjn/jFL+i1HTWTjTWTkxMTGtSjk0MjEzMTFUVFFUUlKuSzkyMTE1NTXVWTlRUVH7ilH8i1JSUlJUUlH/jFP/jVH//UL//0L//0P9ilE2NjbWXDlTUVH7spL/tJL/tZSrSTj8s5I0MzL//6v8/Kv7+0H6Pg3UAAAAAXRSTlMAQObYZgAAAL5JREFUeNrtkjcOwzAMRU3Kau69pPf7HzF0bCAb6S0I4L9oeXoUKQZbfp1sHbY3p/sqrjy3br5geA4R/Md7aR0Hhgrd7J1OlrQ2NUU1iVnu1WGsFWEAnuWiChSKXJCREPvH2EFjAr4V4qLneGCFS7P9MHQggeHyPqEykYUmyh61Fz8wrnVTa1BOUpri1sakVeCNJKWJW5uLkwypst1hQqRyjO+aA+kmI2KScoUT0gFFGWEhDaVE/C6ZRAdb/iVvEZYKQU66UH8AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "219",
+    "id": 219,
+    "sortid": 219,
     "identifier": "magcargo",
     "name": "Magcargo",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAulBMVEX///8xMTFrY5SLi82MjM7WWjn39yn/jFJSUlJUUlEyMjNUUlJUVFFqYpIzMTFsY5OLi8w0MjE0NDCrSTi7i3PTWTnVWTnz8yn29ClSUlP7ilH+i1FTUVE1NTW7i3L39SnTWTiMjMz8i1KtSjmtSzj/jFP9ilExMTL/tJJRUVHWXDjWkynWlCnWlSkzMjL09Cn19SuuSzmuTDgyMTFWVla8jHT8s5K9jHM2Njb+jVFTUlLUWjurSjn/tZRSM2wSAAAAAXRSTlMAQObYZgAAAQJJREFUeNrt0cdug2AQBODs32mmd3C303tv7/9aWUC2lMMi35KD5wAHf5od4ZNj/k/eDnRtFR7WV80i+kfoH106qCjZ5ioC8LgoA2FXevYeEn25e/uQFcoNUH4WCh0FFboodz3O+J26mFBuXkspC3W9bgKWLEqgXHX2vZHy8mqdWR5jic9t6rNpjOxjBQLpDdH4Cz77nJ1St+Ot7pBJV8301efCJuBTahmTWl/ZqvF4NxIbCQlxs9TO0kHHxXCZun7+snGMmS4ESz5gDM5xIc7EieW4k31qB7emE5K2O6f18A7J/0Zi9ljfP5KVEGe1HlgIMLoSIN7i5f2+cYtdx/x1fgDHIBYlW0EZxAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "220",
+    "id": 220,
+    "sortid": 220,
     "identifier": "swinub",
     "name": "Swinub",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAWlBMVEX///8xMTE2NjadWzL3rXu1hGP1q3n1rHoyMTGygmI0MjL0q3o1NTWySVkzMjG2hGNUU1JSUlL1q3qaWTGcWjFTUlLzeZLzq3m0g2L1epO1Slq1g2JRUVG2SlrmTAfUAAAAAXRSTlMAQObYZgAAAIFJREFUeNrt0TkWhCAQRVFLZqFx6lHt/W/TQiSkMDDkBUT3/ApoarVyDrAya8Eozp4aSm6WyEL6ipOc98JT7sMkQxZimoQITkcdb7fRHiqe7/LQqOQkPvlJ9/5PfLBp86u63OLjF+Ro4+YAGRfksop4vn8BkP8CRmAeEiMtolrtznbHfAV5hRINeAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "225"
+    "gender_rate": 4,
+    "rarity": 225
   },
   {
-    "id": "221",
+    "id": 221,
+    "sortid": 221,
     "identifier": "piloswine",
     "name": "Piloswine",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTE1NTVSUlJUU1Kaalmca1r0q3r///80MjJTUlK9hGM2NjadbFr3rXvdcovzq3lUUlL1q3r2rHoyMTH7+/v8/PxUVFQzMjG+vrbbcouNjY3ec4xTU1NRUVEyMjKySVm1Slq1S1u6gmI0NDS7g2K6urKiJpAiAAAAAXRSTlMAQObYZgAAAMFJREFUeNrtzkcOgzAUBFC+O72X9J77HzFjWLAxmGUiZYS94WnGwT9fEEa0hSVUZFlIfveoMyQeNjkkbdZnpaqgxkp/3ZRwxRUzG7f9fXG9ts1GOMtwy3JaAXqW/bCwg7OMh0WHvxPFLV6xahag0EJjcqwDVIBu+T7JiGsLhcaRqiGna3f3/FhylAo+QXcna02/v+Ul9oWMNGBEC41PugLyrkdXxOXyG/GdeWeMhVA0F7pqjTlcJBDUapgVCQX//Ew+klMQcGrJDFYAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "222",
+    "id": 222,
+    "sortid": 222,
     "identifier": "corsola",
     "name": "Corsola",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAkFBMVEX/////a3s0MTI0MjI2NjZRUVGcxta2UmO2U2T7o6P9o6MxMTH/pKT/paWyUWIyMzMzMTHWZEP7anlSUlL7y9P8o6P9anpUUlJUU1M1NTWdxNSbxdX9bHxTUlKaxNO2VGXWY0L/pqb7+/v8anp7lKWaw9NTU1Q0MzP+o6MyMjL/bHx5kqOdxdV7kqP/ztb//f3j2i+xAAAAAXRSTlMAQObYZgAAANpJREFUeNrtklkPgjAQhNm29K6gAuJ939f//3cuoi8mS3glcZJtX77MzDaN/uqCRFvOcNeKc0YXrJUheN6qhujZwGvvSGTHJnLggTmU4dmFNYKj4dYHGOGhUxIbOxcjgSrzAD5wEsweep6/ORyHPem1A4AHZSsWyw4Y3RETK2mLU5DpYrNE4AuCSgnLcexMeK5DLQAWCSJX2f4qNVX6bTaRM0Y/T8/2TxgLqoCJTAisDs+reuVCSnlwDaDY785xru9TmVynpOP3N8TDRYLXx7DR9rcevVT0V4f0AvG6DOVFzDFHAAAAAElFTkSuQmCC",
-    "gender_rate": "6",
-    "rarity": "60"
+    "gender_rate": 6,
+    "rarity": 60
   },
   {
-    "id": "223",
+    "id": 223,
+    "sortid": 223,
     "identifier": "remoraid",
     "name": "Remoraid",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAaVBMVEX///8xMTFrrZ2l3v80NDQ2NjZrrZwxMjKj2/syMzSm3v/9/v+j2/z7+/uk3f1bjZ01NTW6urozMzNSU1P8/Pyl3PxajJyFhXVRUVG8vb69vb3TYkHWY0Jqq5qj3P38/f39/fxTVFT///9O6BwzAAAAAXRSTlMAQObYZgAAAIpJREFUeAHtkre2xCAMBS0uGWe/tzn//0eu2N6g3p6Cas6II2h2to4hoeeD0EtaKJ5n2QUniTeSVwsJPA9gOLjKUO6dWvYeCJWtcO/dVpPGqx4ZTgaignjvkSIyavnThSCQjq8IZa2bLvO6eL39J93F4fnRjen4WGPMZlTW0W+fxTdheKj8i+1smS+x7wW4FlKoMAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "224",
+    "id": 224,
+    "sortid": 224,
     "identifier": "octillery",
     "name": "Octillery",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAn1BMVEX////WOTkxMTH/c3PTODj8cnL+cnI2NjbvUlIzMTH7yylUUVHWOzjUOTlSUlI0MjKEQkKFQUH/zin9c3L/dHNUUlKFQkI1NTUyMTH7cXFUU1P///++vr69ikHsUlK+jUHuUlH9/Pz++/s0MzLuUVGFRET9cnI0MzD8s6OEQ0P+yynVOjnVOzv7sqOCQUH/dHH7+/v/taX/zCq9jELTOTlhlmAnAAAAAXRSTlMAQObYZgAAAN5JREFUeAHt00lvwyAUBOC+9zAYY4ydJU2apPu+L/3/v61D1WMM3KpIGck+fR6ZkTg65N9juMwdN5O7EsZq+/Vks6WmmZydaxGyBXAqMSHtXv12SkQ6A83LbHEbFemabMKt5lW98FHinYEgl5tnnYaQUtOwfF/f9H5YZlak4WK9ecgUMh7IvvfkmBNn/rhCqSLEfWsJPPqDIbb+Qdd1VdgNmzeUKJhfWYnMO94JFWaGuD+phGKutYxVttHNMCY+sCi3o6dGVp+tO4WLWyWXVITAZWPUY2u57MqAHbI/+QHmHwwcbrVxfwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "225",
+    "id": 225,
+    "sortid": 225,
     "identifier": "delibird",
     "name": "Delibird",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///8xMTHWOTn8/Px9RES+vr40NDRUVFT///8yMTF7QkJ8QUE1NTWVZSGVlZW6urq7u7u9vb02NjbTODhSUlL7+/tTU1P9/f3+aln++/v/a1pUUVEzMzP8allRUVFSUVF5QUHUOTk0MTH7almSkpLVOzuUlJTWPDzbmkLenELz8yn39ylTUlEzMTF6QkI0NDD9a1r9bFtUUlJ9QkJUU1HTOTnUOTiwQUAUAAAAAXRSTlMAQObYZgAAAO1JREFUeAHt08dyg0AMBuBI2rIGbNMLuDu99/d/tMhmcox2LxlfLC4cvvmFFu3Fuf6hcn6CXGUqEwadM0HRSTXCxBPNzqkJwPHFeHrrqxaf5o3zy5s4ZaYXILoVuWNZ8I1tydmStfFAWJElXZPOFqK7f5g+kjnEagkmxXB79wnAUExM9jhcNm5Wl2kmds737+PMurHPE/ETN2tyirGKlv1OlEWnltipbbxt+x1IzT/Stx4RO/uFAxkxcvbaY6ezuuS5zN/nOP3GFjEmfS2vRQ4ABbKMxsWQlxc20bqEuXyWv3/y5RAecHfYnOvE9QNGbRBR2gy/ogAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "226",
+    "id": 226,
+    "sortid": 226,
     "identifier": "mantine",
     "name": "Mantine",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAb1BMVEX///8xMTFKa5RCUnNJapIxMTJig7xjhL0xMjMzMzRJapM1NTVRUlNSUlJSUlNigrpig7s2NjYyMzOtnM6tvc7O3vdRUlJBUXFCUnLL2/Orusuru81RUVFKapJkhb3N3fYyMjPbzPTezvermstCUnSrf+8eAAAAAXRSTlMAQObYZgAAANBJREFUeNrtkNkOgzAMBLEhCTeUG3of//+NtRGJkBLUvrZiHoIQk2Vtb+dHSeBLb4w+SwcAGNvI/WX9Nl3blj1bO2WDAFh7TeXw+u6M6RCj0GJT8S1bDPwuIw9RADOZNNvEGakYPFabmyDR90u1gP7Swf1z8gzh5tZoHKktDneZCfTxXA/TTNsv4YhjTUAgMS1VbnJDAKseafQodOJm0YQ1KJTK9Tj6SghWzUKRd39cFHKkKWGHBpJLPev6BsFqLBSOBemTDnLd8ziuMd7O3/AGo2MMCiTQm+QAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "25"
+    "gender_rate": 4,
+    "rarity": 25
   },
   {
-    "id": "227",
+    "id": 227,
+    "sortid": 227,
     "identifier": "skarmory",
     "name": "Skarmory",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAh1BMVEX///+crb3O1u81NTVSUlJSY5yEhJQxMTEyMjM2Njaaq7vL0+xSUlMzMzNTVFQ0NDSFhZWaq7oyMjKbrLzN1e5RUVHM0+xRYpoxMTLWY0L7+/uDk81TU1MzMTFUUlGdrrr///+CgpLM1O1UVFRTZJzTYkKCksvz8yn19SqDg5L9/f3+/v5SU1OkbvLPAAAAAXRSTlMAQObYZgAAARBJREFUeNrt0sdyxSAMBVALA8LGvduvptf//75IA5NF3LLITDZPK8ZzfAWC4FZ/X9H3ArfdlPuFTRE34QMyiO7uU5tuOZF1QqRBaKEpqvXIcBKCnYO1WWHcEBqRYRCRAzBrh4rKhl1sGHIgM7UEuXFRg4cVfenVsBT4LkC/XjjIFrWuKK+ViAuB5KqXy+NA/2idIFohPq7XfGk2MZj+oIZWyreE5gRHKRcSLRhqFPaHzw7gGDfEnsZxPM2G6K4ifFZJR9lNRuw8T2Tik9tOEKS484/E+TgJSpbjiW9+HfK1aE0D2nlqbQwEawCz7XqVkDTlnptyLN2Yhk0Yon8xu5LLOaW83N3ClP8Gui3c6h/rC5F2EDEc0hfMAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "25"
+    "gender_rate": 4,
+    "rarity": 25
   },
   {
-    "id": "228",
+    "id": 228,
+    "sortid": 228,
     "identifier": "houndour",
     "name": "Houndour",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAclBMVEX///8xMTFSUlJzc3NRUVEyMjJUVFRycnI2NjZ0dHS7u7v8/Pz////3lCk0NDTLaknOa0nOa0pxcXH7+/v9/f01NTV1dXX+/Py6urrzkilTUlG9vb2+vr50cnLMa0r0kilTU1MzMzPMakozMTE0MjD3lSxpZJXNAAAAAXRSTlMAQObYZgAAAMlJREFUeNrt0UcOgzAQBdDMuOFG75Ce3P+KGZRkacMWiS/LYvE81senI/tIAttcU4qNA0sBQGNhzXHrZi1KJtZg5Zw0miFscGg0IsSLJVk3T7VUBElBsFgyeJ+fbcsY2pRbiRCsjFf/ykbF0NTS1GnwJw4+7945QRrZopUQlJAVxYgEGSpaIvaCnMg/EUjFxy9cPELY9fpCkhjSikFuptsCH8WTo00jEAG4YrRD5Zba4eKnptfM3OmTrz15U7n0dyiWwKjQ/Uf2kw+Y6AircLWxywAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "229",
+    "id": 229,
+    "sortid": 229,
     "identifier": "houndoom",
     "name": "Houndoom",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///8xMTE1NTU2NjZxcXFycnJzc3N1dXX3lCn7+/v8/PxRUVFSUlJ0dHR1c3E0NDS6urq+vr5TU1MzMTH////zkinMa0rLaklUVFQyMjLOa0q7u7u8vLz0kin0kyo2NjXOa0lVVVV0cnJTUlEzMzPMakqSkpr9/f1WVlZtukfiAAAAAXRSTlMAQObYZgAAAN5JREFUeNrt0skSgjAMBmDTQjdAVlFw333/JzQl43Ax1IvjxZ9hoNMPUkJn/3wjEuAzV9ybHMJY2qasUtc0eRiuvEMZWIZMYoQ5WIKsE4u5UingzTDCg3HRbq6c9pJyhPd1F8YcaqtVNz7KLHBrjMHiI5Rct5f9OR5WKYdmPvDkaITOrcBqp7sEHSsJOnQoJ5wts9SVVRDurfYuXmfrjD6K7aR6JY0JcnJ5Gljb19E0TK6+Q20NM3HbXCZgUUFCRYXldxtNisj/bbowoUlRXGjAOpqkkqEwJdm3/vP7PAEJzAq+g/FlNQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "230",
+    "id": 230,
+    "sortid": 230,
     "identifier": "kingdra",
     "name": "Kingdra",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAulBMVEX///8xMTFKjMZrtecxMzNqsuQ1NTVSU1RRUlMyMzQ2NjYxMjNqtOZSUlKK0/uL1f7G7/eM1v+Uxs5qs+bTkkFKi8RCZLVqs+TE7fatezlCYrNJisPVk0HWlEHWlELse3z7wylttudRUVGK1P1Li8NMjMOK1P5DZLY2NjWSxMxJi8WrKSlUU1GufDjE7PRUVFQzMzRBYrI0NDQyMzNMjcZstORtteT8xSv8/Pz9+/v+/Pz+/v7/xin///9n3VBDAAAAAXRSTlMAQObYZgAAANlJREFUeAHt0seSxCAMBFC1BM7Gnhy8Oeecw///1rLl8yAuc3NXcXsgmoK2lSFJrHN5PCyICqjQculy2CZXoYETMVBcYc3/gn7Fxww2BenQSrpIFwbQJjfnExGZH4/yMHRecTWfhEsXsF7tf71UwmWQNd6Z689DCdVJurOR9Oldgk0SPtar+q79fvIbQ+PpAkfrq+zj9x7d8kF5yY6rtF7zcvysuPc3kXrWKo6Sg5/bV84uxy0UOF3t7J1yCeZSO3J3deIR9K+L6U09U1lfKIuFzKAoCdCQbeQPZTAMWMIRYgYAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "231",
+    "id": 231,
+    "sortid": 231,
     "identifier": "phanpy",
     "name": "Phanpy",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAeFBMVEX///8xMTFapcaU1v9SU1NTVFRZo8MyMzSS0/uS0/xSUlKV1PztZG3vY2sxMjNZo8Q1NTU2NjZco8RUUlJRUVGT1f6U1PxTUlJTU1OV1v+r7Pus7v+t7/+zWWqzW2y1WmvDw8vsYmrsY2vsZGxbpcbuYmtJaor9/v+6SNNKAAAAAXRSTlMAQObYZgAAAJxJREFUeNrt0EcSwyAMQNEI0avj9N6T+98w4GELeG//hVYPwbCYm3JLABjFJCIKaDp5OmOM+DGuLTu+wRyDmnu4fpBMVVd236dzBn+HAaIouiOS122LQiaXZOOBTDFlDVojAApSItPpdVRZZ6xbBV/aCcCpDoTQy6e/7rIr3U9SVOt4oArv+0ByjT+HdYgEeHbVpW+fZ0tCnnPT7A92zQffazkfXwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "232",
+    "id": 232,
+    "sortid": 232,
     "identifier": "donphan",
     "name": "Donphan",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///8xMTFra3tTU1NqanpSUlKEjJSMpc6So6uDi5IxMTJSUlM1NTWDi5NSU1OLo8yUpa3Gzs77+/v///+CipJRUVFqanmNps42NjaTpKxUVFSszf6tzv8zMzNra3z8/PxTU1SLpMyrzPzDy8vFzc4yMjKKo8s0NDQyMjP/aDSGAAAAAXRSTlMAQObYZgAAARNJREFUeAHt0klzgzAMBeBIXmwWwkIgzZ7u/f+/sM/YPdRVp73lkjfc+EZPGljdc/s8ENG/2LzruIT9m4Wo4lWiNSHBzY1lXig3Ff10Hm9C3VRYJFBmbrgUJoLaynfKBMopggTdxEqlm8UYREsS+xkfZGLt4ejWWoQbW4EqnVjI1ZAAcQkoXLOz1dMxSsoQnngJWFzVBIp2+uaGdwp3L70o9l/UZbAexl4ZH2E5bNeJts65j1Um9wVmaTyXPUZdDSxkNhGSnhVuYQN26RX2cxir2rMBzOlkCsBxHCPEfvrxLH0b36Ecsj+9HZYzaNi+nFa/SUImzcusWv4r65mR8D5BMWmkjVLozH8hCyh2ZkninpvnE8DsFB+0xZUMAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "233",
+    "id": 233,
+    "sortid": 233,
     "identifier": "porygon2",
     "name": "Porygon2",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAkFBMVEX///8xMTHWSmNimuxjnO+lxv8yMzTvc5z7+/szMTFknO+jw/ujxPyjxf4zMjKmxv/vdJzvdZ0xMjP9/v/+/Pz+/P3////US2XTSmJUUVI2NjbTSWLWTGXscZrsc53ucptlne9SUlI1NTVUUlP9/f1UVFRRUVFTU1RSU1T+s6T+s6OFjZU0NDT/taX/tqY2NjVDlCxIAAAAAXRSTlMAQObYZgAAAL1JREFUeNrtkscOwjAQRLMusdN7p/fO//8dayI4JTZnYE4j7dOMPLL119dpBfC2GqwFeYtD6L1nj3Pd6RoLQRzlZWSPxsFUCFEkSKpAPgziJSsXM1GcNxMEWxq46TCIJ87dKr9IBPvA8epdTUie9M22fpyOkAasO9DUtCOmOvioNRgXx8y5OMYhelO3IglxtJzc1uSpZgla0NtTVinM526qr6aMsYOflZHaUYtS5DjK/uCj0eBVbGbB+utX9QBTRQs1opvdDAAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "45"
+    "gender_rate": -1,
+    "rarity": 45
   },
   {
-    "id": "234",
+    "id": 234,
+    "sortid": 234,
     "identifier": "stantler",
     "name": "Stantler",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAqFBMVEX///8xMTGthHPWnIRUU1IyMjLTmoLTmoM0NDI1NTU2NjZRUVHVm4NSUlLmtKT7+3HntaXu7awzMjIzMzJUVFLUm4OMa2OcUjnWnYTks6OrgnFTU1O8vJv8/HL//3OuhXNTUlPDYkGNbWSNbWWaUTjVmoIzMjGmfaRTUlHWnYXksqOrg3Ksg3JTUlKLamLu7qyykjH7+/u2lTL9/HL9/XH9/XP+/f26upoVnfDNAAAAAXRSTlMAQObYZgAAAPZJREFUeAHtz8dytDAQBODtGSTxi8DmvPs75xzs938zN+DyyUhcfNu+gKq+6pkZ9M8h//opoEp7OF+9XLTQxxqry6Mdpa9SIAynxTd8ekvDcr9P6eriaOMU2Y6fMMyczGcq7+yNXGMTR/d//hqB7FxpXZq4MV8endDbUvKP07tcCf3NcNLtVMzzdQI0jyH97/B4ca5MMzcrnHbCs8UVrxExgFVuKqZrNrCW+wfu2CRB8PBbkVxHy9GSg0NwXTslKyPQ0tSRMKT8fDyZqWw3rhQTnr3drHgHYGNLGthy0mwhJnR1AZJx+48ABAY/sHWR1nja1kP+KF+erw6uwI6EjgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "235",
+    "id": 235,
+    "sortid": 235,
     "identifier": "smeargle",
     "name": "Smeargle",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABoVBMVEX///81NTX3970xMTE2NjY3NjU5OTnLglHz87r19bz29Ls0NDP09LszMzI4NzY4ODg1MzJRUVFSUVFTU1JUVFNWVVRXV1WdVDqhiXGki3KmjXTJuZE1NDPLupLMg1LMu5PNu5LNvJPOhFLOvZTPh1Xw8bnx8bny8bkzMjHz8rn09Lo3Nzb19bsyMTE3NjY3NzVVVFJVVVRVVVVWVFNWVVM2NTNWVlRWVlVXVVQ2NjRanDFbnDFcnDKJuUKJu0GKukGMvEKZUTmaUTiaUzqbUjkxMTKdVDueVDqeVTqeVTyhiXAzMzM0MzKkjHM0MzOnj3WtrKyvr6/JgVDJgVHJuJAyMzDKgVHKglLKuZDKuZLLglA3NzfLupE4NjY0NDTMhFPMhVQ4ODfMvJLMvJPMvJTNg1LNhVU0NTEyMzHNvJTOhFEzMTHOvJQ1NTTPhlRSUlHPvpXSY3nTYnnw8LhSUlLx8LlTUVFTUlIxMjFTU1NUUlJUU1JUU1M2NDJUVFT29bz29rxVUlH7+vn7+/v8/Pz9+vn9/Pv9/Pz///+bUjqbVDtPq61uAAAAAXRSTlMAQObYZgAAAUBJREFUeAHt0TVzY1EMhmEdXQYz22tmXmbYMDMzMzMz51dnxkmR4tyJSxd+Wr3zNYLSUJaGohBGVIrKvF/VPPNmpojYdoYYfgd0P/Z7Cp1FxWfrOqDh//z6OwcAXApfZDQmyb+f/+eBCHFEFCXpHKfrshqTvydXgHRexCXp2+nBQPCTzwhUBs9CWEeYyvcfdtuvOo7XfKFQAqhId1AH5FFGx93Qda1ZWNQMLXut8FFFjNzc347rKwSfHqj4mNttbI5iBiOXsydgICxoIF5xbOZzbFlOfT/q/QLaclEr25W0bmweCqF6OZ+AnEIf7LfVAMluOzmmqkEWpVXjlEgteWfANqo0ujggW4h2U99g0soCvRz2+0cIcE3mHVWym1iWBTq+cOKdrmqO9QRe/Vq7B0g/OJagCHysJTkBFPTZ0lf2BNP6LM/McQ1TAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "236",
+    "id": 236,
+    "sortid": 236,
     "identifier": "tyrogue",
     "name": "Tyrogue",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA+VBMVEX////evdY5OTlTU1O9nM7bu9M1NTVSUlLbutM0NDSUe62VfK27msy8m80zMjMzMzM2NTfcu9U2Njb///+sejm6mssxMTHevtY2NjV7WhFTUlN5WRFRUVG+nM2+nc6+ns/CYmKSeavdvNWpeTlVU1ZVVVa6urpWVVS7m8w3NTQ1NTQyMjJSUVBSUVKReamSeao2NTV9WxOQeKncutLcu9R6WhFVVFPevdWSeqvDqyrfv9f5+fnFY2PZudHautE2NTbbutSUeq00MzOUfK0yMjDcvNTdu9Pdu9WWfa41NDWqeDireTesejdVVFX6+ff6+vr7+vn9/fytezkGnARdAAAAAXRSTlMAQObYZgAAANVJREFUeNrt0MUSwkAQBNBsdpd4AgGCu7u7u+v/fwx2z+RGUUWfX3XXDPPP12MzLDIeaYYFF+wqBMsq6PinIqJiASJJiSNEIGkPUvSOBhTGHCT+cpIfgOnFpimJjue8eSU7EPhtzxnGlKjQMR2kOSNYFgvmkHXTdYi4iWrAD48OSfLFQMmVTvIOlHaNq6RoeIomQF19FsNXTx+vPOadrF727+/nW4a7CMB2vhhw+Y4HjiKgMtBaCnqi1h5ldeCRVRvD5MaN+ccBOOHyeSH0kV6d+edX8gC5/hHCwlWfGgAAAABJRU5ErkJggg==",
-    "gender_rate": "0",
-    "rarity": "75"
+    "gender_rate": 0,
+    "rarity": 75
   },
   {
-    "id": "237",
+    "id": 237,
+    "sortid": 237,
     "identifier": "hitmontop",
     "name": "Hitmontop",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABMlBMVEX///8xMTHvtYxUU1I1NTU2NjY3NjY5OTlRitsyMzRSUlRSi9tSjN6MvfczMjGUc1rBkWnCkWnDkmrEkmrEk2vGlGvssorss4vutItSUlKRcVk0NDSVdFs4Nzc4ODgxMjNTU1NRUVFUVFTJysnpsYnrsopWVVOLu/SLvPYzMzL7+/uKuvOKu/SKu/ZRidgyMjGMvPSMvfZRi9uNvPWOvfVSUlGScVmTclqTc1qUclk2Njc2NziWc1qWdFw1MzRSi9zDkWo1NDJTUlFTU1LEk2zFk2vFlGvGlGo1NTRTVFfLy8vMzMzOzs45NzfqsorrsYo0MzNUjNzss4lVVFLstI3ts4rts4vttY1WU1LutIzutYzvtItWVFTvto35+fk1Njf8/f79/f7+/f3///+VdFqWdVtHc01fAAAAAXRSTlMAQObYZgAAAUVJREFUeNrtkLV2w0AURPetLGaWzExh5jjMzMz5/1/IOsdyEUk57tx4Gk1xNfNm0UB9VqJXrpnqWgD4B+TqfPBLsSbzEA9uKV0r1WWZjyXBUDqu4ItS/T0V3z47Br9fw6NE6e0zTAZBNVJIkh1b4aRceNErQA5lAMqYMsdl3sENIHQzlLfIXeHzfRdjSjC9KUnwoXPy38KhiVs8PcIDTXMCGSGYthJ5WH50WJZlMdf2pNz3fTMKZJuH+bw42VpCDChG1Xc/njEFkYk0HBxlEyih3VnePUk8xZTbQFFiX8g+Rqcs7+sC45Wqb6o3MWT7iVXKcR6/VdUj6/WADCurpef0vfIDvq549qW6cxIHIlabPys9uXhhVVtO65VjFCuW1jaNXXu9VNStDB0DBWhyzdreSDIhLIzCTIEOYdGXMqg3ZdFAfdcPh9Qe7vyoIF0AAAAASUVORK5CYII=",
-    "gender_rate": "0",
-    "rarity": "45"
+    "gender_rate": 0,
+    "rarity": 45
   },
   {
-    "id": "238",
+    "id": 238,
+    "sortid": 238,
     "identifier": "smoochum",
     "name": "Smoochum",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABF1BMVEX///81NTX//4y1WpwxMTFTUlKlizq0Wpu1Wps5OTnWhMbWhcbezmP7+4qzWZqmjTq1W5u2XJv7+/v+/otRUVE2NjatlGyulGyslGyzWpozMzHVg8XWg8RTU1JUVVPWw9XdzGLfz2ThSYHlSoPmSoT186v29qz8+Yz9/YozMTKqkWqhiTmjizk0NTWzW5w3NjZTUlE3Njc3NzY4ODg1NTNWVFS2XZzx8anx8ar08a03NTe1WZvWxdbZyWLby2IzMjPdzGNVVVQ9hHWxWZk0NDK2XJ3mS4WulW2vl200NDSljDmzWpv09Ku3WZr29a3UgcL6+/v7eKnVgsRWVVT7/IpXV1T8+or9+4v9/IzWhMX+/Y2yWJmyWJpl9QqfAAAAAXRSTlMAQObYZgAAANtJREFUeAHt0ddyhCAUxnE4sOuqy3YTjSZRE0t677333sv7P8fiC3C4dcb/9W/4BiBlqYpyrgkFnBeaa8nDvtQoHMyHGo6uCwBoL3N89wuKmmOo28yg2ccknfvs+uwb2jkqW77FMviVUg13nyzLbrG9eq6+N325DH6eb3oXrH4bqk4044fp4HShZ7PjKFJOr8VTr5P79qKcFuo3p+NnhmFsHLyLVaLM3HqbOKndf9SO0D+cTdLrJB3pzGDQa+w8Xo12/lYItu16d93GP+akdJzBtrtEdDIpJWWpaghJ0xb/B1E/EgAAAABJRU5ErkJggg==",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "239",
+    "id": 239,
+    "sortid": 239,
     "identifier": "elekid",
     "name": "Elekid",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA3lBMVEX///8xMTHvvRD35ylSUlJUU1DsuxHtuxEzMzA1NTX05ClRUVE0MzA5OTnz5ClUVFH25ijpuRE2NjY1MzA2NjXvvhP09KuujUHsuhD35yv7+/uEYhCEYxCFYxGFZBBUVFNVU1D25yjz86tVVE+FZRA5NzU0MjDruxM2NjQyMTDsvBDsvBPsvBTtuxBTUk/tvBDtvBJTU1DvvhDvvhIwMTHvvhc3NTA3NjA4NjT09Ko4ODj15Cj15SlVVVJXVlD25yxXVlKCYhD39qr396v5+fmCYhL8+vj9/Pv+/vv//fcgaG60AAAAAXRSTlMAQObYZgAAAORJREFUeAHtz8WOwzAQxnHPjMHhpNwuMzMzw77/C+1ODtvT1L1Wyiclvvz0l62azcwimNKtDtPp3JL1we4YhrtRjugBmIfg+vwBml4Yvty9vu0935wFYDQoiajoDamAyb2vLktaodPLCQwgpzQn+maNXnSJNXH/nigdMdzdFK9nrNFx/6hkTLjYluCoa2CAJdWu0NpeydInHK0Vn6kgM1DbldEnDvF4WcePDxrE98ytWePQ6ORjJ4mfxKTKKrfRqpxbaJ+raOvnQoAsW/zBofMqe9//vBXhf/j679/pBFwdnpU1+wX64hGd9IfsnwAAAABJRU5ErkJggg==",
-    "gender_rate": "2",
-    "rarity": "45"
+    "gender_rate": 2,
+    "rarity": 45
   },
   {
-    "id": "240",
+    "id": 240,
+    "sortid": 240,
     "identifier": "magby",
     "name": "Magby",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA1VBMVEX////tY2PvY2P3lJRSUlJVU1OvS1PcrGsxMTHuY2M0MjI2Njb//ntUUlIzMTGsS1LwZmT2k5M5OTk1NTX//3vExMzzkpL1k5PHx8/3lZX//f2sSlIzMjI2NTWvTVSvTVVRUVH6+nk0NDQyMTH5+fkzMzPZqWlTUVLrYWHrYmLsYmLsZGPtYmI3NzNUU1PuZGRUVFLwZGRUVFTzkZFVUVL0kpL1kpI3NzVVVFT2lJT3k5OrSlGrSlI4NjY4ODj8+vr8/Pz9/Xv+/HqtSlKuSlKuTFP///0zqt0cAAAAAXRSTlMAQObYZgAAANtJREFUeNrtkUWOA0EMRct2cXWnMZxhZggMM9z/SFNzAVe2kfJkefVkW/5izYrQWPvf0l6PsGN75FPeaUV0OSdKmS/3zwuKxLH8wJNHuqmi9n1keXH6QBGsorrHiQH6Q3TL7A7bA9THwz5hQhR3v2XpBwpSXrPz0bYXI8xTH68P8yz7dFBMUvHUY2POCpVr70e3ls9aSoUa8Aq7B4LD59eITsEb8Hda99OWTqOSE8+au18mywpEnGkI3Me742CMdHj+BA2fTYglt2CzsyHShPew/yqWIYharFkR/gC5XQ611ESwigAAAABJRU5ErkJggg==",
-    "gender_rate": "2",
-    "rarity": "45"
+    "gender_rate": 2,
+    "rarity": 45
   },
   {
-    "id": "241",
+    "id": 241,
+    "sortid": 241,
     "identifier": "miltank",
     "name": "Miltank",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAnFBMVEX///8xMTH3rb1SUlJzc3N1c3QyMjL3963Mg5pUU1NxcXFRUVF0c3NTUlPOhJz0q7v0rLv2rLw2NjYzMjLzq7rLgpo1NTU0MjP29az7+/s0NDT09KzMg5t1dXP3rrzDw8vOtVrOtlvOhZzOhZ3Ms1nExMxzc3TLsllTU1J0dHL29atycnLMs1rOhJr3rr5EbM2rq7r8/P7+/f3+/v6h2y04AAAAAXRSTlMAQObYZgAAAORJREFUeAHt0Td2AzEMBFABBMjNwasc5Jyzff+7eajG1YLq1Gjq/+ZhyMmJc87FsW61TlooosvfNcEmXCEOuYdNNhZd/ioijighp6zSqQP2tgNj5pScly3zz23PnBOROca1/PkNqT51IfNi9cFNJd5yJQqbnqOzIPpyF2l028EqBKodBncNeheGpFm12Ul8oLxlUxbbZQhhf4CGnE91E8LNElJxq/rxGxWNyF477CLcMgKz6u0lNu4O3+jp68GPjoEM109Zj0eq754FcIQSPV69D7M6q7PB/m9gpHTuHyX05LQ55w8uQw6WR+zgxwAAAABJRU5ErkJggg==",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "242",
+    "id": 242,
+    "sortid": 242,
     "identifier": "blissey",
     "name": "Blissey",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAkFBMVEX///8xMTH///9UVFTvhJz3rb1SUlKlxr27YnpTU1Ojw7qjxLumxr41NTW9Y3u9ZHzsgprsg5o2Njbzq7r2q7syMzP9/v3+/f1TUlL3rr40MjP0q7szMjJUUlNRUVFUU1P7+/v8/PylxLs0NDTnSyvug5vnSin7w8szMTL8xMy8ZHz9/Pz2q7r+xc2+ZX32rLz+Q5t8AAAAAXRSTlMAQObYZgAAAPlJREFUeNrt0MeSwjAQBFBrlBxwjmDAmLA5/P/fbds6rofyjQtdpdurVkveM49OIVayUu/WuFeddgLxvFiIe7AcTK+1Vns0o5qfV2S/39plx44oTnQp261jwzskC6VfoWeyQ4/rs/2ii0+bj8rdCZhjpuAKt+i5vny5hQJ97JMB9dXB9NzQhYNHv0qT6q5zECM/6acC6/qWNrbmHMmRCBJvVklnjFh2YUMyb4mkn9wOxj/bIKqXYTDKXCl1QC3uRRgZi7CBnN1Eg8gG3E9CmhEGIyaJQvaD5joZNWSsrQXrMpW8hfM4njkpBM7R+J35x7jiFc4VP/Pg/AHLbBI3/SIHZAAAAABJRU5ErkJggg==",
-    "gender_rate": "8",
-    "rarity": "30"
+    "gender_rate": 8,
+    "rarity": 30
   },
   {
-    "id": "243",
+    "id": 243,
+    "sortid": 243,
     "identifier": "raikou",
     "name": "Raikou",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA1VBMVEX///8xMTFSUlI0MzA1NTU2NjZKpcZRU1MyMzRTUlNTUlRTU1NUVFRx0/t6enp7e3t9fHmaWau6urq+vr7Mi9vOjN78xCn8xCr8/Pz/xil5eXkzMjNSVFRTUlEzMzOampqcWq2cnJxJo8O7u7szMjHLijjLittUU1HNi93OjDhRUVH7wyn7+/s0NDRy0/xy1f79/f1z1v////9Ko8RKpMTNjDsyMjLOjDmjKTF6e3xLpcW9vLq9vb18fHz9xSv9+/tMpsb+xSn+/fsxMjP/xiz//vvMizmCEog5AAAAAXRSTlMAQObYZgAAAWRJREFUeNrtk8dywkAQRJlRzhLKBAMiZ4Rzzv7/T/KswAdRi8EH3+gqaapWb7tnpFXlpD9LhOM4aRDWj7IbhCGRh+3q3igMdfgFgW2u7o30YL+nNFvPAah6WhDqgQ57/Wa+kRDrad6orSGzFLlgDRET36B70NYClg2WygMntuMgtjodg4YpppGypUpJu2DL2QiJo2jWRaYs1LKrCFBD5vjVRI8ojFxMXpRzBRd5CZQslRliNH7zDbYjTl0ES3638nyHzBTbweTjc702bYbFqcC2A9BVcpRvHbx5NmlwMyIqTd0rWi6yyqNU7+RlTmp0jYj8GCtsnux+FrP7eLGUFcaRhowmkvcaEbvGooF2PO5NBYBpOu5xwf51M5lPiKNIEVgzl/dnnEPIDICKGw+hWKiu/NWcc3L8J4HVKU27bSXxOYYSVNl2sf9Kw/4sAf+QQZH3QMaHJXH64mnTFxz3P0PlpP/VN+jpIOYq4+MTAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "244",
+    "id": 244,
+    "sortid": 244,
     "identifier": "entei",
     "name": "Entei",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA81BMVEX///9SUlIxMTFTUlGcY0KaxMScxsZUUlKMnKU1NTU2NjZTU1TDeUnDy9PEekrE7PTFeknGe0rGzdPGztbG7/f39yn/WlLEzNMzMzO0QkO2QkJTU1MzMzQyMTFTUVHEzNRUVFHFzdXF7vZ8fIWLmqMyMzOaYkHNlDPOlDHOlTDz8ymaYkL8WVL9WVEzMjF7e4SLm6SMm6M0NDBTVFRSU1MyMjKbY0NUVFJ5eYKdZEI0MTHLkjHMkjHMlDLNkzG1QkK1Q0G1RETs02Lt1GJTU1H09Cn19Sn29Sm2RET39yz7WVH7+/uKmqP8WlJRUVH9/PzD7PPAkVe1AAAAAXRSTlMAQObYZgAAAVJJREFUeAHt0MVuAzEQBuAd28tZhjAzpCkzM7fv/zSdzUpVpYzVU24Z+fjp98yvbGYNYzF8/yvFmuyy11OmmPjkHtUkac0qDbX/HdfimEnd+CkZ3wM8tLw41jooGQ3PHhOkCWK1o2ko97yaJDJTo9F1Q9WqoFbBi2uKRbi3F1ThzTytNKBo41M7uCpbdVEUdctfz1fzNNV7i6axD+Bp2ip0omEY2bM0rSDVe8Ziu22rfeIe0xmOwqj7keoA0DsUgoOq9albHPs8hy6fCj8IAqD7sT6nvNgtz3U3ENwNstmi2ymIy9CGGcIgg8KnIcrB3dHtCRqEUz9LlUfuXIR2BlHWGSsEok7L4yZ2uZScLbcGyTVQLDklDMr/tAZCkJHmgGeFmAXuLgPN97ZxQLg84O+PlqRHx2iXcodQPr8BmOxzQhIlCeETBRIbUDfQGzBlbbOZHxhsIemRU0zpAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "245",
+    "id": 245,
+    "sortid": 245,
     "identifier": "suicune",
     "name": "Suicune",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAtFBMVEX///8xMTFSUlJSra1anM6Mzv+cWq3G1t7///9rQpR71s4pa2uaWaubWaxSU1MyMTLE09sxMjNsQpV51MwxMTIxMjKUvb1TUlNZmss5lJSycdOzctS0ctW1c9Y2NjbE1d1cnc5qQpJRq6tSUVN508syMzQzMzOKy/uLzPyLzf6Mzv5SVFM0NDQ1NTVTUlRTVFRTra1UVFQqbGxZmszD1NwpbGxbnM46lZTeSlJRU1P8/f78/Pw/SNpdAAAAAXRSTlMAQObYZgAAATxJREFUeNrt0cV2xDAMBdBIxvAwY5mZ+///1acUFhM3PbPobnSOnSyun+Qk2tU2tSCi75dGd5CovpDLydyWTe6uq/oTW9KkE+dlg3tOu6rIZldZPJ13IGWEgNsbp91EFevcxlNrbRz3iLIy6NKHmyKDyK1ssuLeBiMi9Qg3fs2spElvULhNmLDCgHBVVD6reOBGpDhVcLyuOg45s7LgalKcSpJzaT080QW33BHVGRGcT7lK3G+dGcj3i7pzjsfpi9dGALIA33zdLdyAB947OG+01ktxtxQFIJFHDQwS8Vydwt3rdghGoMwOzjH7lV5et57qMKJqY83ijGaHC480IoNFBqN6lgsRoQ1oO+wMRgV0hr4mGoUhgrBr4/QnpGNz+KurgunnJzQ4fHvAhsLxjRPNJfAvt20gRtjV/9UHYMQUuGMZapAAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "246",
+    "id": 246,
+    "sortid": 246,
     "identifier": "larvitar",
     "name": "Larvitar",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAQlBMVEX///8xMTGExmtSUlKt72trjGPGztbeUkqtQjk2Njar7GrW/5ys7WsxMjGs7msyMzEzNDKCw2rT+5o0NTM1NTX///+1jk63AAAAAXRSTlMAQObYZgAAAI1JREFUeNrtzEsSglAQQ1E7SQOCit/9b9Uw0GG/N6WKVIan7unYfvaOPnd+au2DM9Yu97j1wZjRBYPqgi9BUlvel8Xu0pQhQ4hUE8ouPnQySghLToZqRCNTAjeeea2KhKWtJaKABAnDTdOwSo7jxijZVTKn0U5gROkGxGQImNXF8BPIP6y7w8+1u8d2sy93vQNy/fvvnQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "247",
+    "id": 247,
+    "sortid": 247,
     "identifier": "pupitar",
     "name": "Pupitar",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAY1BMVEX///9TU1Sjq9OlrdbGzv97e4wzMzRSUlLFzf4xMTE2NjZ8fI17e42krNR5eYoyMjLb2/t6eove3v+rGCHDy/vEzPzEzP1RUVE1NTUyMjPb2/zc3P3d3f9UVFT8/Pz9+/v////n8kKSAAAAAXRSTlMAQObYZgAAAKlJREFUeNrt0kcSwyAMBVALiY4Ddirp9z9lhCfZKmyT8R8WLN586rDmZxJ8lxpCMT1uZwqB910w6ovhmayDchQPyJ1lJiO4o3KIydrzTFiFwtNmbGxPhFjllT8Mk85egqBctFYhx12NABkAu6RHrFIj77FR7oSFiZXJbh83Ls0yhGmE+5OhI/Pt3AraWF5Gvkl2CG8mnUc3aqfcITnZ93xchbX7j6/5w7wAAjUG3o5MckkAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "248",
+    "id": 248,
+    "sortid": 248,
     "identifier": "tyranitar",
     "name": "Tyranitar",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAjVBMVEX///8xMTGExms2NjZSUlJSU1JrjGODxWoyMzGr7Gqs7mut72v7+/tTVFKDxGptjWWCw2psjWODxGwxMjGr7WpjSs5qi2JrY86Fxm01NTU0NDR6et17e96r7GxjS85kTMxqimJUVFT8/PxxcXGbo/6bpP5SUVNRUVFqYstzdHJ5edt6ettqYsz8/fz9/vwl8nI6AAAAAXRSTlMAQObYZgAAARJJREFUeNrtk8duxDAMRENaorp7y/aS3v7/80LlGFi2L3vb0UEA8TAkOODDXTdRBrAOM06v4YxjLlv0fDQOpQCjl/xKi9Q6FwBgoTFa55BEjnqhsXM/RRtRgHmwavzIppVCPQeeFENRSM38jK+XgtpIBqMB0o5QyhztuzBVi4g6yZUYOceqiFSSy/wo+/bY7V0Qce+5Tqbsz+a4fT7UNsR9/nEZlydIgI9heDrsUbIl6piAno4ze9vudt2LCb2i7w1AaQNMclfxNXRdLXN5OYucFKKdNiyl+OxqZEJy3vzraUNfkBC9ksyg7JmG1ML9yOHBSSGRkn0D6TtgxQmIUfEPS81AzaoL8xu/WXez/O66jX4Bm/8N339HaBEAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "249",
+    "id": 249,
+    "sortid": 249,
     "identifier": "lugia",
     "name": "Lugia",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAn1BMVEX///8xMTEyMjM0NDQ2NjZUVFStrc6urs7O1uf9/f5ZcfsxMjTL0+RSjOf8/Pz+/v7///+rq8v7+/tRUVE1NTWrq8yrrM6srMwzMzNTU1NTVFTM0+TN1eZSUlJSUlRcdf/8/P38/P/8/f5zpe97e419fY1Zcv1ac/9EVL1ypO5zpe5EVL51pu95eYp6e41BUbpRUlNTjedRiuSrq81CUr56JUVAAAAAAXRSTlMAQObYZgAAAVBJREFUeAHl0+dywyAMAOAKMMMYB5Mmzd7de7z/s1VQJ1dMG/K75U/O8neSkOKzP3kYnOicpXBKOie4sjTnzl1RC2UFyXSEEBm6XEcIrT/0R1jUtANTx6BR8QuUKfTRy1X8gsWQQbgE87DTu5eCALRPpS51cBc4C0W/w35dzOs2KQp58076NaJOS6xcIMMY7OdvbdE6QWLo3f2V3gea2cRHkoQfq9YxOPSSOoRD5d21Bij1161dYAXEAyvXwS0GfDYBfNTgAptHDqGvs1wvh3zWw2LPL6EsRU3TlQricJAVQit2YR9hTKMOfFwJJUi7IqFCc6zqyS5EIEdwWKbFlXBSSSk5+eUPypq7zYPZIJV8PI1d7KvX260xflq2GPAM3JonfxsxHpAjn09IuZj2LNaF4x/kmzEoZVo3oc1uDgBNVrJKjsJPPuV+ojQDI/+/zyf1TxqZQk3tswAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "250",
+    "id": 250,
+    "sortid": 250,
     "identifier": "ho-oh",
     "name": "Ho-Oh",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABBVBMVEX///8xMTFSUlL///82NjaVazCVbDDGxsbOSjnkcmLkminlmynmcmLnc2PnnSn15SlUUlL25Sk0NDT+/PxlsyJltiR5eauSajGS80k0MzAyMjKVbTStOTnDw8PExMTGxMMyNDHMSzhRUVHOTDzkcWIzMjBSUlPldWJSU1FTUVFTUlHndGLndWXnnClTU1Pz5Cn05CkzMjFisiH35yn7+/v8/fv+/PtUU1H+/v5UVFQ1NTVktSNTVFGV90yampqcnJydnZ3mdGQyMTEzMTF6eqvExcPFxcV7e61UVFHLSTjMSjkxMzDNSTn8/PzNSjj9+/v9/Pv9/f3NSzvNTDn+/vuUazHOTDiYkb47AAAAAXRSTlMAQObYZgAAAXBJREFUeAHd1NVu6zAYwPEYwtyUmZm5PXzGzHv/R5ltdZoaW2q0y/qivcgvfzmfo0jHuTCI6CJKnG7ZkyhuuuhrJ98O8pvZThc1a8K7dDkM0y1NAOvBr3IYvgigtK0HiZv9e+c1HvJJHmIAAIPacl/i6dnzl8SgeodixNa1MJRwgUKwy6Oc+5p7RBudwJgkhZOd8SxDKE4R5Sqmr3R1vkhkGxq+YjYkTP7cmeI6K+I4SOSIXpS7wJBNmQYvmUMxbmYjh5TeLc+Q38yB3IXEiYJsb8q9ZdtEmiuo28zRefPS8Hse1ONtY8WYuEdhVfeKQz1e6UB9534CIRz18g/9eEXrsOASJdrjjNA5fs/24LUVoFr+tvSDzksMZ04DXJX+2QFC6hBCY9AAYkfOBf8+XyNEYcoUMjrHDP2d/6VSVdeb1H9JvPDu0WFRVf88odCRcDp50YQAFNaHYTaZZW/aBhz6sIDPMi+F5eZpNgpk5eNdH/N2K6GH3K+zAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "251",
+    "id": 251,
+    "sortid": 251,
     "identifier": "celebi",
     "name": "Celebi",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAArlBMVEX///8xMTHn973k9Lvm9rs1NTU2NjZRUVFSUlJSU1RTVFJUVFNZgzlZsvNahDl6tDl7tTmS80mS9EqT9Um703K71HK91nO91nTk87oyMzEyNDEzNDMzMzJbhTlcbVtcbVxctvd5sjh6szkyMzNTVFF7tjl8tjsxMzRbbFpUVFSU90qr2+St3ue603FZallSUlEpY6tZs/Vaa1pabFzk9bpSU1Fatff8/Pz8/f7///9DIyGnAAAAAXRSTlMAQObYZgAAAKhJREFUeNrt0kUOw0AMBdDaE2bmNmVm7v0vVjcHqLOO8kea1dNffHnQp2tRoPl5Z69+2C/aOLD1YJEz8GAAPPVgS5CRqjDpLUO2MkM0BSKm1V8nk2uSSiVbSJWa4BqVoyD3+mwEFTKQ3PhdxxUAs480Ol9usbHbz7glk/WVd82SUTJ0ThrrstSYes4dS2CkDKrleo9IwpIt9eeWmwO0uclJWLQ+3z6dyxcn0Auq1RFMYQAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "45"
+    "gender_rate": -1,
+    "rarity": 45
   },
   {
-    "id": "252",
+    "id": 252,
+    "sortid": 252,
     "identifier": "treecko",
     "name": "Treecko",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAALVBMVEUAAAD///8xMTFBi0pSUlJapEpaxWJzvUGk3jm0UmrVvVrmWmrui5T25in///+0wX9yAAAAAnRSTlMAAHaTzTgAAAC2SURBVHja7dS7DsMgDIXh9Mcnhlz6/o9bJ0TKFCdDhw49YmD4MCAjhtfD/OHX4XAEhjMJxB24h9RaYvAAqkZuIdMOPYVwQGdyriG+QUW5t60pVIEa8ZVVGTTJggXtDi7PiCyY5nl31bi8NSDNTUAsKU7WmSaZvIaDtIXL7GYA5J1pS0j6nAyGa94rjoWsYtuglTLGuIaYhSuCYGOyNS4DiQEgvQxh5OL2hfee1Dt4lu35fyk/Dz94ZgkXANKoAQAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "253",
+    "id": 253,
+    "sortid": 253,
     "identifier": "grovyle",
     "name": "Grovyle",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAilBMVEX///8xMTFKnFIxMzI1NTVKnDkxMjFSUlJSU1JqxHprxntKmlJJmlFJmzlJmjg2NjY4ajhRUVFRU1I5azlBeUFqw3lCe0JqxXqrSVHnUlpsxHpTUVJCfEJKmjmtSlJLmlLz8yk0NDBUUlKrSlKrS1JRU1HkUVnkUlnkU1nmUVk5ajnnVFltxnn09iro+jNKAAAAAXRSTlMAQObYZgAAAQRJREFUeNrtksluwzAMREtKlix5ifcle5d07///XkeCb5Xi3nLJQIAt4mFID/1w1021IfofViaJWkdlVyTQOirLiyZytLreOG+MFejfDYW6xvXWSeCtGwblR45xPDpwITFEyFeC2xtx/nakb+9cgyDsfh7PX1uAkCSi6IjM/D5vWa2mPX3M83w8sc9Rhh19WdZvIJ8yBoodqaAd6pQDeAWpEWetYyPW2Sic67Qz1qb6kEQcK+r3ChzVJjXpIbl4xz+p44rjfV922qRaZ8oVoTJsnHOTcfN8Gm1KVLVtEfs/JD5oOroxufls23jq4HzHHhHFqCXP5VkFoOA+eRSBenhTd91UvzHYDdb70tY1AAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "254",
+    "id": 254,
+    "sortid": 254,
     "identifier": "sceptile",
     "name": "Sceptile",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAllBMVEX///9zxnNKnFIxMTEyMzKc55RKmlKa5ZJCa0IxMjFyxHJSUlJJmlFSU1JyxXJRU1JTVFNJm1Ga5JI1NTU2NjZxw3FRUlF0xHJCbELnUlpLmlKb5pNRUVGtSlLkUVk0MzDnVFn05ClCakJLnVOsS1JzxHJMmlLkUlnkU1nlU1pDakLnU1lUUlLz5Ck0MjH15yr8q1L8rVKGydh2AAAAAXRSTlMAQObYZgAAASpJREFUeAHtkVl2qzAQROluCQmBLAbPs9/LPGf/m0vh5CQfGMQCXD5GP5cruisZnWumMpKrSeFoROIgZyK11irGEbHRWlMcbDmCdwRHN7dx4UaTPx0Xw8KkwRD6/fB6XKjIzDM2RJ/PdxEhlLJfrVa7dTgdIq3gv9+tOXy8Dd+s2uc2nXAQGfAJwKkUtpoQRj/83NB5ZVrYeZoVaHBGy7nzKFLhXe9UV3kuup2dLcjUlM7jQPedNaqZwlHwhK1jU+Z5nobcUdeJHz4Bn0gcYNvoEpiXyzNtHSEebcIILE+zyyta3i+IHl/qsi7PWJCkB6weUM7TPMXlwLq+vy1VzHxe5rLCFvq47b/KCoKRQEl/i1hN9m3GOZDmt7KmsJLEA6P5b9QosnVfMz5fFV4ReaCOJo8AAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "255",
+    "id": 255,
+    "sortid": 255,
     "identifier": "torchic",
     "name": "Torchic",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX////WY0LnpUExMTHWY0HUYkL/3inzkin3lCk0MzCFSkIyMTH2kykzMjEzMzE2Njb72yn+3ClUUlEzMTGCSUGESkL+3SnTYkHk02rWZEHWZEI0MjDm1GqFS0Hn1muFS0L1kimFTEKyijH3lSw0NDT7+/v82yn92ylUU1E1NTX+/fs2NjV4GNSTAAAAAXRSTlMAQObYZgAAAJ9JREFUeNrt0McSwiAQgGFgqWmQSqyxa/T9308uubJcdfKfv5ktZO2nmgESlCXWSZPgnHGSlZAApWSDNEkw0BJjoOpNzV6AOaU1LzgtDnnUfZRe2sX/d78ukLfxDT0tkqDfH88n/b4pTtv4MZcgRQMecUF2vaCh5mEQ6NiW1mxI+HgnaPaUbMpJwvCsFy1Bm8fK0yzHoQVixwpli137u757/AjXkMd6igAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "256",
+    "id": 256,
+    "sortid": 256,
     "identifier": "combusken",
     "name": "Combusken",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAALVBMVEUAAAD///8xMTFSUlKDUkGUakGUg3usUkHFvbTVpFLmakHmxWr/i0H/7oP///9qSEzwAAAAAnRSTlMAAHaTzTgAAADESURBVHgB7dPRaoRADEBRva7GjIn//7lNVhf6EtM+t5cBFQ6SYXSaf9gfh9O3gM/tA2TCjB5iWEDooVguo4NirmaDfkY/VoNuRvAoWAPxKxqI/wrq2sMjnAx/hGRLwDPgQQlZVXUxE0dDP8A9JeL3mNQQYMbvDqCYcYrQz74vW+/6EJdEy5sq5cnoS8Q1DKyuZwUReY0h+VpmOPcappSRi4mznPEtYWTEU32E20aCdM1nxnVZtgbesW87Lczqv7DpHzZ9ARzbDITOMcegAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "257",
+    "id": 257,
+    "sortid": 257,
     "identifier": "blaziken",
     "name": "Blaziken",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAKlBMVEUAAAD///8xMTFSUlJSg96UQUGci4PFUjnFnBjFvaTVxXv/c1L/zUH//8UqquZDAAAAAnRSTlMAAHaTzTgAAAD2SURBVHgB5dBRbsMwDAPQjJysWLLvf93RBoIBS9Xlv0xR/zzQBo+vh/lweKzguOcVRF4SeAaRDyCU7Wq4JeZk2sR/kMu5Tcn30IOZFlMS76DndmaSgRqqUs5df1NBCSHo9j1UGtf1dwjAaWkDI52xaeAO0XvrbVUOkmEtoq3SvxBiJNZC9N1skq8gOhvWOxkq9MxkBF9drRwKYm9jzCaJYp7txpbB3ohyRzjTtaKrsvXei0a4Ymt0fez6amhuhmWTQKsaJU87cUi6p87qjZKnIpE+fIi9hVjnWCkblb3mJc+BEl5eSKkbfyUHBh/AA1i/G6zz0fAHFo8NSF0EEgoAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "258",
+    "id": 258,
+    "sortid": 258,
     "identifier": "mudkip",
     "name": "Mudkip",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///+M1v8xMzNKhM5Ss+RStecxMTH3hDEyMzNLhc5RUVFRUlNRtOZSUlJSU1QyMzRSteY1NTVUUlF7pdZ7xt6K0/uL1f42NjaN1v+r2+yu3u/OWhhJgsv7+/v9/v////95w9t6o9N6xN2t3u9RsuTLWRjMWRhTUlHzgjH0hDN9xt5Ts+P8/PyL0/z+/Ps0NDT2gzBKg8yr3O6s3e6N1PsyMjP1hTSunj50AAAAAXRSTlMAQObYZgAAAMBJREFUeNrtkskOgjAURX2UtswzyIyKiDjP//9pFveFLlwRTtKki5P70tu3mJkeSyLohVgS81Tj3yJGOhHwcmQgXZZGXsXyQDXQJgoUdi+qK0dzyTYCwOxAoJAirRWOt/fOZQw92DJPqe+/eYOblx0ClDHusjbxn/zE7NiPtcMPpdRLBhJJczk4EeCOZq25/nlctaiqVNV3N0+WyHCR2r1v0pTHftzNHzWrkpU+Jq4cSZOxRcj4OjI5UIR3d2Z6fAEL6A1a1SKd0gAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "259",
+    "id": 259,
+    "sortid": 259,
     "identifier": "marshtomp",
     "name": "Marshtomp",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAulBMVEX///8xMTFKta01NTVJsqsxMjJRe3NSUlJr3saM/95RU1O93tYxMzJSe3NqcoNq3cVLs6uL/t1ReXG9c1r0e1v3e1pLtq1TfHS73NRKtKzUVET0e1qN/NtRUVFq28Nq3MQ2NjbWUkJrc4RSVFSK+9szMTGL/NuL/NxSfHSM/t1TenI0MjGN/96SODGVOjG7dFu729NqcYK73dUyMTE2NjVLta1SVFPzeVkyNDNSenL2eln2elps28P9//4mbOLNAAAAAXRSTlMAQObYZgAAAOFJREFUeAHt0rduxDAQBNDbZVhSgToFXc53zjnn//8tr9yLVGHAMKBp2DzMFNxBnz+OAIBO7o4cQVfo1C9WCuhWuZGRIwrDzSrf07EdRRBwh69L28ScKq8rTl4P1jI2mPjcS72YLaxlPKrqC5+8Gma5yWefWG23R77tx2ISn/Euw3dv5UAsb2POOJ1fPzS/3uok6un9OJ3qVPEX7Xaqxa3M89skjp8QM0yWjgjaT0zefJRD1GuDETlubB+v6vpH5nbv/UhRzMvyfI2aAkckpFYgM4x4FwJ3xhiT5g2H0b9Jn2/YChA8J3l91QAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "260",
+    "id": 260,
+    "sortid": 260,
     "identifier": "swampert",
     "name": "Swampert",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAulBMVEX///8xMTFSUlJSU1RapeeDzPyEzv9Kc61Zo+Q1NTVKdK5RUVGDzf6tvb3WY0LnhDn2pDkxMjJSU1NcpORicppjc5x6k7R7lLWCy/sxMjODzP2Dzf02NjY0MjGFzPuru7xUUlHTYkHUZERJcavkgjjkgznkhDtZpOb1pTxRUlP3pTmrurp5krJ6krNUU1FMcqtSUlNMc6syMjNicZrlhTzmgzlTU1PnhTz0pTtic532ozkyMzSFzfv8/f7lANmjAAAAAXRSTlMAQObYZgAAAUlJREFUeNrt08eSgzAMBuBIbtRAek9IJWR77+//WvsDe8NJOOwxGgZrhm9kyYwbl6gdLlEtN33qt6nMiE7C63a3VSa9/uMZ2IN0sd5TXYjaZ2DpkJyaupD+DWCxt0vHoROIwpUt4G0/Rd8JNCAzChYQS9Utmwmr3CktRelscEo+bzuB/Hmba63lqICW2afLZjNRWnutzVyvkFMJUbJSkYYa8Qz3EkfxYZa7nnUc11cygF19Hm4xTx8QTdrgOlNwXsbbmB2BQ7I0CUab6KFFtF4MJoK1kMIRbPlBrrODy5OrcDBBYZZSfqDHijOpwKR5xTActNWeIQVTdWMHDod+Z8wifFX7g2aTsaVF0HycVBp8V/L9W3OUdP8KVvuUiBENvbE3ZhPFs6OXCxVHWHz1NUSLuw6dvodY8JgU5etcS8JBYOo6EtG4xP/GL0XCHdpU0wKsAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "261",
+    "id": 261,
+    "sortid": 261,
     "identifier": "poochyena",
     "name": "Poochyena",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAWlBMVEX///8xMTHExMzGxs5RUVFSUlJra2ulpa0zMzM1NTVra2yjo6tTU1NqampsbGzDw8ukpKs2NjbzYlEyMjLFxc2mQjFtbWltbW1rampUU1DduxCkQjH39Cn9/f13mSF4AAAAAXRSTlMAQObYZgAAAK9JREFUeNrtkkcOwzAMBENSzSru6cn/vxkSgnOj4LPhOQngaFcEdDk5FB3sFYfA8i7RL8CyMLWuTAYpFwxyHMIQ1MAUHf5FogCaWByDxP2QVsoYFM+w+H49kRUi8n5RHjhfHxbmz82hj0j9yKZeXJFANlcKavX4vVeNRQB1GYAicZUtTg0Vs8eMuUDLTBGl1gEYEfVEay1SBpDdGqJMTYoW2l+pTjvp3IHSqaSeHJEfrlcGvgM9zRMAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "262",
+    "id": 262,
+    "sortid": 262,
     "identifier": "mightyena",
     "name": "Mightyena",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAV1BMVEX///8xMTFSUlJTU1PGxs7ExMx6enp7e3ulpa0yMjI1NTXDw8szMzN8fHyjo6tRUVHFxc18fHnzYlE2NjakpKzFw8ulRDPGxst5eXmmQjH19Cn29iv39Cm2vq00AAAAAXRSTlMAQObYZgAAAOFJREFUeNrtkMduxEAMQ5eSprpsSS///52h7CySACPkmgBLzEXQM2nqcNOf0R34xpuf03MD34Dj5ovmJLlIbgOwO9in+XMorjFXGjn7BjaMORFMprhGD+18Ick0qWAfWSS6xmRLSboqdj9BCJIz0ywAtiotNEyPr09O5uISBJzZfHk/J+X5XDk4zuXlweztXMS5tdYTaw0t+9bFqkreOLMa1O7AtNxXkuQqv9nqB6wjJ9Kl4UhnRBy3KzOXBv4JS0XZPCTLJoL7lOYAPCYleD1gZ+kw2vs495uCxND2cNN/0gcuNAn+4QKvbQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "127"
+    "gender_rate": 4,
+    "rarity": 127
   },
   {
-    "id": "263",
+    "id": 263,
+    "sortid": 263,
     "identifier": "zigzagoon",
     "name": "Zigzagoon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAb1BMVEX///8xMTEyMTEzMzM1NTVSUlJTUlKEa1qjimqji2qljGvMu6vOva3v597t5dxUVFSki2qDalkyMjGFbFvs5Nvt5dtRUVHu5t2FbFy6urLLuqs2NjaCalnOvq5TUlAzMzJTU1OljGyzUgn7+/v8/Pw1U+QnAAAAAXRSTlMAQObYZgAAAL1JREFUeNrt0EcOAyEQBMBhyXFzcI7/f6MHLj54x36AtyXEgVJLDWzZAnBgv9/LGThtQOD7UrGB4x05Y4Qznen2IfRNinyyKUZOQS2l76W0zqVYW5c4W4fHxmlkCiVC2fp5tVIYh1E2H63HWLfVeqGYsKlYPy96RAdAQZmpGuKifQgXyhmn5LPO0vdae3RUIa64ny26EK6yrUiIm/Pe0ljtbh2QkiHN/5PXijKYpoxN/r3iq32cPhzVClv+PC9kHwogafjKjQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "264",
+    "id": 264,
+    "sortid": 264,
     "identifier": "linoone",
     "name": "Linoone",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAflBMVEX///+Ue1r35+8xMTHFpJPGppXOxs7z5Oz25e01NTV7e3t8fHySeVmSelkyMjKVfFzDo5IzMzPGpZQ0MzPNxc1UVFR5eXk2Njb05Oz15ezMxMwyMjEzMjLNxMx7e3r9/PxTU1NTjM3Eo5LEpJMxMjNRUVH15e1TUlLLw8uUfFv3NwODAAAAAXRSTlMAQObYZgAAAMpJREFUeNrt0kkOwyAMBdBgBwhpxmZOOs+9/wVrqKpuoGUbKV+s0JP5lgiWzC0dInq5IgKo/jtFTpSBH4TK6+lk8JIdFmwAvnGDt0IJnCDkk8vJKlCkgJwTGgcNSn5IGWXQ2gn5mrF736QsjH44JTnTDpoezOsOqApiYfQpmLOwXmVWmHyYdkLHCpXMw0iINTPZitVIp7RCgHxPe+zOtRmGLTkbbG/8eLmeaj3rOSHdoGNpfLyLxXH2JQ6K2Maj1/+iqn7ONFsyp7wAsBIKd+lGQwgAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "265",
+    "id": 265,
+    "sortid": 265,
     "identifier": "wurmple",
     "name": "Wurmple",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABO1BMVEX///81NTU2NjbvWmPvW2SRkXkzMjLz83mVlXyWln3t7cw0NDIzMTE0NDSSkno4ODbvXGPv787ExKOTk3qUlHszMzE2NjXFwqPFxaQyMTHGxqXHkkPtWWLtWmHuXWPuXmPGxqQ2NTW+Slo5OTn08Xn+tKTs7Mu9Slo0MzM0NTLtW2PtXGTtXWTtXWW+TFzuW2LuW2TBwaE1MTLu7s03NzU3NzY3NzfGlULy8njz8Xnz8ng4NTY2NjO+TFtWUlLtWmM3NjdUVFTFw6M3NzNVVVE2NTS8Slk0MTHHlET09Hr19Hn19Xv19Xz2iYP2ioL2i4P28nrHlUPp6cmWlHuWlnw4ODg1NDPrWGLr68rsWWLsW2P29Xr29n33i4T4+Pj5+fn6+vn7sqP7s6L8saL8sqL9sqP+saP+s6PsW2RyOW7VAAAAAXRSTlMAQObYZgAAAOFJREFUeAFjGH5gFDCGEakuMV2DKIUOKbFshE0TZVBM8mcxIqyQ3dktlYVZSRLINsGv0EuAGQh4QExuPGoZLQP1ZYFKgXZbs7toenLjUigWLmPvYSXPrMTGExlgHs3Oj8tA4QzbYG9udgFmuygWZmkLfpw2q3FwCcbYqMixMPupssi443RiaJCCsSCXj5yvKgtzso66K25fK7NGcClwiGinsWjpiXPE8+JRyaTIKiIhpGvgJMXJZ8qEN9DNDCVChIU4+RJ4CUROnCMrWBkjE36FyoyMTKwIZQQUizGN5Aw5CgDuJRmC+1JzDAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "266",
+    "id": 266,
+    "sortid": 266,
     "identifier": "silcoon",
     "name": "Silcoon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAt1BMVEX///+1xs6zxMz///+MlJQzMzO0xc01NTW2xs79/f02NjaLk5PN3d37+/s2Nzf9/v7+/v7+//+NlZU3Nze2yNDJ2dnL29s5OTnO3t6wwcn8/f2yw8tUVFSKkpIxMTFVVVWxwcmzxc1VVlaJkZEyMjK2x843ODi5SVi9S1uMk5M0NDTM3NyNlJRSUlLsYmnsY2r5+fn6+/v7+fqOlpf7/Pz8/PyPl5f9+/tTU1NUUlKxwsqywso1MjLtdRByAAAAAXRSTlMAQObYZgAAAONJREFUeNrt0MduAjEUheG5xXWKZ4YaWgqkQnov7/9c8QiURcIlrBH/wgvrk3XkZN8OZrZ1XfUvUSs4iW2Ed14lZsE6EFkVqZG46ZyqvKLIIDQ0v5Lg2JEN5BrK7GiTqxrUnDZYnkkwd+2SYgAhygyUAFu5jcBVBKUlqrUETXfQLp9Jv1b8FKAPrEWoB/RyzxcPjzpjDfLETj13xF837wgQYS39YnE51ln/5Px2hID1Z4pg1j94gG8fxwCHIwBM8cx7xLUjez42HSLCENOWX978ZT96cn1U/AbCgiLZqp5J9u1m39LdDdByGhYzAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "267",
+    "id": 267,
+    "sortid": 267,
     "identifier": "beautifly",
     "name": "Beautifly",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABC1BMVEX///9zc3M1NTVycnJSUlL///8xMTEyMjJTU1NxcXE5OTl1dHL/vTk2Njb8uzn8/Pw0NDT9vDn8/f+7u7u5ubm7kkJVVVW7k0JMbc50c3K+lEHT09PW1tbtc2v7+/u8vLxUVFRRUVF1dXUzMzP//v90dHRxcnM0MzEzMjFJo/tyc3JydHVJpP1Ka8x0dHJKbM91c3NKpPxLo/12c3J2dnZ3d3dLpPu6uro2NjVMpv9No/q7u727vL5Npv+9vb1Opv3PYkTQ0NDR0dHS0tJQp//T1NXV1dUxMjXpcWnqcWrtcmtRU1bvc2v7ujg3NzdTU1E4ODj8/P42NTVJasv9/v/+/v5ZWVlwcHBJovufU7cRAAAAAXRSTlMAQObYZgAAASpJREFUeAHt0NVuAzEQBVDPGJY3zLxJyszMzNz+/5d0oq7yZK8itX3Lle7Iko80ltk4/xdUv4Ga+6JKttgpTMWOmgQdKJHEZBfDR6WGe1GZOH7aggNYMbv3fX9SCx8GTAyZBxBqJaaiPkvJ9OBIjDEgqYHY7K2npHzrpcl50LirELSYBr4+SynP5rL1LjmAhhFOZ6XczpbPD2xeytALQ4+cDp403+X+5fzupl3I+NVK6HuW6Xdq9cPy1167kKkuQIILMJ9rtYrCAUpYrRjcE9Xt9KPTli3EBAfgeoisiDSP62tc8OXFW6HSzAA/qMhrtajNdzZWZrt6R1upzM2DyF3Y10erM2CZZBD8zHwuwKubJYdgctwXqsMDxUaJu8VcvdRhpUaVyMb563wDY7AZDskM8w4AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "268",
+    "id": 268,
+    "sortid": 268,
     "identifier": "cascoon",
     "name": "Cascoon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA51BMVEX////Ope/n1vedfJ3MpO0xMTHl1PXm1fY1NTU2NjbLouvMo+0zMzTNpO05OTnl0/UyMjLJoenn1ffKoupTUlNUVFWaeZqaepube5zNpe/Ope6ce53kw/vk0/OdY8Q4ODnm1Pbnxv6efJ4zMjNWVVflw/yefJzmxP43NzjLo+zMo+w4NzebY8WbepvNpO6be5s2NTWcY8LOpu/Op+7hwfnjwvvj0/Pkwvuce5w2NTacfJ3lxP3l0cw1NDadZ8ZTU1Tm0/c3NTZVU1bm1feefZ7nxv9VVFbKoern1vjwYlL1YlP1Y1L3ZVTGBubTAAAAAXRSTlMAQObYZgAAAOxJREFUeAHtz8WOw0AMgOHYAzMNNJAywzIzM8O+//OsZ6O91c296n8YS9EnK/YWrmX2f6oS1w8LRrMcEsM5zk7dc4ah2jQoEsXDk8dENTS+aASqm/CyJ+IrjX+BAZiysKFBOAgPTo5Fwh4yOs7QdWRwLK7Zldt9MKQ0PaSgGzHQ9jK3MF670M8i6syBp9Eow/jua1A7J8Wfbd/FqvnYufkZ1LYIBpNbBm7sNqP115XP78MnGUzylt+eLW0q7/M2wFu9LoN9f1ippDKcBasVKpV7HV/K1qUtvnhcVdXMadeBV5pNh+Wo+AFvQVv2C7DmEs2C476PAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "269",
+    "id": 269,
+    "sortid": 269,
     "identifier": "dustox",
     "name": "Dustox",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABGlBMVEX///8xMTFSUlJTUlNzpVq9hLW7g7M1NTWcY6XnSimczkqezEo2NjZRUVFUUVHnpe/25Sk0MzBSU1LOnVlzpVkzNDKaYqOazEmazEo1NzWcy0iczUpTU1I5OTm6grJUUlK8g7RxoljMmllxo1nkSinko+zlSynlo+3mTCrmTSpypFlypFrz5Cn05Cn35ylzpFq5grGbY6SbyUkyMjFUU1RUVFFVU1WdZKadZaOdy0mdzEmeyUhVVFFWU1JQUFC6grNxolk0NTK8hLRyo1nLmllSUVLOnFpSUVPhSSniSSriSirkSSlSUlEyMzEzMjHlSyrlTCl0plrmSiiYYaGZYqHmpO6aYaIyMTLy4yqay0k2NzX15Co2ODabY6NJURplAAAAAXRSTlMAQObYZgAAAS9JREFUeNrtz9Vuw0AQBdAsmTnksMPslJmZmeH/f6PjWGoqeWX1saoyj6szd/YmpvPnR0Tol3CQvIru8KFlh2zg2zGH9Zrl2wiNF+JgnTrDlba5/Hxg+T//gDgw0zZNRobJFzt8Sqd7PTofhdRpmoyR2lERUt4QelUUJfUNJ1LHTQgEiQWCLt28qqhqgQfr40AmSZLHiJvvtOQ7eY5WcxwoPAJ7TxYFgDfyutppbegap7cusKCKtSgwKZDd7lp2N8LCSEYyQSLB2IUmBV6XsA4WpKBLQzYgUV5VRiOA3OMetFk6lY1DApHZlKNrPFg6N55mJa+8iRuVMshbSj94DuSJgWf2Fs6uK5/HF31a7QeOLzUNPkrw/TbZBza5y7cPRENbO7mQxdtESRQT0/ln8wUOqiA3RmiGygAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "270",
+    "id": 270,
+    "sortid": 270,
     "identifier": "lotad",
     "name": "Lotad",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAtFBMVEX///8xMTEyMzIybJU1NTU2NjZSlK1TVVNTdVNjrGNjrGRjrWNz3HNz3nNVlqxSc1JSk6wzbZVkrmRmr2Zy23I5OTliq2J6s8RTdFM4ODg0bJRiqWJQkqw1NDIxMjNjrmNSdFJSkqtSUlJ7tcb9/v/+/v1y3HI2NTVz3XMzNDNSU1JSVFRx23FSVlL05VL351L46FX8/Pxx2nE1NzUxMjE2Nzh5scJQUVFx2XF9tsW7pFq+p1p7nKYsAAAAAXRSTlMAQObYZgAAALdJREFUeNrtz0cWgjAUQFFSTCWCqKBi7713978vPx4dhixA3vieX7yiP46iLJfCGOuss8OdwPSFCJzuHjSEMHP8PcDm0DpoRMZoIRYo1ssatsLjRvpRBNb3+bBmPxTFU859SHIOg+2wnmpjOASsJ2XOR81UAYW0Uquul1OHKFWVVaUIYRVkd3RfbpExHQNrh0nJDuuH3av8mIwYG5Ah9XIqbaFnWGG36yzPgfyUhJffXhf3iorcvQF9Qwzl/kkkRwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "271",
+    "id": 271,
+    "sortid": 271,
     "identifier": "lombre",
     "name": "Lombre",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAArlBMVEX///9SUlJjtUIxMTFis0JSU1GE95QxMjFJcVFKclJKc1JKdFFRUVFiskExMzFTVFIxMzIzMTE1NTVrzns2NjaS22KT3WKU3mPkSVnlTFpSpVpqzXpRUlKD9JKD9ZKD9ZNSployMzHnSlr7+/uF9JNSU1LkSllSVFM0NDRUUVJktURls0JltkRqy3mS3GJqzHpLdFLW1tZSo1lsy3qC85JUo1pjtkP8/fz9/v3///8n9ohdAAAAAXRSTlMAQObYZgAAAOxJREFUeNrtkEeSAyEMAEECJjI5OcfNOe/+/2MryuXjCN98cR/EpasLSVw4Nw06TtAsEJnPEo2FJI7jgPdayDCMVddvhKiQGPVc7LkHTY4F3W7GxDyi2iupNOaS+iOi7XIZUVOBlrLtR1eqQurlknAat3oTKuh6h9OSgDtPquCA5m/eDHfyQEQ9Vtxuv35ud2/3s0Lw5qeZ7H//HmkRj5i+r4z51hJ5DZ+mAWIqX+op98dq+KgLeiws16u6QCY4lDTpREtzszDrgDHd4g9away+WphJKQgui6FK5vK6REH4spAdNV/W6x2zF87LPzyBEBx09kXqAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "272",
+    "id": 272,
+    "sortid": 272,
     "identifier": "ludicolo",
     "name": "Ludicolo",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAM1BMVEUAAAD///8xMTFSUlJqlFJqtGKUzWqcUlKki1qsaoO95mrNe0rVvXvV1ZzupHP25pT///8XcSgoAAAAAnRSTlMAAHaTzTgAAADvSURBVHgB5dPBboMwEIRhd8ZeNsRl8/5P29mKiB5Y6D2/ZeXyaRQfaF//7NNhO4LO3iVE6OAegjEjbiDQMH13NQSsw326Ew0ooZwZ000augEFlOudYtPZu5kVECu7kpTLbEUB156CZP7qVrCv1Ohx134ONan451aPyc2j3DuFgCT5ZiRaAQ2I6dybEaigMXzblhdeI1QFG4Zc9vp222Xx6gh/LktaD/IShuDyeGxOM8bEOZT0Tezx9OAYg5dwE8zBS5jy/Q/TzYli0TxchaIc0SpojL2cq14tOQYQgd9h3HxceeFj8AIeAeIFLPps+APFzA9gvrAxHAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "273",
+    "id": 273,
+    "sortid": 273,
     "identifier": "seedot",
     "name": "Seedot",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///8xMTFSUlI2NjY0MzJTU1KDemqEe2uakoOclIS8i2K9jGP77IKFbVKakoJTUlEyMjG6ikmDalK9jEpRUVG+jWPDsqs1NTX87IP97YP/74QzMjFTUlIzMzFUVFLEs6vGta3sw2rsxGruxWrvxmszMzIyMTG6imKEa1LtVW26AAAAAXRSTlMAQObYZgAAAKJJREFUeNrt0kkOgzAMBdDaZCAkjGWm83z/E9ZBYhuzbvlSsnr6VqzstvxgIoCVrn2ukB1kMpaq4GhUIzFUiMC4WGKsNRKFMDwbiRSlgzDKqM8Yo+fOIgBb36eI+bsITr4so5nZNRL1s5lnd07UOKf6vJj99MKNpz5NJmbhrhkEuDSxU9iVeZUMY2MtV3jd5/C29oC3I//F6JT3xwJ5v+Vv8wV44gdYnfyKMQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "274",
+    "id": 274,
+    "sortid": 274,
     "identifier": "nuzleaf",
     "name": "Nuzleaf",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAKlBMVEUAAAD///8xMTFSUlJSlGJavWqUYlKcg1qsc2K9i3u9pHvVxYP25qz///8EyAqOAAAAAnRSTlMAAHaTzTgAAACtSURBVHja7dS9DsMgDATg9I44+Kfv/7o9lnbD2brkJJg+GWQjjtfNPPA+PL4BoL2FwHmeQAvFxhiiDYTYrYoYJPs7Qg6LNRBOupujgXBFziduQt9DZLhHVa2Se1grZM0GUuWC78g9RFVmAQty23CAMxU5c8O+4XMuR3ffQkkuZWwrholpNY8CV4RZpqGbdVwXV8sDeygZzIjIBmIawP5oSQkCzQh/AbQ9n9Qf4QfI8gpjZ7EF7wAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "275",
+    "id": 275,
+    "sortid": 275,
     "identifier": "shiftry",
     "name": "Shiftry",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAALVBMVEUAAAD///8xMTFKg0pSUlJSpFJqvWp7WlKUYlKUlJS0e1LFlGrNzc329in///9itn+hAAAAAnRSTlMAAHaTzTgAAAEJSURBVHgB7dNRDqMwDIRh9meKYyfN/Y+7TspKVYmWHqCD4hc+jSVEtj9f5ge/gNsZ5mD7yAVSSNYZ8w7SevdOvYFSH07V4L+wz6iEqcEKvrsszKe1xhLCdJ7HYjhfN/J48HLu1qy1dSNon7J1f6r9CxeYfY99l6w7E7rnYbGaLFSJUHt6OtWq9eosVEQxJRsuIl4SPhpzNyhNrmyKmJUOLuANbkAO9T7eK2qYmp/h8sFLkSWIUFhUuUtKt33A4SJeKkVKHcdBygWsNaVNrjiOfce5NJ6VJyw69iPD+jczARou4aEprxAzYzaPQCJYN8LZnIVszL0X+B6kYbiHpZzmBq5v4X1+8DZ/AXjJD0YyIxwJAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "276",
+    "id": 276,
+    "sortid": 276,
     "identifier": "taillow",
     "name": "Taillow",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAM1BMVEX///8xMTFSUlJra73/////zkJSUpSlrff3Y3v/nFrGOVIxMTMyMjRqaro1NTU2NjYxMTJ7d0vRAAAAAXRSTlMAQObYZgAAAHxJREFUeAHtzjuOxiAQBGFqGjB+7/1Pux2QeuT8d0kQfWpN+fm+Lt65+9z9JfgAjgkvv6fQkETB5s7dkAPtnP3vGQ63ValbJ67Q2qgYRqiTOQeLwpSSxLa2tto5ASU9stbQjGTSri6RLM5YqoseVnlgp5zNgEZ51yv39fUPjt4C/2e4KSkAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "200"
+    "gender_rate": 4,
+    "rarity": 200
   },
   {
-    "id": "277",
+    "id": 277,
+    "sortid": 277,
     "identifier": "swellow",
     "name": "Swellow",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAilBMVEX///8xMTFra70xMTNSUlNtarv2Ynr3Y3tqarpSUlJqarxqarv0Y3xRUVH/zkL///9UVFT+/PxTUVJUUlKlrfdRUZL7+/vGOVLEOVNSUpL//vw1NTX8/Pxta7vFOlT0Yno2Njb/nFkxMTLzYnmmrvf3ZHr3ZX37mlnDOFFSUpT/zUI0MTL7y0HEOVKhP7yXAAAAAXRSTlMAQObYZgAAANhJREFUeAHt0seOwyAYxHHmAwwuNk5PNlvY3t//9XaIkhs4540yEif/9JewUP9u10Wc+X4U8fl7Ckd47TWOkKeg0LcilErtaUow+m21mdet0CVYdp2zIvL5pBL0ugDZcM6aU5AunWzx53WB9RujOuU1PNtZNww34y0hJVaN2TW69Gfev4bHO+FMXde7hsGC/NhUVjorpj1glJw3D87y5skdpoE8pOicm40nmGxWrrYVXRini9y+/61mIVBOKS72wDq8LJf3c+DsEwN4+UXOZbp93mW66roL3B/58g9TMC2SbQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "278",
+    "id": 278,
+    "sortid": 278,
     "identifier": "wingull",
     "name": "Wingull",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///8xMTH///8zMzP9/fz9/v6mxv9rjP+kxf8xMjSCgnGFhXUzMjGlxv+2xsayw8M1NTX7+/v8/Pw2NjZUVFT9/v80NDS7g1lqi/wyMjK0xMS1xsZtjf9RUVG8hFq9hFnzslH3tVKEhHOEhXT8/f9SUlKjw/syMzRqivtkIUNAAAAAAXRSTlMAQObYZgAAAKlJREFUeAHtklcOgzAQRDOLTe8B0ntJ7n/CrCERUuRFHMDztZKfnncsL1xcZmYJ8agEfhPPzyCCoKgo94B+aupmHWZBJJCFJp89qHJNifKD8CUZyc9aRoiT31QHcX2875RsNfWkN10VsRGauzejUNygqQ1qqmECPKwUg8OmtI9EtjxfTsrICj2Uo84uZC4Fvt3ClnaenYuvx3S0997ODj7w/w7iX5gdF5cPN+IH4Pw2MbkAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "279",
+    "id": 279,
+    "sortid": 279,
     "identifier": "pelipper",
     "name": "Pelipper",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAulBMVEX///////++vr7OnGNCjK0xMTE2Njb/50JRUVFSUlJTU1JqrM1rrc59fX2Uc3u9vb0xMjIzMjHT3N3nxlHnxlL+/fz9/f3OnGI0NDTW3t7kw1HmxVLLmmJqq8v75EH7+/v85ELOnWJTUlLOnWRBiqs1NTXV3d2VdHq7u7tUVFEzMzPU3NzMmmLkxFIyMjJEja5qq8wxMTLNm2MxMjP8/Pz8/f39/Pxtrs7+5UL+5kJ8e3r+/v45a4SScnrtqHkqAAAAAXRSTlMAQObYZgAAAOxJREFUeNrtkkduw0AQBLWROUdlyTnnbOv/33KPDN403qNhQAXwViiQzRnt+XOODXBr1szjWH/dOz3SdDkeX7hFXX4KIXpn8qjMshaeW3zul7J1ByddI1v5e9JiloW3VsVSgN4Ybr7Ju7elOn0RxO4vt6StwwBsHhryuIms8eGkaXpwTa8p5EnGbGln4QZasKq6JnkSyeVhsdtbnAdg5VV13X2QyAbfPADtRxTJDTthPdApmBJFrjkdPBUieZuzl+hfqSl5EM/a11jnnDjHIc4UKIx/pyMdPfI/EQ+ge9MRJd3AzI3DGfKjPf+AbzIoFNGT3OmEAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "280",
+    "id": 280,
+    "sortid": 280,
     "identifier": "ralts",
     "name": "Ralts",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAkFBMVEX///8xMTGE1mt7e3uD1WvnUnP7+/v///9ztXJSVFI2NjaD1Gs1NTWC02q+vs7EQmIzMzN8enr8/Pz9/f59fX0yMjJ7fHo0MjI0NDQyMzEyMzJSU1IzMTGF02qdnZ26usu8vM1xsnHDQWJys3LGQmPkUXHkUnLmUXJztHPzeaP3e6UzMTJztXP9/f10s3J5eXlLro9AAAAAAXRSTlMAQObYZgAAAJxJREFUeAHt0LeyxCAMhWEkAjbO4d7NOef3f7tlRz2i9vgvqL45MIjBNeaATtbd7hMAOOkHC7VuriqtlhzcX3STISbzsMuL9Hxceae8ZGD1Vt4hzkLOFYjpgWBAEkzIcZM79Z8RZB7pPvIHk+cCuP8xvZSynQo2t+ms5R3d/idiyo14xSw6U3brbQ0RsG+ttWXNSzCeAceIEhtUY18gJQf6EYCpRwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "235"
+    "gender_rate": 4,
+    "rarity": 235
   },
   {
-    "id": "281",
+    "id": 281,
+    "sortid": 281,
     "identifier": "kirlia",
     "name": "Kirlia",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAn1BMVEX///8xMTH///9SUlKE1mu+vs42NjZRUVFxsnFSU1K7u8xUVFRKlFpztXKC02qD02qD1WsyMzK9vc41NTXnUnNTU1P8/PwzMzNUUlKD1GpRU1JJklkyMzFys3JytHJ5eXlKlVrM2+xztXP7iqNSVFL9/f7+/Pz+/v58fHzkUXHmU3S6ust0s3O7vMz8i6MzMTL7+/tLlFvEQmI0NDTN3e7YRUuLAAAAAXRSTlMAQObYZgAAAOZJREFUeNrtk8cSgjAQhtk0Qu/YUCxg7/r+z2YYR25uuDhe+E85fPslu7Mx+vwiAjpyq/RigIquJFmlQ5Ah8yJQJZhxNwy8kDFWnVMFYqTfcrjRZx/wGOmFCqTTkBUdwPmIMQwU5ruV+SlTB4QU0mqA6r52AvXYr2Ail+448Cx7v+aoUkjXnUVwiGs+AB9TislsGRmipPAeFPJIMAFKe2tnjRGf5JU4dtyQAJoFMhdxlhPy0C1amfPnxqFU57sSfhsvNoTwAY4mAObUygmvO9wuLZoTB2umHeeoaDF82Yquf9Ho8/e8APQjEGOXxS4SAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "282",
+    "id": 282,
+    "sortid": 282,
     "identifier": "gardevoir",
     "name": "Gardevoir",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAolBMVEX///8xMTFKlFpMlVyE1mu+vs79/f7///+D1GpztXJztXNRU1KD1Ws2Nja6usu7u8z7+/tKlVo1NTX8/fwyMzF0s3OC02qD02pRUVE0NDRSUlJSVFJxsnG9vc4xMjHkUnJLlFszMzN6enp7e3uSQ2KUQ2Rys3J9fX28u8xytHIyMzLN0+xTU1PlUXLnUnNUVFT8/PxSU1L9/PySQWL+/PySQmIEccH6AAAAAXRSTlMAQObYZgAAAPhJREFUeAHt0cdyAyEQBFANATYHtMrSKjjn/P+/5gZX+bQefNFtu4rbq4YZJufImJKQ/7C5SjPRU8xtizQrlFLpPesc6jyLynLu3U9nxzoU/nZ2kULvWiGSGIRrxdRKwMjQRXv5rg9J7JHYYb7/1EYmcKzc1Mbqg0iwHjZuuT7VjwsFx//yNnv7epA5Eb9FFC33zzMRfSAuLD+eZhkksZJwqqtbI+8K1RF/f6ONNvblOnw3IX9CObVerhdq82qR1SB1jRQBWtBTvTOBDrjKyBw9NzghenckGr64p8pAXniK9hU7N6QvlT07t9cNRmj0cRKNo1A+5iz5BuF0EZz2I+69AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "283",
+    "id": 283,
+    "sortid": 283,
     "identifier": "surskit",
     "name": "Surskit",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAb1BMVEX///8xMTE2NjYxMjMyMzQ1NTUxMTJio9tjpd6ay/OczvfWpUr/3mObzfZio9ydzPVKZI3722L+3WJJYorzcYpUVFI0MzGdzvfTo0nTo0vVpUw0NDQzMjH0cov1dI33c4xMZIr7+/v9/v5RUVGczfQd/fpTAAAAAXRSTlMAQObYZgAAAJ1JREFUeNrt0kcOwyAQQFFmMMWAe3pv9z9jBsmLSMYYxatE/mIDPKFZwJZ+KQFpDpvNF24+RGjWkMJ2rXP2BFOu27fO0rrJCaiKg6VemkeduG9NX1wi5GQex9xDiLjnuSKYwaoyui5HKSrNVWHM5eqdBNqGXZ4BE3St6bVa+kEUD7v+Q1Bd6QnDkET43JAcHI7NkfolB3IuZMiW/qw3iyYGHwYAnSgAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "200"
+    "gender_rate": 4,
+    "rarity": 200
   },
   {
-    "id": "284",
+    "id": 284,
+    "sortid": 284,
     "identifier": "masquerain",
     "name": "Masquerain",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAh1BMVEX///8xMTE2NjaExvfG9//3e1r+/Pz///81NTXzeVlSUlL3fVzD8/syMzSFxvfE9v5TVFTWY0KDxPQzNDSVRGU0NDT7+/tRUVGUQmOFxPRSU1TWZUQ0MjH8/PwzMjL0eln2elm6ipr9/PwyMTFUUlLE9PyCw/PG9PySQWLTYkH9/f3TYkK+jZ0sFh/hAAAAAXRSTlMAQObYZgAAAPVJREFUeAHtz8du6zAQheFLcljUu1xuei95/+fL4QCTDcXAiwTZ+CwMS/jwU/x33k9Pn+qKi1+E4RsXCusW+V9PX69VGnReoAbMfY9eK/dxJa5txNkE4uR5fy/BrOMioATlHcOk6GeGEgy3b75yy1bS+yU6Yqhf9nd+M+kqi9dwOJkdYFLEApII1EStafA0czCFaKi1ehg7Yhk/GT3PboM+wWH9teVJL5Xr/+G57agvLzmncm6nCju4pW7NsSzLHMOF+/cb3Hw3GnMcTTdlHdFUWDscTAw+EmVkUErhPq8H06h4eHzMjz1+6kwvmT5d8sl/tvM+AYHvDhhlsasCAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "285",
+    "id": 285,
+    "sortid": 285,
     "identifier": "shroomish",
     "name": "Shroomish",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///+9nGsxMTHmzXrnzntStXOEhHvky3kzMzI2NjblzHsxMzLkzXpSUlK+nWw1NTUzMjGFhXu7mmq7nGv97av/761RsnG6mmpRtHI4ilG8m2s5i1JTU1JTtHJUU1JUtXNZy4KCgnn77Kv87qyEhHr+7qxRUlJAqehEAAAAAXRSTlMAQObYZgAAAJtJREFUeNrt0ccSwyAMRdE8IYprcEvv7f8/MXi8yMrC+3DXZ9BIrFL/XEZEi9yjhnJL3tv2DE9Rd3vWABS87Nb2PQzMfNWdLLP7oZ9g6eTBhcXLmDxYeMHRpgzEWR5zNOssVGPyaTIzlJuHUNzkwWldIkDhhkEy46w7iLfMLF+qFjhVrWIn3pH2uyLo44co+oXj8rqIsJ9OpaJ9AWikBpQmHPH2AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "286",
+    "id": 286,
+    "sortid": 286,
     "identifier": "breloom",
     "name": "Breloom",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAzFBMVEX///8xMTE2NjZCc0pSUlJzxmPWxnvn3pxSnFozMzJRm1lSU1JRmllTUVE1NTVRUVHkUVHk25pRUlG1OUJyxWLVxXozMjFSmllUUlJCckqzOUJBcUm6o1m7o1m9pVq9pVvTw3nTxHoyMzEzMTGU1oTkUlKagkHmUVHn3p0xMjE0MjKzOkJTU1JCdEpUU1K8pFlUVFNxw2JyxGJDcknVxHpEckqS04KS1YOT1YM0NDTl3JoyMjHm3ZvnUlKchEKdhUP7+/v8k6P9/fz+/vyrCCJ7AAAAAXRSTlMAQObYZgAAASJJREFUeNrt08dyhDAMANDIuNB7Z3tP771syv//U8QAN+xwyW01PpiZN7IlrKNDDA4CGEOYHTOmH8Nfzn5cMQykanf9tELYSTVkLVRKYsct0zRTmdJtpH66jW4b6cpyejSLde3rxM8zhARmhgTO+AWAV24jByGxrbkBvW70veM/z6MzWtStJFWIByz64OdOCMOb80nafD+w896qSDBNN3ecc6PrF1uA5BfWBWBC6IrrXG9awScfr+3ekPdy8yKmSXO6GwhDkU+I/WXyhoKoHATiChelFHA7TWXOjxxKERamNU7qLklhnulauH6/N7VwLHcoK83UrXV+w3QLQPnScA6qsECofmd4x7rnYGNCJWxH0PVKp1wOmlp/6Q+DUK9D/Ev8Aj1xFcV16UPrAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "287",
+    "id": 287,
+    "sortid": 287,
     "identifier": "slakoth",
     "name": "Slakoth",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAk1BMVEX///8xMTE2Nja6mnm9nHvky6vlzKvmzaxTU1JUU1N5UTh8Ujl8UzqVdFszMzK7mnq9m3ozMzPkzKs1NTUzMjLnzq32Ymr3Y2v9/fzGzudSUlK7mnmTclm9QlJRUVHzYmqVdVw0NDT7+/v8/PuSclmUclmUc1oyMTFUVFT1Ymr1Y2q+RFTFzeW6QVFTU1T8/Px7UjljMvYIAAAAAXRSTlMAQObYZgAAANBJREFUeNrtkNkOgjAQRRlaWkDZd1RUxH39/69zRojxoY2+yw0PbXLm3KHGmL+MCfAbZmWZD985JjMMT/sh/HQg+ggs14BnHyyNPLHI1gRldYt9PHs7od4jYRJbzeZ+qAO77hDzBE6qVuQ8BYvbMRJOTEKsuEQqJUFDnNcJJ0EFTo+hHECOQm6D5rfdzQr7po+5IGVvVJPgzqR3KiZIOp3oy5UvdM2LYrJvz1tB2wGT9KpKcrnIQ6ruRQmwsoo05Yxj3quZLQk1KObjaowZo88T73EO8P37NekAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "288",
+    "id": 288,
+    "sortid": 288,
     "identifier": "vigoroth",
     "name": "Vigoroth",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAt1BMVEX///8xMTH///+9vb39/Pz9/f2FhYWUQmOCgoKEhIQyMjIzMzO6urq7u7u8vLy9QlK9nHs0NDS+vr7T09PW1tb3Y2v7+/s1NTU2NjZSUlK+nX26mnnU1NTV1dWDg4PzYmpTUVJUUlL8/PyScVn9/fw0MTGUc1q9nHyVRGUzMjKUQ2OUcloyMjGEgoPV09OVdVy6QVFTU1P0Ymr1Y2r2ZGxRUVGSQWK8u7tUVFSSclm9RFT+/v6Tc1qvkUrhAAAAAXRSTlMAQObYZgAAAQ9JREFUeNrt08eSwjAMBuCV3NJ7o3e2917e/7lWYuBEDLlxQRcnzje/Yk1yca4TVwMd3WQF3dzsZQXHaT0py3I2x/R4ILlQYeHDYbd4LePpHFGr9DDMf+Lp91piprRnVwCLO8f9k/gokZpbWV585W/xw+V11V9SZGpxwagohP8U36t+skStMPOhFb6HI3rSfBgj8UqyRExbaO30gJfBjTHmVuqIINP9RMeDzTpIkvWn66rMKmH3DuNICKGob6Ba5c7lgh2LGiqkM1kmrt2hHv4SECSaCrVngYV2IwrMuDnd8xn3i/dzmiZwT+5KG+2BNTi90N/Mn0MJUp5FAmwvAvE89rp86gG5bj8Fh5/rdPUPuPEStVoT0iAAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "289",
+    "id": 289,
+    "sortid": 289,
     "identifier": "slaking",
     "name": "Slaking",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA6lBMVEX///9SUlJTUlKMa2OthHPGrYz8/Pz/1q0xMTF1dXV0c3P806v81KxTU1Jzc3P////Dq4rVrJt1dHM0NDSrg3L+1azErIszMjKtUoRUVFOuUoS9xs4zMzP9/v6LamLFrIvTq5qKamLvc5z7+/uchGv91KudhW2+xs7+/f10dHS7xMzUrJvWrZzscprtcpv706u8xMyrgnE1NTWuVIQ2NjbGro1TU1OsUoOdhWwyMjJRUVGag2pUVFSMamNxcXGuVIWNbWX91Kz9/P00MzLFq4usg3Ksg3NUUlPEq4ubg2oyMTH9/fyagmpycnJ1zZ5xAAAAAXRSTlMAQObYZgAAAW5JREFUeNrt0tduwjAYBeA6nkkgCSvsvfdsC6Wb0t33f50e4KYijlRVveTIUnzx6ST57bNT/p7ZL92ingjvUOqHcxNKhXRUBmy13yilboXZK7qJEDeABBtLzjvhbhrbQbbyeIqnJO+0C0r7eVcoBDTWTQkn5fIjoXNVcnDMEK0mKrFQqXGUVFiMOc9G6b3eonTXikoNhCuzB5kVd6NaLvPYgmzoIXlNyaVB1pfGsFZL1++bvDEpBNynARePZIUZkfPRyzB3Q98ak/wxXIyzSWbYcUJ2UM4zmScOlr+wN8eQRyHJl2jnu5CYzDmPEmLLIzjz4JiBlwvX9PczLEdtPDaaaScpseHaRdMB5VYkHon7aRWQU0oJGh3huu2ug5CK1bf6ac0JVlHJLUBQ/Mf+nNIhd9FDZa+4l8XrZCxMwnocnaYwHWGSJIsdbqe+1eOWb/k8WqKQCGQ45ZhhAOooUqXINgC1Gnirc3p8dsq/5hs8aiyNlzvyYwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "290",
+    "id": 290,
+    "sortid": 290,
     "identifier": "nincada",
     "name": "Nincada",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTFSUlJUVFRzc3N0dHS1nIS7zMy9zs78/Pz9/v7///++zs4zMzNzdHI0NDR1dXWymoI1NTW6y8tRUVEzMjL7+/syMjFTU1JTU1Os3Gut3mtycnKDcmKr22o2NjYyMzHTuqvTu6uEc2NTVFI2NjUyMjJrAVXFAAAAAXRSTlMAQObYZgAAALpJREFUeNrt0EcOwyAUBFAPHYN7r+m5/xGDYynKAtsX8Ej8xdcTYgjOnDnKZTkADt18BYrQmARHMNbGWMUZe+/DcmROpv0Qy2jHvWrjlOT9wCTfvDIHnFslU9zYaMPdRCtDqzptqFRMM9dow4lW25DOT00JkRzKL/NyIuTbI5bdXVQIoEKfzLOWaKpTMi5OVG6FQsHbpU6WQYFMPBrnVCfhfWURubHokkzN+g0bvX86q/73OxrBmTPH+QCNIAp3hVwUWwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "291",
+    "id": 291,
+    "sortid": 291,
     "identifier": "ninjask",
     "name": "Ninjask",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAmVBMVEX///9SUlI1NTUxMTFiYmJjY2OUlJRTU1I2NjZRUVEyMzNTU1NUVFEzMzNkY2Kru8Stvca9vb3Mk1LOlFLOlVH700H7+/v/1kL///9UUVHTOUKuvsY0NDS+vbu+vr4zMjEyMjLWOULWPESSkpI0MzH800L8/Pz91EP/1kS7u7urusPLklG6urrMklKVlZL+1EIzMTHVO0RUVFTuLvPFAAAAAXRSTlMAQObYZgAAANtJREFUeNrt0ckSgjAQBFAmC8giILuiIiqI+/L/H+ekLL3glLlaRZ84vDQdMIb8TUa6LpvrQYZQz61vmm8uHS3HsfHzjCH7HhA4xuh1pCiWYwqmiSUkz+Z4pCjDe03sZcdrnid+223V1jAMHcLZjQdNjjauDsjowqxDqFzsQ0AWMm7PpugSC86+jKyAKGQn093sPABo11MRxRYAN77DyZiry3izGqF6t0NAc2Ww9GKaLggpJQTElRFt1VAuJChJ/hRE74+0n7giqvqgPxbX8t8uXeBYnTBsG/JHeQLW8g9B/HfkywAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "292",
+    "id": 292,
+    "sortid": 292,
     "identifier": "shedinja",
     "name": "Shedinja",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAh1BMVEX///8xMTE1NTVSUlKDenK9pVrbw2rexmtza2PdxWr///8zMzF0a2J0bGM0NDSEe3O7pFozMjE2NjbcxGtTU1L7+/tUU1IyMTG8pFq1xsaFfHJRUVG6o1m7o1nu3ZOEe3JxamIyMjLbxGqyw8OzxMQzMzPs25Lt3JO2xsbv3pRTU1P9/v6CeXH52+mgAAAAAXRSTlMAQObYZgAAAMhJREFUeNrtkccOwyAUBP0oxrji3p3e8//fF54jHw3nRF4ECGm0A8LZ8hvJAOZpCzm9YoeU94uNK/142czi0vdjAFztal/Hqs7cip7b9gnzs0zgIEVF6THQmCsCEzdxKbo8ql3BeWowI6eRUIWKFxRW7MSdHggupBQrdtJf58Jd8wX5mp3MZrxkEypka3DW3BxfzfKIYSnWGUg9QpYkWGoi+1FWdJRd4qkUwAAOBWXeTUSMguWzAd6e0vIDnmzs3rNzS62z5f/yAXBmC8xyYj2CAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "45"
+    "gender_rate": -1,
+    "rarity": 45
   },
   {
-    "id": "293",
+    "id": 293,
+    "sortid": 293,
     "identifier": "whismur",
     "name": "Whismur",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAflBMVEX////WrdbvxucxMTGEc4SthM73vWPtxOVUU1Tz22KrgsszMjPTq9PVrNUzMzM0MzHvxuSEc4WcY3v33mOcZHw1NTWuhcw2NjbVq9SFc4XWrdSFdIPsw+SFdIXtxObuxeZUU1IyMjLzumKCcYL0u2L022L1u2Osg8z33WMyMjN4mhmRAAAAAXRSTlMAQObYZgAAAJ5JREFUeNrt0kcSwzAIBVABKi5yXOT03pP7XzBoJmukvf3Xjz8Dg5oz2SyJctiaDoiLDFeG0LGME5Rwwe5dQVSdmIvQ2osH2L4+nShv1rb+jFg8Q2Ap7hxdhCwZCpTX/stdLbm7dohHh8XDtkqE0WnNkpQI/Ti42AhQy7BqxmEDpgHzVYlK4DM6MP1VJWS5Mr1+s8v4n5JPk/1rc6abH8VkCSMztIt+AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "294",
+    "id": 294,
+    "sortid": 294,
     "identifier": "loudred",
     "name": "Loudred",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAw1BMVEX///8xMTFSUlKUlOe1rffOY4RSUlNTU1RUVFJxcctzc850c86SkuSTk+Y1NTU2NjYyMjPOZYXOpUrne6X33lr7+/v8/Pz8/P7z21m0rPa1q/VTUlK2rvdRUVHOZIN0dM51dc7b29vkeqMzMjQ0NDT021n23Vlycsyzq/SzrPb9/f6yq/POpkzOzv/LYoLc3N3Lo0nmeqTme6bLy/vMYoPNZIX23FrNzf61rPT33ly1rPV0c8vOo0pUVFT+/P3+/fz////1B2onAAAAAXRSTlMAQObYZgAAAQdJREFUeNrt07dyhEAQRVH1GDwIz3pv5b2XVv//VXoQTNaIRKVkOyA6dWdoipPj/MGcEnVz90rGHVx0/qgHkCbOQ3vxBmjiPLzTAz9unIkzUkkvjIlMnJXjoP98iUOpjrfBYgSHkd5e+azDzZbFDOTsewRGLdvupe8oVasCcsm6QNrrPE/TF+WjiiQH3dAW5WvejLOTkofW1ioTrfXHBhJ97ttEROMHuKEoLzZOYO8Uf8/oqnZi/rl2tlbQZ0+Pbg7JcJHBAoZSeizspZPbLMu0fkJR1HdkJfYz0V8JIHK8cy0hml3iZWQbnE+vpzEhiysayGyImqe7Vx3/CreaVavflGkf5x/nB6HaF1T5lZr+AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "295",
+    "id": 295,
+    "sortid": 295,
     "identifier": "exploud",
     "name": "Exploud",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAACQ1BMVEX///81NTW1rfcxMTE2NjZSUlJSUlNTU1Rxcctycsxzc850dM6Tk+WTk+aUlOezq/WzrPSzrPY1NDL13Fn33lo0MzEyMjN1dM+RkeGSkuQ3NzVTU1VUVFWlQlJxcck5OTlycsu0rPa0rfdRUVG1rvfne6Vzc8xzc81UUlJUU1dUVFGRkeKRkeQxMTOSkuZUVFZUVVWTk+dVVFeVlOdRUVKnQ1SxqvCyq/Q2Njizq/ZxcskyMTNTUVJycs61rPa1rPc4ODg1NTfMZIbMzP7NYoPOpUpTU1bz21nz21z021l0c8313Vz13l90dMz33lz5+fn5+fuQkOM3NzdUUlSRkeNUU1RUU1U3NzmTkeKTkuQ4NTdUVFI4ODaUk+aUlOY1MzVUVFeVleeWlOakQlKkQ1Q5ODilQlOlRFWmRFWmRldVUlNVVFKxqvGyqfGyqvOyqvSyq/MzMjSzq/RVVVVVVVdXVFIzMzS0rPVxccq0rfYzMzW1q/W1rPVRUVNycsq1rfRSUVI2NTW3rvXKokzLoknLo0nLo0zLy/vMYoMzNDTMo0rMpEnMpE7MpUlzc8s0MjXNpErNpEzNpUrNy/zNzP7OY4TOZYbOZodTUlLOzfzPpUrieaTie6PjeqPkeaPke6fleaPleqPmeqPmeqXme6TneqXne6RTUlTx2Vvy2Vnz2lh0c8s2Nzd0c87021r03Fo3NjIzMjF0dc/23Fz23Vn23Vz23V323lp1dM5UUVJ1ds92dM76+v38+/z+/fz+/vz//vmuyGQ6AAAAAXRSTlMAQObYZgAAAe9JREFUeAFjIA2MAkZmZuLUtW4RESXGOGXP/X6EVTK6R3ft8xMR1hIVIqCwwMhDRES4t3Q9fkOllFkFmJi8Jxp4bBcWxeuP1YJMQLBDkMm7eyMehUEczkz8TEx8Skz8a8XAOoWwhlRU+xQV/k2Cgkx2TF5sncxCDFLuIiIbsFg8b7IKE7clUxJvpZGMwEwfT6FVIsKurhhOsGCeXSNoZ1w9Z6kX0KHOWw8YsK7YNgtTIaMke6SSsXn5/Pi5uxWZ+Pna1mWz8ej1TGqRQjdQUtosTyCMtSIx356JSVzBjV1Zm5ebozkG3cDAOO5aFmV2Vlb/4hz7+iZ2TnV9mTp1TWYMnygY8okxyEsksDZoaORuFtbiDOGNLZERKGTANJGvCuTS5cmysjtXTgjllJawBIZnGbpCeTlePm5doMIUWSCwYePk4pKWU2QSt8YIRQcJHp5wsMI0U1MbTg4uWy62IrCJGGaysDAwOEqmuyxTVc2ycuPh5tQUgJuI4VIO7o4li1QXT50hycfHDjTQfA1WdY7MHHsyF7hMW+gULMGrp28moGaBPfEoSMvp8Dpl7J0eocamzcUlxsiCVZ28vy8nW6OcDg/QV8wm7Ori/XApTO+wMKQygkjGPn4VxV1iKNK4TA/wDXBAEsFnOgsD0WAUAAC2A2GyVnlEhwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "296",
+    "id": 296,
+    "sortid": 296,
     "identifier": "makuhita",
     "name": "Makuhita",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABAlBMVEX///80MzJSUlJVVFLnvUr07XL373M1NTX17XI2NjathELlvEtUVFTz7HH07HIxMTH17XP3c3ucnL1TUlGuhULlu0pycnqcnLyqgkJxcXlWVVLlu0nhuUniuUlzc3tUU1FUVFJVVVM3ODXx6XGamrrku0rkvEo5OTlSUlE0NDLnvEs1NDOYmLj0cnrku0lTU1FWVlJWV1P263H27nGvhkL37nPjuknnvksxMTKvh0OrgkEyMjF0dH3y6XHzcXnzcnjz6nE3NjPxcXmZmbkzMzGamrs2NTVUU1Lz63E2NjUzMzOsg0I0MjIyMjJVVVRWVFM4NjX27nL273I4ODg5NzZXVlN5k/5kAAAAAXRSTlMAQObYZgAAAOBJREFUeAHtz8VywzAQxvEItJbMcpiTxmVmZmZ+/1ep1U6P1vbajP/n36z0lYr+Tc5fXUB+OA6BRIbjcBACyTR+ck9yV1b2UXctKq4cRJibCOA7gt0LiZEC+IXdHa2REG6ieWSMs3M297oJpxCA1g8Wlx7Qrf5hHMcri1zPWuBC+tSYbDHGqsf62csf/t6k4rPc9bIY6/p+vpxWo7fdMqXLzPX8JLmzzHkZydXhcIlzepnUe4/5Jzv9xolY32632Xm911Qly+PqyulUN1r3M7Xar7N9VUx9KNQZemvUeFX0BZWVE9XogKzdAAAAAElFTkSuQmCC",
-    "gender_rate": "2",
-    "rarity": "180"
+    "gender_rate": 2,
+    "rarity": 180
   },
   {
-    "id": "297",
+    "id": 297,
+    "sortid": 297,
     "identifier": "hariyama",
     "name": "Hariyama",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABZVBMVEX///8xMTHWvYznhGv/3q1SUlJjWpy9lDG/lTE5OTnkg2piWZr826v/zkpUUlIzMzJUU1JUVFNVVFBVVFJiWZljWps1NTW6kjG7kjE2NjY3NjfJYUnOY0o4NzbhgWnkgmoxMTLmg2pRUVH6ykz7y0n8zEozMjH826z83Kz9zUv9zUz93Kv+zUr+zkpSUlNTUlFTUVA0MzI4NjZTUlJkW5llW5plXJtlXJyji1KljFKmjVNTU1FTU1K7kzK8kzK9kzFTU1S+lDFUUVM2NTXJYknLY0rMYkrMY0rMZEtUU1HRuYnSuYnTu4vUuorUvIzVvIvWvItRUlLWvo3Xvo1UVFHkgWlUVFJSUVDlhGvmgmlVU1FSUVL4ykn5yUn5ykr6yks5ODj62an7yklWUlH726v7+/v8ykpWVFD8zEtWVFFWVVNWVlH9zUlXU1NXVFNXVVFXVlRhWJn+26r+3Kv+3axhWZk5OThrqgw3AAAAAXRSTlMAQObYZgAAAUZJREFUeNrtz8VywzAUBdDIksx2mJk5acqcMjMzM/P3V3K3ctJNp5vc0UibM1fvWVr5u3gA+B27QKjWvIsyxFmbKKWiIupsoJGLQl3JGgwrfKwpNBjfALa3yXDQlUV2wipYRTXTvlB86nFV7aGst9i/bLaOFIHwKXen8CPgco3j6DoeYFKp5+iA80tcXwfGC5w1CjNsCU7JyusvmCqOaJlAtpwrop/QZizDUBUwnW9AXnl/+0AqcTLUjZNhOK/3NgJ3Jxc5J/l8ExphQcnrOLuPzJxv4SFBcATjlOnsr1Ni6Xpj2DdaF4SHZxnu0BFZ+TpMa2IpZU+LJfGqPOt07rtjJltvH+Tz9s9jTdO6kmVyvQbYUJrYsyVcgcTRTaGbTxbSncSZyemw3yKNu9w0Y4CtDOk3nhOPP1G1BcMMwSpnOXZ5K/+Zb0ODKXqQHSWmAAAAAElFTkSuQmCC",
-    "gender_rate": "2",
-    "rarity": "200"
+    "gender_rate": 2,
+    "rarity": 200
   },
   {
-    "id": "298",
+    "id": 298,
+    "sortid": 298,
     "identifier": "azurill",
     "name": "Azurill",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAxlBMVEX///+EvfcxMjM1NTU2NjYxMTGDu/ZimttSU1RTVFU2Njdjm9xjnN5knd6CufGCuvODu/Q5OTlRUVGFu/VSe8ZSfMaDvPe7WnRRUlNimtpRecFRecM3NzhSVFYyMjIyMzSCu/Y3NzdTVFaDvPZimdlTVVdTesSFvfaFvveGvvdTfMa8W3Xzaor0aouCuvJhmdozNTdSe8RSe8Vim95SUlM4ODhkmtxUVVdknd+BuPCBufOBuvNUfcaCufP1bI74+Pj5+vv7/P6Q2Na6AAAAAXRSTlMAQObYZgAAAMJJREFUeNrt0EUSwzAMBdDIkDgMbVJmZma+/6Xq9ABWt+3kLzxePH+PpGX5lVD+pTPyJNUcc5XCnshTFxyB5UJ/y/k0FxOksrXWwREzFNLHCGTiPFZoRUHyvOrQwGbxJ/fc0hig0LpAmtcQkfQ81gH81DaUmw+7qxv4h0DCKlPufMcizwyEl/5MkXGK5rxt1uUbzNnHnuHUuLxSJSwlAO7GIVrI1I0nAGi6BqGaOmHkdcBdCOkwybq2bX0cTpmW5R/zBvEuDA3K9+dVAAAAAElFTkSuQmCC",
-    "gender_rate": "6",
-    "rarity": "150"
+    "gender_rate": 6,
+    "rarity": 150
   },
   {
-    "id": "299",
+    "id": 299,
+    "sortid": 299,
     "identifier": "nosepass",
     "name": "Nosepass",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAq1BMVEX///8xMTExMjM1NTVSUlJSUlNrhL2LpN2Mpd42NjY5OTlSU1RSYoNSY4RTUVFTU1RUUlJqg7trg7trhLxRUVGLo9tSU1MxMTKcSkqlxv/eY2Nqgrlpgblpgrpqgblqgbo3NzdqgroyMjNqg7xqhL0yMzVRUVJRYoFrhb5shb6Ko9xSZIZRYoKMpNxRY4OaSUlTZIWdSkqjw/ujxP2kxP02NzfbYmJpgbjzgnkgDIW/AAAAAXRSTlMAQObYZgAAALhJREFUeAHt0UWuxDAMgOEwpMzQx8wwfP+TTZL9uFlX/aXuPrmKjZbYGsUYB7nNMLyRIGehfAh0SpAAt32XSj3PwPudH/gxM5LWjMWPQsrq86+D3GHMmatIpooA7jT+92kTOWg/AjhbzhoVFYKz28vwt0+Z/7lzLO6A230l/jHcTlURdEd6FDbeuPWA+zF1IZ4s/Hb+DlzkS3ZzXbbtVP3sEZS5KrnWr0mWYQRntPa81CgkQylaWGtnV1YNyCALFfkAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "300",
+    "id": 300,
+    "sortid": 300,
     "identifier": "skitty",
     "name": "Skitty",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA3lBMVEX///8xMTH/taXvhIRVU1P09Iv19Yz394w2Njb/t6W9pUK+p0RSUlJUVFL7sqNVVVO8pEPsg4PthIQ1NTXEWko1NDMzMjJUU1PvhYPwhYXx8Yk0NDJVVFT29os5OTl7Y7T9tKT+taR7Y7U0MzI4ODhSUlP+t6T+t6XHW0vqgoPsgoJ5YrLtg4N6Y7Pug4M0NDQyMjLvhYR8Y7TwhoWDg3L09IqGhHP19Yr19Yu7pEL29Ir29Ys0MzO8pUP49o1UUlL8saL8s6O9pUP9tKY1NjbEWUo0MjI3Njf/tqU4ODejqrqxAAAAAXRSTlMAQObYZgAAAO5JREFUeAHt0sWO60AQheGu02xObuIwJL7DzMz8/i80Pdl4Mz32NlL+naVPpSq52arl6B/VdElBtehH0nkqag0EijpLvD5iSuUWXko7W0fD9u1iHCWdRk4+OBkC6LWdAjh/kAPywNjO4BJYuOjtevA7PAwuP+Hq4YUfz9caPPfcnKqNGay1wGT+47xQx2frVqkbC7FnaNsLxzIcaZWmdxqcmGnt58yT6Y90qrW+R/PdfRnm7X9fOncxbYpNOvj7H54rpTIhOK94GuNW7OpyflIBGYXZcxB0d+VXBTQyOs3Cq/IQvzQmkiWrsGyJWvUNUTYQxw7lU6cAAAAASUVORK5CYII=",
-    "gender_rate": "6",
-    "rarity": "255"
+    "gender_rate": 6,
+    "rarity": 255
   },
   {
-    "id": "301",
+    "id": 301,
+    "sortid": 301,
     "identifier": "delcatty",
     "name": "Delcatty",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAnFBMVEX///8xMTE2NjZSUlLetWurcrszMjMyMjFSUVMyMjNTU1RUU1J7SpyjeUGjekKle0Krcbqtc701NTXDmtvEmtvbsmozMzHz84r394w0NDLGnN7bs2rcs2vdtGr8/PtTUlOscrzetmvFm91aQhhcQxlUVFT09Iv29YtWVlbbs2lZQRh8S5tcRBl5SZp7SppRUVFTUlFSUVE0NDRZQhjhgp17AAAAAXRSTlMAQObYZgAAAO9JREFUeAHt0ndrhEAQBfAbd+2ernqW6yW9JJfy/b9b3pAlEMgM+S8EfIIo/mZ3Hzj7s0wJaBb8DrZRG329NRiUoDutou9TwoI1kvpT8JB8RlfjMyF44CFRnsPTigMERnKdBtKzvSG1uKs9YxfgEtz9awhWJOULO5e69GfXXe6ujDHvF3dVzFDqA9kP4/i4e+us7VnKvYfjzbikzuaEvW9JaXO+PlqbG/pcX2T0dEBhExabnkh2TZuF9X79cEDxTV7Gyr68Fhxgsu7VHy0rt4BFssg0CEk0r56TReQPqNH5torJN9blsOQ76cqT/5QpH8iqEET4uzxdAAAAAElFTkSuQmCC",
-    "gender_rate": "6",
-    "rarity": "60"
+    "gender_rate": 6,
+    "rarity": 60
   },
   {
-    "id": "302",
+    "id": 302,
+    "sortid": 302,
     "identifier": "sableye",
     "name": "Sableye",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAJFBMVEUAAAD///8xMTFSUlJatPZzWpyUc82c1e60KSC0lNX2YlL///+GbY9RAAAAAnRSTlMAAHaTzTgAAACvSURBVHgB7dQxTgNREIPhwcZeTO5/XyxYISHte6FIkSJ//cnTzbz9sxd8NJwzzJ+WEMbDIYHTAmtYxzjfFNlBui4x6rYwUVql6pYQt9PVZw8txz9OwgICfJetm1xo5xoCNq2646jM6nRZQ+FxdJcxsVikgalXnUkmxBWcsga4Mc0OLuBv4AdjxQBmAwF9igwxbQ0hU6rUPWgLoBq2sLIA4n2IaQi9h2do0579AbzgF+gECUfM9wqJAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "303",
+    "id": 303,
+    "sortid": 303,
     "identifier": "mawile",
     "name": "Mawile",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///8xMTEyMjJzc3NSUlJycnIzMjGTk5PWpUr33lpTU1M2NjaSkpKUlJT23VnTo0nUpEmSakE0MzF1dXV0dHRxcXE1NTX021mSakL8/PzExNR1dHLTo0pzcnJUU1GVlZOmLDRzcXHExNP+/fzz21mUa0L03Fr13FlRUVEzMzPGxNTbUVlWc7uRAAAAAXRSTlMAQObYZgAAAOFJREFUeNrt08cOwyAMBuDYhjCyOpLuvcf7v19tLr2UJLeqUp0LQp+s8BuSf327MoB+LC8IodvlBRcRdrsAO2XWmAC75OTklkacUhqhHbptQUrLRwhRmwXoD7WandfGi405htJwVdqNNggNYRz6+VhNnT3u9phkHyVvX/gwXqvZ1dr0+bjL1keYExn+Q6xsqFQGFU3ba0wmlTBoHQvNx8jL4SCNhxgcJ83L4cCWo5Z+CS1q6VdZjmc6guiUSQGElBhykCpyEgqDEGhL5+Q0ELnY8M5Teqa9XsNNY/+X86+fqBetgw06Q2aFxAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "304",
+    "id": 304,
+    "sortid": 304,
     "identifier": "aron",
     "name": "Aron",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAV1BMVEX///+9xsYxMTFTU1M2NjZSUlIjlN18fHy6w8O7xMQzMzO+xsb7+/v8/Px6enp7e3tSU1Q1NTX///80NDRquvNRUVFRU1Rqu/Rru/V5eXl5e3wwMjN6fHweTta2AAAAAXRSTlMAQObYZgAAAH9JREFUeAHt0MkRxCAMRNFpYcAS3mdf8o9zpAAsfPCRf+VVF3A5r1arI6JD7j0WiPmKG7YCQGjYrlUXIodpLOLDAoMIDDhytQvmmaFQubiD+fVTeQCm720xCATahz2QHs9F56Y5qnNk5vQxF6l3n73qphDdWWpf3pGdK2q1zusPJxcEdiZvJH8AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "180"
+    "gender_rate": 4,
+    "rarity": 180
   },
   {
-    "id": "305",
+    "id": 305,
+    "sortid": 305,
     "identifier": "lairon",
     "name": "Lairon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAS1BMVEX///8xMTG9xsZSUlL///97e3u7xMR6enpTU1N9fX00NDSao6OcpaU2NjYhlN6+xsb7+/v8/Px8fHxrvfcyMjIzMzNUVFT9/v68xcWpCfAtAAAAAXRSTlMAQObYZgAAALhJREFUeNrtj8sSwjAMAyPZSVugtLz5/y9Fzjkpd+hmPLnsSHba+UFm1NkGSPPqB2i2PXesC8dCjtj2aCSvl0XTzQTopJ3oPl2m0s2EZwXKdIlltGPuZILyxMmM2Wyw4/uBZmAVzfSZ5SxzKNd7Q5RBKqt6ISo1N8U4OWx58XJ5PdvVHnlk7TWLZdG5hUaez6zFASW2r5GHG1VLB+X1xSy3tiJBpDZgVAKxpCNtgCCizeP/TvV3/pcPLGIE+gc+OUcAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "306",
+    "id": 306,
+    "sortid": 306,
     "identifier": "aggron",
     "name": "Aggron",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAaVBMVEX///9SUlIxMTF7e3u9xsb///96enpTU1M0NDQ2NjZ9fX27xMS8xcX8/PwyMjL9/v7+//98fHwzMzNRUVG6w8P7+/tUVFS7xca+xsY1NTVpvPZ5eXmao6OdpqYik9z9/f1rvfd7fX1tvvcCsFrHAAAAAXRSTlMAQObYZgAAASNJREFUeAHtz8eSs0AMBGB3SyKDc/jDht33f8jtgb1Z5uSj2xoLqr6SmM1T80pLlrM8cQ2ebweeoyFP21BblXuMEZ1OxO2wIk/+Ky9qmv9Q8jjGRbXAeny4/09ZWaP3bdy81uxoUia3+4jOrHcv7s2mZCQZu1149/X+97o3g/J/SC7URox9b/Dv5vO672ugAnpPJNm2BIbBXatrVGYgqS8i7zG8MzcfilOmsupYTXfODIOk14IAimj/2b0Lk3QH1DBGNPPAZDEd5MLgZv22SQcWSf1BMZXkgccK4CYNRQQDIV2pLJeUmguyhkrQpsxFGMpvLitV5dA8gNl4BKxAMHEOM9IMxYXDkF+GkqCaILCwzEkqSy8slrf1MBAJS2fLPT+v/ABgbgrS5HwglAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "307",
+    "id": 307,
+    "sortid": 307,
     "identifier": "meditite",
     "name": "Meditite",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAllBMVEX///8xMTG9vb02NjZBittSUlJTU1OEhIwzMzPT09NCjN7V1dVRUVFRUlQxMTI1NTW6urq7u7tCa5VDi9xDjN3W1taFhY28vLxUVFRCa5RqsvNqs/RqtPaCgooxMzRDbJQyMjIzMTK7vL1CapIxMjM0NDRCbJXWa3PWbHRCi9zT1NSDg4tRUlPTanLW1NSCg4z7+/v8/PyaqcaLAAAAAXRSTlMAQObYZgAAAMBJREFUeNrt0scOwyAMBuDaCQSy9+jee77/y9W0d4drpFjigr78Ro4nYw2oHLB0aaCs4jTaQEdXGFSooN8RpIOKd6H+OV6avLoJLGBCTmb4by2BC0SpVZih55kPFDdB+Tmk3hooGpGV4eNpZvOuG0rloBuJLKjOpw0sWDc9voq86+7A/3AK9Cmx9P08Bne+5CSY3ohesS2jGScTN7+24iaE2F38PV3ws2yNAuhZRqmxpEda7GOKqxisNpyajjWc+gLhNgt1ajsIjwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "180"
+    "gender_rate": 4,
+    "rarity": 180
   },
   {
-    "id": "308",
+    "id": 308,
+    "sortid": 308,
     "identifier": "medicham",
     "name": "Medicham",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///8xMTHGUms2NjaUlIQyMjLOzs7scZqSkoJTU1IzMzM1NTXDUWrEUmozMTHNzcxRUVFSUlLucpvvc5zvdJr93EHMzMyUlIXksikzMjL+3EPGU2zksymVlIJUUlPLy8uSkoP7+/vGU2kyMTFUVFGUchlTU1OUcxnGVG2CUVnmsyrntSmUdBrtcprtc5mFUlqFUluVdBhTUlKVlYXOzM3+/Pz/3kLb+/KDAAAAAXRSTlMAQObYZgAAAM9JREFUeNrt00USwzAMBdBKMYSxoVLKzHT/o1W5QOQuuuuf8e7NyJbk3j9fxwJDp7PaEGJo5HaBifNAZ9eF0f0oGHIM9KDfyppx/uVEiiyGHAzSlmHKSTsaIuJrm3LVrUapNcweUvOQUgoHgGujfpKTbHfoxMmUdbaQYAunUC50rpAVT4VwkkKVEdFGuR2lIR6No2O+JE2v7yxfjTc5TXGSQLfzcX8jyE+7muPqnA3efQZ6cYB3mvdhzi8a2NJHbB1LqaHS8Bs2rvnH/uc3+QBFKg1J6A6x5QAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "309",
+    "id": 309,
+    "sortid": 309,
     "identifier": "electrike",
     "name": "Electrike",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTFjnGuEzms2NjZSUlJSU1JimmoxMjFztWuDzWsyMzH35yn15iqFzmllnWlytGu9QmM1NTXz5Ck0MzBlnW2Ey2pxsmpys2qFzm26QWK8RGNUVFG+plxRUVH05Cn05SqCy2qDzGr7+/v8/fz9/Pz25SlFSvRsAAAAAXRSTlMAQObYZgAAAKJJREFUeNrt0UcSwyAMQFEkYQQ2rji9Ou3+R4ycZAvOAfgbNm+EGFQup5T+14UxDQaQ5jMNNUwkVTKwtYvMFAUAo427H7sR1ceCLaQdlzRDNmyT7tJ8XYcYh4hl7RuqvTjnquiKfG3xcXp52c9sXfwxQ/B+vO8IOyeKo1AHuVVCI/tZ2JRVFDZ06NdizvM0DYnP2/fPlZBJ3pFOA8DnULnccm9eDQfRO8tT4gAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "310",
+    "id": 310,
+    "sortid": 310,
     "identifier": "manectric",
     "name": "Manectric",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAArlBMVEX///8xMTF7ve9qkrNrlLU2Nja9pkLezlr393szMzFqkrI0NDJslLNtlbZ6vO4yMzO6o0FSUlLdzVlSU1Pz83n09Hr09Xv29XpUU1Lby1ltlbR5uuzbzFnczVt6u+xUVFJSU1RTU1G6urq9pUL8/Pw1NTVTU1MzMjHUY0NRUVFslLXczFp8vOzczVx9vu+Dg3KFhXJUVFQxMjO7pEP29nq7pUT7+/u8pEL8/f3+/PzNcMEVAAAAAXRSTlMAQObYZgAAAPFJREFUeNrt0kdywzAMBVAR7Opdcq+x03u9/8UCxdwS0SaTjbESZ958kBCCc/1NSTbS1dqOghe1Oo7qW5sxUE76RnUmOh0omHdGdadLyllGQgzUKB2kAx0M04yCBgMfb2wgrzgBa2SxWCBkk54L8eydoZlefiULrfuHj03BK+YNnH4+7e/fSpRLWPM28kF1CwB3uzIWKayb1dz6ImcgxAvmxSkgNKq03j/I8qEvx8D5q6HWQ4btqkCHUGNZAlYDgx+5c+tByYyFVcHIfWT5ZgkZfmyvcd50ZGNMNDyMdtvDPmkjGrkJsffENf3dBuf69/oGWN4QvkECfowAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "311",
+    "id": 311,
+    "sortid": 311,
     "identifier": "plusle",
     "name": "Plusle",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAclBMVEX///8xMTG9pUI1NTU2NjYzMTHe1lr7cVn7+3n9/Xr/c1r/dVr//3u9Skq9TEo0MjG+pkLd1Vk0NDJSUlJTU1H9cllUVFK6SUm6o0G7o0K7SkozMjG+Skr8/Hq+TEpTUVHb01m9S0n/rIv/rov//Hre1VqqGazlAAAAAXRSTlMAQObYZgAAAKBJREFUeAHt0seuw0AIBdAHnm7c+0sv+f9fjD3KemCbyHd9dIWAvz1fEwUyl9lQifpsEEE1DaHQssJjdAoAktCddWQ2JEfIZvTUQmRrdaqQ1ownyiWOam/KQkNy1x/ZdyvjYOuMwQOzHFd7au39xcE4ZP58sLdR02VpTKmB/Yxs9mTQ55VlOzc5dsttYKS6YoOI/b8G9m3BbUcUvvgvZs8bFdsHnWBTpSQAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "200"
+    "gender_rate": 4,
+    "rarity": 200
   },
   {
-    "id": "312",
+    "id": 312,
+    "sortid": 312,
     "identifier": "minun",
     "name": "Minun",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAaVBMVEX///8xMTG9pUL//3s1NTU2NjZxo/tzpf8xMjP7+3n9/Xre1loyMjR1pvy6o0G7o0JTU1G+pkLc1Vzd1VlUVFI0NDJMdLtSUlJJcbpKcrtKc73b01lKc75ypP0zMjF0pfz8/HpMdbtRUlMf0TjAAAAAAXRSTlMAQObYZgAAAJtJREFUeNrt0kkOgzAMBVBsZ06YCXSm7f0P2RSxjrNtxV8/WV+2qyM/EwmFTulQ6IqgPN31zRQN3J0EgCy0L7MxpbMVRIOOImwsW0FaSpmeVJc46p2fLwayu95ltyTGwWi9xwezHNs7ikoPHNxK1oOfDXuXdzsmBuxniMaRR1cHFbiZXzkt7crCK46I2J0N/7ZgKULR8wqojvxjPvujBpQHDBbVAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "200"
+    "gender_rate": 4,
+    "rarity": 200
   },
   {
-    "id": "313",
+    "id": 313,
+    "sortid": 313,
     "identifier": "volbeat",
     "name": "Volbeat",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAulBMVEX///8xMTFSUlI0MzE2NjaMnP/z0zj11Ty1SkpTUVFTU1FUVFGLmvw1NTWzSkozMTG9pUHsYlLuYlFRUVH21TlSU1SKmvvvY1L///+8o0KNnPu9pUKjw/ulxv8yMjS6o0H31jn7+/u7u7uMmvxUUlI0NDSNnf96enKkxf+lxPy9vb27o0IzMjG8pES+pkSlxfztY1J7e3OmxvuySUn00zn10zkzMzO0S0xTU1S1S0n8/Pz9/fz9/f22TEkMgAv0AAAAAXRSTlMAQObYZgAAANZJREFUeNrt08cOgzAMBmBsmhA2LXQvuvfe6/1fqy7q2eFaqb9y/GwrkWP88wMpAORyvkyj5bdEI7sJyazE5EdLU5oAEC8SDaSOzVtJnUzpAi9jPL5Kqp5ETjFk4WFmNaZty8VitRqyrk2xXK+sgb315iOFECRVyN26lTEeUvxKGb3VY5w5gszwihAd2cicDcA9D3o0FzFQNt5rI2YtiOJktx1if/6skeQ2Y3+ljjbJM7Cb0bLSyEFEIMa5OBgIcVE2MQ1E6DYdDEJDJ4FOjJj3Uxj//Ere69MPtXpPLrsAAAAASUVORK5CYII=",
-    "gender_rate": "0",
-    "rarity": "150"
+    "gender_rate": 0,
+    "rarity": 150
   },
   {
-    "id": "314",
+    "id": 314,
+    "sortid": 314,
     "identifier": "illumise",
     "name": "Illumise",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAArlBMVEX///9SUlI2NjYxMTFTU1SSecuSesyUe86UxvdalM41NTVTUlOSw/OSxPSTxfYyMjOUxPZUVFLFpM79/P7///8yMzRRUVFUVFQ0NDRclc67xMzDo8vDqynEo8zEpM4yMjLGpc7GrSrz23H023L33nP7+/tTU1FTU1MzMjAzMjN5eXmUfM7GrSl6enp8fHyVfc713XX23XH23XQ2NjW9xs78/Pz8/f40MzL9/v5Zksy2FSnEAAAAAXRSTlMAQObYZgAAANZJREFUeNrt08cOgzAQBFBvFmzAoaX3Bum9J///YxkpZ2yukTIHn57Gq8WIf34ilZIumD3Lw4BZ4LDcPJuu+hMVs625MjinJGvLLE/Z6NzaJQ09h7LpQsYm2F+GHnLK0+FkbSpUCRggHCY1wHo3gkMcyOLKq1vvVKG2KvFHpkYRuIkTev7jqEkqLMkwZesdec15GxuSmoiL4YYIFBMqpe+NRqdYsqsJkUr3XnDmr7hb7Il6t8PY8jCq2DdK8TYssBX6kSOxHStEGSZlYZX81SX/CRb//Eg+VNYO4b5/xIgAAAAASUVORK5CYII=",
-    "gender_rate": "8",
-    "rarity": "150"
+    "gender_rate": 8,
+    "rarity": 150
   },
   {
-    "id": "315",
+    "id": 315,
+    "sortid": 315,
     "identifier": "roselia",
     "name": "Roselia",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAxlBMVEX///8xMTE1NTVKlEq977VqxXJrxnMxMjFLlUtRU1FSUlI2NjZSdLZTdLVZs/1atf9qw3FSU1JKkkqaxJKcxpS77LO77bNJkknGSlv7sqMxMzIxMzRqxHIyMzIzMzNtxnGSy+ySzO6aw5JTU1NTVFMxMjNUU1NZs/xRUVHscZrvc5z09ipatf7+s6T/taW67LL39ym7o0JTU1FsxnQ0MzLGSlpSc7WSzOzucpoyMzPvdJzz8ymTze+Uzu9UUlP+s6NTUVJZsvvfLwo3AAAAAXRSTlMAQObYZgAAAQpJREFUeNrt00dywzAMBVCBTb1Q3UW25d7Te7//pQLFk50oaZcs/NdvCBAktHP+Q2zoBuyg3wJJpoNGIBDtkJqQcdEK7YyiopS3QexOnNIHTDOkHJ0Mm+oTWIecpje/hypH0zsuEyNlBqdcDtVuc3g+3F4wxgyaGnh5ZXe9I+ZHVlivStRhssk/EC4TxuYJG2W6RiZu+VRXeZvfPb6HJsoRTAvNRrd3FrVym39alhXFcTwDmLy5Ze2RVUswjWdX14iHQj7snRLpQjWiYHc5liE1rZVz77263kD5MruxENJK2HzlO57vI1TIlwom1c3hy/EGjb9CVgpOg1SHBDKKi277so6Kzqt1zp/nG/sEFgoQlOumAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "150"
+    "gender_rate": 4,
+    "rarity": 150
   },
   {
-    "id": "316",
+    "id": 316,
+    "sortid": 316,
     "identifier": "gulpin",
     "name": "Gulpin",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAPFBMVEX///9TU1JqmmqSzIsxMTFrnGtSU1JSUlKSy4oyMzKUzow2NjYxMjGTzYvz5Cn35yk1NTVRUVE0MzDGrWmdiBXtAAAAAXRSTlMAQObYZgAAAHhJREFUeNrt0csSgCAIQNEA31pa/f+/RmPTTmVd3vUZVFxmXy0qJWNbPiRuy3InOvYEJWAOrCU/ksWFJ9+fx04iIxpLIrhT0Kt3I8kDcWXxSJ3aUFdZXQ+a94aA7JqV+hggoNDdOUvNGWaYBgtXeEtMkj+8W2Y/7gKv3wXT6nPyKwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "225"
+    "gender_rate": 4,
+    "rarity": 225
   },
   {
-    "id": "317",
+    "id": 317,
+    "sortid": 317,
     "identifier": "swalot",
     "name": "Swalot",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAXVBMVEX///8xMTGUe861nM42NjZTUlOSecuSesyTeswyMjOVfMuzmsxaWltSUlJTU1M1NTW0m85aWlrsy0nszEpUU1EzMjO1nMtbW1u2m8y2nc6ymstcW1ntzEz1Y1P9/f7xf8geAAAAAXRSTlMAQObYZgAAAKJJREFUeNrt0kkKwzAMBdBIiqfYmTtP9z9m/EsJ3dgudBfywcaLhySwqj0bTE1EP7CebiJyLNIaTEDLbpX/Q7iu9SKva0HW08ELD/K85GE/NcpLsTcKNkNszY9TVqKxeVf8SHbpL9GsWi/nOY7aGcCU1IyEuVGt4UBZFyzkHfdIGRjG0a63dcmF0N+QM1P2OkCgmGZH2WWMACe+igtZAe3ZXBbXxgeQoZB5vwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "318",
+    "id": 318,
+    "sortid": 318,
     "identifier": "carvanha",
     "name": "Carvanha",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAn1BMVEX///+9pUI5SqUxMTGtSkI1NTXbYllRUVExMTJKa9Y7S6NSUlJTU1FUVFS6o0E4SaM0MzH33kL7+/u7o0I0NDRJatXz20HeY1oyMTGrSUEzMjG8o0JKatNLa9P23EL23UJTUVG6o0P8/Pz+/PxUUlLeZFneZVxUVFE2NjZRUlStS0LdYln020L020P03EQxMTO7pEQzMTGrSkJJatM5SqOo6ygQAAAAAXRSTlMAQObYZgAAANJJREFUeNrt0skOgjAQBmCmU8q+K2hRXHDBfX3/Z7MCiacWrxr+TKaXr82kGa3PL0TH9mi7NFUafjq7qSDwBgpXhB1QFw27oUACBiYrIuAK6YN9AgCbmCm4qIL28AxTixBi+lzO8HGdWqLIGxooc7rvOhPLIsMLBoQsgEtlZSy9ye5pxoNgMYtEQqmMPVaKGrBVMou2KB+SZVnpLTf0QOeOI5xK1qGUzhPlPxrHdevuuat8En3YUzpCHOe8a9WMejp9PFLDeimaG50w/HbPtT5/mRcKFA/NcoNhdQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "225"
+    "gender_rate": 4,
+    "rarity": 225
   },
   {
-    "id": "319",
+    "id": 319,
+    "sortid": 319,
     "identifier": "sharpedo",
     "name": "Sharpedo",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAllBMVEX///8xMTFae/8xMjRZefsxMTJSUlQ4WZo5Wp1RUVFRUlNSUlI5WZo1NTVZevxZev05Wpxbe/1cfPyutaO9vb3WWkL350L///82Nja6urr15kNTU1P7+/tUVFTVWUIzMzPz5EH05EL05URbfP8zMTGdxv+ttaWlOUKmPESrtKb+/PyjOUK+vr7TWUE2NjW7u7u9u7s0NDRkBkRPAAAAAXRSTlMAQObYZgAAANVJREFUeNrt08cOwjAQBFB2bcfphHRK6L3z/z/HWrlixwLlxijy6WnGspTBP/0lAjtXc2bpXPEV/L1QJomNjLhLzgZSYYesAdSh4JCB+XICuBOSQ0RmhH6MbTqkt0pP+0k2QnSCAAxwWZZly6jZFXqXTcoUycXm7TtHXFMhOcZR/5oROZKpEzM5pI8q4TOc7TaKOnDbcsb16yQrlSYUUkif9gF04zCrrnk+DROKaJWOepfDvCie+dTI1PpxXpyrJngsjK695wvGObkuCUDHeGH/v/7TT97WDg0IPzSBKwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "320",
+    "id": 320,
+    "sortid": 320,
     "identifier": "wailmer",
     "name": "Wailmer",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAaVBMVEX///9SUlIxMjM1NTVKc84xMTFjlOe9pXPv1pS8pHJikuRJcctik+Y2NjaUe1qVfFq6o3FUVFPs05Lt1JNCY638/PxSU1RTUlK2trYxMTK7o3JUVFRRUVFRUlMzMjLu1ZOSeVlKcsz9/f2kAc9CAAAAAXRSTlMAQObYZgAAAKdJREFUeNrt0skOwiAUhWEvc+fZWau+/0N6CmGHt66b/gm7L4eEcNjbXlIv/cFyVRpjBEsrrXODRk+ZseIBF2KkLFR0rKwKBSjydRgHV6W807sMIO4edVr2HSi/GeF0I/Jriii8k0hC103nDyyylsDMeElPNicCBb7OgIsUP+AAinpnwyRcWrpmcDjWx/wN2dYLzILjP88rs3UWHU9byGe8ladQe9vrC0KACkM9htdmAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "125"
+    "gender_rate": 4,
+    "rarity": 125
   },
   {
-    "id": "321",
+    "id": 321,
+    "sortid": 321,
     "identifier": "wailord",
     "name": "Wailord",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTExMjQ1NTVCe85SUlJSnPf///9RmvNSmvQzMzNTnPdUnfdRUlOjxf6mxv+6urq8vLu9vb2+vr77+/v9/f39/v+EhHRBeculxv9TU1MxMjO7u727vL1SU1SCgnGEhHM2Njb8/f79/fyFhXWjw/tRm/axDArFAAAAAXRSTlMAQObYZgAAANBJREFUeAHt0sluxSAMBdCYgcxphqRJ57n//4n1RYhKyK3YPL1NroDVEbYsF5fOmTei+P4PK6eI+CkyJEd2iTy+zcPfjfkEaESoGaDacNc6BasPyWmg4bYsO/eO2ykSHTqHu2ldDAoLTgig7GSZAZ3KdKa3OfDZ1smfWobuqUlWQn/x/MJgVPX7oaV02OuyLVu0mGBfixuhR8Bg4czjva0FqVcof5gymzmNXw5JBgsEl5BYfP8A+5wCI5FB0ss073xeJ4EllMbdK5klFurM9fMDVbEQ8r4oQ7wAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "322",
+    "id": 322,
+    "sortid": 322,
     "identifier": "numel",
     "name": "Numel",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAmVBMVEX////GrVpRUVFTU1Kce0rEq1nGrVn820r/3ko1NTVUVFH+3UpSUlKMzmuNzmqaeUmdfEoyMjHFrFkyMzFTUlHMxIPOxoT3770zMjHDq1maekr93UoxMTGLzGrNxIPNxYOcfErT09Pz7LqEc1r720k2NjZSU1L93Er9/Pw0MzFUVFSFdFuKy2qFdFnGrVuFdFr+3kvErFr////8pvWTAAAAAXRSTlMAQObYZgAAAMRJREFUeNrt0scSgkAMgGGzHVikSFNBsff6/g9nVs9Ezo7/+ZtkZzaDf7+VV9f9HJNQof3qN2MQmY6TcxiOahIya7UxfhNiI3JiEO+M4s3WNigpp4I45YgwCjKtAl/7Hzg1h0649vGNbjUNvWVZ3i/J4sr1EJkhYXnaP4/aYMOpgoqAxW31EDs3UQHCTlm0mQSAwDEuq+6vZnYiUng3JyDSSMxaR3lOOYRskuUFlyjpw8Dt2BgQ9rm2KAWR9Ltf3Pvv13oBZ6cPnfmb+PIAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "323",
+    "id": 323,
+    "sortid": 323,
     "identifier": "camerupt",
     "name": "Camerupt",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAnFBMVEX///8xMTFSUlJUUlKcnIzWa1r0i1n2i1pTU1JTU1M1NTVzc2uamoqamos2NjbOzr3TallMpPxRUVH1jFszMTH3jFo0MjEyMjLTa1wyMjFycmr0jFyjnK6mm6vMzLv7+/v////OzLt1c2rOzr5UVFRxcWrVbFubm4vzilkzMzP0i1qdnY31jFpLpP10cmrLy7r3jVx0dGz9/f3NzbzCYUs6AAAAAXRSTlMAQObYZgAAARJJREFUeNrt08l2gjAAhWEzAmUUQau2aud5fv9365+kq5Ij3dmFN+hx8Z2bmITJMf8jJ4L8wVU3m7r+WO4lvqp6y6TcPIxXFfqrrrVe7Fmbr8pKnef5HTCOBE/hqtIf+DyPMnE/F0UQ6Sonj30fkVWjbK9kGaqUvYRN13HYJMqqVagi07PZUFYCB7O+Krg147T7XWeMkrYnSkrrWRTS2HrmYpTFMfH5DDj4000SGIpPgC+4Ady+05UwmFt6SJ+JwavbC3Z4e81yTeKWhzOvy8jhcSSfux3QxSnFzy4KkU86DdI7YNQhNdCjTjR8Rwpb7ldWepewQyLc8uilKDhkvWjdPjHl2HtCNYfpG8eCJ5NjDptvtrUZK0oCAocAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "150"
+    "gender_rate": 4,
+    "rarity": 150
   },
   {
-    "id": "324",
+    "id": 324,
+    "sortid": 324,
     "identifier": "torkoal",
     "name": "Torkoal",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAh1BMVEX///8xMTFSUlIzMjFUU1JqamqUWjnOc1LskmLvlGNra2syMTGtraWLi4OMjISNi4M2Njarq6NRUVHMclIyMjLkYllTUlHtk2JTUlIzMTGVWjmSWTjOdVTLcVE1NTXnY1rlY1ruk2LT09POdFTV1NP7+/v+/PyTWjqMi4IzMzNsa2rmZFtTU1MJc41LAAAAAXRSTlMAQObYZgAAAMhJREFUeNrtkscOgzAMQLFDCCPsPVq69/9/X52q6qmBnBHvmqen2LK1siy2AGaa63nMwHMFsWdWApPhhHIKG1IpZQEzYufUdvrCVD7baa/2ukoVo2jXwoTIAPoqJGuMIz8sZorlGJPok1/8H9qzXfVH0ZSU+3oaUyFEw5WGiAAaEzbiQ0M15JgLpt15ln+WbiNyHwldsneqnDy1do5wOJ7uOs9xAp4/0FWLoq9og7drQM8ZDePDzJX9xmcm53YeLgMzvF+wVpbGGzXXDdPyn3yHAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "325",
+    "id": 325,
+    "sortid": 325,
     "identifier": "spoink",
     "name": "Spoink",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAz1BMVEX///+7u7u9vb1UVFRVVVWUlIQ1NTVUVFO6urq8vLySkoKTk4M5OTm5ubm6urkxMTFSUlKRkYFTU1SQkIGRkYI2NjZRUVE3Nze7u7qSkoEzMzOTk4RSUlH9tKRVVVT5saL6+vr7sqP8sqM3NTT9tab+tKS/vb3vhZTvhpbwhZX5saE0MzI0NDQ1NDO6urtTU1IyMjI2NTRWVVQ4ODiVlYWVlYa4uLg5ODi9vLw2NjW+vb3+taT+tqb+/P3/taT/taX/tqb/t6f//Pz//f3///+yrZtlAAAAAXRSTlMAQObYZgAAAMNJREFUeAHtzkdyhDAQheHuVp4RIzQBsAHnnHPO9v3PZJ1A0pYqvoVWfz01jAZEnru8bvv7czer+/37ej3NCX/ej/YzwtXJx+HxznV6cLKx2fc3uJ4cROKsRJKJzBWGaOs+PNFJuZgrVhjZHDzpM4iw1dRozoq9txe+vIpOPpBCVEhE3EXDbiYuBEPExJHWq6ChOzXTNcTc+mkrgkkpIU52a20wd5DwGD5npfI1pFivjViGLl1Wl9UKcshFDVnsMwzH6B95Fw2QSDkNPAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "326",
+    "id": 326,
+    "sortid": 326,
     "identifier": "grumpig",
     "name": "Grumpig",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABBVBMVEX///97e3sxMTF6enpSUlJTU1N5eXk5OTk1NTWtjLU2Njasi7NSUVLLq9PNrNXOc4zOrdbsq7rsq7vvrb0yMjLMcoupibEzMjJTUlPJqdE4ODhTU1RUU1NVVVVjY2NkZGQzMjPtrLtQUFAzMzRlZGU3NzdSUlN7enp7entTUlJ8e3t8e3x9fH0yMjOrirKri7M5ODc2NTWujLWujrWvjbavjrc2NjXKqdHKqtHKqtLLqtLLq9JUU1RUVFTMc4vMq9PMrNTNc4zNq9TNrNRUVFVVVFTOrNVVVFbPrtfpqbjpqbnqqrlRUVFWVFViYmLtrLztrL3urL1SUVH7+/v9/P39/f7//v84WBv9AAAAAXRSTlMAQObYZgAAAPVJREFUeAHt0cVywzAQxvFdrWSB2Q5DnKTMzMzM8P6P0vHdkB7byf/8m2/HFvyNxik2onvkv5AsHWasBE6veHqJWYhYKYRTbvs0SAgHcb94cCdIS+i4XnLZ3vSC/a9etcyFcbjuTXzoSVbIKuzu7Sk6v7H1coOl5f+Z4cNrvLGl9REhC2O/numcw/eh6db05/cttxJEzqPMT5c1u2EAuifutXslCK2OPxdlbraUSu/vXR6ImcVZFP6L70T9/CckRNG8mBfirDNYvc+F8lkQERcCkVcNSIB82ePKIkSLGShMrilQRAuOgfJks73bglGS2wb+W+N+AFm0FaFXdv1HAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "327",
+    "id": 327,
+    "sortid": 327,
     "identifier": "spinda",
     "name": "Spinda",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABI1BMVEX///8xMTHMu6Tec2v33r1UUlJWVFR1dHS7UlI1NTXOvaXcc2s2NjbedGz027v03Ls5OTlVUlLy2rpxcXHbcWq6UVG5UVHJuaIyMjK9UlJRUVHPvqbNu6NTU1N0cnJUVFNSUlLbcmp0dHM4ODj33Lz33b10c3L5mbHLu6MzMzLMvKM4NjfOu6TOvKVVVFNVVVSlnIymnI2mnYw4NzfacWkzMjFTUVHdc2rbc2vLuqN2dnSkm4ozMTGkm4vPvKXPvabPvqW9VFTZcWo2MzLacWpWVVS6UlJTUlK7U1K7U1Pdc2vec2q8UlJycnLedWzefJTfdW3x2bny2Lg1MzPz27rz27u+VFS+VVT12br227v23Lv33LvJuaE2NTXKuqNUU1P9m7TuqAjwAAAAAXRSTlMAQObYZgAAAPlJREFUeAHt0cVuAzEQgGHbM8uwm2SbbJhTblNuyszM3L7/U9RaqddxblWk/CcfvvHIMhv2n1mc9+cKZn7jb4SEI/nKZpycIjlBwYpoxInrOLTMiG4CM07HpGDYa4gy5/xh/kxC+jk+IlZ9NMQ46SJ4Q5naaastRA9A44yGuty8VqvVYYq+sZD220bggWaWSBj25mYfjXS1rp3QkH3mtrZt/VIcfnVj+gtToz/X03Y5t0461sxeHH+P2XZJv2d0YXYm2CkWnXPYV0jrrtXG1+doBZYU8Ojp5f0KUnuLk4rdH+L0wLvZXXaZotB1rdtgYoH1U9Ny2bCB6RfXKhoFgGFRngAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "328",
+    "id": 328,
+    "sortid": 328,
     "identifier": "trapinch",
     "name": "Trapinch",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA51BMVEX///81NTX3lHPWc2P0knJSUlJUU1JVU1NWU1LRcWLUcmPUc2M5OTnWdWU2NjZUUlI2NjXXdGPxkXHzknHWcmP0k3L1k3L1k3O7u7vTcmJTUVE3NzY4NjdUU1NXVFO5YlG5ublSUVIxMTH2k3L3lHLTcWL3lXX8/Pz9+/vUdWTVc2TVdGTVdGVXU1NTUlFTUlI0NDS6YlHXdmbwkHC6uLi7Y1LykHG7urozMjG9Y1L0k3PxknFRUlFUVFQ4NzXWdGT1knLQcGE2NTXRcmI0MjJVU1LTc2M4ODhTUVL9/Pz++/r+/fz//v0CFUrxAAAAAXRSTlMAQObYZgAAANxJREFUeAHt0MdShEAQgOHpnsAysMPmxSAogjnnnLO+//PY5ckLPVy1+Ku4fcV0t/gbtUFBNWFDRJRnPgqH+BNRD0wucdhAws7YqO3HZaSeWEh/M2QRZaILDyQ6mKJZvfbDTF+pTCvu7bii8SijpvQ4d044wZJgRwczMlGmXkI4uiPYl5Icu3kc2pGkKoIlfu7Vy1cIbRRFz8HWwWSty569N7uwG9jbj6/1000Owv750ctG930FO0v3dp6ZMj+ec4tpeoH9N+cEU+zoe4B88mtp1g/GN6KZ7Im2f9Y37SwSLuINzzIAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "329",
+    "id": 329,
+    "sortid": 329,
     "identifier": "vibrava",
     "name": "Vibrava",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAulBMVEX///8xMTFSUlI1NTU2NjYyMjJSs1JjzmNxcXFzc3P396VUVFNTU1I5OTlizWJRUVFRslFxc3FycnJyc3IzMzPCwmrGxmtSU1Lz86NydHJkzWQ0NDTExGpStVL29qQzMzH8/Pz///8yNDL4+fhRilFTtFNQslBUVFRUtlNzdHNzdXN1dXXBwWlVVVLDw2pWVlPExGvFxWvGxmpizGLw8KHx8aIyNTL09KP19aRjzGNjzWNSjFJRiVI0NDOw9bu+AAAAAXRSTlMAQObYZgAAAOlJREFUeAHt0cVuBDEMBuDY4QzzMpSZGd7/tWrtpZfG3etK+x9mIvmTx+OIHcs+EraFTm/XTh41mt4ALHOa4GcDznvgPmrGWmxalnMPnJsTpMPojA6s29Tl03fbguBhpYSElibUPByTq/zFx2Oj/vsV2RznNucmBChqBHDv1lpTqSgrZouQzNLa5HYyOdexZjd9vwghJPVqfem9q9WfjlSKr4EeuFqfImLs9jIo8PktwcNpOXQP/TK+wmwUbhM0LwflgN1SSAlRWXT311/mZFAKRMaskIpXdykqIlLwIUqM3FT+UpaLfXYnP6sBDrvxDiSwAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "330",
+    "id": 330,
+    "sortid": 330,
     "identifier": "flygon",
     "name": "Flygon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABI1BMVEX///8xMTE2NjZSUlJSnFJUVFKbzUuczkozMTFTVFJUUlNCe0J6rDl7rTk1NTVSm1LWSmPscprtdJrvc5wyMzE1NjVUUVIxMjFBeUFUVVFUnVJ6qzlCekJ7rDozMjJ7rTp8qzl8rDp8rjpRUVGcy0pRmlGxQlmzQlq1QlrTSmLUS2MzNDLscZpSU1JSVFI0MjI5OTlVVFN5qjhDfEI0NTRRUlEyMjEyMzJSU1E2NTUyMjKay0lSmFGbzkqbzktSmlKczEo2ODWdzEudz004ODiyQVmzQllTUVLTSWJTVlLUS2I0MjRCeULWTGU0MzNCe0FUmVPucpo0NDLzkvP2kvT5+fn6+Pj8/PybzEqbzUmbzUrSSWG0Q1pTUlG1Qlu1RFyazEkpW6rdAAAAAXRSTlMAQObYZgAAAV1JREFUeAHt0cWOrEAUBuDy0wiFcNvdvfu6u9877i7v/xRTkLCqhllNZtP/gpDUx39IHbTOA0VinLxlq5L1CsdW/sqlM6Uo/cKYVVRu7zoXf6K7iMVKHcuu/z0w/bChu3yfzWMWz/3rFapv/fZ/ffx2n0WZRyyWhd9/xjl98vtw143cOKmQuEt1hpbd8NlH16UnW4cbyR3JflFzeHQ1+VrmnC/xgYJyFoYNjD880SAZtk0BAMJbzhrq/3oAQWSRLgcjUwhhXF4Q5VpnECVYdTlPh6OCSTt8H+FJy3EiGXgrV0PI4MZQx9Mpn3heT9WZ2uSk9KgO4geAoNTwQ5NWX6OUvJwLftwRiwWvG7RmWcUUJ0svKJSBMvb5X93ZSXXo56ZjiE+CM1Y5p7aUKDXEdoxTCpUK3FLFMoKbNiE2AFTfocyQGo57n3/LdgoR9XjT1Ha8Gru1/L0oqX30rHMHAw8g7WVeuJYAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "331",
+    "id": 331,
+    "sortid": 331,
     "identifier": "cacnea",
     "name": "Cacnea",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAgVBMVEX///8xMTExMjFKi1JKjFJSU1JSe0Jqo1Fqo1JrpVKLzHqMzntSUlJRUVFRUlJSUlE2NjYyMzJBaklUVFFCa0qKzHo1NTVLjVLz5Cn05Ck0MzC9pVpJi1FqpFFUVFSLi4tJilGLzXpDbEpTU1S9pllRUlGKy3n25Sn7+/tSekLMzNycx1uIAAAAAXRSTlMAQObYZgAAAMFJREFUeNrt0kcSwyAMBVCLXtx7Te/3P2DkmWQJ7BN/yuoNSAzRlh9MDusMsyjvx34MuraE/jJN96DME5oO1VBBEB4YSykOAG8bcLMdw9QzIx4mNY9NxxprOa3B6cpFZIoba1HjUsQFpVi4OqKDx85YrZ0wUZrIurF8/zob7YZRC4DanBoeo8MaCl/f2I/SuPgTiy2wIc/9HyqM7TxPVF5BIospkWI90/91EspS9OJbpufcmazligzCX3LdAKItf5g32QgKTFum16sAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "332",
+    "id": 332,
+    "sortid": 332,
     "identifier": "cacturne",
     "name": "Cacturne",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAbFBMVEX///8xMTFCe0o2NjY5Y0pBekoxMjFZklF5q2J6q2J7rWNSU1JTU1JalFI6ZEp6rGIyMzKazIqazIubzYtSUlJBeUk5YkqczoxRUlFDfEtRUVE1NTV8rWJZk1FUVFEyMjEzMjC6oxDz2zj02zl2h6hFAAAAAXRSTlMAQObYZgAAAL9JREFUeNrt0ccOwkAMBNB4e0nvoSXA//8jzpLzepE4Zs5PI2ucnTnCU92gktxVs7v6b6MpZZLkaZCDrkopII52VqBjLCq5VrooAqQk2uBCVHR4lEIyIYVEOagY3N08ziNAxqNfYUI8t9dtpca5WOf798MiJGiQCQ4MMkc745y3znU10K5dmglTE9D3Laq8pSSAYQ3CnpJY2k1fuKioGyqPpsktfaXz4UoAcu9QWdOLA+xnHpBqZdVKsqM1O/NTPuLwC7T6iUgOAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "333",
+    "id": 333,
+    "sortid": 333,
     "identifier": "swablu",
     "name": "Swablu",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTFSUlJSU1QxMjNZmuRanOeCw/uExv++vr7b7Pve7//9/f0yMzSDxf5TU1O7u7tWVlY2NjZZm+b8/Pxcnef///9RUVG8vLs1NTWFhXWFxv8zMzM0NDS9vb04ebpUVFTc7fyDxPw7fL78/f6EhHOEhHSAPHTpAAAAAXRSTlMAQObYZgAAAJpJREFUeNrt0UkWgyAQBFCbeVSJYGbNfP8jBrJwF2Cvtf6vHl00W9abHVQ6ykiVPsI8EODC1nTih4V8pUMoSV6qc15OXXwfxVB0ZrxyEWNzB7k+OcranwRKmv/yc7goHV5nITAl2WNAaR0IFxhBYUZ1et9Di/14Qyi/otLPIboY2eUlUIZ7I01JJgp75KObCnBZYHHF79yyznwBe0AIS9DzZXsAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "334",
+    "id": 334,
+    "sortid": 334,
     "identifier": "altaria",
     "name": "Altaria",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAjVBMVEX///8xMTExMjMzMzM2NjZSUlJSU1RalNZ5uvt7vf+9vb39/f3///9Zk9VRUVE1NTV6u/y6urq+vr7e7/9UVFRZktO7u7tTU1NBappCbJ0yMzTb7Px6u/38/f9Ca5xcldaVlZUyMjI0NDS8vLxRUlNCapp6vP4xMTL7+/v8/Pz8/P38/f59vv+SkpKUlJRg+zUfAAAAAXRSTlMAQObYZgAAAPlJREFUeNrtk7d6wzAMhAX2Jlld7nZ6z/s/XkB6TAhm8eYbwOX/eEcArG66lgQAxFriVutaawYTK923rlnzVGsoGuNVopFQlcHji7FWsxSTJp/tFjAAmC2dca8gHZbmzOaxvfgC2UFjozQDsoOdW1qbpGaeR0Xn3IIvOXxG0If7LFi5ZTecNDNWq7cQCPI1jLthOH2EMXLnO8iDYZRSTipxPvQ8y4UeY+qLc9ZcdB5BH8bWHigOyUZ++eSJ6tHZ/W29Mpt98kzc94NzGbASuArH996nqA5JTmyOmrHrUmLlANQUIY4RI8z8H1+rmdJSlCWIn/Vr7DddST/ClRCH8zDNMwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "335",
+    "id": 335,
+    "sortid": 335,
     "identifier": "zangoose",
     "name": "Zangoose",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAclBMVEX///////9SUlK9vb3va2sxMTGEhHNTU1O1Wlq7u7szMzPsamo2NjbvbW0zMTFUVFRVVVX3rf9WVlb8/Pw0NDRUUlL9/fz9/f3+/f//pZz/pp26urrzq/s1NTW+vr6EhHT+/PxRUVG2W1uCgnH//f2Dg3JerALqAAAAAXRSTlMAQObYZgAAANNJREFUeAHtzbeWgzAUhGHmBhmBwTlvDu//ijtSjYS3cuP/SN135jbPHtvyXnfr/gmXXnWvNyVMrB9n4Ls4XW9VR/h9BPbem7VV6QCGD1x/huS2M/Dwe7x+0a3jolmXnfjLGcPYbCXqQnb7SSgwbHxzHmz8jJocCKclM7NDVLodSs5VDbgYVrx7AvDWFZzALsit4qnsWiEzBDpR1vm0E0IawjZDzhWge1AwsdYovQSdX0OGZkJXjosqfCYWai4NqrtCghBWZb6fYHKzUeI+yJpH9+wPi1AIPMyiaxQAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "336",
+    "id": 336,
+    "sortid": 336,
     "identifier": "seviper",
     "name": "Seviper",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAclBMVEX///8xMTFaY3NSUlJre4yljPfvzlL3c2NtfIu1pUq1WkpqeYoxMjIxMTJZYnI2NjYyMzMzMzFqeos0MjFre400NDJufYyji/Q1MzKyo0k1NTUyMjK2pku3p03szFLtzFLuzVFRUVHzcWL0c2MyMjT//f0VI9d1AAAAAXRSTlMAQObYZgAAANVJREFUeNrtz8mOwjAQBFBXb04gbLPBbOz8/y9SIuRmZ+aKRMkHW3oqd6dnHi4L/BceX8d7gAHmqsT7cmpmXQ+np5pEG82HvxEOsgwRbfyEm8z691etkoW/O3dDGqAVKxHhl032+E4A+r+7YqG55+waioim4/5lCSVU1QjlrFz9c786rM8FONEbCzGlM902OpdZCWKSlY6QjvJFFMUZEzJAd49KBSZCYrtRlvLCnyuSR/wORQWplsERiYCuDt2FoQuyUSg0AmnpxqVIq0ig+0uC6JkHyhXLGgec89htawAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "337",
+    "id": 337,
+    "sortid": 337,
     "identifier": "lunatone",
     "name": "Lunatone",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAWlBMVEX///8xMTF8c0J7c0JSUlJSUlEzMjF8dEK7pFm9pVrU1GrW1mt5cUE2NjZUVFLT02ozMzE1NTW6o1lTUlIyMjG7o1l6ckJUUlJRUVFTU1LV1Wq1UmvkWXHkWXLNkKOFAAAAAXRSTlMAQObYZgAAAI9JREFUeNrtkkkOwzAMAyt5t7O36d7/f7NSfS99TZA5D0QS0OlgM/REbdpYykTYG4uQnhP0EpssYvIweUms5kAw/GdKTyTOKg529Si6yyGys9fo8ejgPq8zONnfrULv2+rBEoHxRe0YOQfYsdYM8VFXY1HygThT9djR/3OdMUY93HBJCl8a/lFUT60ffrBHvkc8B0KPivJSAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "45"
+    "gender_rate": -1,
+    "rarity": 45
   },
   {
-    "id": "338",
+    "id": 338,
+    "sortid": 338,
     "identifier": "solrock",
     "name": "Solrock",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAh1BMVEX///8xMTEyMjE1NTU2NjbLq0nOrUrWa1L3lCn33mvz22ozMjH33GmljErTalI0MjDWbFLzkin1kyr2kyn23WpUUlKFc2mFcmr0kinTalGjiknMrEqFc2ozMTHNrEr13GtUU1GFdGtUVFI0MzGCcWqEc2pRUVHbSUFSUlL022r3lSpTUlGDcmr6pE46AAAAAXRSTlMAQObYZgAAANdJREFUeNrtkrcagyAURr2gFMXe0zQxPXn/58uVJRPg5uI/wHK+wy14W9aPv5Cj4bRQGEo36WuORU4uiDx/d4qJG2SRpjEUwAbGBLBEcFbq726FOhciBXQbIZhFuZjTDKwyCWkQnyLIVVaKsRPNHoVGY3Ao0Da+5KUTqbVpLVRSyndDAOxbycr0cbwn7YBjB4uyL4VQMuP8iCVXk3mMn4TzOqm/ZB4CmDnsu+ect/sDsU6boINenwABvmoJ1ce8Exoy5vyNLCZ4Ie0kNQPgBv/lOUjwtqyfHzK7Cs8aAf6gAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "45"
+    "gender_rate": -1,
+    "rarity": 45
   },
   {
-    "id": "339",
+    "id": 339,
+    "sortid": 339,
     "identifier": "barboach",
     "name": "Barboach",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAYFBMVEX///8xMTFSUlI2NjYxMzQxMjNSUlRSU1Rqsvtqs/xrtf+MjIy9vb1SjNYyMjIxMTJLa6SLi4tRi9W6urq7u7tTU1OKioozMzNqs/1JaqNKa6VKbKY1NTVRUVFTjNVRitPYzX+KAAAAAXRSTlMAQObYZgAAAJJJREFUeNrt0UcOxCAMBdCYEkxLz/Ry/1uOnVmbYTFLvhAI6elL4K6lpRwNde7xtrz/1PpwGg1XVzrMtgw1fJ3zpuye3m1nAAzMQYI9rDvBlNLL0p20KBUXrolCtdflNgoSQwjUuKstcqaLEb8Rcz/HqJSaaU2LFd+Te+8ATgcd8D7KI6RFB9E4VIyIKXQtLf/KBwlsBqeo/ozcAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "340",
+    "id": 340,
+    "sortid": 340,
     "identifier": "whiscash",
     "name": "Whiscash",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAk1BMVEX///8xMTE2NjZSUlJSU1RSYrNSY7VZkttzvf+6o0Hn1ow1NTVRUVFTZLNUZLRUZbZalN4yMzS7o0O9pULk1IxSUlNTZLXk04txuvtyvP4xMjNTU1EzMjFRYrIxMTNyu/z7+/udpr5TU1MzMzK7o0I0NDRyu/29pUPk04pJaqtUVFLm1Yqao7qao7z8/Pz8/P39/f3efRPuAAAAAXRSTlMAQObYZgAAAOFJREFUeNrt0scOwjAQBFBsb+x00hNq6L39/9cxFuGEE+UKYm6WnkfrMvjnG8JZT+ek0x574KbMaSSviHW4dxGcbcdYtEItkQFXVBM7uGuD87Tz2Ewic19FEZUnUa7NhXyWhUmQhVLmCk5F4yo2QdRlruvuA4nkGo4w6af0b0OZBMk5bJyVixrOIC8FBHJ9LAsNMazRVWS94H27GHZBNSIhrFfjqs010rZhESuDmzOz8xQJfU4dDNHah8KxMwFFSJd2SLyfk06EULRJcamA7dFP7eNUrM/n5Mdd3Puj//ODeQIFaw8mP1/GsQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "341",
+    "id": 341,
+    "sortid": 341,
     "identifier": "corphish",
     "name": "Corphish",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAkFBMVEX///8xMTH0ekJRUVFTUlHDWUHEWULGWkLn3r0zMTH3e0L+/Pw2NjbGvZxSUlI1NTXk27vl3LtTU1PzeUFUUlFUVFOcSjn////1ekE0MjGdSjkzMzPGu5rDupozMzLFWUHGXETk27qmk3JTU1LFu5qcSzrGXEPm27ujknKllHPl27qmlXT3fUT7+/s0NDRTUVEwRjI4AAAAAXRSTlMAQObYZgAAAM9JREFUeNrtkscOwjAQRLOOe0jvoYXe4f//jiWcENqEK4g52JenJ83Yzj/fk9GnXFp/QoEDCOI9BAooqnrAihpwQpdZZQY4oZQBlzXFjfWBoVAYzprK2gFhMUeXxXjnrg9Q5HSzTljGrHe9tAZSFFOgj1yUM68sW47qHjJhy1jn0ntwTYX1yX3c6HRYya7Tcat2Y7KQu481KjtQa5oTHI1PZaRzoJeczGChtZ9ILnkQSEMKjRPC1Pcf7QPJ6SHheWJSm71gdKn316Y/0j8/ljvHzwz+4hLduQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "205"
+    "gender_rate": 4,
+    "rarity": 205
   },
   {
-    "id": "342",
+    "id": 342,
+    "sortid": 342,
     "identifier": "crawdaunt",
     "name": "Crawdaunt",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///8xMTEzMTE2NjZRUVFSUlJUUlGzSkK1SkLsYkrvY0pTUVFUVFFUVFRrrf+ySUE0NDRSjNbEq3rGrXvezqXsYklTU1LuYkk1NTX11UL31kL8/PzbzKPczaYzMjJqq/xqrP61TEPuZEu2nELz00HDq3k0MzH7+/tsrf3////sY0zsZEyymkHby6O1nEK2TET000Ldy6PezKNSi9OzmkL9/PwzMjFOk8MrAAAAAXRSTlMAQObYZgAAARdJREFUeNrtksdyxCAQRAWIrAjK2pzXOf//p3ko7xF5ubh82YbSQfWqZ3qY6Ka/EkGB3O4QgnVoN4SA5OGpH7ZfQYUH0CEE3PbgGMAlH30i8bW5IBRL9pJIhX/FciGElopJNqZocqAk5j+cUmwsjgX8qb3GXS5aAGebtw0bz+cUoVopH0lyzeHMqqoCMqWSST8IHcXUNMt5dbpXjEKrvFXCG6qLjW3eV1lZ3ilAuYbLfbX31i7iZVmuMrDk2jSUUuTfBxSRx1OWzas1xAJ7ahaTw8xf1+4ITamxdopzebhw0pDrUtg7ytY152IAJ0WLpwxrgZGLTiVYSiUEnlwK99nbBqboeRhPelTjiByfP4vre3kpcNO/6RsQgxK9Q8Zk4wAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "155"
+    "gender_rate": 4,
+    "rarity": 155
   },
   {
-    "id": "343",
+    "id": 343,
+    "sortid": 343,
     "identifier": "baltoy",
     "name": "Baltoy",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///+9WkozMzJSUlKEc0qrmlmtnFoxMTHVxHrWxnvmcmrnc2tRUVEyMjFTU1Ksm1lSUlG6WUm7WUq8W0qFdEq9W0rTw3nTxHrUxHo1NTVUUlKCcUk2NjaDckqFc0rVxXrWxHpTUlHkcWrkcmqEckrmc2q8WkrmdGutmlkyks4mAAAAAXRSTlMAQObYZgAAALtJREFUeNrt0zcOwzAMBdCoUc1yb7Lj9Hb/E4YwPEsaE8B/0fJAgh/QYc8P5JjofE/T3Dy2LmWv7LWmMoG1xRn4SCOuUlq3nI84NAxvBOUaGnTiSVRHyKppCGZ3Qoy1FmUYisbYE+cvQxS4UINlbaYB13bk4UIDZydykTPGlgKCUB58xgQAL/JY4140V4YZaAxW6m0vGhOVAvDyaYhKn9UfyKXsEcbkUko8DGV0Nzh8Nhhuc+sq/mX2/FG+YbsKqMredy4AAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "255"
+    "gender_rate": -1,
+    "rarity": 255
   },
   {
-    "id": "344",
+    "id": 344,
+    "sortid": 344,
     "identifier": "claydol",
     "name": "Claydol",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAolBMVEX///8xMTFSUlJzc2NycmKLi4uMjIx1dWXExMRUVFJxcWI1NTU2NjZRUVEyMjEzMTGubVzDw8NTU1PGxsbsalnta1r05GL8/Pz///+ua1qralkzMzO7q1n7+/tTU1L9/Pz9/f3/nJyNjY26q1lTUlK9rVp0cmJ0dGQyMTGKioo2NjVUU1P352MzMjH8mpoyMjL9m5qsa1o0NDT+/v6ua1tzcmIXFxA/AAAAAXRSTlMAQObYZgAAAP1JREFUeAHtk8duwzAMQEVSokcsx3tkp3vv/v+vlWqRm6X0VhTIu9AGHh4oCFJ/z4kMfufNbvn5uCQ5qwkBVBb0ymVqUERDebkMLFdeGxaPxGSK/WaWGmYm4XvmXm8diXGAqH/zLJj2Q3SoCfKXT4vNuI3i91r2JDf6op1PixYW20GIJCYUN820qO4kWbx8ONkNX9Alu+Rpv7+P68qNLgHPoS2cb5p5c4WoESyuHpVXtPq1HS+6h2TRjp+58oquI7XV5UYjIii/CSUz/qApZAKsz5h3Q11pQ+4KA1FtdhFRXEkRIWSmhHFdVwhgtT8pzCBFFM19HX0yop34N3wBHccQO8+gVXsAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "90"
+    "gender_rate": -1,
+    "rarity": 90
   },
   {
-    "id": "345",
+    "id": 345,
+    "sortid": 345,
     "identifier": "lileep",
     "name": "Lileep",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAh1BMVEX///8xMTFSUlJ7e8ZRUVGtnM69Y4Tkg6PnhKX3tbUyMjNUUlNUU1N6esR5ecM1NTWsm81zc3MzMjJSUlP0s7M0MzNTU1PzsrL2tLS7YoPmg6RTUlKrmsyrmsv05GpUVFIzMTI2Nja6YoJ1dHK9ZIRTU1FycnLEqyn05Wv2s7TGrSnkgqP352stwGucAAAAAXRSTlMAQObYZgAAANFJREFUeNrtkLcSg0AMRC2JSxzRgA3OOf//91nnxhWC1jPeuaDijVaryV8/pBzGMDDJ567hQqT3c+eayFgPoRD6PbVeWI+IxnI17QcPeom4OZbI6vROsI5q6y9leduaNgHBmidzgUTTctUII94TxDrhw99pMe0FrV/Napcg39XM2N40eZRWgVGBTisQwmRVp5cpfd5Y3DiwPYNsG/rJaEZE8ReTlomjMIiujzPAIJdRtXltU4oHybUiKtQgl6+ZUoqKeHBEyArFqWFMHKb++hm9AXbODJ5J/tK1AAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "346",
+    "id": 346,
+    "sortid": 346,
     "identifier": "cradily",
     "name": "Cradily",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAtFBMVEX///9SUlIxMTFarXOLzJqMzpz/taVSU1NShFJTUlJUU1NZq3I2NjYxMjKNzpurWWKtWmPTeYLTmovWe4Tky2L15nP7sqP8s6NSU1JSg1I1NTWuW2RUUlJZrHLVeoM0MzJRUVFRglFShVOKy5rWnIwyMzLlzmPnzmP05HJUU1IzMjJUVFL9s6P+tKRZq3EyMTHkzGIxMjG1lELz5HGLzZvTeoP353PTmoozMjGtW2MzMzFUhVI2Q+86AAAAAXRSTlMAQObYZgAAATVJREFUeAHtk7dywzAQRHmHAOYcICrnLDkH+///y6BodQBHhd3psWHxZnm7M7Tu/Ac+3ugl2e6mOEyy+Hx9N3vRKBtEh/FFi0bxueO78cGtFjvLL3l/ZDyiTgYAFXerMZaccxe7AwHSbcX7DoAXmLuULmVEpotPJzpwFzrqTIAyJtJteuw60sc5uyBU5nnymg1Q7ymteAuZoEQCqnTDlf5zyIqQrZTpybTZ6ERMYqGeVUikF7wf+ThfP33oVsx/A0VvGFh12Y+dhy/t3E2R1ToU7YB1YqwypUxB5GbfirGDltEkNmzW349NvgDKlqaxW7wAr4MuEXXmyQboDYns2ZS1EHsY6Ew8ERLg1Aaq+s8oeWEznaioERsf87DYq1RBl2h1UmO+pUzF3/T7zInU52lc68+58wMvtBgoj6LqZgAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "347",
+    "id": 347,
+    "sortid": 347,
     "identifier": "anorith",
     "name": "Anorith",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAgVBMVEX///8xMTFSUlJTU1MyMjJSU1IzMzO6urq7u7u9vb01NTWCq4qDq4uErYyLi3qMjHtShFr0cnr8/Pz///9UUlJRUVGuZWWrYmKtY2NUVFQxMjFRglm8u7uDrItTUlL3c3v7+/uKink0NDQ2NjY0MjL1cnr1c3syMTGuY2NSg1m+vr7x4KO0AAAAAXRSTlMAQObYZgAAAOpJREFUeNrt0MeSwjAQBFBmlB3khMk57AL//4G0uHBYj/dMFV0uS4fnHsmTbz4lGb2XMUXzxW/aHPWYPc8XG+WDxe6oCVZg1LMPQXlL1EeOlRbr0MdeMXNRGtEluQkoRFWVJI0csUdfrJgjpHbBkuTah+IXi1wYbmfXyzA8nHCdl4TzQTX7/aDMnM1NM00SsO1mO5ZmO1X8TBkWhYqlQsAegpvbLh2w65ZMNOzyssZ/KQ2DLcWrAK63hnCdO7cncmpkcl6vEq9XB0BLyESSOs3HywUFJCfDA4hP3mWiXW8B/w8a/zhx/DeflSff7Q8PCxUbWAAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "348",
+    "id": 348,
+    "sortid": 348,
     "identifier": "armaldo",
     "name": "Armaldo",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAolBMVEX///8xMTEyMjNRUVFSUlJahLV6q9t7rd5UVFJSU1RTU1I1NTVZgrJZg7MxMjN5q9s2NjZSUlPEq1LErFP023L23XL33nN6rN1chba6urpzc3N1cnLGrVL0Ylk0NDRbhLP7+/v8/Pz8/f5TU1MzMjFUUlLzYlnz23EyMjJUVFT03HT13XRycnL3Y1r3ZVx9rt40MTHDq1H8/f1zc3T9/f3///9qSZ5VAAAAAXRSTlMAQObYZgAAAQ1JREFUeNrtk8duxDAQQ5fq9rrX7S299///tVDI1VZ8CJDL8iBAwAOHI83MzvpbzTGNKxKdYZrj8nORAfgdTN538nG1ugVTIEhKtV0rCrm1AqGY12u1fbpSRhy+XkSAyz9+uNPdkVwIjFjXWBuZcGWSlnroNrE6Pr8GSdx0xNI6Zkf+OitGUalUquvW0ZIX5GIMfNtr6t7RkuBY2Dlks9nXra9PS+SW7WGwmUg1XedU49KSEXQvMMjxXaKqdTyRlFVMMhv8QSOkopOxugSbIkluCISfNe/U05opqsvRwSWoS2M9R5LgiIrlRZpBGp+VowEE1gE+AvyvT5hgssY7Tlmgw6I/7SatGhjirH/VN8MQEIWZYN6nAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "349",
+    "id": 349,
+    "sortid": 349,
     "identifier": "feebas",
     "name": "Feebas",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAq1BMVEX///8xMTFSUlJUU1KSsvOUtfe9pVrexntqmuQyMzQ1NTUxMjOag1KchFKdhVK6o1lTUlLWY2vbw3ncxHpTU1T3jIyStPZLhM5UVFTdxXr8/Py7o1mTtPaSs/SVlZU2NjZTU1NrnOdKg8w0NDSUtPTexXvTYmrziopMhcwyMjHbxHpRUVFrm+TdxHq8pFlsnOU2NjUzMzKSkpJTU1L2jItJgsv7+/u9o1r9/fxUzrc+AAAAAXRSTlMAQObYZgAAANdJREFUeNrt09euwjAMBuA4aZKme7Mp8+zDXu//ZLgVt5jcIST+608esszeeW48YKwGG+gYcIwVlFJaQXdYjKzgsbKDrHYKYFbQnfqtrGkGmY5yvQWsbCiXaQzK6NuRhnBxTyvVa6TAjSiISvAfhPrLv+82GZYTu0kr19P70msmFP3xpIFiRkN16fa7PMjVHhgjJML5CeEqTFyfglHetB6ECXepGT/Lcik458FCFpT0fj/S9F/w4G/YqaQBonV8KNOzCpOR7PgPHiHGdTG3A5IUbq/zzovkCrPWDuhhLMPfAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "350",
+    "id": 350,
+    "sortid": 350,
     "identifier": "milotic",
     "name": "Milotic",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAnFBMVEX///8xMTFUUlJjrf+9WmPkanLna3P/3pzOtWNjc4RUVFM1NTVjrP02NjZTU1JSUlJSU1T825pTUlLkanHMs2LLsmI0MzLmanK7WmNicYK+XGNiq/wzMTEzMTJRUVH+3Ztjc4UxMjT725plcoO7WWJlq/zNs2Jiq/u6WWK7OTk0NDQzMzHnbHM2NjX7+/tWVlb925v+3JsxMjJicoNT8vmdAAAAAXRSTlMAQObYZgAAATNJREFUeAHt0UePgzAQBeAdFxtjQoH0XpLtff//f9t5+BZb4phLnpDlw6fhMTzcKPeMKByD7nmN8ziFHnaTHWC3GR5oGULi7B9/BT2gn+wspAf0Twfqn1jS0S5nSq2pEwQoD51YySsIqb6XMyMqbXq3rbTgq477jjBQNO+C2PHAWl9qnYJfDcOfrDxzW/S81Ks68WYM5ExpGyCk3Bc1RdADTj9fGRKFv8SfE7swMn95LM+tPhW9GGE3iXxsx1mWAZpTgXJ+USSk53ZtNc5KLf4c8tuvMlExPyuGu5yXJ6VyPHPh4onYr2rHZWMBiUg5uZ+rdTywM0Y0eWMtJC+ZnJurliKIkVABmg2RlHuuiSTWiPB3a8OpKmwzLcE4b8Q91AwF0pImgeGKt6dZoJxwxeWmuecfNFAYG9a7iQAAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "351",
+    "id": 351,
+    "sortid": 351,
     "identifier": "castform",
     "name": "Castform",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAQlBMVEX///8xMTFTU1OcnJzExMRRUVEyMjIzMzM1NTXGxsb///+FhXTFxcWampr7+/v+/v42NjaDg3LDw8P8/PxUVFSCgnHqSnhjAAAAAXRSTlMAQObYZgAAAIBJREFUeNrt0rcRw1AMREG4b+lk+29VJzZwSDnDF+8ACCB3l+mhSfcaLeP66XLQVJOrl2iacBYDNT4PUZmHfQfJyF5w4DEnh/scx7A3pFchcn4UnDjpm6//1QJIpW3uAsdkgTPl7hvuvkpV/hRnIpVOXAKOTYTU8ozsT6rK3WX6ARifBaDOjKh0AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "352",
+    "id": 352,
+    "sortid": 352,
     "identifier": "kecleon",
     "name": "Kecleon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///97nEqczkoxMTH3561SUlI0MzJ8nUuazEoyMjGdzkvUxWrWxmvz5Kv05Kv15qs2NjZSU1HTw2p8nEpRUVFTU1F6mkp5mklSc0I1NTWay0mazElTUlKbzUpTdEJUU1IzMzG9Uns2NjUyMzF6m0lSckK7U3pUVFO6UXmDnbUyAAAAAXRSTlMAQObYZgAAANFJREFUeAHt0UeOhEAMBVAcqBwoAp3D5Ln/CYdp1oXXLfX39unLsptXniMdNd0yBxlGtbNRRSXBQ9RQErMiCR5hgdqHcJcgTskBeMlFl5lZgw93AbLD7LIWGrtjdohZ9YPddmNiduAHL8H+1raJ9WPBjojqK/Yh3NqkwTbvo8GJao7GdvZhgDLb0cD+9FHrG8D+W4ALTuZ6ulYl0Xpyg1AMYhWu+vec+GepvQhu9/12bg2Ur/0n2E1YljLEaQZL218kelyGViZ9XMlqbW1eeZr8AXBrDPTmQ2z1AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "200"
+    "gender_rate": 4,
+    "rarity": 200
   },
   {
-    "id": "353",
+    "id": 353,
+    "sortid": 353,
     "identifier": "shuppet",
     "name": "Shuppet",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAS1BMVEX///8xMTEyMjM1NTV5grJaY4xSUlNZYooxMTI2NjZ6g7R7hLW6o0FRUVFSUlJ8hLOkxP16g7NZYot8hbKjxPxTU1Slxv8yMzTz8yn9jKauAAAAAXRSTlMAQObYZgAAAI1JREFUeNrt0TkSwzAIBVCDQKvX7Pc/aZBSqAO1zvg3at58DTBdOU3SqCMcg24QuuUoCCN9/iicTZqIc6nhqLvQmC0TUEUI8qIK56265fEEQvNvnLf99SYP6tCBI3zuuzjZkiGFQlhvnFFfo5BfoupkFr+KNaRre+ReactsHdwBNNtHVlu7s1phuvJ/+QIpDAW8uwx15QAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "225"
+    "gender_rate": 4,
+    "rarity": 225
   },
   {
-    "id": "354",
+    "id": 354,
+    "sortid": 354,
     "identifier": "banette",
     "name": "Banette",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTFzc2tRUVFSUlJTU1JxcWo1NTWSkoqSkouUlIyTk4t1dGo2NjYzMjFycmoyMjHLq0HOrUL21UkyMjIzMTHTUWI2NjX31kr7q8vMq0LMrEJUUlJ0cmrTUmLUU2PWU2Tz00n01EpTU1GVkos0MzH9rMzV8Lt/AAAAAXRSTlMAQObYZgAAAM5JREFUeNrt0tcOgzAMBVCuEwKEPbr3oP//ibWh4olAX1txI1mKdMCRE2/JjyTFFyiAF4QNgDlnNEJLOqcCMzD2I0siqZg8XsjOWj/y80mYKmES0iJTwAHXT0b9T6W5IQ1HZyHno45YGGKqXNLE9rLaXU/S10iBGpXBLaH4JY43G3wmOyrLOiG6t/1mepKHunrkRfdRBieD0pyc4gZ8jm3rcqpTRDqyPsqqrjI3BAw7GaTec2sXhALXfuKFMJfkxTUcLnv+UcIMbl4v+bu8ARhCCR9/DlNuAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "355",
+    "id": 355,
+    "sortid": 355,
     "identifier": "duskull",
     "name": "Duskull",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAt1BMVEX///9TU1OampKbm5OcnJRxcXFycnI2NjY1NTVUVFTs7NPv79ZRUVF0dHSZmZFSUlJTUlIyMjJUVFMxMTHt7dQzMzNzc3N1dXWYmJCZmZI5OTm5uaK7u6S8vKRVVVQ0NDRVUlIyMjMwMDDzYlmaUks4ODeampM3NzZ2dnU3Nzebm5JSUlGcUkk5ODidnZW5uaFSUlO6uqO7u6N1dXQ2NTW+vqXq6tHq6tLr69JWVlRWVlVWVlZwcHCuX9ojAAAAAXRSTlMAQObYZgAAAN1JREFUeAHt0VVuxTAQheE7EIMdvsxlZobuf12dLMCx36pK+Z8/Hcnj0d83pI+SmBkvmiSHvB8lwjJlUSOnLJopIjFPo04hfy2JbROhq/JiPvnu5Pv5uFeeOu/9TmTh5oc9TzIf3jv3CsiIBLQPutx5V8Db55IKa4nLyxD8cX52UF8/yaSETfAt+WayO76pBSIxVjp87fX2+aSuHlu0SBB+t1kAnYFFUMgWMhM+Y06b9uruQc2kTPcd/J5gvW2VsF4n8iWrqm4Qot99a3TeUVmMtsqUUuISpNbi/klDvwLbDdxZfYR5AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "356",
+    "id": 356,
+    "sortid": 356,
     "identifier": "dusclops",
     "name": "Dusclops",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAvVBMVEX///9SUlJTU1Nra2OMjHs1NTU2NjaLi3oxMTG9vbXe3sZqamJsbGSJiXmNjXy6urIzMzLGxqXd3cU5OTm7u7M2NjWKino4ODiLi3tUVFMzMzMyMjJRUVG8vLRSUlHDw6PExKNtbWXZ2cHb28Tc3MQ3NzeKinlpaWJTU1LCwqJra2I3NjbExKRsbGPOXUXPXUVRUVLZ2cLa2sPb28ONjX25ubHd28NVVVRpaWH2ZUX3Y0L8/Pz9/fz+/Pz///8lqEC2AAAAAXRSTlMAQObYZgAAARZJREFUeNrtkjW2AzEQBDWwomUyM31mxvsfy/LGa8uJM1egqF5rpiVx5kQEWjeH1wtXdqDDWeYVX6wjbzyvmfDwCG+a502ef0Yi0sd4lTEm8u+cMjmUd8h69PP/OjYM2hO4+f36/pv7I+u0uH94T3aRhxoP9CZUqyIxhglmebbfSxlDdy/NSTmxGLR766HzsKp6Y5fIBEtr28wgWyQwgTfTw9QYJNgrLvq95z6MFELMjGA/GrOlpXL01NUxXqJCfATLlmGZY9vu3UDIT+ows4oQwoLyyWzP9whC6NxRRKAYiOi2K6fZtM0sLwgwVnAdRXCFIIWQrjPRbtJNoHfb4OE3LKVs9MhBa+GjjJVDCj9lLV30mVOwBUl3EqkjGKVKAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "357",
+    "id": 357,
+    "sortid": 357,
     "identifier": "tropius",
     "name": "Tropius",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABMlBMVEX///8xMTFSUlLGpYRSs1lahFJKa0JRs1kxMjFSU1I1NTVStVpTUlJZg1FZhFI2Njakg2vEo4NRUVFStFk5OTkzMjJRslk1NjVSUVJKakKEY1KEZFGlhGvDooLDo4JSsVnEpIPFpIQxMzHOpULx0UL01EI4ODVZg1JVVFM2NjVUVFRTU1JTVFKBYlFSUlGjgmpSVFE2NTVYgVFJakEzMjFSVFJZhVFSVVGhgWk4ODfGpITGpYNUU1PGpoLMo0LMpUJUVFPw0EE4ODjy0kKkhGqkhGtStFrCoYLCooLDooFStVlRUlHEo4I3NzU3NzTz00FUVlT7+/ujg2qkg2pVU1NSsllSslqFZFKGZVJQU1GigmpSs1o0MzGCYlGDYlGDY1KEY1BZglFZglJVVFI3Nzb8/PxcdxiDAAAAAXRSTlMAQObYZgAAAXZJREFUeNrt0eeOgkAUBeCZoQvSBHvvXbe7vffee999/1fYi7IxWcDV/56EhJBvzg130DgjxoeHdFN+vn8GD4Isi+3XoCjgQY0M33t7Z5hA1kVgiN1o94kyQAcLipAstiu9CuG4FZlheGxVWl+gT8y6OoGQEsOQCDTa0MOVAvCkqVoEGmEwy8m8C7w+IzTnJxr1C1kodjru8f67mpJ5nKRutVqkB8E5oNw2z6tL4Wnka2jdSjcHq9ElNRq93P5cAZm0hh+Cdb2OlqrGpeZqrgvjcYmUrEVB/kpDUfDpWyFXRKHWFkBaAMpy1g04W9dP8k8o5CcP4GCHsFVaDrhdooIM+NkPEia0CFAULqT+cIeebNNztHjAWVAzkWcqOm0NDXYdRZme7oWkZm/q6fIavVNPe0Pfc5Q0UzNQRZX1veWjRS9oNF6lzpWaWKCoxLySj20Wkbf86qjSbiZjdneLPGPAjib02N0+wP+zkS/EjoeB0FtB44ySH5rPKfyY7RYdAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "200"
+    "gender_rate": 4,
+    "rarity": 200
   },
   {
-    "id": "358",
+    "id": 358,
+    "sortid": 358,
     "identifier": "chimecho",
     "name": "Chimecho",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA2FBMVEX///81NTXe7//vc5ykxPwxMTE2NjY3Nzc4ODg5OTlSUlJUVFR7e3yhwfmjw/ulxv+mxvzGrUrb7Pvb7Pzd7v8zMjLpcZkzMzT23VH33lIyMzTrcZntdJ18fX42NjUzMjGjxPukwvo3NTakxf00MjOmxP00MzOmx//Dq0nEq0o5NjbZ6fna7Ps5Njc0NDXc7f/d7Pzd7v1RUlPe7f3e7/4yMjNTU1E1Njfsc5zsdZ9ri6zucpvudp/vcpxrjK3vdZ7z21H13VRrjK42MzRti6ztcpt6e3vf7v5yEtGlAAAAAXRSTlMAQObYZgAAALtJREFUeAHt0cWug0AUxvEzgrvARbjuXneX9v3fqDRhPZxd04RfAqt/vlkcuLgGkSRc95F497guTREl8Y3PxBsEN3VdQKmh6+VfXBL7n1acTBiu3LBszp84VDrlo+9rN3SKV1FIrMnhh7aNx4IxFoGAKtumecvHu8UoAjEiW9zhm+cMammy1Mce0c4AReHDP9TgQ1gdpob23aOtJ9SkT2fT7RtmsntcsvwXUcZzlr8Aghrvv+4AQyPQuBInmQENrLteCrEAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "359",
+    "id": 359,
+    "sortid": 359,
     "identifier": "absol",
     "name": "Absol",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAk1BMVEX///8xMTFSUlI1NTUzMzNTU1O6urq7u7u9vb38/Pz////7+/tUVFRiYmpjY2txeYo2NjY3Nzc5OTm+vr41NTZRUVH9/f00NDR1fY25ublze4wyMjJ3f4+jSUG5ubhlYmplZW1weIm8vLxxeYliYmnlUkvnUkr5+fj6+vpyeov7+/w2Njf8/P39/Px0fIz+/v5WVlivEVdjAAAAAXRSTlMAQObYZgAAAQRJREFUeAHt0sduwzAMBmCR2t7bSbr3Hu//dCVdBCjQMFEPveU/2dYH/rJs9YccowHSWL05SXHEINH9qpCc/rk0QL0bIkCeZTPIDRxdVhgzTm+2DtROSG71ynL+frA5BPtgYGl4omaxukAfgo0zjCWCMBFKRDh7KzzB+BkLkI6Rt393f4EE81PaQ7vvxKuKnc+fL+P2paR9orc+vKPNZchy9JZGTlnh40fWyC5fTicQNu5x6jXIEyNL643SsL4ORu2TC+Rr58TyxtsYnPVhRR9lcOJAzW3rFlwgo2/Ev727rVyrOtXG3vCtWExLvDY8TAQPR18hnjcJsGvG+kUlpdPqmP/KF3pGDwybH6jDAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "30"
+    "gender_rate": 4,
+    "rarity": 30
   },
   {
-    "id": "360",
+    "id": 360,
+    "sortid": 360,
     "identifier": "wynaut",
     "name": "Wynaut",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAn1BMVEX///9zzv9zzf0xMTE2NjZTVFVjpNRjpdYzNDVSUlJVU1NRUVE1NTVkptdxy/tSU1Rzzf4yMzRyzPxCeptCfJ1VVFNyzP1yzf4xMjM2ODg5OTnVXFz9lX3/lHtWUlJhotJiodFio9NCepo1NzdCe5w2NTVyyvpDe5tDfZ4yNDZRUlMyMjI3ODjSW1s4ODjWWlnWWlrXW1v9k3sxMjJBeZpLFs/6AAAAAXRSTlMAQObYZgAAAOJJREFUeAHt0reWhDAMhWFfyUEmw+Qwm3MO+/7PtvbWi3E3zfwF1XfQQUIdu1MVc55r4Nac5QB38z0NL1dwLk+62DpjeBnpqp9gz9Kg9VdLIC2v/YC/JqCQMDKkoIUAneFmvhyDEgKeCISHGv3PGNwOCDUbT8Udgp6Pfo4eQhvF5uOMCiqcHwKs+D8ZCk+7e198LnbWx5OXnsf3bV8Phy+rOVynTP5I0u73RtSbde5RJWJCXdcQxRMX1x7Ugai/te78JfnKrr0nU2pVXSSd0rOZMTYO3ap0WlvrtcopbvTInfoFBjgMK+PUA5sAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "125"
+    "gender_rate": 4,
+    "rarity": 125
   },
   {
-    "id": "361",
+    "id": 361,
+    "sortid": 361,
     "identifier": "snorunt",
     "name": "Snorunt",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAXVBMVEX///9SUlL/3owxMTFqu/w2NjZUU1LGhUP3hEpRUVF6enp7e3u+vrb824vzgkn0g0r+3Io0MzJSU1RUUlFUVFT2hEozMjH724rkumrnvWt5eXn8/Pz9/f0yMjI1NTXmEc8MAAAAAXRSTlMAQObYZgAAAH9JREFUeNrt0scOgEAIBFBnce299///TFfiWbhqnPMLEwjenxfFktKNpla5omIouyhSyaNoS4ayA2Sph/ZyomTnN0oIF78RpJ36ds22DlBA4KIOOvkA5yC5lwmr55EBkCA3hqFYnodu4iAcMr57Sbr4ku5EMUjztazVP/7nczkB79cHgNllttMAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "362",
+    "id": 362,
+    "sortid": 362,
     "identifier": "glalie",
     "name": "Glalie",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAWlBMVEX///9SUlL///8xMTFTU1OFhYW7u7v8/Pz9/f1RUVE2NjZrnP+CgoJqmvujxPy9vb2+vr5SU1QyMjKDg4OEhIRUVFT7+/szMzMyMzS6uro0NDT8/f81NTWjw/spoBoIAAAAAXRSTlMAQObYZgAAALpJREFUeNrt0skOwyAMBNCOTYDse9t0+f/frHGk3pzkGilz4PTQYOB25Qwp+CishqMQfAzmAPMxOMZsYFZdmHs+iwuUAQhEL+ZqGswjRqJZnK6jOAveiSib4uoA3oAahdtORFDonUpr5pAqo8CubR38w4L1W0cWpq41YY4g1Z0iiTjzGn2kznFd9iId2w+zpM7m+U0Q2IJS6tCUPQRqtXlBWZKA/x/RfsTZrzPz3h/n3ItjdbtW2JXT5AckrgifffgPkwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "363",
+    "id": 363,
+    "sortid": 363,
     "identifier": "spheal",
     "name": "Spheal",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAmVBMVEX///+Mrfc1NTU2NjZUVFRjjM6Lq/QxMTHexnv/561ii80xMjNii8xUVFMyMjSKq/OKq/VSUlKNrvfbxHrc3N1SU1T75Kv85Kv+5qxUU1KLrPZljc56enp7e3xSUlNCaqNTU1KLrPVRUVFCa6VDbKaykmLbw3lEbKTb29tiistEbKU0MzL7+/tBaqP8/Pz9/f5kjc5ljc3///8FUvCKAAAAAXRSTlMAQObYZgAAAK5JREFUeNrt0UcOwzAMRFFTlkzJvbd0p/dy/8OFcLIN4b3z1w9DQLL+jTYbhzlxVB7igLnrOgaAEJF3F+kAtYmhQBZ25D4VTsi4SLUAd+n0myE/OFsVGAHxlJH2QSZOf5bgK2VhFUyTpHq2JCfMM4nSBDdZGUNSqbmvvJ+bJMmZk5s/OCi6rDaU1nuXHRTbJUmtdbNwc4nIfSHirsl0Hfjel7G4NOZsDYms9W/EvQHV2ArojGiW6QAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "364",
+    "id": 364,
+    "sortid": 364,
     "identifier": "sealeo",
     "name": "Sealeo",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAilBMVEX///8xMTFCnM5Bmss2NjZEnMxRU1NSUlJqxfZrxvdRUVFCmszWtYQxMjNrxPVUVFR7e3vOzs7TtIU1NTX////Ts4NSU1T026MxMzR8fHxqw/P7+/v8/Pz33qV6fHxUU1Lz26P03KVqxPRTU1P8/v5txvd9fX18fHtUVFMzMzPLy8vMzMx5eXl6enoWeYi9AAAAAXRSTlMAQObYZgAAANFJREFUeNrt0kcOhDAMBVDshITQe5ve+/2vN3HYRsAa8Zfo6WNHdtYsLRwAZrACeqVUO0n55qZM2rEucAqfCtEbhfydvfxfrPbxNTkrjMxHAJv8frKsi2nCHgfImQBbY5fK5pFKKQPUEsgFkb3x0uye27JMtPVqYIhC2irJEbxrS3OKAKna8tS+hkamVGlkZN/naKBuTEyZIGVNMchEVqGbu/RXe7gfnHbhQVZuHro44hhNlYeEKNHo5TBjzB5TZ8aE3ljVMOcimYdeO/t61ywtfxSyDh2m1izoAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "365",
+    "id": 365,
+    "sortid": 365,
     "identifier": "walrein",
     "name": "Walrein",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAgVBMVEX///8xMTFSUlJKjMZrte/G1uf////8/PwzMzPE0+Q2NjZTVFTE1OUxMjPexmuFhXRCY5xLjcZRUlM0NDTE1edSU1RKi8RqtO7E1OYxMzPD0+RUVFFqsuxqs+w1NTXGnELGnURTU1HWUlKCgnH3jHv700H7+/uEhHP/1kL/55RRUVGH5flxAAAAAXRSTlMAQObYZgAAAQNJREFUeNrt0Mlyg0AMRVH0JDVgsPHszM5gZ/r/D8wT2aQohuy88S2a1aFFd3btYs3kn+7Oi+xJZOoLeasrkfeUNvKdb2TYuePRdJ0/H19y6lGoB9vJ+fM+DzcqgbIC8uRe/J5O+hzgfyokmz1sV3Pp2W+BqPSo+agLuoNtiw6kW+A1XmW42huUdLS3HQm6FgarqKtypTe0HZgJ4QlfMHjMJwRI4ye7UtBChbOGt2q7/bz3ggwB6fhUdKZ0vTIZzBxQwMINQBFNKbmqulKt9wNQdJk0cjqoQgl7nVImJ1OzVtINQFlGFoFOBo4iwkUOOjWAbiSJKGM+5USUZHTTkmXXLtoPzHQL8KTMj2oAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "366",
+    "id": 366,
+    "sortid": 366,
     "identifier": "clamperl",
     "name": "Clamperl",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAclBMVEX///8xMTFSUlL/nK3///97rc7Oe2NSc9ZrnP9UU1NUVFRUddZqmvsxMjNSUlO9vb1SWZpSWpwxMjQ2Njb8/Pxtnf9unv8zMzNSU1NSU1S7u7uExudSWpul3v/8/P79/f1qm/4yMzU1NTU0NDT7+/tTUlJO+S5LAAAAAXRSTlMAQObYZgAAAMZJREFUeNrt0EkOwjAMBVA8pEknOlDGAmW8/xX5kdg6ZQviK1ayeLLlLP75kqyIPnNVCD2uOX19qJa+pir0SXrbTMxD6c/QvrYdTXCQWkAnICnH7BlJScACojvmzO1yKC+hN2XDXddxJtkTUteQtnMsKiJ5u8T02u7o0E8IJ06/2+sACkIk7HZkO8zmjCA1w+uwtR2fTiwxPI7cUOofIbF1vBjOlKDOgaMaNLSlVyhwVIBLSlXvY3nAlCSKht5uxsKg/vm1vAB1Pgh3pXE5TQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "367",
+    "id": 367,
+    "sortid": 367,
     "identifier": "huntail",
     "name": "Huntail",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAsVBMVEX///8xMTFZmttSUlJSU1QxMjNanN5zxv/3lDHzkjF1xftUUlE0MjE2NjZxw/tRUVEzMTGtQkq2a1HTcjHWczEzMjH1kzFTUVGza1RyxPxUU1HTcTFbm9vUczM1NTXd3NutREz0kjH0lDSuREyyalH3lTT7+/v8/PxUVFTVcjE0NDTWdDPc3d5yxf7e3t4zMzOzalJ0xPu1a1G1a1IyMzR1xv+rQkr8/v/9/Pz+/Pv+/ftS0MIsAAAAAXRSTlMAQObYZgAAARNJREFUeNrt07eSxCAMBuAT2Tgn7M1593LO7/9gJ5viGoOr7VbDmOYbgX7GV5c6d8UwTnoVEz5Cl0EEs6om7c1r5jgL+i2oqpBSIharuzkfYoEqMuhhSITgjo5x+mxUYVQEaYmOO+8YYz8rO8g9U+PRhSlMBAkrQ/Cnkm6mgFsvwecmUjKwY+PpzvQSibXV7zi9qsJy9eToF+jO/R40oxs1xRTrYTf7Oeit/ro9fgjBaDnHIJ0dsZ3CjkLYN3HPQhYveEdGOlmDZ+jTNcXVOe4L57hrPvPGOl/Yyf06z793eUMY8cElYZTS0+Ma4cj7kQcpEU9Em3ndPgOARArRGhX5INjv/s0oL/zPfcA5f5xLna/+AGfsE3l1gpbIAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "368",
+    "id": 368,
+    "sortid": 368,
     "identifier": "gorebyss",
     "name": "Gorebyss",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTH/nL02NjZUUlOMhP/TcZrWc5w1NTX8mrs0MjOKgvuLg/wzMjIyMjT7mrpSUlL+m7xSUlT/nb5RUVFUU1NyYswzMzONhP3Ly8vOzM0DAwPTcprUcpxxYsvWdZ00NDT7+/tzY85SUlMyMTOLg/7//f1e4ytxAAAAAXRSTlMAQObYZgAAALtJREFUeAHt0sfOAjEMBOA4Ttls7/sXeuH9H5EEBJuDQb4hpJ3zp9FYsljy+STAYghZyWOa5aofppMy5bkUBAumAiGiCEA7W0Al51bs85aSiUchz53J5nw40ZcMLpaYaV3S8LJVLoJUI0Jw//turkSj/EaizsNdBNEUQFyNcKvspLXNXeLvJOhgv2rkUI9rVTsvjS1efwQYq8Zjrlsn7d/09hfDsCxASRTGwccG3ncY27BgkCBYQRDfkSVXWBYIdYuBDaEAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "369",
+    "id": 369,
+    "sortid": 369,
     "identifier": "relicanth",
     "name": "Relicanth",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAXVBMVEX///9SUlJzc3OljHPWvZwxMTEyMjIzMzLVvJtycnLUu5txcXHTuprTu5pUU1NTUlLUY2t0cnI2NjY1NTWji3KjinHz26uki3NRUVH03Kx0dHPWY2s0NDP13Kz23aw9K1FQAAAAAXRSTlMAQObYZgAAAOlJREFUeNrt0smOgzAMBmC8JRB2SpdZ3/8xa4+R5mJojzNS/wNSpA87TlK98kdyEnnKLR2lB0I2V+djdmEDS1uyrXbdhZmzOcRUfbaY9p3B5dZgElF9CAfpmBARYMVrKE86gbqe+R0thZnSvmuwEFquNWGKT26DnqKFY3iuDdLY4DT/FIykuS9VXnL6mH2HGMHumz0DNNNc2H6JXPtmBWmE3oQ1HgCkCiHRuGpvg+ootRhWLEymHAL02S8yOEUduOdtcBfhm1xusNYD+BZ/u8bnyExalZJoV4exlDMp6rIvjp+t6Kd65V/lDmAFC3rDZikgAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "25"
+    "gender_rate": 1,
+    "rarity": 25
   },
   {
-    "id": "370",
+    "id": 370,
+    "sortid": 370,
     "identifier": "luvdisc",
     "name": "Luvdisc",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAXVBMVEX////3e4w0MjK6amrzeYr2eosxMTH3fIz/taW6amu9a2s1NTXz08P1eos2NjY7UmuEhHP31MUyMTGVU1P11MQzMTE0NDSFhXSSUVH31sb7sqP9s6P9s6T9/PyVUlKPsSUZAAAAAXRSTlMAQObYZgAAAHpJREFUeNrt0skSgkAMBFA6swoCOsqiAv//mYYq7umz0udXPVNJqjM/mS7GSLn5kx+FcG4BIAR8Q1MPlmu0cI9whQpNlyEu6NN2Yb2OHlsx3PWV0F8CxHLT7ZmAe1JoN+7Q/qMHuPE0noSdC8dmOCnU9bTYCn2PZ/42X7qlBLTbyWGPAAAAAElFTkSuQmCC",
-    "gender_rate": "6",
-    "rarity": "225"
+    "gender_rate": 6,
+    "rarity": 225
   },
   {
-    "id": "371",
+    "id": 371,
+    "sortid": 371,
     "identifier": "bagon",
     "name": "Bagon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAn1BMVEX///+EtfdSUlJSUlNSU1RTU1Niistii8xjjM4xMTG9vbU1NTVKYqNKZKZRUVFRUlNljc6CsvODs/SDs/WDtPYyMjKLi4uMjIy7u7MzMzPnvVr8/Pw2NjYyMzQxMjNUU1JUVFSKiopMZKM0MzKNjY26urJii828vLS8vLY0NDTkulnku1nkvFtljcz004v01I37+/sxMTL9/f1KY6UzMzFP5ZzrAAAAAXRSTlMAQObYZgAAALBJREFUeNrt07cSg0AMBFB0gQuAydk455z+/9t8Q+POupYZtn6zzUrOmMFkqpSd2mqucLcklda6VlauLPe6toB9Z5kjclJx4zgpMBgzUnHSbhDnxQCMtMdHdF8jhWByeEXy8vkP3QxASiokLXJESuPahaAFUcgyp6aZ+6HoKxE68cMEmMWMLk0gSIOnhWNEZNAh0HPp7fpOAeQMrzyvdpk0EL9J5aLut1Fn+xDOmGHkCy7pDEq9RJzaAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "372",
+    "id": 372,
+    "sortid": 372,
     "identifier": "shelgon",
     "name": "Shelgon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAeFBMVEX///8xMTF7e3tSUlJ9fX27u7S9vbX8/Pz///95eXl8fHv7+/szMzO+vra7u7M1NTV6enpRUVE0NDRTU1P9/f3LUUm6urJ8enpUVFRWVlYzMjE2NjbEqzEyMjKEc0pSUlH9/Pw0NDCDckrMUkqFdUn09Cn19SozMTHiv+uZAAAAAXRSTlMAQObYZgAAANdJREFUeNrtktcOwjAMRbGTNOkIdJdV9vj/P8RuCy/I4REhcaQoinR0Y1ue/fk+CwD4bG0AUudc+VFLfe2cRuwh6MXW16RZFw5dWU2iZo3sXs5L2eEzhpZhkZnuUvIm4XX1wvjSSXkWaeVIn6jcJKYeNI6UZqMVkbPCB00m9XI7FqPpE0QTZWIzy+tlr7br2EREQpOUzKUiTruDRhQTWWyjik3rI4Y9ySzmQ20jFciLGKs512YGL5drjPF8h5YcmmbWdAoCS8v73XSoYHiE4eS3X+XkP7/CA0p0DHOBsglFAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "373",
+    "id": 373,
+    "sortid": 373,
     "identifier": "salamence",
     "name": "Salamence",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA2FBMVEX///8xMTE5c5xSU1R6u/x7vf9SUlJSlM69SlIyMTE1NTVSU1N8u/ySOUKUOUI2Nja9vb33a2v9/f1TUVFTUVJ5uvsxMjJ7uvwyMzQ6dJ2FhYVRUVGSOkRRUlO6SVG6urq7SlK7S1QzMzPzamr7+/tSksz///80MTEzMTGSOEExMjOCgoKCg4SEhIQ5cpo0NDRRksuSOUNTU1NTksxTlM1UUlK6u7xUVFRRk827u7u7vb68SVF5u/29S1O9u7s6c5t6vP70amr2amo4cZo7dJz7/P08dZ19vv9Z8UzmAAAAAXRSTlMAQObYZgAAAUdJREFUeNrt08duwzAMBuBQ03tl75226d57r/d/o5KqgwCO0ORQoJf+B8OQP4sSbZX+8/uJAWAtoctOFEUu4h/eiI/mhiMtCw7jNE23wA41Spq0LCQPywPHebFTDyWUPGhPn3gYRSSJWqbsOQGVPBdyAYkWJJWsS/6cLpyRJttFWJV84DzcB5KgC9BGuCrJyZvRZPYpm4x1wSzFAsk17+QyjVI8JgPQK8rXK826SmBhpRQ2PBd0U6gN/SRJTnArU+2HLq2wAvD9pNhIwB0ooX3ESgydisAlAGL79/EFD+tSkpUUflADsDitfTWIUFJyyVht1TG298jM/qkNw8DAY9cy3/V+1sopn3ZuAxwCsBTuuLtZK5tdCoLYxVOt5ysL7Cdn5v+ZtDIDGzT2djGynYNln3LprTsaXtXADRJPPt4PN4Gm6H/+Ml+6lR2u5162fAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "374",
+    "id": 374,
+    "sortid": 374,
     "identifier": "beldum",
     "name": "Beldum",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAYFBMVEX///8xMTFKaqtKa61SUlJSUlRjjN5RUlNii9tii902NjaEtf9JaqtRUVExMTIxMjNiits1NTVUUlFTUVEyMzQzMTFKbK6CsvuDs/2DtP5SU1TMQjnOQjnTYkHTYkLVYkHzLS5EAAAAAXRSTlMAQObYZgAAAKRJREFUeAHt0kcOwyAUBFD/DgYXp/fc/5YBsSZmnXjWTzNCn27Lj6UHgCY3X0M4tMBzCEpjA4xE5HWCdTkwelWdVhik6Ru7BNefcvIqTr+vL/FSIHphV6f9rMJ5VxPTTKtQ7u/H3ilZ5mRQg9Fex+cOyQsaepV65VAahdEckeFYr+Rk0BjJnLj6iXqIRCPALMxcd4VCbiavSg03X0pz47/s/jVbPi5rBx6MPgGSAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "375",
+    "id": 375,
+    "sortid": 375,
     "identifier": "metang",
     "name": "Metang",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAllBMVEX///9SUlJjjN4xMTFKa62Ds/3///82NjZRUlMxMTJKbK5JaqsxMjNSU1Rii9tii90yMzSDs/wzMzOEtf/8/Pw1NTVUVFS9vb1KaqtTU1ODtP6Csvu6urpUUlFSUlS7u7tiitvsYkL7+/tMba5RUVH9/f2NjY0yMjI0NDS8vLxTUVG+vr7sYkGKioqLi4uMjIwzMTGrQkIqJDhbAAAAAXRSTlMAQObYZgAAARpJREFUeNrt0tdywyAQBVCWJqzeou7uxE5P/v/nciF5k+TozS/eGdBo5uguAti9blgPQvzO4j841LkQfcG79Br1xOmDKCvgMMJZxryhbhvlHMdIZ9wuFO8USwXjIotIzEApTcy5RKRzvlTppON8k0VWIrQDSzjkTCCgTEBReODDKRgkfNOoqDwiCcq6Uj+dxzt4inkYmFLro/l+oRiOtvWjvowSh1Yw76C1rvZfb+tYGuR9Pudi3Nu515ayaL8mzH953vTJ4Fzc7qAgbZM+ZVM0MKAWRkQkdli2ApyU0pCtRsoV3pQ/A9EetJFgti3v/NWVO+SKwfk4z3TBLe7tgY8Sx8mHirIlgdissiIsYUnkNmdLoP2le92sfgC07RL0Cz7G2QAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "376",
+    "id": 376,
+    "sortid": 376,
     "identifier": "metagross",
     "name": "Metagross",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAZlBMVEX///9Ka61SUlIxMTFjjN6Etf9SUlQ2NjZii91RUlOEhHO9vb1ii9tKaquDs/1iitsxMTJJaqszMzNSU1QxMjNRUVG6urq7u7syMzTvWjmDs/xKbK5TU1M1NTWtQkL///+EhHSDtP7g+om0AAAAAXRSTlMAQObYZgAAAQ9JREFUeAHt0seOq0AUhGGq6jTZOd983/8lpxo2CGYG77zxLwvJ0qfTQV28tne/9ZyrDs2qlJaw0icuDfBCamicv70vHeTvoSF/pNxdGWIhFcyQ3GzT2M99Ue1Qn+cuCBlGIEu7Os47YC4VIKiOYeka9qV/myVEhGVn6Ure/nmrJ25QYz91VRgG2RqS7Nwvw77sYzrSpxtchIlxZj58eOXGcjKz2gUAQwyq1R945fh/mu+yuoSTwOzIxwNM7sQ+3AReRVKFutb0LyKYkG+oNCw1fTM2+b+IUQ4QdUnpepxd+fiFZWseGaK5HYvqqzcEUjJCpCR9+9zkwSkHu5VEO647n41kZ7gu1cnumezevbAPhFQLJkNDnAAAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "377",
+    "id": 377,
+    "sortid": 377,
     "identifier": "regirock",
     "name": "Regirock",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///+9nHM2NjaUc0oxMTHGY0Lnzpz3hFLFYkFTUlFTU1KScUkzMjKVdEucUjGdUjG6mnG8m3IzMzLDYkE1NTUyMjHkzJrlzJrnzJpRUVHzglH0g1L1g1H2g1FSUlLmzZs0MjHEYkIzMTG7mnLky5qaUTH2hVOSckqVc0qUckm9m3JUUlIG7nK7AAAAAXRSTlMAQObYZgAAARxJREFUeNrt08dygzAQBmDUQaaI3nG3U97//bILmskBwfiSycV7EvDx744E3rv+oih/0XXi8oorOjGeOJS95DuB43clozRcrtRpy6kkqKS0kt4Ht6R5HPtB3zwagDZ/C/oiqB4NJJIQ81XiX1zwvjgrczEidEfihFggda8EdBAOSY2enrWFLOihsxsW7VSBqJGxVG9Cekg1dCaMsUF9wJBd4se+w/H2ycqbJMdoUAg1z515Brpxj7bXo4wGcLhB8Fq4dvgMB2A1gRHtOl3BA8ObkHgWnynBNQbKzHNAVi5bdP4ieuLo8NDXEhxCAgq2KZuHWMHfj68whM3nkxmCE+z9DPwGLgquBGTp7ZQdjpt5G3Ylkjl73y3kXf9cP9X0E5tE7aHhAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "378",
+    "id": 378,
+    "sortid": 378,
     "identifier": "regice",
     "name": "Regice",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAkFBMVEX///8xMTFzpdac1vdSUlI2NjZSU1Sd1vdxo9M1NTUyMjNae61RUVFyo9NypNUyMzSa0/Oa0/QxMjIxMTL8/Pz9/v5BWZJbfK6b1fZTVFSd1vRUVFRZeatZeqv///8zMzNcfa6a1PVRUlNCWZJSUlNDW5XN5v7O5//05Er05Uz15kz7+/t0ptb8/f51ptN1ptbctgEuAAAAAXRSTlMAQObYZgAAAPhJREFUeNrt0kVyAzEQBVB1t1jDYLbDTPe/XQTLieRsUtn4r6ZKr/60gF3yVxHwS/f2ZSOHc04hWia69XDGPRF52a0bW3JGf6gA3X1ty4UafZxrJIQpSxvZEFHAErQbsq56/nzZve4849N1/u9Cyyk2EsrppKjNOr+F6OZ9PytCm3epcD7t+zipzbgIg1Mog/wZmkOCwT2+y2ylgABr3ARHmK0MO+b87rbHlAS3fbuEUB0HqDiPTZLHjy33chEDTByaaHiNfo6jP3GA3NVwv+xuiB5G6NrSZa9GCANwYKZrS89sNTJ2pePBmIJLq4uybMQCZiW75L/zDanoD8iuCLw9AAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "379",
+    "id": 379,
+    "sortid": 379,
     "identifier": "registeel",
     "name": "Registeel",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAXVBMVEX///8xMTFSUlJTU1MzMzO9vb1qampra2uMjIy6urq7u7s1NTWLi4syMjI2NjZsbGyKiopsamtUUlPscprscpszMjK8vLxRUVG+vr7DWYLEWYPscZo2NjVta2v9/f28+HdTAAAAAXRSTlMAQObYZgAAAOVJREFUeNrt07mSAjEMBFC3fB9zALsLe/7/Z9I2FNHYsxkJihy8cssqWb3q2TUD/2EZ0YaJes9Fa7UItRmnxsWLOEnWjmRexSVN5/xQ5qiTDVS8cEnsAOgErxT6HryII8cAfh0atDr9XXrp87l8aPd2vMFRmzNWedzYjW6SLzkdHWUdkwycFKF13pcQJteBP/g8+JssgU7lbZkjR/KAExShx5bTkkxdCalONbcJgWiqt61MBzba0qRNR0Pl799tp+5pUqtMYMundzWUdTRtRcxww8FXSaFkz7tbHgT1sP9vAPWqJ9cVTB4JeUUVDQ0AAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "380",
+    "id": 380,
+    "sortid": 380,
     "identifier": "latias",
     "name": "Latias",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAllBMVEX///8xMTHOWkpSUlKlSkI1NTX8/Pz/e2P////7+/u6urq9vb02Njb7eWL9/f1RUVFTU1MyMTGjSUH9emI0NDS+vr7LWUlUUlJUVFSdnZ38emIzMzM2NjU0MjGmSkL/fWX//PymTERSU1T+/Pz+emJUrPScnJz8e2W7u7u9u7v9/PwzMTG+u7tTq/Q0MzHNWUmlS0P35TkwtryVAAAAAXRSTlMAQObYZgAAAPpJREFUeNrt0NduwzAMBVBRkkV5j9hZTuKke4///7nSNgojVFU/FgVyH6SXg0uJ4pI/SwLDAbMuaomFtp51cUGsaWcLc6WMtbwwAeaCfIsr47p0z2FoO8SX7AwG4Likd/uwOYNBtZDymY9A/Hwj2LSTS4mBcKCU1+Tib7iD3v207SgeMsqEGHfTy0eb1UADDu/MubUZ7ShFlFKXwp9dlFnKSS+QF/K9G3Kbu/gD8VD+4qLCdMdNZtUW2RvZd3LTIR7Xxq61lOBzlda6TG/v5WOhHpTfhSdyIli+XtHglVQK/JNhuJY39GXo65lwq59qIaCaoL96vMQl/yBf+KsOlgTcS4EAAAAASUVORK5CYII=",
-    "gender_rate": "8",
-    "rarity": "3"
+    "gender_rate": 8,
+    "rarity": 3
   },
   {
-    "id": "381",
+    "id": 381,
+    "sortid": 381,
     "identifier": "latios",
     "name": "Latios",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoBAMAAAEJ15XIAAAAJFBMVEUAAAD///8xMTFSUlJjWpR7c7WMjIycjNa1tbXe3t73UkL///+15B55AAAAAnRSTlMAAHaTzTgAAAFVSURBVCjPrVFNS8NAEJ0MiO0tLYLXdRpogxdxLSE3qTl4lNbQH+Ch5No2DHoq9pLcRNC6v8OT/66z6aaUFg9KB2Z483jztQutlg8+ALTFzyYKbG4dJTfiTQbHiYFfCgV+L9MSYUDg+N1ozYPGm42nCxsxnlx5cFLOZx4ADgQfVB1AH+nVtfK7sXKwnX8vwjENLQtB+RnlrARi0u2nussX1Smy1S14v/T9C9y8gpjARlPVsBduYWRqQXv1U7PneUlhHjxYAXaWGWtlIXTME6fPFgbaxMyzSnDH/fSa2QoAE3VT9QV7Atqy/61+RFK2AnfwxryK7KmwVHskam3e95Xhisv9cuSXy0yURARIypFULL+KfvxheJ4Ot4NkVGGMmWlmppqkR21MFnE+Zj2tpyf3RWSiVT6KRDolV06E6Uinw2SAMq7uKdaRbhionUEA7sPJkcd/zzWtVlgXMQuVNgAAAABJRU5ErkJggg==",
-    "gender_rate": "0",
-    "rarity": "3"
+    "gender_rate": 0,
+    "rarity": 3
   },
   {
-    "id": "382",
+    "id": 382,
+    "sortid": 382,
     "identifier": "kyogre",
     "name": "Kyogre",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAq1BMVEX///8xMTE2NjZCWpRSUlJZcbpac730Sjv3SjlSUlNUUVExMjNrlOdZcrszMTFccrpDWZKzSjq9vbX///8zMzP8/P01NTW6urK+vrZbdLxEWZJRUVHzSTj0Sjn2Szo0MTGySTj9/f1BWZIxMTK2SjlRUlO7u7O7u7S7u7W7vLW8u7O8vLQ0MzFDW5Q0NDTz7Elqk+ZUVFSMjIREXJX7+/v8/PyzSjlqkuS1SjlTT6w2AAAAAXRSTlMAQObYZgAAARlJREFUeAHt08duwzAMBuDQoob3trOH0713+/5PVlLwIY3j1rciQP5DJASfSQ1odMp/x4GBbm5W7Qfwm6vmU5FGzBohtgfaQTtZJ4Khwwy6rn65LexkhihYwgyJdd29SJMt1ZWK4yLiwngAZCuAHdikXwnJzyBgx3QRK+2F/siRLu7QqqGK5+Ra2ToXQLqhUv7P3Uj1FATXm/GEHenymQzFh72F0vquNnmejycMy9fLAiS7/fOjP1mS49ZTYrYP/XZhm5JqfkT9NxIz0sbwyLD/jono1eMdj3YPAD2yXhpzFq1vsqUX2tKED3eHOqMUACB1rMh6F31FgWIn0lZ0sQs7h6pj7WH2F7R3jPgOQx7EW/4AQ9/OMeSUb8VEEg+LaxoiAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "5"
+    "gender_rate": -1,
+    "rarity": 5
   },
   {
-    "id": "383",
+    "id": 383,
+    "sortid": 383,
     "identifier": "groudon",
     "name": "Groudon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAArlBMVEX///8xMTFSUlJUVFT3WilTUlFra2OzUkr0WSn7+/tRUVFqamI1NTVtamKLg3KyUUlTU1O2Ukm7u7vzWSlUUlH1WSk0MTD8/Pz///82NjYzMzO1Ukq1U0tSUVG6uroyMTG8u7s0NDSKQTj0WikyMjKMhHP9/PwzMTGKgnGMQjm8vLu+vr6LQjnz20ltbWW0UUlTU1H120pUVFGMhHSNQjiNhXX9/fz9/f3+/PuulULNwCWXAAAAAXRSTlMAQObYZgAAAVhJREFUeNrtkldzwkAMhKO78517w40Ooaf38v//WFZmMsEZwDwkb6xm7JfPK2nli7P+WF2uU7hOwXUKmNkoImrhopxBlRkLaKthYglj2ao4jPrbxkLYmekvpV0cbGwZy6xun+xkKcuqmhIdAx8/H+yPqpJpr6OyYyQaq2QSh/OOCjTtixarJDkGLCXWDhcMzgraG62/vnp+exWhsBl0sbgzBfiSo8ZN0hVChAsG594sIwcbRZt7rtVua/JALTQsmVOqiCYDzGz60A7oO9LTQuB8awwY6FlALsdpmLXox8+RwtNaE8+KAQONDwTilHC00vfpDnkde8x13XDuSKziwmoS4wHPpmPaY+5ySM5dKSnK66ubph/vMurVb/dm7Jb1ZRRfHvp9S86fHTdjR6Zx7QiQ7fYL5BC7R9tkVnTkdwP2/Y8gwBb5owGDrRwvlcaYtB1EDDzCWf+gL98/HVV58cUpAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "5"
+    "gender_rate": -1,
+    "rarity": 5
   },
   {
-    "id": "384",
+    "id": 384,
+    "sortid": 384,
     "identifier": "rayquaza",
     "name": "Rayquaza",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAtFBMVEX///+E1pRSnGsyMzJSUlJSU1JSVFNSmmoxMjGD05IxMTFKc1pRmmpRm2qC05I2NjaD1JOD1ZM1NTX/zjlRUVFRUlJTU1FTnGpUUlJUnGpKclkzMjFKdFpMdFmF1ZKF1pWzUmLEmjnEnDnkanHna3P8zDn8zTn8/PwzMTEzMTLDmjjD+9NTUlJUU1HE/tTT09NUm2vkanLka3JMdFvnbXX7yzj7+/tUnW1VVVWyUWL9zjpJcVll+L8BAAAAAXRSTlMAQObYZgAAAVVJREFUeNrt0sdyhDAMAFAkGzd62b7Z3tJ7////igzJxSzM5pxoOADzLNmWvL8dyakuVL+HuTFdEH9kcjln3dBx3bUTE0Plku6UeZjVLn8/HHe5CX3jvWkQfDkxNaSfR/JlQqKvYZpOtzNgplwcvHy9OW/AiwHuzoII7bMtihmIxWF9hw+OTEr9UZylgFUEAdkZKyWiK5MYM2Ger7mklMqE1vakzzmXquH4ss+19baA3a8YpzBVTkIAQJ/fb4YamP0WXBO9mQNzYKU2Q6oU2yNzDUgQMWPuLb48DTkx4+UxiDFtkGCjdN06G3UPCdaSa9be8s+gN/4+s/QJtjsKZWib+7ngElU7jFDZllLCIAVgrTBCREUTcvsYZeibjrHcFSOyqz7fv/oyUK2QmrIbEV5NjG2l7XXrYOJqQNXptZSubF5pPeVXMogc2bYkVNWiU6z3HyfEF4f2Gc/E9lMrAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "385",
+    "id": 385,
+    "sortid": 385,
     "identifier": "jirachi",
     "name": "Jirachi",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABI1BMVEX////OvTn89HL+9nL/93PMuzlVVVVWVlbJuTk2NjbNvDg3NjTh4eHk5OTl5eXm5ubn5+f783E3NzP99HH99XE5OTlRUVExMTFqqplqq5qnjjanjzOxsalWV1bLujjMuzgyMjIzMzE4ODbOvTvPvjo0NDLj4+M1NTPk5OVSUlJSU1NTUlH58XFTU1E1NTX99HBVVlNWVlP+9nFWVlU2NTGzs6w1NTE0MzFTU1O0tKy2tq63t6/JuDhUVFTKuTnKujpVVVM3NzU3NzjMvDpWVVPNvDozMjE0NDQ2NTNRUlLi4uHi4uLj4uBXV1NYWFhSUlA2NjLm5uWjijGjizH58XCkizGkjDKmjTKmjTOmjjL99XCmjzT+9XKnjjQ1NDL+93KnjzJbKxErAAAAAXRSTlMAQObYZgAAAQhJREFUeAHt0MWOwzAQgOHYmTBDUmaGptBlZmbm3fd/irVyrpNcK/U/+PRpPBpmjlq0n0rmgj6qJHLnHbySxPmZLq7HjlQaDz0C4SeOcei9lx5h5+8sghXKWzJC7PUehtwX2FTHZ7qSKJc+AJwJkOwTOmQU7rE2ZD9rQyDlKJJPF1LF0moz+31lHk+cXxePyjPhjcB44vORbpqnzTf39YkbkC9oeZJqaoagZ60XRfIJpBeofNvU29uVcJcIqAzy2v3mdG1nqeF3Ii9eHPvrhrYx3UV3LfqKooxuLz3VEC708SELdosuOUVivPzygc+xLoBVpcogfAnus3ULExcXkbgqJXDh2EXz0D9mEBzirksm2QAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "386",
+    "id": 386,
+    "sortid": 386,
     "identifier": "deoxys-normal",
     "name": "Deoxys",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABKVBMVEX///8xMTE1NTVSUlJjrZTRWUn3hFrTWUljq5UzMTE2NjY5OTnUWkrWWkr2g1k3NTWbSjkxMjI4NjbVWUlTUlJUUlJVU1JWUlE2NTRjrJMyMTGbSTk0MjGcSjk0MjLSWEnSWUk3NjU1MzLUWkvUW0vygVhJgWlRUVHzgln0g1n0g1r0hFo1NjZSU1NlrJN7SsaCy7KDzLOEy7OFzLOFzraQYeGRYuGSY+WTZOaVY+SWY+GZSTmaSTiaSTlKg2s2MjEyMzKdSjnQWUo2NjXRWkvSWEhTUVE4NzZTVFTTWkrUWUk5OThUVFRVUVIyMzPWWklJgWjXW0vxgVlXU1FiqZJiq5JjqZA3MzH1gln1g1n1g1v1g1xJgmr2g1r2hlz3hFlKg2r7+/v8/f39DWlAAAAAAXRSTlMAQObYZgAAATNJREFUeAHtkMVyxDAQRDUCy7ZsLzMzh5mZmRny/x8Rxbkla3lve9k+qEtVr2amG400fGEYEGtq2UG4lUfNtg3faXLcol61c2k1x+3c1IJOadU2lHeKxu3XjAs6mpYFFbn9Mq/T0OdJS5NSRsJzeo+Qj84YpR11djz7s9rgPlcmAaI3tAd+peNgJPgQI22ZBFRYmhcMqD1p75sRx7vz7kZjtRhGgi2NP9uEtLxCdy/WopaBMAqwSmUP6IEHietd4IUw8HV2Go+XEU6RVt/tx4ACRTlwK5Jg1jnPZyFF2rF+kQL5YqaERP3wCDBLXL6CCbXrSRr6ywlmBUvS8W7GRJi/OYBM5hCYOPtHmqZry0n5XE3vyB+ulZHw7FO40e5C7hbtHqklWNg1q7nvR/6aPGdIGukbEe8cGDJHjFAAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "387",
+    "id": 387,
+    "sortid": 387,
     "identifier": "turtwig",
     "name": "Turtwig",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABLFBMVEX///8xMTG85oM1NTU5OTlRUVFSUlJTUlFTU1JUVFKbxEqcxkqjekq5oVm7o1m9plq95oO954TNxWv25VL251K8plpTU1GaxEpBq0m95oQzMzKawko0MzG9pVq9pllVVlJCrUoyMjFRU1G+pls2NzY4ODjLw2q65IIzMjGbxUqcxUs3Nzadxkqdxkudx0ujeUnOxWvz41K7pFoxMjG954K954M3ODWle0pSU1G54YG65IE3ODY0NjEyMzG7pVm744K75IO75YJTVFK85YM2NjW85oS854NVVlE2NjZWWFa9p1u95YK95YNxiUlyi0lyi0pzi0lzi0p0jUm+5YK+54LJwWl0jkrLxGrMxGp1jkuZwUlDrErz5FHz5FL05FL15VH151Oaw0pRUVD351Jk0uZnAAAAAXRSTlMAQObYZgAAAPRJREFUeAHtz7ViwzAQxnGdLDtmxxBmSMrMzG3KzNy+/ztUzW7ptiz+Tzf8hu9I0mBTsC4/h4V1LhUABGwC5OucS2XTfUU4LlVXB0DNnGqgGLiVyjDCDXknae+sKHPH236/XcnKsVWO5qM7Lu2GgCrdcbpzEJXfFjzdXkrFS3ZP/Wf6VX6vhlXdFkD+is+Lbr3w07BTWrzsrBz6p4VCJvx9qmnaMhCBpJlWa7r7cWRmjdI6iY85j0EQ1AwzZ+UeRjYEUvnR1WzJsm6+r8wJEWTnl+2X61E6edF2ZteISPYIU7fSe8X/S1bHmdlcJJhYb58kDbY/yzAbQY4zq0QAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "388",
+    "id": 388,
+    "sortid": 388,
     "identifier": "grotle",
     "name": "Grotle",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABcVBMVEX///8xMTE1NTVCe0rexilJm1lKnFpRUlFSUlJTUlFUU1FUVFB7rVqMxnPErDHbwynbxCk5OTkxMjGjejkyMjFBeUlTVFNCeUlCekpVVlFWVVB6q1kzMjGDckqKxHGLxXKMxXJKmlmNxnKjeThRU1KkjDmlezmljDnBqTHDqzHEqzE2NjY3NzVRUVHcxCo4ODXexyzcxSrdxSl6rFoyMzJSUVGFc0mFdEmIw3KJwXCJwnGKwnKKw3JEfUqLxHGLxHJSU1KMw3CMw3GMxHKMxXFTUlBEfUtTU1GheTmhiTlTU1OjeTpJmlmkejmkijmkizhTVVOkjTkyMjA2NzWljDqmjTimjTmmjTqmjjxVVFLDqjFBekkzNDFWVVPFrDHGrTHJycnLy8vMzMzYwCnYwSnYwSrawilikkpjlErbxCrcxChklUtklkvcxirdxShklkzexSk3Nzd6rFnfxy35+fn6+/r8/PxSUlEzNTN5qlnawyh98ihZAAAAAXRSTlMAQObYZgAAAUtJREFUeNrt0UVvwzAAhuE4dpiTldu1KTONmZmZmZnx1y9pr0nX2zSpr3x8/MmSsUZ/Gg5AfcwBoQp+dw7KDY2jmldqQ2hG0QDMkiqo6UymMTokIEGaw9bQtQMd1Fyc0UkzSKgg5beUistNaRGOdhNkpWhANKClzGlxLs/qVQepdHuT3TMnORlxbToZNQ4dECeAjYswMmI1jmZk1mAHdoN4boY7R96tPIqVEUIdtoNZyZtfKyOpxDppGSGW9lkv4hIyWrjyOAeahUEn5eN5a5g9eUTS997HsNB8exkULp55PmYl8dTuWckDjjbWhx6Cwk33ytTqZsIKKsnRRar38614nQgJQn8rphweTwPLN3aFxjtHwnfzTE8ovLRsXM1kbP7lq6Uvti0WwFhi/96P2WYuJMVCBsNPiy/pgr2r2sr06/sTVk8KjmON/ks/X/opol/sVS0AAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "389",
+    "id": 389,
+    "sortid": 389,
     "identifier": "torterra",
     "name": "Torterra",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABOFBMVEX///8xMTE5azlKjDlSUlJiq1ljrVpKizlTU1M1NTVRUVFRUlE2NjZSU1I5OTlJizmcnJzGxsZJijicc0IxMjFSU1E3NzdSVFJTU1I4ajhiqloyMjFLjDl6Yjl8ZDp8ZDuackKampqbckKbc0I5ajk2NzWedUW7klG7klK9lFLDw8PExMTExcPFxcVSUlGbc0E2NTSZcUGadEI3NjUzMzOac0EyMTGbc0Sbm5tLizmcdERUVFLExMOfd0e5klG6klG6k1FLjDtirFm7k1K8klG8lFK9k1G9lFFMjTvBwcE5aTnDxMM2NjVRU1EzMTHExcQ7bDszMjHkSyn5+fj5+fn7+vnCwcF5YjlVVFFVVFRhqlhMjTydnZ2cckGZmZmackE0MzFJiTlUVFRlrlz8/Pz8/fv9/Pv+/PsRYX5KAAAAAXRSTlMAQObYZgAAAW5JREFUeNrt0sVywzAUBVBJlsxO7DAzc9qmmDIzM/P//0Ff7cx0EaVZdbrJ3djjOfP0rsZolD+MgocTm3kEH8a/u8oEUsJuIgnE7bM/DIY4TNyCHZCK6OO7dF3O9RwhBGMPQF4DxVOTqWQz4EQTRaGDeceqgDQJTG8qZWKWB01ZIoQZ0IQ4UpM6XszbEBZkomhQmgNJ3Bpl2ShnRQ/ZtawjJo6tla/m9neIkQ5m2q3+g5eFmgUBmfUW12MaTcvcgRXLrDsOsnV7eGcGI35VRzwJzCkBsyt1OeLPPHE2xCqtWj+RG8xIeb3RvsKmKTOo62CZUibc+FP3jwecq4HLXhEFjUKY/dZOZBKT/Wer0EI4+Xw1qjCwVA7FG/Fu8iKAOJJK73vnL9Xv7terodT4ZTeZR1xISxtLMe1hGiZulo+Ra8DP61L154WZvI7pYqFZLDh9+RK5dB0e21Mf883TABoW4Gdvs62hzKEKGuV/8wXImibIhCVoDgAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "390",
+    "id": 390,
+    "sortid": 390,
     "identifier": "chimchar",
     "name": "Chimchar",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABCFBMVEX////356U1NTUxMTE2NjY0MzJUU1K7ckK8c0O9c0LcxXPfx3Tmk0LnlELnlUP05KP05aT35qRSUlLcxHJVVFPexnMzMjHlk0O7m1JUU1G8m1JRUVG+dUT15aT25aO+nlTGTDr+WTm9dEO9nVO+dEK+dUNUUlE2NjXESjnGSjnGTDk1NTPX19fZwXHZwnDbw3HcxHFUVFNVVFLexXM3NzVVVVThkULikULkkkFWVFHllENXVVPmlEK6ckE3ODfolkTralDualHvbFLvbFPvbVXvb1Xx4aH0zEK7c0K7mlE5OTn25KO7nFP3zkIyMTI2NTT7+vn8kzlTUlH+/v3/Wjn/Wzn/kzn///+y4WScAAAAAXRSTlMAQObYZgAAAPZJREFUeAHt0LVyAzEUheF7BMtsZoeZmRniML//m0ROv1p1bvw3ar45o7k0bsQxbgr3q9xUulUzF4YmkLXsoHhx+39PVSDZmlTIDYaScx1cPQpn2t1JJRvxlGZV1NO2jxSIGjEgKT9+DuDmOsVGfNXVwcEuUHlbvgT6F1pIDPBnfyOk/UflFjSwAyx9Vry6EEQTGvhqddBrepaaU/ArT87JEzsrlayyU5Mv898/eZA/rN8zxlqOX96sufL9eTHvgytNoR6ZwY+svTN5l3+doeOO5WFr+gM9TtpEZmeJGxx4ySkVSJV9eLzDySBx+5QwMmkgGI0baX89lBYFi2IPMQAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "391",
+    "id": 391,
+    "sortid": 391,
     "identifier": "monferno",
     "name": "Monferno",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAzFBMVEX////vnDkxMTE2NjZCa6VUU1HOezkzMjH3zpzsmjk1NTWcaznLo3HOpXPsmjg0MzHsmzpKjN7z20n0zJpRUVH33krLeTj3tTlTUlHva0pEa6PvnDrzsjjzy5ozMjJJi931zJo0MzJBaqNSUlL7+/v///9TU1IzMTEyMTFUU1PsmzvumzlUVFTvbEnvmzmaajhMjNvvnTnvnTxEbaZRUlPMejnNejn020pJitv2zJr2zZv23EnOfDrOpHL3zp333Uk0NDTsakn8/Pzsa0xg2jbCAAAAAXRSTlMAQObYZgAAAQ9JREFUeNrt08duwzAMBuBQy5JXvLN30r33Tsf7v1PJBu1JsntqL/lhCCD8gSAIqbXNH4T/1r3t1v9nrBkSi8Frchy/GH5czwV5OMZ2CFkdJBftGHREsRoe9xzSD78dNWVZZ91pO1rOE+gLkQDIPBpnZVnaIb8TSX+SpiKRudYzlqFzQYEO5VUePbghyTQ9ADjbwBZ3t5xPPk685WVCI1I9dEBa3f1s+TIAudlk7NkZK3JN2V+8v1Jd2Z1/eqO6OByy1QWg8e2QV0oFe8UC2erIPJZths4KQ+Ux5MFU64G8Pf+a0zEiHcV1MH06BGkAvKZbWxhQXaMUwXo7wnVXz7hyTONb8Ee4c0usI2/zj/kE9uQWQP0+U4kAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "392",
+    "id": 392,
+    "sortid": 392,
     "identifier": "infernape",
     "name": "Infernape",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA7VBMVEX///8xMTG1Yzn/1jn3WjlSUlJUUlFUVFGFhXUzMjHbekLee0LzWTg2Njb91Tn9/fz/1Tk0MTH////80zlZituEhHOFhXI1NTWyYjgzMTG2Yjm2ZTy6o0G9pUK9vb2+pUFJcavdekHdfENKc61MdKv0WTlRUVH3Wzn7mjj70zhRUlP91DkxMjL9/PtTU1H+1Dn+/Pv+/Pz/nDkxMjM0MzFUVFRZi93beUH1Wjm8u7pMc6szMzOzYjn7+/u+pkT8/Pz9mzm+vbq+vr5TU1NajN79/f3+mjnbekO2ZDk0NDQ0MjG6urq7o0L/1jy7u7sB069+AAAAAXRSTlMAQObYZgAAAUpJREFUeAHt0sWOwzAQBuCM7TCnzMzMy8yw7/84O64Pe2hi7aW3/lUjxfryK55YOeVYcf/pck4IIJ4ASCwDxXUYJuQ3/YCuYxVHIXcvwfIDoB/oEOt2poOkh3+67DHRGw+1zoxmM3cBpXon2SFcGKOsb2RGVLe0DgtBSYYZPzJ8Q7VsDUAyv+tIZGNdjKXzm0clQibcbVdiCeKKXWdeOmOsOEH4au5X8g3bNmNgER1jc6z8c6Rw4AY4k2Jh0EOogtidbQIcuHJlekWwYhFtUjVvzQsP2zist1pDy7Y1Vf3yahVvDfEO4RAw3dR9tfqYovStoUHiweHX7u03rU1V2OF2JUEX3VT8DeBOZrrE5Qk5f35o4vSA4CeXFP5ULz+b++FB2WtDsgTYz3nxruTq26dkKCbq0fZYyaVXaSlEmW7xQ+HiTxrxAqccKb/4Bx/WNjljdgAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "393",
+    "id": 393,
+    "sortid": 393,
     "identifier": "piplup",
     "name": "Piplup",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///////82NjY5csQ5c8ZKlPdSU1SDzPyEzv8xMTExMjNMlfdRUVFRUlNRU1RReaNSUlJSU1MyMjNTU1Nxq8s1NTU8dca9vbX7+/v9/v9Jk/YxMjRyq8xyrM15eXl8fHmCy/tJkvODzP2Dzf4yMzSFzv+7u7O9vLJKkvS+vrbDqynGrSnz8yn39yk4ccP7/P78/Pz8/f79/f0zMjA0NDA0NDRUVFQp971PAAAAAXRSTlMAQObYZgAAALFJREFUeNrt0McOwjAQBFDcYm96b9TQe4f//zSMyNnLFZS5WXoaa6fX5WdCAeArdqwFtwF1muloisFGfNI3u6wtRCtpM9PoQhyskk6UUhUhWiJ/05GsyKMkDub2h/GZ5CeSo1dvd6sr2SSAD+4uiyIJmQ2YY5zzWvjMM8ssjZi3Fr60mG0sTGNwpRVKpSwwQujRclE9NZzj5wRTZUldiA90C4bRIMYb4b37vX3huMvf5QXF1ArDO/AzxQAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "394",
+    "id": 394,
+    "sortid": 394,
     "identifier": "prinplup",
     "name": "Prinplup",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAtFBMVEX///8xMTE2NjYzMjFCe8ac1vfGrTH33kKb1fZDfMZRUVF5q8t6q8x7rc59rs4yMjMxMjPFrDE0MzHz20H13EExYor8/f5RUlOaejFSUlKc1PP8/PycezFTVFTEqzFTUlE0ZY15q8z7+/s1NTX8/P56rM2a0/RTU1FBesXz3EOc1fNSU1OdfDGd1vfDqzGcfDQyMzSa1PZDe8MyZI1EfcZCesRRUlKaeTExY4yaejKa0/P+/fskSV19AAAAAXRSTlMAQObYZgAAANFJREFUeNrt0scOwjAMBmDSrG46oYNC2XtveP/3woV73Fsv/JEiRfpkWbFb/zQcjZB67u4LimuAu96JeaGUgdqNwR33kZRSUAxmP4fDXiQ3g7QvCNpjJFYG6/Yp0mS8FHS0NZiHFIyf/vsyQaFmJtBhxg2mhlr8uCXwj5AuweC1UtXlKZzlrPNyMT2DVkqYsJmXw45bSaxLS3c6rl7YDJPjF3d0zgtbN5CSpg0VQaYzflDOWsyJ5UDahBBswTUL3PeFL69Pa8EwCINWLQnnn4bzAdwUERSSV72xAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "395",
+    "id": 395,
+    "sortid": 395,
     "identifier": "empoleon",
     "name": "Empoleon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAb1BMVEX///8xMTFCQkJKnOdSUlL/zjlCc8a9lDn///9RUVE2NjZUU1G7kjlDQ0H8yzn9zTlJm+a9vb0xMjM0MzFCQ0S+lDn7yzhEREH8zTtCcsS6kjhKmuRRU1RJmuRTU1EzMjGEhHNCcsM1NTX/zjxEdMO9vXGvAAAAAXRSTlMAQObYZgAAAOZJREFUeAHtz8lywyAQBFD3LIAka/Fuy9mT///GDJGujJSDb+4DRRWPHtg887/Ua935sMp9jf0aWOOsenpfdmO77VUPK2Bsu1xYYwm+UXepgIUPYYw2+lLRtl+A0QpPbUWdNvCh2OTXF1sbAB6kqAbvV23kNuwdGFXpMwzX5jawOUeqJqRv/XEdQKJGNbsjyo4spmIIfKSKShIhBECCMSLJQYHCDrALnNKHTFJKpeYMmhMi8qG5kP4kexKRmHdJUoZMTiWYbXJuzJJF7vuSDCxzwDnlVwKzs60DJ6tRMd9y4AQ2D8ozv/UwCjQk4MKHAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "396",
+    "id": 396,
+    "sortid": 396,
     "identifier": "starly",
     "name": "Starly",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAASFBMVEX///8xMTFSUlKUhHP///9jY1p7a1q9ta3WY0L3lCliYlk1NTVkZFs2Nja+tq40NDSWhna7s6v7+/v8/Pz9/fwzMzOTg3JRUVFmM1h6AAAAAXRSTlMAQObYZgAAAJlJREFUeAHtzkkSwyAMRFG3EAN4yJzc/6ZpHUCYtYsP7F4hLddrtmLM7U0G5dqGIPATGO+v8EFklHvDU2+uw11ztID2fR8bXKiq0ZIWX8cW4bmgGsyafLiOEEpJTkhM58Fcq4LHoHQcKgvIdCK9D0VKseGEfC6kJCUS3hB8R5hypjHWh5Q2OZ06ShhKqZg7o5BaYHDELhds9gfAuwPRIC28YgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "397",
+    "id": 397,
+    "sortid": 397,
     "identifier": "staravia",
     "name": "Staravia",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAilBMVEX///8xMTFSUlI2NjZiYlljY1qUhHPW1tb7+/tkZFs1NTVlZVyVhXWro5rU1NRRUVH8/Pz+/Pz///80NDT3lClTUlLzkinWY0I0MjCSg3LTYkEyMjJ5all7a1p8aln9/f3T09PVZEOTg3KSgnH2kykyMTFUVFTUY0LWY0HV1dUzMzOupp3+/fv0kikibBPRAAAAAXRSTlMAQObYZgAAANVJREFUeNrt0kcSwjAMBVDkmt4oSei9c//r8QOTrGLjDcOGr5VnnuWMosE/XwoncnIBCUaOLSEdoSRH5wQ5pXjagaEfXHc0uZ2SCLVsfTU61UkwrQ0w8CK4LGxgIBKtfepvGG/yYujdfEAu4ovBAU73o/vQC5u3hUw0LvS7lD1G5xwOYSLx4Q3LMC3LvCggARmz/CDugcWrt7SNnafZUTRGblFk3RvUCyplgxheFsKyGoOfmVD7kdG4HkPC2WWkmszo8/rMF6flwWlxJ9WkGjhJ1D8/zxPnjAm6nFvZfgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "398",
+    "id": 398,
+    "sortid": 398,
     "identifier": "staraptor",
     "name": "Staraptor",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///8xMTFSUlI2NjZTUlKUhHP///9RUVGSg3JjWlJ6all5alllXFR7a1oyMjIyMTH8/PxiWVE1NTXGezFkW1NUUlEzMjGro5qupp3DeTHEejFiWVLU1NTWY0L0qzH3rTGTg3L9/f2SgnFTUlGVhXUzMzPTYkFjWlGcWknWZUTW1tbzqzE0MjH2rDGtpZz7+/uupZr9/fxUU1H+/Pv+/Pz+/ftkW1SPjGcWAAAAAXRSTlMAQObYZgAAAQtJREFUeNrt00dywzAMBVADbOrFclEs9/Tec/+j5VOe7ESaXmRnUBvNvPkkiOHoXCeUoEBWxxTi6jgOgeOb1d1tgBQHByjoGFxNmTuifeHpDBuDVfpKcpSX9p+odsBppXWrlIKz/XMXEw1B2qv3FixfXo8EmF00fMi5UkW6fPghCzlBpANePH/ff7UTNE4mAXREjs16s3l72WW4IkagK1IY5kXzqXsXKZnADjlImu80+p70UMlIJqXjxk2lM3zMB1iQczaviKsysL4wH2diFqMBQK8DtEhyB+mFkD2RnGy9DlNMIWxJIo8Tj82M0nyLVR57MoQ5XnL0t6039WPRzILeoVk/Bb/sc/1j/QLMxBBwTQ7AVgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "399",
+    "id": 399,
+    "sortid": 399,
     "identifier": "bidoof",
     "name": "Bidoof",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAflBMVEX///8xMTG1hFJTUlJSUlGLYjmMYzm0g1EyMTH354w2NjZqWUprWkpRUVE1NTWMjGOyglGzg1JSUlIzMjG2hVLLy8vz5Ir15Yv25YtUVFRtWkqKYjiKimIzMzPDo1nGplqLi2JqWUn0YlH05Ir05Is0MzJUVFKzg1H7+/v+/v6cDM/TAAAAAXRSTlMAQObYZgAAALNJREFUeNrtkkcSwzAIRQPqLrHl7vRe7n/BoChbEu/jP4gNb74kYDFrVgLTysna1DxKZW0h4AClUKZmwWXuEWsoEVFUXgBrGIgIUeYtE9gNrkHUBoXHcDiwc87tB0LfIGrLcJui6J27dk3kUAADHk+r7NDfLmTJchHMgs7N5+Yvn85TAu8Y3yiUZbv4GNNMKiO8lkoC8HNpn2OltNaSsuU5smy3NMMYP1aGmk4RNHnHZv2vXq7lCLYlSGuhAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "400",
+    "id": 400,
+    "sortid": 400,
     "identifier": "bibarel",
     "name": "Bibarel",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAolBMVEX////OtWP354wxMTGzg0q1hEprWkr25otSUlFTUlG0g0lqWUlSUlI1NTU2NjbMs2Lz5IqMYzmNZTr7+/s0MzL////OtmVsW0r15YptXEv8/PxUVFS2hUtqWUqKYji2hUzDo1nDw8PEo1nLsmJtWkpTU1NUVFKLYjn0YlH05Ir05Iv15IozMzH25YuNZDkyMTH35400NDQzMjH+/fz+/v1TU1LORg9sAAAAAXRSTlMAQObYZgAAAPlJREFUeNrt0kd3wzAIAOAAEpJsN57ZbbpnRvf//2tFT8cGO7dcwgXr+XuAxugcp4zxke6i6o6rd+86Isk0BCtsMvtFFWwHYHs9x2aDiF1cEZFW8OcDEcBh42k0zpmZDsOb2d0OvidT12T1uzhFSo2XB15+ttN9Zm0oHcxUyBLL6Gp/xVyKpMPHePso/42VCPLBrwttyHayKoyts+giBDknRa5MZIVJkklxa18C/BYm9e6Fb+DAXUp3gbojgYiL0obnNKayldwEY+dP0liyQHEK5DScCSmT+hrztOWi36X3so5X4o0NlFyPzeXm/D+m3Hhig1LKneP08QcTLA+17g3akwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "127"
+    "gender_rate": 4,
+    "rarity": 127
   },
   {
-    "id": "401",
+    "id": 401,
+    "sortid": 401,
     "identifier": "kricketot",
     "name": "Kricketot",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAflBMVEX///9SUlL3e0o2NjYxMTFTUlFTU1KKinmLi3qMjHsyMjLGWkpUVFOUWjlRUVHLunHOvXPzeUnz5KNUUlH0eko1NTX356VycmozMzLMu3LNu3IyMjFxcWr05KP3fUz35aPFWkmSWTmSWTg0MjE0MzL8/Pz+/PzGW0rFWkpzc2v/XySvAAAAAXRSTlMAQObYZgAAAMtJREFUeNrt08cOgzAQBNCMscE2vaYB6e3/fzBrJcotXm5cmIPlw9N4V4jVkjkTSDnNRQZTZBsZY+znKrlCbb83y4wYWXdm2lV7aaZt1SUamiCzD0AKkIyrkjhWGhi6K+NwSlPVxMorgzy8jTXQCEGy2PyFbR7KUghxH4WotwR9la7vUooaPkjyfKQJ6WHOZbSLAoj5XWSeCkNHSSAZuCtCDEVIg/o/dnlItHELOeinGUHWUdoeMn/ESk74HWj59WvPQmf7n+Nbl8ycN6yHCvOs9t43AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "402",
+    "id": 402,
+    "sortid": 402,
     "identifier": "kricketune",
     "name": "Kricketune",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAflBMVEX///8xMTEzMTFSUlI2NjZRUVE1NTV6emq6WUG9WkLva0p7e2vuaklTUlG7WUIyMTHsaknsakqaSThUUlFjY1p8empiYlnvbEu9pVKaWTnz5Ir25YpTU1IyMjF5eWqcSjntaknta0qcWjnua0pUVFK6o1FUVFS7o1L354z8/PxRZJAQAAAAAXRSTlMAQObYZgAAAOdJREFUeAHt0snOgzAMBGDGSUhidmj77/v+/i/426nUG24vvTEcENKnGGtSXSVbPC50KdMl3oe+QD8ymbCeX4byPgP9PKQOxz/IZMPQ03EyElmubIORM4kmE86vnFsWY8oyVWLCIpFa5tz1rS196tzEvPx9TzasQ2ycmxYEhfK9Xkx0d++daNgFPrvoEFxsmiezbj0Qlf961CMxZloteoC4+99PgVG2MqBu+nDDiw5PbaZVKG7fvO1ldVhXra5O8LAD1mHBWuGCcNi5yb5p4ef2gyqv0HIiASSVGG2oNgnx8pyLkGtlyz+CsQr2eHrl8wAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "403",
+    "id": 403,
+    "sortid": 403,
     "identifier": "shinx",
     "name": "Shinx",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAgVBMVEX///9qmuR7xv8xMTE2NjZRUVFSUlJSU1RqamoyMzR6xf73zikxMjNrnOd6xPxKdLY1NTW9pUHzyyn1zSz2zSk0MzB8xfx8xvt9xv+7pUR5w/tqm+Z6xP1ra2tJcbJ8xPu7pERsnORUU1HsYjjvYzlRUlNra2xTU1G6o0H9/fz+/vuy3xvcAAAAAXRSTlMAQObYZgAAAOlJREFUeNrt09cOgzAMBVCwySLsUbr3/v8PrNNUFRJpxGMr9T4RcmSbAME/35MIxym8Nq1zq8Cg6K0qXbphtF4kc9VbV1rr1gXDVGSgsCfLhuTQbXcijCFNzHgW7hHRBS9ZvogBVBiTpjvMqgGkxs/ky9nE1GWSoFPGLwd1ByqIyLnh/F2wIYhy9QEWBs5uU6i11p2yjZ0VD8cN1PcpQF1OFOPWfRqSKppnEdLjSCJRSAXncmUG9FHGOc8gPfshNSeRAeQnyTl6oXg2TxCZH7IwWS8hp9cygMNPstKtvbLxHZIa/af880t5AO98C836zcxsAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "235"
+    "gender_rate": 4,
+    "rarity": 235
   },
   {
-    "id": "404",
+    "id": 404,
+    "sortid": 404,
     "identifier": "luxio",
     "name": "Luxio",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAh1BMVEX///8xMTFSUlJ7xv82NjZSU1RqamJRUVFra2NqmuT3zilrnOcyMzQ0MzB5w/t6xPx6xf41NTV9xv+9pUH0zCkxMjP2zSlrbGW9pULzyyl8xvszMjFra2W7pEO7pURJcbJ8xPvsYjnvYzl8xfxTU1H0zSv1zSxtnOS6o0H8/v/9/fz+/vv///90kLbOAAAAAXRSTlMAQObYZgAAARFJREFUeNrt02lvhCAQBmCHEVDwWs+92u19///f1xdImlS61m9Nkx1jMponMwxocok/i3SdIlK0wm10LlVGIaelgrkFzIiQVnb46kI/QQEJWjEXgeFRUASlEl6K+vrewVQLQaRiCQSl4MbnwTu/DhVDX02K+mkfCpKfS9G89dE5Zpk3kpLUA8BdSUQx7Lu3Vgo45dbnYTea8ts+AqJx/97yhMk15iLnjJk5LW7vbvj1o2Wp/EwKLt2ZbiyjE8wbZvabGW5yL3Xv4NxqgVKIegpnFAoksXx5UBkYsz1mi+eNEXAB8oSpz7vT1fZAqjf7gvQS3OTWDui/Pbgc6XlJBPFoyt++SY8r2xRrf4nkEv8qPgHmSwxa/d9XcgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "405",
+    "id": 405,
+    "sortid": 405,
     "identifier": "luxray",
     "name": "Luxray",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAeFBMVEX///8xMTFSUlI1NTVSU1R7xv9rnOdRUVFra2N6xPwyMzS7pUTzyyn2zSn3zilqamJqmuR8xPu9pUFJcbJra2U2NjZUU1F8xfwxMjN6xP00MzBKc7Vqm+Z8xvtKdLZTU1G9pULsYjjsYjnvYznvZDhrbGVUUlF5w/urYgnGAAAAAXRSTlMAQObYZgAAAQ9JREFUeNrt09lugzAUBNDMNcbsZOu+N2n7/3/Y8aUOBQdBH/qWK6QI62RkD7C6zB/GYKFrl8GrNsM84uUIZ/ZCBB+YCX6tAajuIygAYQYF3VrVbOszUOgI1Z9k0wylWaeJwh8dlqttPZBm95hQ6DBZengNYBDYu9wmCOc1cB2LIV15U6wMK4BufQThTrCsnwoGaaXKh7INeZYw8Q0IgFgaTZT3jU24Ryq9cD5SUB0/eeRQk6iTMXw7bMrXFxoir/wAbuwovyznQxuX9Z6/VAK6SDo+Ha9Ecv6BxAQWSQlnT/d5EYPeaaQIsLuzz7fTjsIXD31H0mlI19Wk8oFwQiIUD72b+wxl2YeolVzmH+cb/s8N7BCJNggAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "406",
+    "id": 406,
+    "sortid": 406,
     "identifier": "budew",
     "name": "Budew",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAllBMVEX///8xMTH353M2NjY5azlrrTmUzlL05XJSU1G9tVIzNDNShEFqqzhqqzk4ajiTzVEyMzHM9LPO97Xz5HFRgkH25nJRg0GVzlJSUlI7bDlRUVE0MzJtrTmSy1GSzFGSzFI1NTVSUlEyMzKrzYqtzoy6slG7s1IzMzHL87IxMjHM9bPN9rNShEJTU1L05HJTVFNThUNUVFI7A9l1AAAAAXRSTlMAQObYZgAAAJxJREFUeAHt0kcOhDAMBVBsJ6GTSSgwvfd+/8tNuYC9Rnxl+ZQvWw56mCEEIHMT5xMJpZN/di7hXaa3d/e6JAKooz/kZbq4+t1GMMzSGDNi3SqzxuizoNjqdN3lrKS5TsOZZbspiw414lcy7VRAifh+tNyXVIVxXE/Llp2HihARxyqPgIGVam6/B+weoVCNUqLzgX18lJ5u0L8M+QDPXwjeUhGbZwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "407",
+    "id": 407,
+    "sortid": 407,
     "identifier": "roserade",
     "name": "Roserade",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA1VBMVEX///8xMTE1NTVqo2JrpWPvhIyEpf82NjZrhNZChEKDpP6M3oy8vLu9vb2+vr7TYkHz00H31kL7+/v/taX///80MzExMjFqg9PWY0JSVFJSU1KK24ozMzP01UJUVFRiasxUVFHWY0NCg0IzMTFRUVH+s6P+tKSEhHMzMjK6urq7vLsyMjJUUlJspWRtpWLTY0Jqg9WFhXXWZEMxMjON3Ipja86CgnGDg3KDo/zsgorug4oyMjQyMzKEhHRDhUP7sqMxMTP8/fxSUlKL3Yv+/PxSUlQ2NjXL3VFrAAAAAXRSTlMAQObYZgAAAOlJREFUeAHt0sVuxEAMBuDxQCbMy8xbZmZo3/+ROpXPsY/tYX8pOX36x5Ys/kl2kYKOBcD/3pB2ZZ0OAa7jJEloKcv6N2ebmJHWQaTx0+aAcyixk4cpOlam3DpSvTl1pIN9ylkQMj/WelQU0xtqlRezFd9Kj1plPZ4H7cZXs1VltqB0cPI5nrehua8yZnZ/CIMoesa6Bni3NuvqfCFsXkzfAQiZdVdmdvm4VLo/Cf0LQkLWXcBSffQmoec90FfmvkHUu/U8/+qVO0nX2An9ECtp6WY8xSHpSFD9jv8Fgo3NWwC8w6X+Nrv8AJ3oFRvgW6AfAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "408",
+    "id": 408,
+    "sortid": 408,
     "identifier": "cranidos",
     "name": "Cranidos",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///9SUlIxMTFRUVE1NTVTU1N6enKrq6utra0zMzNKhM57e3M0NDRrpf+rq638/Pz///99fXVJg80xMjNCY62srKwyMjJJgsvExMT7+/tqpP5SU1RDZK02Njb8/f/9/f1RUlNtpv/Dw8NCYqvGxsbTYkExMjRqo/tqo/xCZK7+/PxKg8yZsyAIAAAAAXRSTlMAQObYZgAAANNJREFUeNrt0tkOwiAQBdDOAIXudavaxX33///PixqfRHzV9CaENDnAdCDo8wuR/CXsNtFjZvbBXcTIvEw9UBBpYxTNIo87ZVljbfXZHbN7zqun7JxwsbYuNyYhZnwf3rtpDYY0WhVlmTqhnMZx/ThZ6WUaSFTilAgKtP/NDOeDqhjQ1W4fjwJHlXDhpNpfAMdDrBq5Gx5OkqIcJLTN2/EQzgE1OmMDb9oc3XRLq4hC0souckvJzGIWCdyN0CqsfK9SztFHAedLxxivx+bFHPT5p9wAV88O3ktQ+LQAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "409",
+    "id": 409,
+    "sortid": 409,
     "identifier": "rampardos",
     "name": "Rampardos",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAnFBMVEX///9SUlJTU1Ojo6NKlP8xMTFCc8Z6enp7e3tKkvz///9RUVFRUlNRU1Q2NjZCcsRJkvszMzOlpaXLy8vOzs77+/s1NTX9/f0xMjRUVFQyMjL8/Pymo6NBccNMlf98fHx9fX2axf+cxv9EdcajpKakpKSlo6MxMjNJk/6zSjk2NjXMzMw0NDTzSTj0SjlLlP15eXn8/f9LlP96enxLCtKEAAAAAXRSTlMAQObYZgAAAQpJREFUeNrt0Edvg0AQBWBmtoPpxTg26b2X///f8hb7EikjcYiUi58WicPHm1mSY/42xVLX1kthVx9aCzM/Muzq/jkZkqLSo8GbLJkUQ1Q6N30qwyELWutcMdE2TTdGdNXF5WeU5OA6DqMEJ3uvI9wXon2UJpcW1K6I1HpDFKy9Ey4zWQTOxRNyKiXYp1fRPdyy8hT0NYtS8Ra3fdmxYrVOzz0ZAWZYj193PE92Hjn5XT6ajFTDzlP5BYWQEUoH1TQcexW7G3xC5UqSGB90joNPGhYh5LufC6N7y/ejpU5HDrUf6alFnezajg0yxZ/vcGtZYtphWed/QHFZcotcy09nSyBWwA7H/GO+AZ4tEACwkxb+AAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "410",
+    "id": 410,
+    "sortid": 410,
     "identifier": "shieldon",
     "name": "Shieldon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///8xMTFSUlJzc3NTU1MyMjGamprv3owzMjE1NTXOzsZycnIzMzI2NjachEKcnJy9pVrNzcVxcXHs24pRUVHMzMT8/Pyag0KdhUObm5u8pFnNzMN1dXWchUSagkHs24vt3Iru3Yu+plwzMzP7+/t0dHT9/fz///80NDS6o1nLy8MyMjKR/8eoAAAAAXRSTlMAQObYZgAAAL5JREFUeNrt09kOhCAMBVDaoiLuu+Ps+/b//zdoSHxq8HUS7/PJLTQg1vxPQgBYwBIoiejrrisRMTLS7YzCyAWTEv2MFsik9osZugvdsI6IXNDeZIbAu4+WE5wWhM0VADioJZr4hZaE3akfFFtpk0k8BkEQs2ekxrJohL0nOOkTtS+47WgqzHMl+Nn39mkdpoPiF7QpzGCoTB2keu8JVtaInVcF+TkWdjucPKSeCN+Pi3K/71FvJSz9DWLNn+QHufgLaf2jbCwAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "411",
+    "id": 411,
+    "sortid": 411,
     "identifier": "bastiodon",
     "name": "Bastiodon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///9SUlJra2uDg4M2NjYxMTGEhIT8/Pz///+CgoJqamoyMjJtbW3Eq1lRUVE1NTW6urq7u7u9vb1TU1P023JUVFJUVFRsbGw0MzIzMjH33nP7+/tsbGrGrVq+vr7z23G8vLz03HL13HP23XI0NDSFhYNTU1L9/f0zMzPy/x7oAAAAAXRSTlMAQObYZgAAAQlJREFUeAHt0MmSwjAMBFDLjuzse8ICsy8z//+F08jHKIHLFBe64JDKq5Yi8y95JOEb2WnmW1wd0vTzenOSeeoGV7BptpsBY4rYvJomI3KRSvOGG4+TM8Z7eV6FCQqlMvbCXYHS6wkftepEWOH4dwOrjmvpszaOzy3or+LavvcCpdcCYjyrjW0/SKFMrp7Ob1/ve5Mo16ljYXgeiAA/jsg+KxbuNFeHzNuQIrDjxWEJBZZhzrEcel9/0nQeJ6q+neUFzG0oCbA6vEyyJhY9Lx1kZi1eBlQZnBs/olyDkJfzhRLNjrCEw8lxSU0yo9XFFRBuh1io2xqI826HqY24DQvS7rSpOjf3zCN/V/AODnGnCjEAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "412",
+    "id": 412,
+    "sortid": 412,
     "identifier": "burmy-plant",
     "name": "Burmy (Plant Cloak)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAWlBMVEX///8xMTFSUlI1NTUyMjIxMzFSU1FShEpis0pjtUpzc3MxMjFRgklRUVFTU1JSg0pSUlFxcXFycnIzMjF1dHG6o1n05SpydHJitEpUVFFiskm7o1nz5Ck2NjYjPZN6AAAAAXRSTlMAQObYZgAAALBJREFUeNrt08cSgzAQA1BWuFNMTc///2bE5O71LTmw4+H0RrYMNOf8wbRS596zqXSpEg6QugMysYYNC7AYlT1idEuCKI6MDnokJfMSghO1MR1hjFaJfG1VsGVlRl7uiuQRr4abm30EpAztnJi4JeRJip2DZSKA7H1XeiuB1IHPryxnch33LlIqjeDyjZKwWGZfpZ8Yyc2t8gu0vZ+A56h+kZRd77t9bXTJ4GOd89v5AE6QCBeo3Vb7AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "413",
+    "id": 413,
+    "sortid": 413,
     "identifier": "wormadam-plant",
     "name": "Wormadam (Plant Cloak)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///8xMTFSUlKczkp7nEpSU1FxcXFzc3N6mkoyMjI1NTX8/fxKe2s2NjY5Y0pTU1F9nUyay0k5ZEpycnJRUVExMjFKpWN5mklRUlFKo2JJeWqazEpUVFQ4Ykn9/vx0dHQyMjFJempRUlJ1dXWbzUpJo2Kdzky6urr7+/v8/Pw5Ykpzc3IwZzmcAAAAAXRSTlMAQObYZgAAAOZJREFUeNrt0bl2g0AMBVBrGWYGMKv3PfGa5P//L0INhY8ITY4bvwKay5OGmbzzf5nCSJbEUW7W+nEwQRzBVP7RmAJA90o8wqDbFx/5HEBk1K9suSmEihU4vS7m9m6bPC9W2HofQd2A/BTWBREBBuB+9XX2GvyWTrBcXbYxUdbiuimEGo74Rxu7B64XjSHTmg47XTHej91skQqf5aPKRGojbktbpsuscoEdIoYLUSmlDRh3uHTBbYnocCNidmD+o3SG6qqsYhdOQxdea1m2C8y9sxZlFmVO7Y+uzBZ95dNQS8rQd16fX34BD2MK5dSAAAAAAElFTkSuQmCC",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "414",
+    "id": 414,
+    "sortid": 414,
     "identifier": "mothim",
     "name": "Mothim",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///8xMTFSUlL///9UVFSEhHPWY0L3lCn3lSw0MjDTYkK9pUI1NTVUUlHzkinz7GpRUVGCgnH7+/v8/Pz9/fy6urq7o0JTU1ODg3I2Njb0kilTU1E0NDT372tUVFK+vr79/f3TYkG6o0G9pkIyMjI0MzG7u7v2kyn2lCv27Wq8vLv3lSq9o0L3xUn3xkr37Wn37mozMTEzMjEzMzOEhHSFhHHVZEIFiF8wAAAAAXRSTlMAQObYZgAAAPZJREFUeNrt0cduwzAQBFDtsqtZVrEt23FJ7z35/0/LgNEtFOOrAQ8ErA4PgyWZnHIU6YkOY6Vxh7jawv3fm3c7IQkz3gtQC7HGKI0ZYE5jUDJRLezgejRTcEW5UNwIIazze07ONsvAEn33qZRqhdh+UNJD+WzoL5x6J5nwPzBUumBha82XuvRuyIMLF65LQJo84+AvYFeBC82nvGitA+SlQZ5e4RIkINX9rYFLb37dxXsyApmo4mY759kdjjH+jHiHfF9c72RaMHP0tQE10OxbP2Yrirlunmpd0HmWrdK3GMSSjSTMvfYuZiuqCIPizAt8pxxTfgDDAhKy4aEcigAAAABJRU5ErkJggg==",
-    "gender_rate": "0",
-    "rarity": "45"
+    "gender_rate": 0,
+    "rarity": 45
   },
   {
-    "id": "415",
+    "id": 415,
+    "sortid": 415,
     "identifier": "combee",
     "name": "Combee",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABPlBMVEX///81NTXn9/82NjZXU1DxkSlTU1FWU1ExMTG6o0G7o0K7pEIzMjE5OTn0kyo1MzFWVFG6w+zzkyg5ODg2NjW5o0I3NzA3NzG5okJTUlHx8iozMzFUU1HzlSn0kilUU1L0lSr3lin38ij39in39yj39ymenp+4wem5oUE3ODU4Nzc4ODg1NjQ2NDNRUVFRUlJSUVBSUlK9pEK9xu+6okHzkikzMzQ3Nzc0MjC8xe9XU1E2NzjxkSo1NTbykim5wenTwlHTxFHXx1DXx1Lh8fni8fnj8/vk9Pzl9Pzl9fzmW0HmXkHm9v3nWkHn9v5TUlA0NDQ0NTXxkipUUlEyMzI3NTBUVVFVU1Hz8Sjz8ylVU1I3NjX0lCk1NTH1kyr29Cn29Cr29Sn29ipWVFM0MzL39Sk0NDCbnJycm5z39yoI2pClAAAAAXRSTlMAQObYZgAAAP1JREFUeAFjGGZgFDByEKlQm4M45YwQipcZjxrrALhCRrxmCRrbMkTzc/CkEFDIa28pqBujyCJqJG3Bz5EWi8dI9WTWRFUhAVF2BUUWKRUxoBCzWWAIFiP1+EIjM8VYWcDKpZLEGbTSfZjUsKlkjXdyTgiTAymXk3Fw1HFnYmJyE2bAqlJZNtxGCahclp3bwNWPyROqDlMlH0twlJ2SMlCdiTSji0eGOS4P+Sv4elkFxbFzc/IwAoOdGafPTSO8U4UE9Lk45Xnwx6ApxCdcbIZcCJXYvQPxCZukhiYDAZUgn3BKSmgSSD7CrHwyEtxsEG/gN5NZRASobBiCUQAArwUg/iSBYoEAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "120"
+    "gender_rate": 1,
+    "rarity": 120
   },
   {
-    "id": "416",
+    "id": 416,
+    "sortid": 416,
     "identifier": "vespiquen",
     "name": "Vespiquen",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABVlBMVEX///9SUlIxMTG9pUL33jn03Dm7pEJUVFF0c2I2Nja8pENRUVHe9//02zmtQjk1NTU5OTlUVFJVVFJxcWJycmIzMjFQUFC5oUK7o0IyMjG7u7szMTC9pUFTUlG9vb3LYkHbSjlTU1HxkSnz2zhUU1FUU1L1kin12zn3lCk2NjcyMTE2NTFUVFRVVFE2NTJWVFFXVlI2NjA2NjVzc2N0cmIyMTJ1dGJ1dGN2dWOqQTirQjkzMTGuQziuRjuvRDg3NjS5okK6oEC6okG6o0E3NjU3ODU4ODjNZEIzMzIzMzO+pkJRUlHMZEFSUlDOY0LOZEHPZEJSUlHb9Pzd9v0zNDTxkCpTUVHxkirx2Tjx2Tnx2jny2jjzkSk0MjH0kilTU1A0MzH1kihTU1P1kyo0MzL13Dr2kin2kykyMjL33Dg1NjD9+fhxcWHeSjm8pUE5OTj0kyreTTx4TnCPAAAAAXRSTlMAQObYZgAAAUNJREFUeNrt0cVuAzEYReH+hmEIM3NSZmZImZmZ8f03dSaVsug47a6qlLvySJ+OpXFTY385E6FfOhVQ7aMOVAEAoSpzdwfrwUAyYZQsxhZECHHkdDLxYhildESqQNjUtG1b6PBbcFcnpM9yDHKSk60Jy5GIBKEtTWvh3T2Yy7hOHwibGIrFLoHnzoZyhYtRw8gTURcBQrEFDkwv3xZGnj6MvBgoRytJXnFf3CtcjRmEudUoAOI5d/CoAzI0jV2B8rCqk3MbNI7CvRsg+1+ThzftIGAEyE1tpBm/W+t5LrI/iV1OQVGiDKoeG+lIzaSkYuWgTihK1ncPPgQeAXu/Jd+a5sxqe8W55POeZNF8P8ZfkPOMghPFj9fDA4sYTzHIl6bwuHP93kyoIMzymUUPOqU2ncqyzBM1SSm11I+yi9Ua+xf7BGzTKCql1y2UAAAAAElFTkSuQmCC",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "417",
+    "id": 417,
+    "sortid": 417,
     "identifier": "pachirisu",
     "name": "Pachirisu",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABEVBMVEX///////9zxv81NTVyxPw3Nzc4ODhTU1MxMTF1xv+FhXWd3v+6urq9vb35+fn7+/v8/Pz8/v/9/f3+/v42NjZio5q+vr5jpZ05OTm7u7tSU1RRUVFVVVW5ubm5ubpXV1Vyxf28vbz9/v+b3f/WrQD31jQxMjJxw/uHh3czMzP9/fw0NDQyMzR1x/9UVFS8u7ma2/ua2/xipJtjpZy0ZHS1Y3NCe3NkpZy5urm6urlkpZ27u7pTVFE1NTS8vLu8vLxVVVK9vLtSUlJWVla/v7/TqwDVrQJSUlPaeoL31jF2x//5+fh3x//6+vn6+vuBgXH8+/yCgnGCgnL9/PyDg3OEhHOFhXT+/f1hoZn///5BeXGKw0ZeAAAAAXRSTlMAQObYZgAAASxJREFUeAHt0UdvgzAYxnG/tgmEPUhC9h5NCN177713v/8HKXalnjDiUqmH/K/89FivQH/dLJLVDcNMjEOiZJgb4ooiHiW/sEJxhZYGIlf4+UKqFJdapVYocl9LDBLF0jBPCAtrA/6snce42wFN8LS/0JniUImvWOQOQEuczOmuNr1yIB9fgbEDrAlKSh3fsJm8E1E2qL6Oi3MJjMg2gKs2XICiTB1Q9wwjySFigQcn7q4FAFEMo3KyQzmz+PzuTd7G/ct5mUFF9P8Cc2X1Abx+73SHdjv8DpGsXhzq+2e9g0LL8dgdwqTH7eNaQ97YWm4baY5cN6smjM4/1tuGLqXA4H6zWbNhdFTWy8yJI093nwAg1yUfpRbUX249sHLpjEvfN20JZSogaNZ/6Bv4IRy352A5mAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "200"
+    "gender_rate": 4,
+    "rarity": 200
   },
   {
-    "id": "418",
+    "id": 418,
+    "sortid": 418,
     "identifier": "buizel",
     "name": "Buizel",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABO1BMVEX////3lCk1NTVUUlExMTE2NjY5OTk0MzJSUlIzMzFUU1FWU1HTumrUvGvWY0HXZkX0kin0kyo0MjD355TRYkLUY0I0MzFUU1LWY0LXZEJUVFLwkCnzkilVVFJTUVH00zn01Dn05JL2kym7pEL3lSy8pEMxMzTQYUFSUVLSYUFRUVH3lCrWZkMzMjHSYkLSumnTYkHTYkJTUVDTu2o3NjTUZEHUZENTUlFTUlJTUlRTU1HWu2rWvWvXZEE3NjU4NzbXvWrXvmw4ODjxkSnxkivzkSg0NDTzlCvz4pHz45Dz5JJUVFVMkvj0lCtWU1BMlPv045JXVlP05ZP1kij1kyr1lCn14pD14pFXVlT25pL25pO4oUG6o0H3lSq7o0L3liv31jn35ZL35ZP35pNOkvj7+vn7+/v+/Pz///9l0i4HAAAAAXRSTlMAQObYZgAAAQNJREFUeNrt0MVuBDEQRVFX2e404zBjmJknzMzM9P9fkE4ry6btSHPXR89ykU7tE8Z1BTsWYwWw4zGQzUi5bMKA68COdnD19ggyi/oFABhGDeSnofBBFy59/zTOdfonMehQmAeAS/urkc3QcoqgKrG9Lj8o9IuHzyvSp6FnFA+mxaoL/aR6cus4q+o0rbx4cOLOHxIcH9E0rZgrV1w3upCuOgFQSFBxPld/aCqMYB81Xxcl4t8asvt6Uylax92l5JG16w0GjLKZXhO2D+aG9dqmzElwk+rpxsXHfpLmrVaYw57r95vZqexYiYcw75iJnbPB/1fDJed83UptkTgJiKRT2/QLN8EcY1Rq+i0AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "419",
+    "id": 419,
+    "sortid": 419,
     "identifier": "floatzel",
     "name": "Floatzel",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABJlBMVEX///8xMTE1NTVTUlFTU1H3lCn/55zTuorTu4vLakm7o0JSUlL0kinJaUn85Jr+5ptUVFHOa0pWVlRXVlS6pEQ3NjW9pUI3NjbKako4NzbMakrOa0nObEtRUVE0MjDWvIrzkinz0zg0MzL00zn3lSr31jn745lUU1H85ZtUU1L/5ps2NjY5OTkzMTG5o0K6okG6o0E4OTc0NDS8pEO9pEI5e847e8rJakk8fM09fMlKsvzMa0o1NDNSUVA1NTTPbEnQuIkzMzIwMTFUUlHxkSrx0jrzkSjzkSk0MzHz0jgzMjE3ODb0kypVVFL01Dn1kin1kyr2kylVVVRWVFP3lSw0NDNXUlH75Jr7+/v85JlXU1A4ODX+4pr+5ZqFhXOsUkL/55u5oUIyZ1mcAAAAAXRSTlMAQObYZgAAARZJREFUeNrt0cVuxFAMBdA8ygvDMDNDmZlmyszc/v9P1Fmkq9CuqjR3fXQt28Ikfx2MIrJKfhiN2QRFYAxcbhjmHhuMsXYEJwIEiVB4YdlssHa9eRToKtD2/nF1uU1+ZXrPx7HS013ediFGPO0Bi6pWNmt8F8nk4vjVqZP4vedoboqQgluIOY/dbG14uK4qmY5TUtRZO7kT64itzqwHrFuqVCAKVTV4IpaJIbZOsddbqk1L6irUgHOWBKw/PPdqPgeqAoRaQ1xJnMhEY+Ok3ylnqBQfWerS2mKC5q5ZVvDJ4JsaX3EltbAKULcDfo43l996t/tT89M0k+0L/hnoJLP+efhyjuYcFiT7kOLBmbtFmMbCJP8nP52FH2ATuB5uAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "420",
+    "id": 420,
+    "sortid": 420,
     "identifier": "cherubi",
     "name": "Cherubi",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAkFBMVEX///8xMTE2NjbEY4P3c5xKlFK+Q2w1NTXGY4Q1MzNKklI0MjJRUlFRw1FSxFJSxlIxMjHBYoE5OTk5cjn0cpo5czlSUlJSU1IxMzE0MjNUU1MyMTFJklEyNDLFY4QzMTI3NTY3Njb4dp5RxVI2NTU3NzdRUVFSxVLzcZo4ODj2dJ33c5s4cTi9Qmv4+Pj8/PzL7tY6AAAAAXRSTlMAQObYZgAAAL1JREFUeNrt0UcSgzAMQFFJFi5A6JDee7//7WIzk6XxPpO3gM0fCRv4+zkKsX8Eu1GeT3CxzyfD3TJ3xnEUKKsss10URQWOhkcSZedxFxfuM2EYndo2rQsIU21Nj7bAwMFNktQItkwbTvzZxrCUxgDgrGH2l+rCki0E1Pal177w2DzZMUCltnyhet0k7+79yKsQYuvdPLfN2+1EgINS/v9SSslT1lpQ6AqF0A5CQEUkxMoNDCPqvl04hb+f9AGqawkaVW8QfwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "421",
+    "id": 421,
+    "sortid": 421,
     "identifier": "cherrim-overcast",
     "name": "Cherrim",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAXVBMVEX///9SUlIxMTFKvVo2NjZKu1lRU1JSUlRqWbODavyEa/+9WoTucpvvc5xJulkxMzFRUVHscZq7WYNTUlJrWrWCavszMjKDav1SUlO6WYI1NTUxMTNUUlNqWbIzMTI9gU9GAAAAAXRSTlMAQObYZgAAAJNJREFUeNrt0skKxSAMQFET59m2b57+/zNr6L4R3qrQCwqBAyIqzo6VGjGIQpXKuynHX5GVdW1OOS6ah8UAzIuWFXfd6/vQUhro2/7pimBvzBla4N4MNOCtlsZdGAjuHoLVHTKys5711rFwi+C/juA18HDckcTmiQFzZ6IN6K07ZOUzxZQ/gDjwcXHKt23gsTg7SiuK1AmAQ5iDrwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "422",
+    "id": 422,
+    "sortid": 422,
     "identifier": "shellos-west",
     "name": "Shellos (West)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAq1BMVEX///8xMTH/jLVTUlLOY4QzMTI2Njb///9TU1NUUlOrSmq9pUK9pkG9vca+vsbLSXHMYoPNZILOSnNRUVH39yn7irL8i7P8/Pz+i7RSUlI0MjPOZYL29itTUVLMSnL9/f41NTW6usPLYoI0NDBTU1H+jbLNYoP/jbb//f29pUT39SszMjFUVFH7+/szMzOuS2z9irO9vMO6o0HOS3QyMTG7o0Lz8yn29Sm7u8REEBSsAAAAAXRSTlMAQObYZgAAAMxJREFUeNrt0tkOgjAQBVBn2goIRQREdtz3ff//L7MYn6e8kniTvp3MJLfT+acl6QKo18D1/QL6vmjiSr9IQAuHVunXVuhhhMpq4XjKFIxuCmoGch5bvTOm2s3I6zDQuOcCEdcrxNOdhkGEuJ3VPAUgJ+4ftr1TkDNPAFAyDENn7nHWW4phSv701X45A84iy4sVJGnw3gxiRCvxBC0nMs/ib02CdAfDcPNMsQTohkZGLUPHvhzpxebIrQxXSnnUXjhMKtf8tajHnX/akg/uDg341lEKowAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "423",
+    "id": 423,
+    "sortid": 423,
     "identifier": "gastrodon-west",
     "name": "Gastrodon (West)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAn1BMVEX///8xMTF7WjlSUlJRUVGce0LWc4z/lKWaeUE2NjZUUlJ8WzlTU1GaekIyMTG9pULTcotSUlH39ykyMjEzMjLTcYqdfEGdfUS7o0G9pENTUlF5WTj19Sn39SqbekH8kqM1NTX09Cm9pkG6o0F8XDhUVFHVc4r8/Pz9k6Ode0P29Sl8Wjq7o0L7kqP7+/szMjFUVFR9Wjr9/Pz+k6S+pEN7mFxDAAAAAXRSTlMAQObYZgAAAOdJREFUeAHt0bdyxDAMBFABFBiUw+XsnLP//9u8RxeuBF93jbZh8wYzu0zOlTHhVLeu6ETIXCWBfnVQZWsoLaUncN8rMH0u7t5L2dyQF+m1k35ljq4UUWF4nQNsZqI65ED+KPy/MFzlzLvP+arUHeSLcx/VmlE+0WG6d27bXe/ixUCKJNz8zrmFCR5ao1O7zLnCdWOISKPT5eMsducWv6Q22mLKe/cgaqtDuo8QubVPizd1oiiZF3Vd0PBCzZez2UXXXdaFMU1Gg1WyxlqbGSA8jR0+SYSFkAmeibZPxDD61/zRZMy58wOttA3q/C7whwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "424",
+    "id": 424,
+    "sortid": 424,
     "identifier": "ambipom",
     "name": "Ambipom",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAq1BMVEX///8xMTEyMjNTUlNzWqWSesyUe86Secs1NTVSUlNUU1JxWaNyWaM2Njb3Y2tRUVGTes1SUlLWtWPz24r23YuVfMz33owyMTL13I3Ts2KVe8xUVFL024v1Y2zEUlnGUlpTUlKVesz33o3DUVk0MzJ0WaPUs2TUtGR1XKTzYmoyMTH0YmqjQUn024ylQko0MTH23YzDU1kzMTHFUVn7+/v8/Pz+/v3TsmK+vrazOdgjAAAAAXRSTlMAQObYZgAAAUFJREFUeNrtk8dyhEAMRNFEco4bYdc5Z/v/v8yawS6KXcBcfNuuuTD1qiU1GuOk+fJgLugUM0lTkSbAZFE82tKTQpBRbv9wg8fwAtfigsC44d1r/VxvXtAy1Hbj5Kdd2QoMOOm6MeGYi2PbLQzl+FPYu97C3gc4BJFjrAApWEihbdt/9KOtD/38LCx8jnO0IjqFZLmK/D5oOoxZm5qXmbhMM0VKhM0kj9MYDmIEDKZKc6VMULSmkKiPjuuq8zJHfeziBeXrhkarQRBNpQbP3naZWPsNkew+z69CMpTlQpQapLcNziOZ5YasOHZEMlWlsUkC+saxAIZWDILo/espzwgMbl1HMgwpin5N9F8aXkbAkLggE1znmmSUE9DCzCcW/CJdcupiD6EaaBwMKhs5C5T+eIaSOL3opt5O29w8+KT/0jdwtBY81CDi1gAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "425",
+    "id": 425,
+    "sortid": 425,
     "identifier": "drifloon",
     "name": "Drifloon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAP1BMVEX///8xMTFSUlJ7a72cjN7////39yk0NDQyMjO+vrbGrSn7+/v9/f38/Pw1NTUyMTNRUVGai9s2NjZTUlRUVFSIW5A9AAAAAXRSTlMAQObYZgAAAIJJREFUeAHtzDkWgkAURNH//tDI4CC6/7XKQSOT6oyEF1VwT9nhna10srkGtLvN41JVQwesGhftVh7XejvKEZkvf2bcFczKvYtye1qS9MJs2X5Qy0Q6I76PgYkgt9zBNHWPCCkxNuZgCGfggZmGZoBpie0pyDTRBQ3+h4jWeiV2dmQfsH4C1oCb8h4AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "125"
+    "gender_rate": 4,
+    "rarity": 125
   },
   {
-    "id": "426",
+    "id": 426,
+    "sortid": 426,
     "identifier": "drifblim",
     "name": "Drifblim",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAh1BMVEX///8xMTFSUlKUhM7Gvf/39ylza63OtTmjmtulnN73Y1LGxr37+/v///8yMjM2NjbDw7qSg8w0NDT1Y1PExLuWhM2WhsychDkzMzRSUlNTUlNTU1NTU1TGxr4yMTL2ZFRUVFRyaqvNtDtya6wzMzGSgsv29iwzMzOThM1RUVH8/Pz+/v2Vg8yIpnj8AAAAAXRSTlMAQObYZgAAANdJREFUeAHtzceurDAMxnE+lwRCucPc03vv7/98x1akswK8mt38Y0sB/QTNsUP0D742IRz2GMb9rn+P4O57tG77WA5/MJKfX+PDSX+NyL3yFc02PIVurrMpwS58A3lx+kGzmwCCC1UTSPC9wbMY4plJ+Y34/4/DdLfxb2K1LQ4fza3CRMpKbKXLdmq2pBmDItTeYJ2hoyTCZC6h7SYAi4y6DoBIIiHYc/uUXxZYtuA3h+K3xQ8in+f6HqUYNLkSnFVnUkXRBKHYUSuWfjTHsmpF7Kpsjh2gX83+C213pChZAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "427",
+    "id": 427,
+    "sortid": 427,
     "identifier": "buneary",
     "name": "Buneary",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAeFBMVEX///+UY0K9hGM2NjYyMTG6gmK8g2IzMzHOvVr+7pMxMTGSYkJUVFM1NTUzMjFRUVFTUlFTUlLLulnMu1lTU1L77JL97JI0MzL/75SSYkHNu1n7ioqVY0O+hWVSUlL7+/vNvFo0NDS7g2KVZUP9/fy+hGP9i4u+hWOicCWCAAAAAXRSTlMAQObYZgAAALhJREFUeNrtkkcOwzAMBE2qy457jZ3e/v/D0AFylXjzxQPoNlhihU12tkR4z/IOnXUDJ68biYErfnKOad1D57wy8wKS1UrMi0yEQpA+Ik4AkryjG4ewpxGrO3nhDzgoxFVE6IOiuJyQuLbpmjiEWq+Jv9vQWxMQFb5f+LwpOp5T65AJGvMihdLHdjFpIGR8ReIfF00sU9CVj4tF42xLVXhby9LohkRtujE7M8ZTNMbX1rAmSS/Z2ZovzkUKcF5GxmYAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "428",
+    "id": 428,
+    "sortid": 428,
     "identifier": "lopunny",
     "name": "Lopunny",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAgVBMVEX///8xMTG9hGP/95xSUlJTUlKjako0NDL89Jo1NTX785pTUlFRUVGla0q7g2IzMzK+hWPOvXOMUkJUVFO9g2NTU1KjakkyMTE2Njb0eouma0szMjH99Zv+9pu8g2KNVEPzeYpWVlb3e4z3fY26gmJSUlH99JrLunH9/fzMu3LNvHLCNIcPAAAAAXRSTlMAQObYZgAAAOdJREFUeNrt09cOwjAMBdA6O90DWvbe//+B2AHeqPPIC1eqVKlHN4qtJv/8MDN6IO58ahPfF0PiIVKYWuiLIoO8XEag7ExmMuU6lFGolJNdKaKy1MGJlWVc7pAQdLV4VAy8TsmF1horx11D8N1ar+R36SE4IXQpCGLsSF1DEHM7TorsJVmoYbdgIF75jnI+EXp+WAyQSu7wKtkrQzukkQYIXyVQ7VQpg5JgoKMTWsuwwNxJRlLjWuKd2vaML1ylh5PQpt3QJClNxSxcmct2s/yczG7c4XcckE3JMRJyh8BD9P8h8M+v8wTMNRAJb0TGGQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "429",
+    "id": 429,
+    "sortid": 429,
     "identifier": "mismagius",
     "name": "Mismagius",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAjVBMVEX///8xMTEyMTKSappSUlJTUlMzMjOUa5zWjM55UYJ7UoRRUVE1NTWsQjrTisvUi802NjatQjm8cryUapq6cbqVa5zTYkF8UoWuRDy6mjhTU1HVYkHVi81TUVH8zDH9/PtUUlF6UoO9c717UYIzMTHTi8zUY0PUi8wyMTFUUlOTaps0MzG7cru7crz9/P3SiMBAAAAAAXRSTlMAQObYZgAAAO5JREFUeAHt02eSgzAMBWCkZ9l0SELK9t7L/Y+3xt7M/lqJA+RlwvDjw55nQXFKzli0tMj1vvfLYFm+0TK3f/GWim47lKXl2t4TQhi2XOiF2kkQUpjUQi2OUJ607cfmCOXzXsD/OgS5q99nh/RnFcY4h2S1JUOCyIWUMpRJ7q2fZJOoEFmjOTtHEHf9YY+6co52jxZLcm7NttvdRvd9eCWdUYPu5rB5Xm1qJlK3RXexukJIJ8pKE4S6e4hc4s2XV16fPMU8w3WE5rghGLzWZhKquOIGa0/Gt1qM82+69MY50u8D+7/K1srLMs6XU34ATIoMcntiORgAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "430",
+    "id": 430,
+    "sortid": 430,
     "identifier": "honchkrow",
     "name": "Honchkrow",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAnFBMVEX///8xMTFSUlI2NjY5eqtCY3sxMTI1NTU5e61BYnlCYnozMTFRUVFRUlJRUlNUVFS7u7u9vb39/f0xMjK6urpiYmKVfEmyQTGzQjK1QjE5eqxBY3u9pVpTU1Pz5Cn35yn7+/v8/Pw4eav///+6o1lkZGQ0NDRDZHy7u7y8pFlEZX15eYK+vr6Ue0r25SlTUlFTU1I0MzBUVFG1QzMadkp0AAAAAXRSTlMAQObYZgAAAQFJREFUeAHt0seOgzAQBmDP2IPBYArpvWR7L+//bjsObLTS2gm3XPgPCMGn3x7Zos81IwE6OZ2pQSP1hb59rnI4vgzOsUwt5nGcA+z54b54iyX/baAhi4ob5SSdpD73mwXNY3YMZzMPzNQfGbXOK+HUmUPr/JJLUTmGhgvDjUKvN5uv8jvdFuU9S51M/Y2S3fj1vayL3eHwFEFCNOWp4Z+7eRs/LpcfiOwKRDQUgZCeDa4/IUMsa8cUD24hdDBCDqvKOTfRUQbp80PrHLRu8YDkyvpl1UIi58KyWqFqXARBp50zZA2F2emCJ2RHiNiwC3Z4iyOGXei22N2JTpQj+lw3P+kXEn+571erAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "30"
+    "gender_rate": 4,
+    "rarity": 30
   },
   {
-    "id": "431",
+    "id": 431,
+    "sortid": 431,
     "identifier": "glameow",
     "name": "Glameow",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAh1BMVEX///8xMTFSUlI0NDQ1NTU2NjYyMjNTU1NxgopzhIybrLScrbWaq7L///9yg4uaq7NRUVEyMjLvc5z7+/v9/f10g4x1hY3scprtc5tUUlPvdJr8/f2drLSdrrbtc5y6o0EDAQI0bf/FzdPvdZ370jD70zH71DTGztb8/PzscZp1hYr+/P2drbKTDueRAAAAAXRSTlMAQObYZgAAAPFJREFUeAHt0smOwyAMBuDYYIKBLGTpMm1n32fe//kawqVSSJNjD/0PkZA+/UQ22T23EgJY5WR76sSqQtcVxYwkuDy0xRyk+luskvTzJy67CdqNT8OjVVkUsYpAJyS5x95YBQCu2xxEHA85lYBs7Bjm3VGBZvZQV1Moh5vH5Num6bFiRCxNDtPGj/+xzQS4R6zCCSdOAjy9flneNfsStz2WoRDSWyR9KN6e3x96Zu/yoVLN7SVM+OXzd3AZOWvnXFzvieN/yRquvyyosfRhneF7NaQNe9C85DLpxqnAotNY5fHaZWin60hPSUS3LLMbyD1nE7UMEsg845wAAAAASUVORK5CYII=",
-    "gender_rate": "6",
-    "rarity": "190"
+    "gender_rate": 6,
+    "rarity": 190
   },
   {
-    "id": "432",
+    "id": 432,
+    "sortid": 432,
     "identifier": "purugly",
     "name": "Purugly",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAjVBMVEX///9re4QxMTFSUlJTUlNTU1NqeoOUe86So7KSo7OTpLQyMjOUpbX///82Njb9/f01NTWVpraUe81qeYJUVFQxMjJte4SUpLWSesyVfc6VpLQxMTP8/Pz8/P39e5T9/P6Ve81RUVFrWrX7eZL72zH7+/v8e5OTes2SectqWbJUUlOVpbL/e5T/fZU0NDRRYKf0AAAAAXRSTlMAQObYZgAAAPpJREFUeNrtktduwzAMRUNqWcszu1lt0j3+//NKOXD6ENHoW1EgF3qgwaMDUvDklj9Mjb/jypeHu58PHAWf/VC/UsmEeoaUlzsSkReahR8uEWk9A+4OiwCzvjSGQO18Fix2awAXPGLRGmOkFpzyOHfhnFYuE6hn+WfsBg6e3pZSMFw5qYsL97FupQ0+z5V4Nrb7+Dl3ajNlyASTsloZs2+C2sRGWUZZY7eNK396r4gBV00t5Iekc0+iEJTofUoTmA+RgpaFbYxEamDBktaB9OhVAyBGhHUnbEjpbUXamlUKLGhG7YIf/SWpSQc7uBqPwR/jF9O6Ft/yT/INcl4RKr/oMCQAAAAASUVORK5CYII=",
-    "gender_rate": "6",
-    "rarity": "75"
+    "gender_rate": 6,
+    "rarity": 75
   },
   {
-    "id": "433",
+    "id": 433,
+    "sortid": 433,
     "identifier": "chingling",
     "name": "Chingling",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///8xMTH/5zlTU1G6o0HTYkk0MzE0MTG7o0L85DlUUlFUVFEzMTFSUlK9pULWY0rzakH75DgzMjH95Tn+/Pw2Njb///9RUVE1NTUDAwPWZUwwMDD2akL3a0L3bUS8pEL7+/sDAQH8/Py+pkGSg0LTYkr/5zz//vvVZElqBUyUAAAAAXRSTlMAQObYZgAAALJJREFUeNrt0kcOwyAQBVAPzca94Ti9OO3+J8yAxM5msk3kLyGxeIL5gmjNj2WE7xTIKqeduZyO6W2X024YUD5oWPcIYyAdSISx24WhrK57sCxQyABGpo7Vy4VGaBhjWaGZglAh07yGJ8qJJ+/q0KOMYd4xC92ZOF6/xUFn3UYzH2WHXewhuJeZRwsnQoNGu6WCUvCkU4Lfz93URoQsbJIWyN8lypLTzr+M8BeTOFrzl/kA9+0K8AkktqsAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "434",
+    "id": 434,
+    "sortid": 434,
     "identifier": "stunky",
     "name": "Stunky",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAkFBMVEX///8xMTF7a602NjZSUlN6aqs1NTX77MP/78b87MRSUlJUVFNrUpRtVJR8bKy6uqO7u6W+vaUyMTL97sVUUlF9ba2EhGs2NjUxMTI0MzP+7cN8a6vsizrvjTx5aqtRUVH97cQzMzJTU1NqUpIyMjHsijhqUZJrUpP87MX8/P3tizqFhWz9/fyCgmr7+/v///95ocCHAAAAAXRSTlMAQObYZgAAAN1JREFUeNrt0kcOgzAUBNB8FzC9pUEgvdf73y5jwi62yDZRRpZXTzNYYvDPF8Yhog/YhNwszvsdT4oPHMdxR0z0TAOV5KosZozlPTBbe1ksfF+aJX/duq1QI/QJn4zvTFaELLzAU3rYuuwk46XCaCQAIYV1+bZUSFQPva5QkOUNYJfxoR5KreyFuwru+mhmAtBayInmR8DtvZmFncxNLllLdq6iEwpRBZjGYTg1yYVkXVEL0xXtAQ1x5h3EBwQShlsgZAvTIvA37apD1h8V8+GU3PJt1fB00rc+//xanviyDSIgZYt4AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "225"
+    "gender_rate": 4,
+    "rarity": 225
   },
   {
-    "id": "435",
+    "id": 435,
+    "sortid": 435,
     "identifier": "skuntank",
     "name": "Skuntank",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAjVBMVEX///9SUlMzMzJSUlIxMTFrUpR7a62+vaX788u6uqM1NTV5aqt6aqs2NjZ8a6t9ba0yMTK7u6O7u6W9vaVRUVFsU5T89M399s3/985qUpI0NDNUVFO7u6R8bKzvjTv89MwyMjJ9fHwxMTJ8e3ltVJTvjTx6aqxTU1N8fHv89cz8/Pzsizn+9cvtizr//v6FWYxBAAAAAXRSTlMAQObYZgAAAQ1JREFUeNrt09dOwzAUBmC87UxnJ90FWjbv/3gcDyrR2JSbipv+spSbTz5D8d0t105OLwKI+ab6d5ZyiKYW5lGXWGZpm3ENNipbQjIrUQYnCvMWFDtyF4DxBn9Gh51hyFXuS16vOUOUBqVvsB7GUax70TE03ccrA/N5RBMLwOTExBMhpBpEt+oAzl1feuYXVDdNg2eMStMW1FsCc0HVOcwpMJ8SfTuYucJnUxgm7AzL7ARZACroxrm3wm8STQDpbDG+8v71UBiUmQa7FQ6uegtuJzcFskuvsXKTzO/cfzy8fPoL7f+onncBmMhx8w4T4RSRbcl1/C0kqsFw5IKqYVxceEz+SIH//P5u+e98AYs1FTPunwoTAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "436",
+    "id": 436,
+    "sortid": 436,
     "identifier": "bronzor",
     "name": "Bronzor",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAXVBMVEX///8xMTFKjJw2NjZKi5pJaopKa4w1NTUxMjJSUlJSU1Niq6Pz8ylKbIxRUlJRUlNKi5tJippiq6RjraVRUVExMTL09ClKaotirKRLa4plrqO9pkFUVFFMbYr09SowxL6RAAAAAXRSTlMAQObYZgAAAIlJREFUeNrt0lkOwyAMBFBsjNmz0729/zHj9ABx/pOR+HuaQQhz5cyxYPR4MHbkpjtB4ORotd51eU6RMGi1PldmnuZ01+CIkk3uT9vyqsOjDiIx7EJwXaTf+6nC8snYQ/kqUORC2N+kUbujLMdceUrETYGEx54HlkgoCdu0SiOo7D/P7fA3u3LqrB58BiUp33aqAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "255"
+    "gender_rate": -1,
+    "rarity": 255
   },
   {
-    "id": "437",
+    "id": 437,
+    "sortid": 437,
     "identifier": "bronzong",
     "name": "Bronzong",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAeFBMVEX///8xMTFClKU2NjZBkqNCc3syMzN6xLt7xr1CkqM1NTVRU1NSUlJSU1N5w7oxMjJ6xbxRUVF8xLvWY0JCdHxDlKVEk6NTVFRCcnpCk6R8xr6FhXW9vb7L7PvL7fzM7PzM7fzM7v3O7//TYkHTY0JBcXnVZUTUZENBdJnJAAAAAXRSTlMAQObYZgAAANhJREFUeAHt08dyhTAMBdAnuceAKaT3/v9/mCucXTBml3kz3AVlOAgk8Ol/c0TRTtd5u4sr3VvKfDMXnffeEnWcqk/2zNwLr0mOpEXaWkVO8qL1gr4lGkIFKtJ92wSOgEWpSHrl+HzH2DauBNXSAMiNe31DriFpdYAZJtLG3OKodcw4Q9bg8k1m5xmJQcaJ/R9JRL8TFyi112GOeh9xWWJxT9kBXgF+TyNKyrTK8PHhktl8oK7NMytN89M83b98TeNs0vZvNgQ2Zul7G0rzsGC0Z9UgpyNnkx8KKQnCm9WpawAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "90"
+    "gender_rate": -1,
+    "rarity": 90
   },
   {
-    "id": "438",
+    "id": 438,
+    "sortid": 438,
     "identifier": "bonsly",
     "name": "Bonsly",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAZlBMVEX///8yMjFSUlIxMTHDo1lRUVE1NTWUc0o2NjbGpVnGpVpSjFJTU1L+1TF5WUF7WkJ8W0KTckkxMjFSi1LEo1lavWtZumrnvUH70zEzMjGDzYsxMzFZu2pZvGqScUmSckpRilEyMTGzXyDNAAAAAXRSTlMAQObYZgAAAJZJREFUeNrt0rcOwzAMBFBRvbrJcklz8v8/GWbJSq4GfPPDAUdJXDlRrGK6pd05zi+3xpBemfpsaSKdqVJWdCR8pySlwmK6cVLaAb0Hq6zOD84eu4XM2WN1CTHTe7yOCOOuBA1/2VmurIGUvpuxbgtx+BDwBUqXdehHEJR00PWjA/KK5nAY4PxaI+WMYzhU/x394FdOky+5EweZVep7DAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "439",
+    "id": 439,
+    "sortid": 439,
     "identifier": "mime-jr",
     "name": "Mime Jr.",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAclBMVEX///8xMTFSWt5UU1NSUlI1NTU2Njbbo6PepaX8zMT/zsZRUVFieexieuxieu5je+/WUkL7y8NRWds0MzP+zcUzMjIxMjPTUkI2NjXWU0RUW93dpKQ0NDTsglFSUlT7+/sxMTP8zMb+zMNUUlHDgoL///8r2HAOAAAAAXRSTlMAQObYZgAAAKVJREFUeAHt0TfKw0AQhuEJm5WD9Afn4Ptf0bOFW40KgzHorR++gV3Y+nwOV7rTY/9eCLao5lWubJoV0GFRNURn1ckc1fpkhjl10WFPJIvapCvpklL6r8UuStdnl6Uy+dsfTUxDp0Kwh/YWBVI9a5/y017lNqPiPJsozCAo8L5jI3lGROW0ybfZcwzTsuz+BIYJ/TiAIsMYGMEiKFksX2+oU/ietp4cuAkCbxWNKwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "145"
+    "gender_rate": 4,
+    "rarity": 145
   },
   {
-    "id": "440",
+    "id": 440,
+    "sortid": 440,
     "identifier": "happiny",
     "name": "Happiny",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAbFBMVEX///8xMTHvhJz/xrU2NjbsgpozMjL7w7L7+/v8xLM0MzP///9UU1O9Y2s1NTW6YmpRUVH9xLOEhHP//v2+ZGzvhZ02NjXvhZyFhXUyMjI0NDS9vb1SUlL9/Pz+xLT+xbTelJT/xrYzMzPug5sOlEDsAAAAAXRSTlMAQObYZgAAAJ9JREFUeNrtzkcWwjAMBFBLinuaU+gQyv3viAJ7y1t4mYVW/81IbfmpVABFrrVUQ5kjCiXDXOhDgdNoehlWYKcmBZBn701aX5ThlJiKsnIPIqaLJHdgaWQrjbf6xkIjXzo/c9DWnmj/gRFysPf1xQfLbsxDbVw8WQouRoTsk+4wDEdgN4PKQjZrZmxACbK7MkM0SkkSuheab59s1Zb/yxuG/wb2piYgagAAAABJRU5ErkJggg==",
-    "gender_rate": "8",
-    "rarity": "130"
+    "gender_rate": 8,
+    "rarity": 130
   },
   {
-    "id": "441",
+    "id": 441,
+    "sortid": 441,
     "identifier": "chatot",
     "name": "Chatot",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAjVBMVEX///8xMTFSUlJRUVEyMjFUVFRxcWL8/Pz///82NjZUUVI0NDRrxms1NTVycmJzc2O7u7u9vb2+pkHWSmNSU1L+cnJTU1PTSWL75Dj7cXExMjR0dGSMMUKNMkK6uroxMjMzMzNCesS+vr40MzHTSmJCe8Zqw2pSUVH7+/tqxGr95Tn9/f1Kmvz/c3NsxWpduHttAAAAAXRSTlMAQObYZgAAAL5JREFUeNrt0DcWwyAQRVF9hBBKVg7OOYf9L8+DrRZBZxd6FcU9M2dwxv6hxNYJDkuYphyWkKjZuRMuUgabgRxwzTIQygQuhhUAwT+PYSYYBdN/BupcBfF10J7LJuQoP1LTtW5ahuxQlyFBGemvSdr6WYZ+dPEIeqDFZuhLudsQ065eLs5qNUGPPWZ6iJYQleV36Sk4QOEqlzf9wCG7mmdN1myPa8ckT9W1snFd8YrjCiZHEuiK297oeuuM/bg3mkwKuilcHlgAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "30"
+    "gender_rate": 4,
+    "rarity": 30
   },
   {
-    "id": "442",
+    "id": 442,
+    "sortid": 442,
     "identifier": "spiritomb",
     "name": "Spiritomb",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAgVBMVEX///8xMTFSUlJTUlOUc6U1NTUzMjPEi8TGjMaa23LDisOaq5qScqPFi8VSU1JRUVG7o2pqzHKScaPEjcRrzHO9pWs2NjZrzXOEhHMyMjL09irFjMVTVFKbrJyc3nNszHSTdKSUc6RrznPFjcRtznGUdKSDg3IzMjFqy3GbrZucrJwgp/cRAAAAAXRSTlMAQObYZgAAANZJREFUeNrtkscOgzAQRNniggMkgTTSe/v/D8waK0fjMxKDZMvS08wOdjZqMFqBLArSnLMaQJYEqpz9S8ehwH3Xnx0TQI+ZBu932t4b8eubjktrufSOPhmiXEeQSQwpoM+keSMIB1z3OFJ+s4TzyvhD1FIGlGjKr5XpKulobTLyIaIJPymSrcAR5vuiFN+uf+t0/FIoPz4W566Ljt64qg/rCqUJTuK5gXxLA6aCF7JT75OAyYVF3jn1eqZYMBPOXgmuZhHNlssEKOEA0+dm04ZjGs5GDUU/3DoOLX5e/zgAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "100"
+    "gender_rate": 4,
+    "rarity": 100
   },
   {
-    "id": "443",
+    "id": 443,
+    "sortid": 443,
     "identifier": "gible",
     "name": "Gible",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAbFBMVEX///8xMTFrnLU1NTVReZJSUlJSU1NSe5RqmrNqm7QxMjP3a0pRUVFTUlJUVFRqmrIxMzQxMjJSUlNrnLZrzf1rzv+9Y2P0ako2Njb7+/ttnba7YmK9Y2JSepJUUlFSU1RqzPz8/f3+/Pz///9eH8QOAAAAAXRSTlMAQObYZgAAAK5JREFUeNrt0kcOwyAUBFDPB0yz497Sy/3vGHCUpYFtIs/6iUED2Z5fygwggTFURCbBORaHDEhyM28VrRBAgsvFvSMThd4NQ2eC1RV5qKgf6iwKTeHgDdFlzHIQQigyAVco1wssx/BCjLf+pMdrddTXwCac7NXXSqk95M3msxSTtfZ5+IyeX5rtdi/PpXILSZ0jC17zNI6lUETGuZCUDcB1/F8wwO8p9dfF+Z5/yxtFzgeqvAaswwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "444",
+    "id": 444,
+    "sortid": 444,
     "identifier": "gabite",
     "name": "Gabite",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAolBMVEX///8xMTExMTMyMjM1NTVRUVFSUlJ7jNa1vf9TU1RUVFRqasRra8Z5itN6i9UzMzRSUlT3a0r8/PySmtuTm918i9P0akpTUlKUnN6yuvu0vP5SUlO2vv+9Y2M2Njb2akp6i9P7+/tqasM0NDRsbMa9Y2J8i9S7YmK8Y2SVm9u+ZWXzaknz8yltbcazu/xUUlF9jdZUVFH8/P78/f79/f////9xXJ2DAAAAAXRSTlMAQObYZgAAAPFJREFUeAHt0sduw0AMBFCNtuyqF/diuaT3/v+/Foo5BVgxvgUGPNDxYQRyGZ3zr+mA49ghX+Fvq4nZnXNOsRUdMXIL75QIf1z97L2vIg0MyoLdzo2XvkIx2NqxU4Zql0mWl+QEqB7faJ46y/NYdgYmW1lyMlRF3aNesusQhpyP+2tHPOb9B2u1udlwthNHFDDcG5SW6GzaNC9ZOTyQxuF9XcGQaya0TP5/+AHjfYpIP1xtqbJ97XcQLiREn5ne3W5m7ddTyVI6jNF8nrSptRYYdovP9WWMUdJvcyxeEACei7Z+zK3rfdpeSODXaKeRc74BtQcRPCAz4IAAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "445",
+    "id": 445,
+    "sortid": 445,
     "identifier": "garchomp",
     "name": "Garchomp",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABlVBMVEX///8xMTFjY856g/R7hPc2NjdRUVFSUlRSUlVhYctiYsliYstiYsxjY801NTV5gfF5gvN6gvU2NjYyMjT/a0pjY8wyMjUyMjMxMTM3NzhUVFRhYckzMzVTU1VTU1d6hPd7g/Z7g/cxMjR/g/H54Tn5+fn7+/v85Dn/5zk5OTk1Nje7u7tiYso0MzFiYs775Dh5gvFjZM9kZMxkZM81MzMxMDF6g/b5aUlXUlIzMzd8g/NSUlP7akk4ODh8hfZVVldiY8w0NDH85Dv9a0v+a0n+5zj/akk2Nzj/bUr/bU3/bklSUlY0NTM0NTY1MjFTVFd8hfF8hfU3Nzd9g/R9hfR9hvR9hvd+hPV+h/BUVFd/h/FUVVO9tZv4mDj44Tg6OjpSUlJTU1Z7hPVSU1dSU1RRUVNSUVR6gvD4+PhUVVb5akr5mDlVU1L54jtVU1T6+/5lZc77a0hmZcz75D94gfL7+/78akz8a0p5gfBVVVL85Tn8/PxVVVX95jz9+/wxMTI3ODR6gvQwMDE0NDRiYck2NTVQUFLYtnInAAAAAXRSTlMAQObYZgAAAZ1JREFUeAHtkEV720AURQfeiBlkW5Jlduxw2jA30JSZmZmZuf3dnXQZS5+788ZnIW3Od+e+i3pFH8PF/6VhTV3AcYy7eSohC9coALgxYriaKV5VLr4faJ0CjuXqxHYzzW8Da5eW/3k3aQm0fLbXulABDhVXd9ul7UBWxSkVx1prn0+DZR2aEiiQV1sIDerWVqe4VN/kgdZRfGWPaFqrjMdRaxCl0K5/OFdJ6P0jd2iCDcQ0GzIubzv1Y/Nnv+yvUZjjHiFyAaEsdWbDW1yfpXBY0UdJHhlfEfuRqrKZ9dlHb2uVpyuhwgMNNdCCFO0EliXhwYbn1eiN1ysxf0LRCQncDq8ZDsuTU4ue9+ZJ0ZwuzfHRolHZ93d0NZpD14WRhyPP9+09acOtXWW7ipgQFRxn5+T3Qj+4PIkfbx6Yn1DPN49P5PLRQZx2M1ZJTpbuvhx7URY/Dj0ri5oUMZQC7/5nWJfeieMgNj5RSH5lTMnN3E/FLzgCTYpFE+C2kzn5b96A/8zl72fE8WkXdaPdCBtLjtld5LnO9gf16SF/AZnsN4CiYyqIAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "446",
+    "id": 446,
+    "sortid": 446,
     "identifier": "munchlax",
     "name": "Munchlax",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA6lBMVEX///81NTVajKX33oxZi6Q5OTlSUlJSUlNTU1FZiqJZiqM2NjVZjKRai6RdjqXGrWP13IxYiqIxMjJCc4xRUVHErGTz24pVVVNTU1QxMTFBcYpCcosyMjNbjKUyMzNejaNejqOqxNSrw9OtxtZTVFPFrGTFrWVSU1Tx2Ynx2otUVFL024r03Iv13Io2Njb13Yv13Y323Iv23Ys2Nzb4+fr5+/xXVlRYiaHBqWLx24zCqmFZiqFZiaFFdIuvx9bBqWFXVVQzMjFaiaJRUlNai6VajKQ1Njc0NTZcjaRcjaU2NzhRUlJZi6P7+/tKPZmvAAAAAXRSTlMAQObYZgAAAMRJREFUeNrtkFcSgkAQBZkBVKKIgphzzjnnnO5/HVcPsMuvFv3d1a9mOI/fAWIuvXjYdKNCJPFICKaboOB/YphpgozEQ2SJl3wKb4hME+JEGa6RQB8HWcDc4MVOwiaDwqiABGtHE8WIHczqOuoW76P/Upz2ezzPt5pB1s8hMG8YRqno09J08VzbRgMHRzupSG3CRJ11y1dEZ6+16csrScUPFcYx1c548TVDJEg/265LR1kNJTkGIgAs/dL9G2TKisJ5/B1vNIYPyTr/8LMAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "50"
+    "gender_rate": 1,
+    "rarity": 50
   },
   {
-    "id": "447",
+    "id": 447,
+    "sortid": 447,
     "identifier": "riolu",
     "name": "Riolu",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA1VBMVEX///8xMTFSUlJKe71RUVFzpfc1NTVSU1RxovM5OTlycnpSVFZxcXkyMjJxo/NypPZzc3tJeboxMjNJeblyo/RypPRTVFdTU1NzpPU1NTYyMzRRUlNUVFRUVVRVVFNJertKeblKerkyMjRLe7w2NTVRUVNypfY2NjVRU1U2NjZ0pfW4ubG7urO7u7TEs1lCYplTUlHhyXEzMzNTU1LlzXP0YlI0NDRLfL42NjdCYptRUlJIeblKertwcHhKerxxcnlxofFxovFSUlRKe7w4ODj2ZFP8+vqaWPeTAAAAAXRSTlMAQObYZgAAAMJJREFUeNrt0EUTwjAQhuHsJqFCSwV3KO7urv//J8GQcxPODO9tZ57Lt+TfrxX51nm+0GpIfYBYoHYO59ThahjjokDhWCKT4RpiQgWtNKZhMGUIcndwLa33eBbQtN8XhOo7M/O36KLf1UzXBo9SP0wanbie5LU8ouniXrhQCuPScHY9CSgrO5kXmZ7COPWy0kG79vYYrTqrRmVNZBmj8kZvpi56LkJUT4flOamByhkM68QAy5Yqsfvz+pYSCt0i/36uFym+Djj2JYOVAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "75"
+    "gender_rate": 1,
+    "rarity": 75
   },
   {
-    "id": "448",
+    "id": 448,
+    "sortid": 448,
     "identifier": "lucario",
     "name": "Lucario",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA2FBMVEX///9SUlIxMTE2NjY1NTVxcXlycnpzc3tzrfdSU1RRUVFyq/RyrPRzrPUyMjJSUlNZgstSUlRZgclxq/NzdH1wcHg5OTk2NTVyqfFzc3w1MjMxMjNRUlN0dHx0q/N1dX3BsFjExLzHtVrx4oLyZFVyrPZZg8xZhMxyqvQyNTdyq/VTU1IzMzRahM0yMjRzq/M1NjdxcnlxqfFUVFM0NjdRU1RTU1NSU1U0NDRTU1Vag8w4ODj0YlL15YRSUVEzNDVWVlM1NDNxq/RahM5QUFD6+vr7+/v8+vu82hU9AAAAAXRSTlMAQObYZgAAAM5JREFUeAHtzVVyQzEMhWFJluHCdRyI2zRlZmbm7n9H9Qpkv3U6k//5m3Pgj5vFpS5MyzCHjykNjwtgvd1rXCHEpgTOV02VJokybjiadM5N0FgvQ21P3itjEZFEl5bswtqSxWRJ3NP2+vFn5cyTlr651n0z2lx2dwQsXkcebLXdUQ+Nh0xR1QcXaDq3J2+meHX9Vfuwe/l9K8PTeuPpDVh/ZRyHm2fsv9DYKBnGwf1i1e5fKQWZ+FOdtzuHkC0qiHPaeCiKx6oMPjD8k2b9AqFyDjKIIyzAAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "449",
+    "id": 449,
+    "sortid": 449,
     "identifier": "hippopotas",
     "name": "Hippopotas",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA21BMVEX///+ce1JSUlJUVFKaelI1NTWdfFLGrWvl1Ivm1Yvn1owzMzKdfFPEq2o0MzLh0Ynk04rl1IqEWkIxMTFRUVH9/PyefVNVVVPEu6vFrGrFrWs5OTnGvq6aeVHj0ooyMjHk04ubelFSUlGcfFPn1os4ODc5ODczMjGbelKbe1Kce1EyMTIyMTE1NTIyMzGefFQ2NTXBqmnDqmnDuqtTUlJTU1NUU1I2NTbGrGo2NjZWVlPHrmxXVlOCWUGDWUI3NzaFW0OFXEOFXESGXEQ3Nzfn1o76+fn6+/s4NzYnKcERAAAAAXRSTlMAQObYZgAAAPdJREFUeNrt0FdvQiEUwHEOcBmHu4fVqnXbvfe0u/3+n6hImj5hr8/Gf8IDyQ/CgaxbuYKiWM6VTwfL0OCxeh1y6NXDc1PyqjPq1d/YvGxefx0fkRNT1Mh8UHWer/a7APF/E5eUA+SDXfbylkeHZOZnKdoY7buVCYjis22Pc8zRPoukDgH22OnE84Fc4V9WQqgb2pAFUACoXyg1ZhgvgOKCcicFQEtqKT1PbHeFRkYpdS9ohEqynZac+IZOxsiGFmpEeZMh40IZ4qudqPHdxkjjlnrYvNcmSNSU+OVtouZNizT7SL/t3u8cnWfvhs93Ups7EJB1q9YP8RwUxscCkJkAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "140"
+    "gender_rate": 4,
+    "rarity": 140
   },
   {
-    "id": "450",
+    "id": 450,
+    "sortid": 450,
     "identifier": "hippowdon",
     "name": "Hippowdon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAolBMVEX///9SUlJycnLWxlo2NjYxMTFTU1NVVFMyMjJzc3PUxVo1NTVxcXFRUVGtnEo5OTlTU1FUUVH8/PxUVFKrmkqsm0tUVFTTxFnUxFpTUVEyMjH5+flUU1J2dnZ0dHR1dXNTU1KqmUo3NDWsm0o3NzU4ODiunUvBQTHDQTHRwlnTw1kzMzM0NDTUxVkzMTHVxllwcHDkSTHkSjHlSjI2NjUzMzGnJzAHAAAAAXRSTlMAQObYZgAAASRJREFUeNrt0EdzwjAQBWC9XUlWszEdAoT03sv//2tZ4VyIzYQrM7zDHjSfnoo65iASzX7uInnX6DzNzl3mbk7emayjTGAXNbfztQd5711JsgGEbunScFYIw0cf4iGQXIe7KooZs/efL+99Qk53pQuBJYXI/qjeFHbKR2vtODyLLArmpUByCRid/HHRS2DPm1quamrgtNqWsYTPkdrwynwjnQCJY/7ehmkDU7b3zFIrNLsWfNtAADI4FPx7gSkvzRbslTY7Yww8KkjjQ8CoqtH6yWsSaJ1z1p+N5aJhaHFZy2LrfzRJ5C2EMfKjEiGWE7ScyPiVxGoNa3O7iaq3oMGT6khPa62UWfncbJoFtTt6gBWdCvw3GgO9mES1h9RyqDrmMPIDJXAOzwTdpfUAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "451",
+    "id": 451,
+    "sortid": 451,
     "identifier": "skorupi",
     "name": "Skorupi",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAkFBMVEX///9qatNra9ZSUlRTU1QxMTFRUVGSmvyTm/6UnP/7+/uSmvtatb0xMzP8/PwyMjQ0NDRSU1NSUlJas73///8xMTM2NjY1NTV7hO9TU1NZs7u+vr5tbdb9/f16g+xUVFSCgnFqatWTm/xqbNWTnP1ZsrqVnf+6urq7u7u7u71RUasyMjNatL79/fwzMzOFhXX5i7VEAAAAAXRSTlMAQObYZgAAAO5JREFUeNrtktduwzAMRU1qUZaHPOLsdGR2///fVRL60AKyq7fkIQQhQMLBJS+p7B63EvNEbsitPxO43gY6AVx/ClnZ/yXPS2BVbxPMAL5sbYrr1ycm0uYjgep4W0L8vkmlta5jmPnzPpgRLu83xFdlNne6g08gLqKFAR1YlAYJu0bk/QMgzqKk0U4RSGNXNIpXJz5KCrkq9qTfy2PjjXAIXLx8d/gRVJq3rRib3OPHJnSokBy2W7yN/oSvZ43ssl0vW0C2W0yQVrqalXdMfELST4+1niPuMmxqEoWZw1RYyyTqd2PqiFwcz+5xzfgGfOAOMW8NReEAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "452",
+    "id": 452,
+    "sortid": 452,
     "identifier": "drapion",
     "name": "Drapion",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAolBMVEX///8xMTFSUlJTU1OUSpy1c7X8/Pz///82NjZTUlNTUVOSSppKs7NKtbXOnM7Onc5RUVEzMzOUS5ySSZq9vbWreavLmssyMTKte62zcrM0NDS6urK7u7NLs7QzMjPMmszNms3Nm81UVFQ1NTX7+/tRU1OSS5z9/f39/P19fX1Ks7XMm86ycbJMtra0crS0c7QxMzNydM38/f10c86VTJ2+vrYRsjuPAAAAAXRSTlMAQObYZgAAAT5JREFUeNrt09dywkAMBVBrq3vBpoPpJb3//6/lriFhECQ88oI8lnc8ZyTtju3d4lrh49ot6H/XqcvufnF4SaeOOmmriweev9BfDpCOXameZzJ+fZylWuv6x82JCJjLoD9LEVL0IX0Hn5J1aI6gj8bh3sWria6pxBx5nKy3X4XHpJw493GfvD2kMlKq22ky28+iVKGDOoiT96yBUwwhwNiI45XJJJrr7WCZ7ZxWKHgGjqoKJYSxmQ4iHELaOuOGLRUaO0chFQrRB5zCYU0cFpRjIMKWRhs7h5zCoWpaM9lgpByt70Tk6kYHx3EzbDOCmxCnIA+tOW6/oJhzQNHRZthxDqui3es5Zz7VOFn/Jd2gvpPSWMUgk+6mdi8wwrUWo4IBxolydCeyli7+GdUG3xdZpEty6Qx5l2Ph3eKK8Q0rjRg7bYvbSgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "453",
+    "id": 453,
+    "sortid": 453,
     "identifier": "croagunk",
     "name": "Croagunk",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAk1BMVEX///9SUlJjc8YxMjM2NjYxMTFSUlNSU1RicsQxMTJqanKDkvw1NTUyMjRqanFRUVFqa3Rra3Nta3FiccODk/6ElP+7u7v8/Pw0NDBra3U0NDSCkvtkcsODk/xkdMVTU1G7o0JTU1O9pkG9vb3WY0Hzkinz8yn0kin0kyr09Cn1lCz29SkzMzNUVFH3lCllc8P////NIHzqAAAAAXRSTlMAQObYZgAAAKZJREFUeAHtksUSwzAMBSs55jA4ZWb+/6+rZnq3fW6z5521knmjgR8j4TzOm3VdFuGm5BHIIoJfsoBX2A6FEqpFxkNBeRkfH+Qj84rYyvVtuzo9X1jqUBLAXvfzdtJPA1eSq1AYcHf/94BCxBKs7N+eZJqfawC325iFdEvmCR5qzRt6uKrAev9mwul1JQyFLbLwMOgC3bC4ERUAPGpHORgdv8yBv+QDE4cKT7fnQu8AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "140"
+    "gender_rate": 4,
+    "rarity": 140
   },
   {
-    "id": "454",
+    "id": 454,
+    "sortid": 454,
     "identifier": "toxicroak",
     "name": "Toxicroak",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAjVBMVEX///8xMTFSUlJSU1Q2NjZZetNae9ZiYmp6mvx7nP98m/zeY0oxMjNSUlR5mvsyMjQ1NTVZedNjY23bYkqtSkJRUVGrSUFjY2vbYkl6m/7eZUzz8yk0NDBlZW2sS0QzMTG7o0K9pkFaetR6m/xTUVFTU1HcY0zdYklUUlF7mvxUVFH09Cn29Sn7+/v8/PzwYTkNAAAAAXRSTlMAQObYZgAAAONJREFUeAHtkseSgzAQRJkZZYIwDvbmnMP/f942XnyzhG6+uKuAy6vuh0rVSXNOT6VgF0tBH6kQ9KaZR9XaeWS2VXXmwvsJpSzoDxEnlBdsnbBGr+gmayhf11efPJpmGtXunfn+++GF2Q1sH5sMWddgl0GAZrZB/tz8XtZhNMW2pRRGHaqAmAncUmI4eFmO26xNa9k+DZQQDEKbt3q1eubREaXxGNijMFb9Bpxu3bDlFKh2d7QXXesWJy54THPccfos8Cu3H5EW4LJRRN1riJUquMTQwMsylYBqXztL/itU55wsf1OLDJd6EMN0AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "455",
+    "id": 455,
+    "sortid": 455,
     "identifier": "carnivine",
     "name": "Carnivine",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAb1BMVEX///8xMTFSUlJarVKExmMyMzGtUlq173PnSilChEK07nJbrlK9pVpZq1Gz7XI1NTWDxGKExGI2NjZWVlaFxGKtVFoxMjGFxmWrU1lCg0IzMzKy7HFRUlGCw2I0NDSDxWLlSylTVFL7+/v9/vz///9drgeEAAAAAXRSTlMAQObYZgAAANxJREFUeAHtz0luwzAMhWE+khocO2mSzvPQ3v+MJSsBXUSyvSm6yW8I3nx4tujcH3WBle45rHKX+wBvEQY8Ju9hgR+N1d73GroOxaluXN4/oedScZ9ftyZtsrcJKe7lw2D5zwYCISb5HUztOYjB/APlVTfj7vrQdEeHBIdiz7gb7zpQpMiYoto5vF117+GQgJQ12wmoCziFLhnKzMqg6rY3jckBGAZM08QigDNs5QSSK6NUpVFn7hsU5cVs0rK52RDXSXPCsX59FmaDmbmoeQmToOVAgMF1AfSfnfsGIuAI6wLkXn0AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "200"
+    "gender_rate": 4,
+    "rarity": 200
   },
   {
-    "id": "456",
+    "id": 456,
+    "sortid": 456,
     "identifier": "finneon",
     "name": "Finneon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAZlBMVEX///8xMTGc1v97td5SUlLnc5xje4RKWms2NjZ5stsyMzQyMjLGWnsyMzNjfIUzMjLEW3zFpc5TVFRTUlKd1P3DWXlSU1Sa0/ua0/zGpM3Gpc7ldJ01NTX///+c1f7mc5xieYKb1P2E//AkAAAAAXRSTlMAQObYZgAAAK1JREFUeNrtzUkOwzAMQ9GQluwOSed57v0vWSZdK8m66Aes1QNd/fvNJmPdtNEBRsHJ6z0bdik1OLIHzrt7m6bV9sSFIXIoqAAtrmpBcoNosABZ9guv58csGiyWMyT3rXPfhVBOD0iHDi6rGJplZSTXTw1GUqytuFHFLn9ZcRpdrg+a5uRAd4ROqNzhFyZUYA/MtcONZi0B4p/d3eRICvWFklIC8pCTVN2n/36xD7bgBi3FPFibAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "457",
+    "id": 457,
+    "sortid": 457,
     "identifier": "lumineon",
     "name": "Lumineon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAclBMVEX///8xMTFje4Sc1v9SUlJTVFRieoNjfIV7td6a0/yb1P02NjY1NTWa0/t5sttieYIxMjJSU1RRUVFleoQyMzN6s9x6tNxRUlJje4VJWWpKWmvkcZozMjIyMzRKWWqb1f40NDR6s9vkcprldJ3nc5z8/f7vtAqkAAAAAXRSTlMAQObYZgAAAOhJREFUeAHt0LeShDAMBmAkG2eDCZsvh/d/xRNijk5eiiuuWFUw8/FLP83fz2PiXtfN2yPUYNpgyup5T2LMypaac25enS1QC7wcWMb++Kp4dQQBXg+DBugRSRKMPRYBngyiNgtc3PgxCfDklRvIYeDFt6+pCG3OGFRrKHCFgmsSXUeo1Z668KsQSC5YDK0h2QJcriD8nmyDUvZIV2r9PrzITrnvt9tEkWtvchJUn0+/MCxX1uREWVYb7i3L0VvKcmfUvua4Nzss2c1VmUZtiEGT8p3IbvAt8CdwF2516xI67ruLNv9hHvMD+24Nt/C0928AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "458",
+    "id": 458,
+    "sortid": 458,
     "identifier": "mantyke",
     "name": "Mantyke",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTFqq5o1NTU2NjZRUlMxMjRrrZyj0/ul1v9RivtSU1NSjP9Tjf9JastKa86MOTFRUVGj0/wxMjIyMzQ0NDRqq5wxMTNrrZ16tP97tf9SUlJKbM1KbM6k0/uk1f2k1f+l0/xTVFTEUkrFVEzGUkr7+/tjM+oWAAAAAXRSTlMAQObYZgAAAJhJREFUeNrtkMcSwjAMRJETtzSnAKF3+P9PZEeTqx2dIe+iy5uVtKuFXyMnodeEcfJFYl5UZk6cPInIebOnZjCzwkje6agjUT24D5tJojEmqTW6r6v9zfsDTEp0qHsPdoO6shoVtyWL68/GYdRxk1T5bNsLJ2L9OYzRFsm93ncPHsqegqbEQ461o7IE0g0pCwYSdM5ZC//LF/AKB919sNZyAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "25"
+    "gender_rate": 4,
+    "rarity": 25
   },
   {
-    "id": "459",
+    "id": 459,
+    "sortid": 459,
     "identifier": "snover",
     "name": "Snover",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAilBMVEX///8xMTE2NjZzc3O1nHP7+/v9/fz///9SUlJSU1JTU1JUVFRZsopatYwzMjJ1dXX8/Pz9/f05hHOLelK0m3K2nXUxMzKzmnI4gnFZs4tRUVGymnGMe1I1NTU0NDQxMjJcto26urq7u7u+vr7T09NydHNRUlJZtIv8/f10dHQyMjKKeVFas4vT1NRAMXm4AAAAAXRSTlMAQObYZgAAAL9JREFUeAHt0seug0AMBVDsKab3zuv9pfz/78VM1oyzReJKeHWEda0Jjuwp+KBC8yKzVRkiWWJQFSUVpSjRsJMhO3I/lJaj+ayIZPhsyEGOIPG9ulOe0m4mK+Ppk/j1rz4cLE7gdQlXVpdvpXz3QRivDLmG8ZbBsa5/BtvZVSWlV77CorW2nbaUTH9v/dYVgT+WLvGUZVm/WQjPYdPqOAyHfHbSUwhgbp7aPMC0/o2EhwELS0gj4M0SZYPMdpAjN3PtDM9QehSrAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "460",
+    "id": 460,
+    "sortid": 460,
     "identifier": "abomasnow",
     "name": "Abomasnow",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAilBMVEX///8xMTH///9SUlJUVFR7e3t9fX27u7v8/Pz9/f00NDRSpXM1NTU2NjZ8fHxCemK6urq9vb2+vr77+/tRUlIxMjJSo3JDfGRCe2NSU1JBeWJRUVFTU1MxMjHTkvPWlfdUpnV6enr8/fxRo3H+/f58enrWlPe9vL0yMjIzMjTEWkrGWkrGXEwzMzP18UqqAAAAAXRSTlMAQObYZgAAAQVJREFUeAHt07dywzAQBFDfITOQIhionOXs//89L2gXLgRYjceNlg2KNzuHw/Dhnr9IeatrM/o+URIWrTRrIsJBP6cb2VeWOaPWuywFZ05b1koBa5XqLLZPgX4lS8KztrvHM1hyyLJF3e5lCyjpl8swh0J5MM1HynmnjeMQbeKwWFmtXi+WvfNOxiEGFMK+v12sxsfSZjF4WoQylkIc7LTL67JczjuAyTL6mKOwMxVqwiN6BxiRgBuaNU3jGCMqMRz3x31/FRKeejSglVKmWQ95nvex66zqOSQymhQscB1BhAFGHIZ8MUQboaZiIUTdDT9hdFF1R6ee0m5qXm5u/NGwg3/NPZ8o5hCUvxcZ1gAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "461",
+    "id": 461,
+    "sortid": 461,
     "identifier": "weavile",
     "name": "Weavile",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///8xMTFSUlJSUlNra4yLi6OMjKWVUkrWUmP3e4Q2NjYxMTKKiqNRUVEzMTGSUUk1NTXTUmLUUmJTUlFqaov8/PxUVFRqaoq6urq9vb3TUWIzMzM0NDQyMjL0eoMyMTH7+/tTU1P9/f3///9sbIySUkqNjaNtbY3UUmM0MjLWVGXzeYKUUkr1eoP11ENUUlL31kSLi6S7u7v8/P28vLz+/PyMi6ORapjYAAAAAXRSTlMAQObYZgAAAPBJREFUeNrt0sdyg0AQBFDPbBZJJGWEkrMVHP//0zy7ZR+ZPeqiroLTq4ZtuLvl2gGfOBtDcXTO9DE6enWGIF3PvFvYP+ei0tTrAK3pOQeQKcS1s9ZUOQdToTQqgaWprM2H6yDVWst3EWg/WFe81UqfHnRIB9yGmdpdPBSqi8yYUqFMNvvHpxwAWKnl58v3pMGSP/coa6RPArCw7D5FjdhOsMxpBM5N/YLn+8r8dOxZZgd6KH3vGhXtw7j5fOnfk5hQX9tBOZ4tge5TchI/dvvVYCMEvW0SyBo6UkuS/4P8nKJdhcV5u6G2fxVtveW6+QWioQ9+eUT1SgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "462",
+    "id": 462,
+    "sortid": 462,
     "identifier": "magnezone",
     "name": "Magnezone",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAnFBMVEX///9SUlI2NjYxMTFSU1NTU1RqkpqjxPyEhHQzMzNTU1M1NTUxMjJrlJxrlJ1RUVGjw/syMjKkxf2lxv+7u7u8vLu9vb2+vr78/Pz9/f3///9UVFSEhHO6urreVET39yltlZ38/f2CgnGDg3JslJy9pkFUVFE0NDDeUkKlxf3z8yn09Cn29Sk0NDT7+/u6o0EzMjFUUlH+/Py7vLwduNl6AAAAAXRSTlMAQObYZgAAARNJREFUeNrt0sd2gzAQBdAMo4Lp1VRXYqf3//+3jOacrFAiFs7Os4DN5elJ4uY6/zce4jL39nx6XwQfd7s7hwkR6eFO9NJqvTJru1b2NsaFSNAlj2OOm+DpjPiXwlSXsu0bH6baz389J0+Jth+qrm/WPCvTJECre3kdKkb+WJPBY018BjNZdYOWFcPaBy1hAsvSoSqkEjoRYGhAjgpbK6aqKKVODtsPANBl8tU1D0lkOxgAE3rY3n/2e/qGGu/jCC1uGimIZG9cKaFtboWKZhAI5pgRUHFBvqC2oJNoXpECkfZOWdyRh908E/kyMhaCgmOB9hv8eZsxe6MvnRPy5nIX48rAF+OWSyP5z1wQyHu7zuXnG03KFTkQZSgtAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "30"
+    "gender_rate": -1,
+    "rarity": 30
   },
   {
-    "id": "463",
+    "id": 463,
+    "sortid": 463,
     "identifier": "lickilicky",
     "name": "Lickilicky",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTG9UnM2Nja6UXG7UnI1NTXnhHPvc5TucpPkgnFUUlMzMjJTUlLvdZX8/Pz///9SUlLscpLvdJPnhHTscZJUUlLsy1kzMTLOY1LOzs7vdJRUVFTvzFrvzlrzusv2u833vs7mg3L9/Pz+/P3+/f4zMzPuPABhAAAAAXRSTlMAQObYZgAAAMlJREFUeNrt00cSwzAIBdCAJKu42+m93/+IATsZb6xIm0w2Zv0GfWA0m+onlQBEObEwJoMoR4XrKIjWZBERWaINSyGpIceMyhiOyW6QYXjfN4YGEgB+iHndmExSzhQk+tsKp/WSKD2dK0SfFOA2V01UWUSb1soDE6ffjhhnTdWoE51jWF52pLqBRuFprntXFXyevCw80H1cxR35PF9HpnfPj8J00rscANp43HESkoc26Fiuji3TYdleCUQx7PqoIG/bZ/RnnOqv9QI3FAx5mt0IGgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "30"
+    "gender_rate": 4,
+    "rarity": 30
   },
   {
-    "id": "464",
+    "id": 464,
+    "sortid": 464,
     "identifier": "rhyperior",
     "name": "Rhyperior",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///9SUlIxMTFTUlKSg3KUhHOtWkL3lCk2NjZ7Y1L0kik1NTWTg3JUUlGrWUIyMjLDurLEu7PGvbXTYkLWY0HWY0JUU1FTUlEzMTHVYkKVhHGVhXU0MjB5YlGuWkF6YlIyMTF8Y1HTYkEzMzNTU1PzkilRUVH1kyn1kyr2kymUhHSSgnHUY0J8ZFOVg3KtpZzFvLPFvLRWVlbGvrb8/Pz9/fz+/PzqPc4XAAAAAXRSTlMAQObYZgAAATRJREFUeAHt00eO6zAMBmCTKrLc42Kn917em37/ow2ZZDUWAu+yyQ9Ii+ALSROQ98y84iN6IWIHmOWrjTFj7CLXEJiy/5iFuJVKKZHoBu+/OBVm/9+Pam+Goqj6yNQ/pe2mpHKCe1NLUfR5UjekiteC6fJnpFJy5WF8he7lnBRHBMbUAEhQuaRPnyIAvkYCghpkys4F/YkFkN+fx5sjs1lEbRjixFooYqBcO0saYGijvzAkRhDkW54fRVDzEC5IbXsXe2tJEeSSJlhEbZitYTbfBqVugJoCQDKI6U8tSCV7K8/flFrvyrg4TPWgirm4wPYS+VrqnTFTPgPdEHSukctCcoc1ADyCFnhDdGaRtSzdkOUckbg8V/8EZhca3J0Qka/t7FwtoMOr+KCl9tYdXxl6z8wrvyZ0FwizbLPdAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "30"
+    "gender_rate": 4,
+    "rarity": 30
   },
   {
-    "id": "465",
+    "id": 465,
+    "sortid": 465,
     "identifier": "tangrowth",
     "name": "Tangrowth",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAilBMVEX///9SUlIxMTFZesxSUlNSU1Rae85RUVFyq/xzc3Nzrf+Uxv9ycnI1NTVyrP42NjYxMjOTxf8yMjS1Smv8/PySw/szMTE0NDSySWpxq/tZecv9/f1TUVJ0cnJafM51dXVbesxxcXFTU1Oampqbm5udnZ1TU1SzSmuzS21UVFTbYoLeY4QzMTIyMzRGjeQTAAAAAXRSTlMAQObYZgAAAQlJREFUeAHtk7dWxEAMRZEmeIKzvZmcA/z/7yFpCwrkgW6bfT7T3XNHerYvzjlxOkQ+f2OrfN2vcv4qo80uuTAkypDGIkdETskBhFQiuyo4MC1J83MogM3e23A0hqFENhUEb+lWjm99r24rI3pv56d70/pW0PE3t53WzFmYN3dRxiTQogLe+h53ztiHw83j4S04Yo12d4e8iAuujnHeVDyq8QpIaRD3ljxQkxGINBYXa2SS2zaWj+kX6zbk8RK7NKP4GGOXdOmOyg71hX6MYh3x/eNTrb0SIR9DD5X5Oq31MYFSU+UMUrM6J06sqMoINQBKZ4WPEnF7FeOLplJe/XSJ//zDiDvnlPkGPNcO8+YW8TwAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "30"
+    "gender_rate": 4,
+    "rarity": 30
   },
   {
-    "id": "466",
+    "id": 466,
+    "sortid": 466,
     "identifier": "electivire",
     "name": "Electivire",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAjVBMVEX///8xMTFSUlJUVFE0MzBRUVHEq1n05Cn35ylTU1JUUVE2NjZUVFSai0ozMjHGrVrkSSnz5CkyMjL15Sn25ilTUlH8/PzDq1mdjUk1NTUzMTDnSin35yucjErnSyrkSinnTCzsmpp1dHHz86uaikn09KvFrFn25Ck0NDRxcXFycnL7+/u7u7v9/f3+/PtlW8WhAAAAAXRSTlMAQObYZgAAASBJREFUeAHtk1dvwzAMhEvSGnYdD8cjo+neo///5/UkqE9l7JcCeckhkRDk8/Eo0Rf/rbMuiQjLMnd3XTA9XGWLYLPfkXFeCFooja+xufPeZ0sJtq2Pgm/4RUc9pz5xT8iK1DsdM+x+DWPWZl+Qwk25k9XaS6SxwtIwqRz+Hm+LZCuMChr4+BxIal4ithmYnbBW2awGWIntfdZ8l8zBONM4ZouQY4mNbwpGWjxV/T1ABLJ1Zfjzq0whN2vYq55hJloJqIsYR06/wdYLQ04csLpXU8YjOsDHoWObA0sXqYL1YYBdbBmYS91oOW1lbC+pOEIe9SR8prrO2VbY+/tubt7QEpRhl/dufiiFw0xs37rZWUfS8fWjpBhk+X0Ec0qd9QN87g81l36ZqgAAAABJRU5ErkJggg==",
-    "gender_rate": "2",
-    "rarity": "30"
+    "gender_rate": 2,
+    "rarity": 30
   },
   {
-    "id": "467",
+    "id": 467,
+    "sortid": 467,
     "identifier": "magmortar",
     "name": "Magmortar",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAqFBMVEX///8xMTEzMTFSUlJTUlL02zH3azH33jHGWlo1NTW9pUHEWVnGWllTU1HMenrOe3v0ajE2NjZRUVH3bDH8mov/nIw0MzE0MTG6o0HzajHz2zFUUlG9pUL22zHDWVlUU1L3pTH33DFUVFH7+/tUVFRxcWr8/Pw0MjH0ozEzMjH2ajFycmr23TFzc2vFW1t1dGo0NDT33THLeXm6urq7o0K7pEL+m4u9o0LROeUcAAAAAXRSTlMAQObYZgAAARZJREFUeAHt08dygzAYBGB+dYoAU8C9O72X5P3fLIuSnCKIb754DxIM3+z8mkHBOafKiNzyv1syLFPduLeQBqBxcn3p4KTtlSEkTTUqw2GISiG1Lme0ZDRRqh1wV8+6k7HIlYNE/YVrpRIDCOcO6IMi3+hSAcL9QuOTRa42gDMOB8469xfCvVmIdrf/gYJ8DvDAU8GRVMQ3btDYeGEQHniVZR8ZNIhzXjkaW86rGi7+tBzxQ7j53Motvi90hCf92ElGnhHfbSpkqZKFBr+97zqZ/y+jF5EnBq6qV2By64egBSp15+oVdh1de5mTnGhsATMho7umz4WvD4a5EXB02VCfgyT63os8YUfdnt3+4ik4SqL6nBPnC740E4tltAFAAAAAAElFTkSuQmCC",
-    "gender_rate": "2",
-    "rarity": "30"
+    "gender_rate": 2,
+    "rarity": 30
   },
   {
-    "id": "468",
+    "id": 468,
+    "sortid": 468,
     "identifier": "togekiss",
     "name": "Togekiss",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///8xMTHe9/+tvbZTU1OtvbUyMzPb9Pzc9fw2NjZrhHNSUlLb8/tUVFSrvLNqgnFShL1shXWrurJirPZshHTd9v1Uhb4zMTGru7NThLy6WUkzNDRSUlNUUlK8W0tSU1RSg7s1NTUxMjLb9f1RUVFjrfervLWtu7PzYlG87ZH3AAAAAXRSTlMAQObYZgAAANdJREFUeNrt0scOgzAQBNDsumE6BEghvf//F2aMIi52yjVRRgitxNMOWEz++brs6UOXCv1uE7l73XL/illKB2BTzub6uQJjzoioiIScSwqaiV3OBmeYhWriXAZW2iJX+rYGAUySxLCQCZwPa6UkHju2m563bhJoDkppHDPdtFxhquKIuQ/Jk+EKO7uyPGYYI1zus0InzI/AcZW37KjQr52rjl25X28B+5S9CO1DVPmMnr5jhcpR+WzYiZVCIU2MHEblS8Kxb66Qi4umd79YDeVVhi3UP7+YOwHpCwmIgmbEAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "30"
+    "gender_rate": 1,
+    "rarity": 30
   },
   {
-    "id": "469",
+    "id": 469,
+    "sortid": 469,
     "identifier": "yanmega",
     "name": "Yanmega",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAllBMVEX///9SUlIxMTFUUlFjhDlycnLkYjnnYzn///8yMjJTU1MxMjFUVFRigjhigzl7pUp8o0m7u7s2NjZRUVH8/PxSUlHkYjh6pElSU1E1NTV6o0pxcXH9/f00NDRzc3O9vb3kYzm6urozMTHvpoX7+/tVVVXnZDoyMjFlhTztpYPuo4LvpYS+vr59pkxzc3L8/fszMzO9vLz1sceIAAAAAXRSTlMAQObYZgAAARxJREFUeNrtktduwzAMRUNKtrz33hl1usf//1xJA36oK8B5bIFcCBZEHV5Slg53/Q0lSOMW7mL1vnsDmxw7ywMkdr/00TEgcBF3Tet2ACPurNfPTXxNrddACs0VqYX+J1YodWI0aW36UKRQkXTX/FVJoQRknmETN9gLXPuyvC6bG/D5ywFjsFsAw04Nm/zC3xyXvnjEAUAgc/RzmhZDHeqX79CEMm/CioapN+TeIwbChZRlWAEe9GDKFINTVAFAPDqoRflvMPc0K0HU6EBmWT1qe5RyUsIkLsjjka86O88n3bHfqKwAMAVimlkkz1QakCw/HidBe0hZadydX2aBmsrLNQqTMV49gKk2ftuHweY0EQo7z4s998XcXf9K3081E/SIUUIpAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "30"
+    "gender_rate": 4,
+    "rarity": 30
   },
   {
-    "id": "470",
+    "id": 470,
+    "sortid": 470,
     "identifier": "leafeon",
     "name": "Leafeon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAxlBMVEX/////94w1NTVzzowxMTH99YtClFoyMzJatXNxy4o2NjZyzYuUYym6o1m+plrOxnv784pyzItUVFJRUVH99IpZsnGUZCmUZCqagmKdhWM0NDK7pVpRU1LLw3lTUlH89Iv89YsxMzKTZCqVZSz89oxSU1KSYilElVqag2KchGNbtHKs1Jqs1Juu1pu6eSkyMTC7eim7o1kxMjG8pFq9pVpSUlJzzIozMjF1zoz7+/tBkllTUlJTU1JCklkzMzL9/PuVZSr/941UEAgxAAAAAXRSTlMAQObYZgAAAQxJREFUeNrt0UduwzAQBVAPOVSxenHvjp3ee3dy/0vlk/AulORdsvAALBIe5oNka19/VO1dXWexK/QWzM3tAdeZdG63H76rZ2YLFB1nvJWCfenqP4F02SY99NTAlxIrFscB/Q2jUxOOdstH4zWzhhdw8zyTyxCwbZztMDx5z0aKBue98AxAQywWGHXLoznpujBHfg08+82Kl2+KVdwtc0Z7DeGt8LAk+tocYB6mNOzfPbUqYEqA0xnlDzeKCH2rSkQKdHCiZ3StdJDFRzC6h4sxEmauhHiLMWKTz5SSxJE14VwcK6RiM+kx14X332Zw5g5qnHnF1bNrdnD18nqaQTaWuAyvmJudidzX/6gfiB0RGUH8OoIAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "471",
+    "id": 471,
+    "sortid": 471,
     "identifier": "glaceon",
     "name": "Glaceon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAk1BMVEX///81NTUpg5owMjIxMTEpgppRU1SS2/yU3v9xsssphJwyMzQiXHU2NjY4uvs4vP1RUlMyMzNSUlJSUlNSU1NShJQphJ1ztc4og5uS3P2T3f4hWnM5u/yS2/s5vf9RUVFxtM1RgpJTVFRrbG0qhZ1xs8wshZ1ys8xytM0hWXEhW3UiW3QqhJxSg5I0NDT7+/v7/PyACa7GAAAAAXRSTlMAQObYZgAAAQtJREFUeNrt0ddug0AQBVC2sA1M77glsdPb/39dLl5blrwG8eCHPHi0iBUcLsPg3eu2tZjrVsFM+CaDedDvr8kF5+MQN1F25xt2AYn+ACQAZKWGCnDNNwbQkQVHwDbVXdj3+9Q7Q+dzmriKq20XNuDeEbaB46IqXmO9S6Xq1E5sd3YuXIsMjVpoH3EHBIiVvODmCSLQhT/Ppg0bFgmOuQzO5rmBDAnh73ckKHYBH44rjkRCqqEnXSwFbZV64i6zk2Bcd5BlvhTSDnwM4r9svsqcmgRwRMLww+nhtRjgo7yAjtdlnmGO6KL+ZJOwkIcowtHLhNvQRNbpsesp6CcZZaeuR5n7xmnq3etf1B8uqBBJGELTBAAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "472",
+    "id": 472,
+    "sortid": 472,
     "identifier": "gliscor",
     "name": "Gliscor",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAgVBMVEX///9zc86SmuwxMTFSUlNTU1RycswyMjM1NTWTm+6UnO9SUlJRUVFxccv0YlL0Y1NUUlKUmux0csy9SlJ1csx1dcv09Cv3Y1KVnes2Nja2hVm6SVG7SlK8S1R0c8vFrCnzYlFTUVJUVFQ2NjX19Sn2YlKzg1v3ZVT39Cn8/P7+/PxX+ogFAAAAAXRSTlMAQObYZgAAASNJREFUeNrt0sluwzAMBNCStERLsuPsqbul+/b/H9ihWtSILcDHXDIHQYfnEUj46pLzpBY7e5l1HNUgq8w5xwp4u4oqczAq4DpEUoHtxTJyPccM8QUqEVjGSZVMCv9kbZUWY91hq1MIR4CPn9f/bLPW8dNtgPQG2/0uUMjszfpqGUs4g40njPP+uuus70WE9RQSVR6O3WJLtL85PnTo620ZVJINO//1AWoDD8s4kSItVckHl0C/n3HTpgSRulkclhzBE1g2LiXAicuAQCKZs3p0AhYko48zdHdPnqjK2y1JlP4+7RZL3GDNlWG436wcO3wBVoK1YEwIj3cTkqXK1HGewWTFFLIVY6VGH7D2SnAhxTmwaacB3FoafohiJxSSzSXnzQ+jyRCTGct4MAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "30"
+    "gender_rate": 4,
+    "rarity": 30
   },
   {
-    "id": "473",
+    "id": 473,
+    "sortid": 473,
     "identifier": "mamoswine",
     "name": "Mamoswine",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAqFBMVEX///8xMTFSUlJUU1LDw7rvxoz///+1hFpUVFR7xPx8fHyLYkKMY0KNZUQ2Nja1hVozMzPExLvGxr3sxIvvxYxTU1P3lIz7+/v8/Pz+/v01NTXGxr7sw4plpt7uxIuzg1m0g1n0kov2lIxSUlGKYkH8/f5SU1Rjpd4zMjF5eXmygll6xPx6xf5TUlL1k4t7xv+1hVs0NDQyMTFrSkL8/v/9/fxtTESNZEMxt96nAAAAAXRSTlMAQObYZgAAAQhJREFUeAHt0jdywzAQhWGBCMw5U0FUds7h/jfzPsNuLJBWp0Z/geob7CwGk0tnL2LoBHZjoys2rjTTdMTVKuzt/2VXK6XCAPVjshPt/LAjCw5qloCedaslaD8II+E187vDdzsNB+WTbbuP+zSpnUbLe8aMD/hQFbG7t5pp+Qv9l79sEs0kX1VaWj8uCI6cSEiuK74qZGy7b3qZ4Bh2omQzKeW6KqQk+v6xBDPBrLSWC0I8p+Pz1YfCaZBZmccL3ji55BacCUJep3RpDshpax/KACHpE243tK+TtsqBMjuNtxtSCo4GM+GlyQAUWVIrhcm4rBv+6B3TODS8jBHX0/Z5ckoYeumsfQE9nxrzEtPjfAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "50"
+    "gender_rate": 4,
+    "rarity": 50
   },
   {
-    "id": "474",
+    "id": 474,
+    "sortid": 474,
     "identifier": "porygon-z",
     "name": "Porygon-Z",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///8xMTFSjP9Stf9TUVJUUlLEQlLGQlLsYmo2NjbvY2tSU1RSi/wxMjQzMTE1NTVTivxTtf9SUlJUVFGr2/vDQVFRUVFRivtRsvvuYmpSUlTvZGv3paX7+/vzo6Pz8ylUtv/3pqYxMzTEQ1RSs/zGRFH09Cn2o6Q0MjKu3v9StP80NDDNBwSaAAAAAXRSTlMAQObYZgAAAL9JREFUeNrt0kcKwzAQBdCMumvcu53e73+/jJPgrAZrFwL+GyF4+gNiVkt+HcfWDVdLaEIrBsYNYd6tjYuR8LkB6YauHWX4vvXbPQX7XddqoepROlnMCeiYCzbKc6oEAFQcHQHz2kX32JyEcaV/JwsrzholEKaJkT5jAeH6W8y5hzJNlBZ+A9Tg4shZAJhc66hJVEh+DprXWSgdMXb4QvpFOblZWmC5lSwDO1exwMplsQdWENfBcvJ84bSJS/4lT5zaCqciyAulAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "30"
+    "gender_rate": -1,
+    "rarity": 30
   },
   {
-    "id": "475",
+    "id": 475,
+    "sortid": 475,
     "identifier": "gallade",
     "name": "Gallade",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABPlBMVEX///81NTU2NjY3NzdZq2L8/PxCe1JCeVF7xsZSU1JYqWExMTFZrGJarWO0tLz7+/tBeVD///8yMzI1NjZRUlEyMjJUVFRRUVE4ODgyNDRarGM0NTVipKN5xMR6xcV7xcUxMjKxsblCeVL6+vo5OTlCfFP8/fw1NzY0NDRZrWJGeVJHe1RHflYxMzEzMTJRUlJSUlI2ODdSU1NTVFNUUVI3NTUzMzNZqmFZqmJZq2EzNDQzNTVBeFH5+flBeVFcqmFgoaFioqJio6IxMjFipKRjpaVxcXFycnJzc3N0dHR2dnZ3d3d5w8N5xMMwMDB6xMRCelFCelI1NjSkQ0KxsbhCe1Oysrqzs7tCfFHYS1HZSVHbSlHbTFTcSVHeSVL4+PgyMzNCfFRCfVL7/Pv8+vpDfFP8/P1DfFT+/v5FflUbRe0mAAAAAXRSTlMAQObYZgAAASxJREFUeAHt0EVywzAAhWFZIMtxDGFmB8rMzMzMDL3/BSqlW1dyF93lLZIZzze/LIPO/jDNNAPCXfZoBoSMzQSFLKN2qQPuSmtllZvPF1mdvuUzardXD1sWXZYnc7TAuONzV5TBDwFxtCWDnr5aFEGcNZIEabLkYolDHE8CEnEIkiULT2HL6H/ZJg6C4klz/5fk0lkYj9y+2u+CcYf9L5WLG9UJo2JvDZ/WpqPC4T5fd0jdAZgaHTTcGNSPytEpy435nTtLOQBjN92XJgCeptOsf9BLVWP89/r+buE4IV4w1CWCfrJ9A3R10tPYSQAt9Bwakn3Lh96vRsRBIK1PNmVufLNGCNHaB8jchn2OIFy3EZDPq1xA8Tf3qZTaT9mJtIB6IknSgaC4yb+ss29BXiDsQBn4RQAAAABJRU5ErkJggg==",
-    "gender_rate": "0",
-    "rarity": "45"
+    "gender_rate": 0,
+    "rarity": 45
   },
   {
-    "id": "476",
+    "id": 476,
+    "sortid": 476,
     "identifier": "probopass",
     "name": "Probopass",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABL1BMVEX///9SUlJznP+Uvf/MSlIxMTFRUVFTUVJUUlJahNZxmfmSuvs2NjZLbLbNS1LOSlL3a1o1NTVznP5TU1RTVFdUUVEyMjRXUlJZg9Nag9Q4ODhKa7Vxmvtymvxym/5Ka7YyMzRQUFCSu/yTvP00MTGtQkquQkrKSlJRUVLNSVExMTNSU1Txalnzaln1aln2aln2alo2NjU2Njc2Nzhbhdc3NzhRUlIxMjNymv5ym/xym/1SUlRzm/85OTlSU1ZTUVFJarKSu/2Su/6Tu/xTU1NJarOrQUmrQkpKa7MyMTHCwsLExMbKSlEzMTHLSVLLSlLMSlFUU1RUU1VUVFRVUVLPSlHPSlLPS1FKbLZZgtHzalr0aln0a1r1aVlZgtP1a1pZgtQzNDVZg9X8/f7///9vd86ZAAAAAXRSTlMAQObYZgAAAUBJREFUeNrt0sV2wzAQBdCMbJlBYWbmpMzMzMzt/39Dx8lWtlc93eRttLnnCUaBSf4oQTqKv5PEPmO2TH1hl41S8S3c7zmutk59+hSx6qQpP1d8Nq41bUy1x7zhXo/VnEZcDj3hiWMYQ908dWdTnxKI1viMtocLlvQIQKNuY2QA6sZauhDWrkR57oi+He9AQp3nu0x+U4gAjkWBn+/rhKouU8qF2sMWFl70u/EGfOTQlYQwV65qpXD0HAtFGbJkBIWCy/SiT/cDFhflmRBRQSjoai7GgynpxXYKzxRthZC2QHVzKd/iVnZuB69x8UZpZAlZKwvpDCEx7tbQeb/DN7QuFwn5ape3Zw3+bSQAqFuWBdpCKGSmwXD/i0UYZ9c0Nw5cHVYaWIq4+JhMTqNzl2gBj2oMh2PmZY1AKhiY5P/zC/1QJY/d9VBwAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "477",
+    "id": 477,
+    "sortid": 477,
     "identifier": "dusknoir",
     "name": "Dusknoir",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA0lBMVEX///9SUlJTU1MyMjI1NTV6enJ7e3PExLPGxrUxMTF5eXE2NjY5OTmjo5JRUVEzMzP/3jl8fHF9fHLGrTnFxbTDw7J/fnFUVFGkpJOlpZTBwbDCwrHDqzr83DnErDlUVFQzMjE2NjV7enP52Tn72jv72zl8fHT+3TlQUFChoZE4ODc4ODhVVVXBqTl4eHA0MzHDqzg2NTU0NDR7e3FSUVJ8e3F8e3LGxrM1NTTxYVH3Y1J8fHJTU1H72zg3NzT82zn82zp9fXL93Th+fnD+3TpUUlImbuThAAAAAXRSTlMAQObYZgAAATBJREFUeAHtkkePhDAMhcdOnITO9N4Ls733Xvb//6V1uA4RXFZ7mScQEv70nu2k9mfaS3peNe48a84qoTJ+S5uzClzbYFm49Ph5uTPGJCVgJCLR/k7LkqUXR6iNVWLd3eBBDyFq5aDXLoyXyWX+ObVkn11RI8DuSDIetu759+t1hA+PP2QpXTSS9MHnolg2QB9PSW+AtOkjGzpImjwP2WjTaxn2JCV2yTAGjVsfCIZmCtYQaZyeFY1DPeRlNxSykwJmx12AovBBEvB9uFVKXU2y9AOI4SIyDPIG6gulRlnzKTfVqBPH2sPl18Kyi/q4i8Qgo8Xk0bK+7qw+OyteFFi5QG7hZN0Yvd8E3uAw8JUS7iOXgPFW2Kb5dWJc9IlAiFq5wgsZA1QhbeR8XtvrX/UL5YgT17OuZfEAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "478",
+    "id": 478,
+    "sortid": 478,
     "identifier": "froslass",
     "name": "Froslass",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABL1BMVEX////////8/PxUVFQ1NTUxMTH5+flKc7UyMzRZktOKzP26urLBSUI2Njb7+/s0NDT9/f05OTlRUVGLzPyNzv+SecuSesyUe865ubFSUlK7u7O8vLRTUlPGSkL4+PlTU1M3Nzf9/P5XV1f9/v9MdbZak9aPz/+Oz/9TU1RalNZblNVblddcldVcldZcldd7e3p8fHmJyfmJyvtJcbI0MTGMzv+Nzf0yMjMxMjNRUlOQz/+RecmRecpRUlQzMTFSU1SUfM2Vfc6Xf89TUVK5ubI2Nze6u7U3Nji8u7UzNDW9vbK9vbW9vba+vrZUVFPES0LFSUHFS0M3ODjyaFDzalHz8yn0alL09Sv3a1JUVFVVU1P6+/xVVFRWVlb8/P38/f9XUlI4ODgzNTf+/v5aktL9x6ArAAAAAXRSTlMAQObYZgAAAQNJREFUeAHt0bWSxDAQBFDPCAy2DMvMx8zMzMwM//8N5yvno3CT7UDRq1ZVj9HN9MJF8mrdjGPFzM9YOmibS0XsOEPmok6mEAA65jsEGpjNNyFJIAQBG9nDEFgRE0oU+ttNn+XylX/JBAUBWG7hbhJpZ0QSoLXS93Ac/58mJ+LyB9jmachwjB6IF0LwAeAVA819vuTZU0puDWIgbh9n6clXD4S9huy+Wl2noCodGcp9Q+ZdkpC7+6NWuY4Ae56mcNiu1Fov0O/Q87gnvxsXO5hpw/g3BaNCqSFuPmvL7Y/5OYuUyoi8q2cZDoxMX1MwqS2f16fSsdPLiV2l9C6WnBu9dDl/3nsZ/uEHm58AAAAASUVORK5CYII=",
-    "gender_rate": "8",
-    "rarity": "75"
+    "gender_rate": 8,
+    "rarity": 75
   },
   {
-    "id": "479",
+    "id": 479,
+    "sortid": 479,
     "identifier": "rotom",
     "name": "Rotom",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAxlBMVEX///9zzv8yMzQxMTF1zv+z3f/3jEL////9/v9xy/t1z/92z/+ySUHTYkHzikH7/f8zMTE0MjG13v9UUlFSUlL0i0REfdZDfNXWY0LWZUT7+/v7/P8zNTe03v/+/Pz+/fz+/v+1SkI2MjHUYkLVYkJyzPzWZERzzf80MTGz3P/1jET2i0L2jUT3i0F0zf/3jUT4jkX6+vz6/P90zv80NDNxyfn8/Pyy3f9wyPmy2/z8/v+13/+33/+6urq7u73+/////v+9vLsmL8x+AAAAAXRSTlMAQObYZgAAAN5JREFUeAHt1MduxCAQBmD+obNr7O0lvSRO773n/V8qDjkmNijy0f8BJPRpNKAR7B/pgrYhUiHdIs35gW0VUnacAgHyamARdcS9UvMiJkEVU0FG+lueV+zk4nT7Ac3wdTZRauPjKFIStJxO1OfscrFz0AClESA/Gt9N3/b7N7UQT1qAMeLZul7Mi0cXGwVQNhpzi6tebUURJPnwjJD5nxLSaC0C7O9uFTa03MMvd5/r57Xrn/NVzveqzTk5jAx1aFYONwWLpPxeVsz7yxlLyWFuwm2SaLp0LDFlu19Bly/e0g0IZqrFrgAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "45"
+    "gender_rate": -1,
+    "rarity": 45
   },
   {
-    "id": "480",
+    "id": 480,
+    "sortid": 480,
     "identifier": "uxie",
     "name": "Uxie",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABFFBMVEX///8xMTE1NTU2NjZSUlJTVFWMpdatzv//52NTU1QyMjNUVFWLpNSMpNQzMjGry/urzPyszPyszf0zNDW7pEK+pkL95WL+5mNSU1SNpteag0IyMjI2NzdUVFI5OTlrg7O7o0KJodG9pUKKo9P742L85GL85WMyMjFSUlMyMzQzMzSNptRUU1KOp9U4ODibQ0Sbg0KbhEOcRESchEKeREOeRUU0MzFVVFKsy/xqgrJqg7Oszf5RUVGuzPyuzv24oUG6o0FrhLRrhLW8pEK8pEO9pEKJoNC+pEM0MzK+pkO/p0PcxVLtU2TtU2XtVGLuVmXwVWP54WKNo9T7+vkxMjOLpdb95WGMo9P95WP95mIzNDY3ODhJVc/hAAAAAXRSTlMAQObYZgAAAUhJREFUeNrt0LWWwzAURVGxZGYIMw4zMzPz///HyEnpODNdmtx6+2g9g+kmOQTh/9hhGJjwT7bbCkIhgro53kE/DELJpF0ffJcFL5sX0kkmBhI11Izg9fvDWcKGUkKmjrwMieBlTXyWCKmGQ7jwEdu9ETC6Wr0XNLfDFdKSBzXY7XNs816qin3xKMTcvhAzcf6kbsIGY7G9vMlTUdiOIiFOmxsSVM3kGhm820s/juHBl4hKpRtjNr/SkY4x1Up6aYmf2r7vU21psQOG/wdZCUyvjDHs5jj1wADG0OIyOXqezbnBPQ+grePXzCLyCtxyGXU597TtLoQZDsw71KWawYjjcJfArKAc1gnhmkEwdhSCM4OJhIrBSR+AwlEBFHUVZMuKYhD23Sek651jAMZJouj6G6U1/QeMHcYViGq6Xkz30hSUEQLTTXa/CAweCCWqlcwAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "481",
+    "id": 481,
+    "sortid": 481,
     "identifier": "mesprit",
     "name": "Mesprit",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAz1BMVEX///8xMTFSUlJSU1RTU1SLo9OMpdarzPz/jKVRUVFTUlJqgrI2Njaszf6tzv+uUlvGa3syMjOry/sxMjNSUlM0MjL8i6P9i6M1NTWKo9OtUloyMzT7iqMzMTLDann+i6NrhLWbQ0ScQkKcRESdRESrUVmrUlkyMTFqg7OsU1usy/w0NDRshbZthLRUUlOuzPyuzP1UVFTEanrFanqMo9PtUWLtU2TtU2XvUmT03DqMo9T7+/tWVlb8/f39iqONo9T9/PyNpNX+i6T+/vuNptbjUnVgAAAAAXRSTlMAQObYZgAAAS1JREFUeAHt0sdygzAUhWGuOh3cbeKS3nvvJXn/Z8pBZuMxItl547tgGPj4NSC8lc56IqL/qQ1juvQnm4z6BpONm13FyunaCy4X9EqT9isZDfM6N5gEe/2HKcxZDzjdB1Q5UR2Uhx87byYdBZDX2diXmzdcF0suA9y6naZPcSKsDOTdO9dJsViNJtl4t1z6M1azTs/MpeJ6+yhZjEbkRfiG5uLk8fuHV0kE78+tW7T+1Zc5fT1+BqySecv2liT2BfKSeS9lMmBYpVW49pB8GQs80fWZ5NRKbLLW4p6KC8TCWbupCJcIjZB/0CFyOASEFkwrrktO3sAFsW+caSE5WoI5g1bOXwYnYdv+F24ZdiSXOfmMkdtVkkmlOA5wjZLCNg2VyqnZWeoNCGw9q5xfFhUYnakOIT0AAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "482",
+    "id": 482,
+    "sortid": 482,
     "identifier": "azelf",
     "name": "Azelf",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAt1BMVEX///8xMTFzredSUlJSU1RTU1QyMjOLo9OMpdarzPwyMzQ2NjZqgrJyrOVyrOY5c6aKo9NKhMYxMjM1NTWszf6tzv/tU2X+/fury/t0q+RRUVE5c6VSUlP8/f6NptZzq+RMg8QxMjJRUlM2NjWMo9M6c6WNo9Q6dKaaQ0SbQ0ScRESdREQ8daZJgsOrzP6sy/xqg7NrhLWuzPzDmjjGnDnGnTztUWLtU2Rxq+T71Dr7/P1Jg8U0NDQGY0qIAAAAAXRSTlMAQObYZgAAAR9JREFUeNrtk8eOxCAQRN1k8NjGAdsTN+ec4/9/17bRSj4saH2Z25QQEuJRdKkh2Wk7qgFgApbCOyFETMImgClig8pqGkfEBG4E02jagRvJ2ooo2O7nI1lbJQCCF5frq70RTO3FMdMmCJ6/zgkpll85KTJh1dsp084A/I3Szkm5/HjurjNSHFKpFNOXd84EwiD3+f3UbU6yImNUomH7aAJpbnJSrl+6TePOsuLAKiV6Z4K5sYHlLae+MkyDiXoEQzqCBZUNB3/MMuidtwy64p5qDCT17KHClYk9xYFjGo0W9ytcmZgd15xKTzoOUUNfF9VcMvTiNGroyd8wWGIVfxcoBFaSSYHpKYxchPTdw0n89wtnFQxtgQkfFgckO21FPyXaFH12kA0XAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "483",
+    "id": 483,
+    "sortid": 483,
     "identifier": "dialga",
     "name": "Dialga",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAsVBMVEX///8xMTG9vbX8/Pw0NDRSUlJCYotCY4xCeqsxMjJDfK5RUlJRUlM2NjZTU1NUVFRqu/V8fHu6urK7u7O7u7RCe62+vrb7+/s1NTVRUVExMTL9/f3///9CfK59fX2j0/xDZIxBeaszMzNBYooxMzRrvfd5eXlEZY1CZI38/P2j0/tCeqyj1P2k1f5qu/Q2NjVSU1QyMjJ6enpDZI1UUlJquvOl1v9Efa5TVFTzYlF7e3u4yrrrAAAAAXRSTlMAQObYZgAAAYBJREFUeAHtkWeS4jAQhd2S5YwcZDkDQ5i8mc33P9g+iR9bZVucgKYMJfjoF+Tdx/M25HXk4bmNdVRJektiaif/Jtcruf/5W/DJJ3t2yVZM7g3WHC21af0lQ3YfODU2kgzX+k88J1osO+KnXEQZb2Qw4IsnvuPTjvvekuwFIKGuXFUC3HGYWIBWNlcMwv9Bfy3xPskUYzKKK5wqNjZgBS3B9pd+zaH86QzQkIyV9bjSZ4eS/3xH8AQrN71QrLR9Lkz2iJEiDhwQHbTOsN1iHc3CqAdwx4P+kACK8JEZ4jP9OM/qIeqRsjsU24znBtQ6JjoV55m0eVoD6oxPeVR8fPwSpEHx+DKs3TZYJB/NwksKt0EYrnE2u60vKl7SqNgabQf3dqmZaT0L0kgX29hzDBzWqA8eYzq9I5CbrFj5Vwi0jj+F726Lp/RbLU03ILrqoS6/OvbhdhSTNgeCPb8+D04wHPBmNAH6KNbNQb++anZ4OSyS6c2tORu35mycmu65zz+iOCIKYCDjIAAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "30"
+    "gender_rate": -1,
+    "rarity": 30
   },
   {
-    "id": "484",
+    "id": 484,
+    "sortid": 484,
     "identifier": "palkia",
     "name": "Palkia",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAB4FBMVEX///82NjZSUlLezuc1NTVUVFQzMzNTU1NUU1RRUVGRgpGTg5OUhJSVhZW5ubHbzOTczOXdzeYxMTH9/f3///+RgZEyMjKThJNTUlM3NzeWhpa5WalUUlO6W6u9W629rb2+Xq/ayeLby+Q5OTkzMTLdzOZVVFX5+fn7+/v8/PxVVVVWVVZVUVS9vbXayuO8vLT+/v6Sg5JTUVP5+vlVU1S9XK1VU1VTVFM3Nzi+vrbZyuJVVlU4ODnay+PbyuRWV1e5Wqrcy+WQgZA0NDS6q7q7Wau7Wqy7W6v6+fq7u7O8XKz8/P00MzS9Way9Wq3azOMyMTK5qrlUVVS5urK6WKq6Waq6Wau6Wqq6WqszMjO6qrpVUlS6urK6u7I3ODc4ODg1MjO7W6y7q7s1NDS7u7S8W6xVVVY6Ojq8vLVVVlZWVFNQUFBWVlZWVlc1NDW+XK6+Xa9XV1dRUlLNk8bNlMXOlMbZyeJSUVIxMDDayeOSgZLayuSSgpI2NDY2NTU2NTeUgpPcyuTcyuWUg5Q0MjPczeXdyeXdyuSVg5Q3NDTdzubeyePezeaWhJbyYVLzZFP1Y1L2Y1P2ZFSWhpVUU1P6+PmWh5b6+vqXiJe1UlK3UlL9+fm4qbj+/P24uLA3NjipX8qiAAAAAXRSTlMAQObYZgAAAghJREFUeAHt01WTo0oUwHG6m8YdJu7ukoy7+8y96+7u7u7u7l91e1O1tUM2U8m+z/+J4vwKqANQK/17tNEiGw9u+n1Iso0Mmjb+sDuS49e5MSOCEGKWwqRlWT2MQTA9HpScGNN0CqtIQ0iPLIVRxbRMYk1rjMYQskrKLO3FET0oSR5of6xkKs9Cnk1bZqmHVfoSlTVYlGWPhgb6bRAoRzNpC6scLBfz+XZVD+yHq4I6Qqjb5g4oePpbqlhkVZSFEE4snnv15YSrLEtXHfUb2fpww86L3/s0NIJClal4/PXnT4d3bw5up+oCyuy1F4/4Xk0/uXj7WPhsR+L5yydvAah3UQXj1MFtbsP4OtAReIAnzjzNVoZjtdmNOjkzIwKK5h2OUdGfGx58HJlN7KFI3etidkmT+xAIjwBe8Pu4S0OZwtxxCjDh0P9UfTVH3h3kLjsz06X3b7KOtluhcP/fMMrDeSPGC04fV/3oGZxLy12TI0zD74ZRuancaexd2FI1ZWcXJ0qCu5FzaYhTA53vTnkXXMLqC2VJEIlrAM/rKBsOxNurQ2t9nJZtE92AalS0rXBPT6y/H8r1HpJ0pDE0tUyAFZw3O71X9rkKxIn2y9nXzgobJ38AYIz+p8vzyzkiwXUagNqiJI9Huks1D6gaeuaPNXXk35DNXS5ANZdJ6cMO4lqQgLBWW+knjElNrWHi0FMAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "30"
+    "gender_rate": -1,
+    "rarity": 30
   },
   {
-    "id": "485",
+    "id": 485,
+    "sortid": 485,
     "identifier": "heatran",
     "name": "Heatran",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABCFBMVEX///9SUlJTU1MxMTE2NjZ7e3O1Yzm7u7t5eXE1NTV6enIyMTF8fHSMSjmZmZmbm5ucnJyzYjlRUVG5ubkyMjK9vb2KSTiLSjk5OTmMSzqampqbmppUVFSyYjgzMTFSUVE3Nze7urpTUlG8vLx9fXXdgzH9ozFUUlCNSjiNSzjbgzFUU1KNTDv+pDFRUFCLSTmdnJozMzOLSzqLSzu2ZDi4uLg0MzO6urp6eXA0MzS8u7p6enM4ODi+vr7agTDagTHbgjGNTDx8enDehDH6ozL6+vr7+/s5ODg0NDT+pTObmJg2NTWNTDqMSjh9e3GdnZ2xYjmYmJn8ozH8/Px9fHO1Yzh7enL/pjQCxW47AAAAAXRSTlMAQObYZgAAAWBJREFUeAHtkuWO8lAQhpk5XpcWdxf43N3dv5X7v5OdEpIFtsBvEt5wkvPj4ek70xZOOY4YxthhhqJV6iQr1rB8rhoE4v9LR6UIJZtRGq6dB5a1j8/JpxwVIIRy+P5cNnc82uo5QqXL4D/iJClzybiXpuQk1iGlHCwmdq4wepchGiwBMF08kFJ2b47D2Zvx7MMvIfrJpzqEgyWXkWx75Hqp5SEAfLz8egdD6bZC2Q0J3RrIeAGihVWMf2OcZuAzLLWANYabNc2tv77wI7DQe4y0JgiHE5e4ginWkg2wOPomqpxHFtIPLPhDJbvEafr/OsnvvfpZeZQt3QItSIzhYKbuLt8Wrs3zwvO5oUM3o0GTNsa6UF8KJoLpuBZcO8s8O6vrd9J6tPr+RUKdXHv35/SZysY91Zk3mRZk2xf+pHP24/b8KTP7ubJ3v/L29ShW7f0ckeyhanNOtQ+SBJ1yHLkCjaUetRxR1FoAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "3"
+    "gender_rate": 4,
+    "rarity": 3
   },
   {
-    "id": "486",
+    "id": 486,
+    "sortid": 486,
     "identifier": "regigigas",
     "name": "Regigigas",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABblBMVEX///8xMTFSUlJTU1FTU1NUVFS7u7u8pEK9vb3///+7o0JBillRUVG9pUI1NTW+pkH7+/v95Tn9/f3/5zm5ubmce0KdfEGdfUQ8ZUm6urozMzNBi1lCjFq8vLs0MzG9vLszMjE1Nza+vr775Dg2Njb85Dn8/Pw5OTlWVlZXV1eaekJVVVVCi1o3ODW8pENqs3K8vLxqtHJrtXOEhHSFhXWZeUL64jlMrsY8ZUxAiVgxMjG5okH9/Pz9/fw5Y0r+5jq6o0H//v9CiVk3ODScfEM0NjKdfEKdfEM4ODU4ZEq5okJRUlG5u7pRUlJRU1I1NDG7pEG7pEJSU1K7vLtTUlE5Ykm8u7syMjFTVFQ6Y0lVVFE6ZEtWVVC+pkI0NDK/p0G/p0LVZEP5+Pr5+fn5+vlXVlH6+vr74zn74zo2NjVpsnE0NDT8+/hBilj8/fz8/f42NzQ3NjVBi1pBjFn+5jk3Nzf+/fyae0Kae0SbfELOpJYDAAAAAXRSTlMAQObYZgAAAbFJREFUeAHtz0dT20AUwHFt10ralVVkbNkYISMHTE8CJEAopPfee++9f/s8k5NkDeSS4eI3mtEefvN/u8Zg/sdo9I+uHbQAI7S7q80e3/Bc8mA3WJv97QVB4F5KEJSTHYKNn16rHUB4/5UscFG/QagH3SNDN4GBnwdXFSrpbwUt5GQAPTi1a43m+ayqVBFCinQ9d4RaAGGzG90+C4sVwagANwin2FIEoPDArUqWVQXB3IwLspJS3BUjtCOHhLJOvttkiycECc3Jt3nndBjuMCtBlaVfQkU3Hv9gViTuQNHPSV2nmPsMQVlCEjZvTjhnopXp8MWEzhd5XAG3fYdjAJc++uNO97Px6dqzQhLB9/cOkFyVUqZmrI2j4tFzsmyUDKxOfWAHh01476mX6+vfHt5DZQ7elJq9OTBM8eLlmZlX3v2LJdD+ICXjPQdJahHm4AVLJUW3z55vvmlejTWqz9VNGo5zk1FnYWW6v4i21hrLY3AIb2FOn0jGOKUld4ToGDBDHz5999yhqQsOq/DJ8HtO5Pl1+4v99f3U6NM5WnTF8NaaPfoa/tsbdqRaG3s5g/kDNwA2ZHuTw2oAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "487",
+    "id": 487,
+    "sortid": 487,
     "identifier": "giratina-altered",
     "name": "Giratina",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAq1BMVEX///8xMTFSUlJTU1NUVFGMjHu9vbW+pUH82zFTUlGLi3o0MzG6urK7o0K7u7NTU1E2NjYyMjL93TH/3jG8vLQzMjGKinlRUVG8pEKMjHq9pUI1NTWjg0LTUUn72zGlhEKrUkqtUkr/3jS6o0FUUlGmhUE0MjEyMjE0NDTTUkrWUkrzeWpUUlL7+/ujgkH8/Pz93DIzMzP9/fykhEJUVFT//vv////2emqMi3ojAfjJAAAAAXRSTlMAQObYZgAAAVJJREFUeAHt07dywkAQxnHtZeUgkcEEcM7Z7/9k/lZyYTTHDA0dW9gUP/63I3TBieY8BdFxbCTIx3upYiRaxx8Oydm2ignuD8wgibzu7SNqjHSqk23cYwt63MSJFK5WXRPFbmjfXajnjc3Tqra5U9iV2N3e7ajvauVqDBz+K2a02NHi+wrf+Q+3leLadDplCMqw7RXDMtiTuXBw+Mvu8+sGvfsH8KHuQaQuQxznum7bS2SkRVT2nk7O269DZ3PBw72ogYTrny1S3tDm83AeZuY1MTKT/SDLAY4XCIIz1AIsk9RzkPxbwHVUZIYZwr634mkZ8kNmx/vBRrrxSSRXIVe7njFGppPS44ZaiNU6FGzQ07qRTpEXal2OcKrhWPRiJyWR70Vb/rxfBzNK0EIsrWwVB94N0+V40JbHlZ1g1wEdvAvUvUuWY0dcMpbx8Vf2PKeYX3iCGiwJLUy0AAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "488",
+    "id": 488,
+    "sortid": 488,
     "identifier": "cresselia",
     "name": "Cresselia",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAolBMVEX///8xMTE2NjZSUlJTUlO9pVrOa5T023r33nvLapLMapLnlK0zMTKlxv+7o1lRUVE1NTWjxPxUVFLkkqs0MzLz23lTU1K6o1lTU1T/1t4zMjHObJUyMzRUU1P23Xp6ktv+1Nx7lN40MzMzMjJSU1TObJOljELObZVUVFTmk6ymxvzs++RWVlZTUlH23Hu7pFwzNDP709v809v8/PyjikGjw/sM1CO3AAAAAXRSTlMAQObYZgAAAShJREFUeNrt0UeWgzAMBmCEK9j0Tnoyvdf7X20k8l5W9jwfIFoAi8+/hBxdK7xiCIVdGwiHbajsdJh8ybdBshzEBZYA4O9c5CTpCz6naTqCxzVmc+4dEyPpc0ZypXWLcSsp5R6lD24YRtZfKwsACcqjc8AG82qCqV3GTJyw/Ll7Zd/3nCCcTyZ7h4vRqVv5Vityfkh767TW1Ll9/gC0pdstQ0FHgdX6N8vWOOEDgP+uRV9lYzWyVHJWofe5min9lI3EloX6Whcpz3tMWhJV62GJlDzlDO9xd7ghCU5HjDGm6sZIvju8z0UqrcshSy2tqKYB85laOGSJgRaislBC9NR22WRzcv7J+TUIIWbA/hYSYy7SeQLwKR8NFcH/CyBB6hjSHQ3RtYLqD6LnFOinYHCEAAAAAElFTkSuQmCC",
-    "gender_rate": "8",
-    "rarity": "3"
+    "gender_rate": 8,
+    "rarity": 3
   },
   {
-    "id": "489",
+    "id": 489,
+    "sortid": 489,
     "identifier": "phione",
     "name": "Phione",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAV1BMVEX///9zxv8xMTFxw/tSlM5SUlIyMzQ2NjZSU1RyxP9RUVE5evxSU1NSksw5fP81NTVyxPxRkstyxf4xMjOs5v9UUlFUVFQxMjR0xPw5e//TY0TUZET8/f4KVV/NAAAAAXRSTlMAQObYZgAAAKdJREFUeNrtkdkOwyAMBLPmCCEnJL37/99Zg4TyUpc+txkJCYuRvUBz8Gu0RPSVpzY4YqqiXwDHy350W1JwhpigtV5FdVbYwFjeJnUgKd/UIWNTlZsK+fpuunVZlM18EpHF3ZRFwI1xFwcSQgL6eV6g1/L4bzXyZox69SN7EiX7YPpLKPMk5pC63U+m0jHN5pSPa7qOrf+1giUFwFZNynaZXrWpOfhfXlBDBjCBQQL6AAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "30"
+    "gender_rate": -1,
+    "rarity": 30
   },
   {
-    "id": "490",
+    "id": 490,
+    "sortid": 490,
     "identifier": "manaphy",
     "name": "Manaphy",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAclBMVEX///8xMTFSlM5zxv9SUlJSU1RSkswxMjNyxPxyxf5Rkstxw/syMzR1xvs2NjY1NTVSU1NUlctRUVHz8yn09iz09Sz09Ss0NDAwMjF0xPx0xfxTlMur5Pu6o0G9pkFUUlEpimI5e/47fPv19izUU0TTU0SEgwXfAAAAAXRSTlMAQObYZgAAALRJREFUeNrt0tcKwzAMBdBK3iN7dO/2/3+xSgqhL7HyWsgFgx8Okrl4s+a/kgMsYx7RAO88llJKbVhXSiuEUBI4Z0UEAJ/cnkNQNsJ4rS2aeUY74zR7DhYD+5EFzMw7PbNJpkKPItRmPGzICGWJxjQ8H4TA/nJ07MhAm7dN5dAk2VCyax9dxTiPiKXUPeOoNeq31u8r/x1yuO3Cay+UdhEY6u9dRgUt6Byg1mjCF7J2PGv+JB9S4ge8pmHyQwAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "491",
+    "id": 491,
+    "sortid": 491,
     "identifier": "darkrai",
     "name": "Darkrai",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///8xMTFSUlK9vb3WWkJRUVEyMjFTU1NUUlFxcWJycmI2Nja7u7syMTG+vr5zc2P7gmL///81NTW6urr/hGMzMzM0NDTTWUHVWUGrQTirQjn7+/v8g2L8/Pz9gmKtQjmuQznTWUIzMTHVW0MxMjKtQztUUlJZxLtEnY00MjExMzNTUVEzlA7IAAAAAXRSTlMAQObYZgAAASVJREFUeAHt02dywjAQBWC/leTeMb1Aesn97xftokysUUQuwP4Rs3zzntHg5D7eVPhPAMLUMhrhjv2wAhYKt5vYDUOrVCywMnO4UrHA8cdhYJdg5uBDAh/YC5x9YXd+NctKWLv0mqwLZOCkKYR0dNBbIuKUynDdAHaLaCDV6qWRRdmlhlkAWbbZ2+fiST/asKLrOvoT7r5qlR3fn7ebnMMIBTEMr/xB53UG9NNr2dlJkxGh48ztuYEhOui89FuD8sMHgPV5k1N509HudGn6SeuciGJwhOGnmy4ncYAhQO4yiON1r/XVuWuEjO8IfK6lFtxQOBcG8lTSyWMhy+j/lj8SU5cYe7H4RxEPCirDQP9hHUyLNMoYQigMpCQ+I9uIClJ/1X2+AVyQD91y8pxQAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "492",
+    "id": 492,
+    "sortid": 492,
     "identifier": "shaymin-land",
     "name": "Shaymin",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAnFBMVEX///+czkI2NjZCczlCpTlSUlJTU1FUU1MxMTFCozkyMzFDdDlRUVEzMzNSU1FTU1MxMjF5mkmay0GazEKbzUIyMjG7u7u9vb3vc4z15in7+/v8mqv8u8z/nK3///81NTU0NDSdzkG6urpUVFS8vLxCcjm+vr7W1mnscot6mkp6m0l7nElCpDlRUlH+m6xUUlL/vM2cnJx8nEuampq0vKduAAAAAXRSTlMAQObYZgAAAK9JREFUeNrtkkcWgzAMBXE3EHqv6b0n979bbNhkE5E9zHre/7JkY2LEzKWB5R8eDs9uhCwJuyorRDxC/BgjC6zttB7QxLNOK/YI2YT4wHy9pbULpdQHPA2PbK1RIDGIiyXitWDMpFRVg4mcVc1DbAk5JeBbeN3k+d2Em2fpKwncQ35TJrnK31ss23ZRrlkl9JSpA6xRmbvMq4WUq8yBL/jePD0VNvwv8HfYoGtMjJoPBOoLBj6C/EUAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "45"
+    "gender_rate": -1,
+    "rarity": 45
   },
   {
-    "id": "493",
+    "id": 493,
+    "sortid": 493,
     "identifier": "arceus",
     "name": "Arceus",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAtFBMVEX///8xMTFSUlJTU1O7u7v8/Pz///9UVFQ0NDRUVFFTU1E2NjYzMzN1dWW6o0G6urpRUVG9pkHz7Dj07Dn37zk1NTX9/f29vb37+/u+vr4yMjFRU1EzMjExwzH27Tm7o0K7pEJycmL9/fxzc2N0dGQ0MzG8pEG8vLq9pUIxizG9vLs0xjSagjjVZEOagznz7Tjz7jichDn07TmchDudhTz37zwzxDFVVVW6vbpxcWL+/vtTUlHuuPubAAAAAXRSTlMAQObYZgAAAUFJREFUeNrt0lduwzAMANBQg5JnvLPjrO691/3vVaoqiiKKjKDoZwgZho1niiLdO8R3RAD7sSHqfdwQu11kbzW5ZNzl+rHdVklU0AkHMVB1Suo+74YbiUgOdfbb1c5HLxJdWLsdoFfWoSYX2cvtgD2tDU2meNcw1JnEUbxdYrr6gfbxKQ/JcdiGRW7kxcQ0x+w7uw3EYOCevzZwdPU8kYpdH0+hqCqCnO2ECQOYvXLBWVnlYZmHzHUkATJalEXi40cbCl4Gwp7Etf0GFRMNoiLEpRK+EUWUlDAmi3kVtHNzmtg3x2bUYHJfBWVANS6F13GxMc1jy8WpSeh3yzWTSOO4HJs+PpzEu+EbIygaRUPOzm7ysL0be1KmIZPJWn5N+6gIIJ364BTSlf0PIuqsWZ5OmgmdE9wjaM/e/0Iq7hB/iE/JPRYB/1/NXgAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "494",
+    "id": 494,
+    "sortid": 494,
     "identifier": "victini",
     "name": "Victini",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAnFBMVEX///8xMTE2Nja9pULd1WL//4wzMjFSUlJTU1FUUlG7o0IzMzG+pkPTSUHWSkLb02I1NTXzcUH2ckL3c0L7/Y3+/Ir+/ot7xv/e1mM2NjVRUVHTSkIhjM4kjczd02I0MjFUVFIkjc7zc0T1dER9xv26o0H3dUT7+4r7+/shi838/o39/Yr9/fy9pEIzMTE4UZL//43///15w/s0NDKoU6XCAAAAAXRSTlMAQObYZgAAAL5JREFUeNrt0scOwyAMBmDMaPbe3Tvd8/3fraFE6s3kUCmX/Fc+2cZAhvQc2tVFi//CMEq6QfqDFQDoIQWIEqQ4laetUg6D4MWN8v0bPqKKZXMHc4e9YkZQYq66H9dNz2ypcSR8FRs/e65SId74Emv38hCzaSrcEdFIIcS2OMnGOBzb54Z+HUWf5WoaNjNBshqbk0LAeMm4A0Guu8+OM2ZOYkuzIOrNGeO5WiSaEEC2dUeAu7Zs+x/0EsiQ3vMByfoNPPtHmV0AAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "495",
+    "id": 495,
+    "sortid": 495,
     "identifier": "snivy",
     "name": "Snivy",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAqFBMVEX///8xMTEyMzE2NjZSU1FyzEpzzkp1zkn39626o1lSUlI0MzBxy0kxMjFyzUlBkkF0zkpElUPT02rW1mvz5Cnz86v25Sn29qv35yn35yxElUFClEI1NTWS9EqS9UkzMjG7pFm9pVq9plvDUVHEU1EzMzHV1WpTVFHW1mxUVFMzMTH05Cn05Sn05in09KtDlEKSSUH35ytRUVFRU1H9/Pz+/Pz29as0NDLpgNfdAAAAAXRSTlMAQObYZgAAALhJREFUeNrtkscOwyAUBE3HvXen996T//+zIOSrwefEcx7tvkUYAz8HAoI+nu9RWrt6z6ESqCv1x9KTmdq0U8FkJAJdYhp60iuECQFwOvublG+D5f76LFn9IJhA0Jlpvjn/LF4lg3dCqVC790Rxzm+V2x4MVdPN2eVY2AZKmGo7cvB5nlXTzAYJE54iMOU89LBlHSoXKF89yvlutCGq+9rh6zjAFhGehsacREGvbwFE/ao9T+8O/DNfFHMK+WY2qNUAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "496",
+    "id": 496,
+    "sortid": 496,
     "identifier": "servine",
     "name": "Servine",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAq1BMVEX///8yMzE2NjZxy0lyzEpzzkqltWM1NTVRU1FUVFExMTEzMzJBkkF0zkyS9UlCkkKmtWKmtmTM5orN5ovO54zO543s88vv987z5Cn05Sn35ykxMjFClEJDlEJSUlJSU1FTVFFTVFLDUVHEU1GTTEIzNDOUSkJyzUlzzUrt9Mvt9sujsmIyNDF1zkkzMTHu9szL5IrM5Iujs2Lu9MyS80lRUVE0MzD15imktWKGr6AJAAAAAXRSTlMAQObYZgAAANNJREFUeAHtk8fOxCAMhHHAkLJlN73n773393+yP6DNjchcI2Vulj6NZmxgqxYkLwydOFU+g5Ob5miMY+sLIDmOWjS32RmwbU4zYThZel9Pc4a3I/Qn7xBMqc1uDuQPW7y6uT92jbY7Ewj2haq82F6+XHxmkR50jMHa38uz16I4JqkEDZocCDO7/u7fZVfVP0zpZlN9G1seRi4QwIHbE069q8NvHez9vS/iiDj06DcIxFgCcZ0y6AXGphFBPiZpKmmOqbfzjyQKnR5kfu36E9iqBekfEp0MgGf1EzUAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "497",
+    "id": 497,
+    "sortid": 497,
     "identifier": "serperior",
     "name": "Serperior",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAtFBMVEX///8xMTGM3oxSrUKL3YoxMjEyMzJKc0lRq0FRrEJSU1FSVFJSq0JSrUNrpYyK24qL24s1NTU2NjaN3oqN3o3z5Cn7+/v///8xMjKL3Yxqo4pSUlK7u7v15ir35ylRUVFTU1Nqo4tJcUlKc0pKc0tLdEtTrUJUrUFSU1KTTEOUSkK6urozMTHDUVHFVFLLxELMxkPuzLs0MzD05ilspYz25iltpo1ycnL9/Pz9/v3+/v1SrEMb1y81AAAAAXRSTlMAQObYZgAAARhJREFUeNrtkkduwzAQRT3Dol6p4m7HTu+93v9eGY4hIAsS8M5Z+IEQJODpT5FGR/4JFezn1e3yeT/PJL7Q6k+5qjWaLq7QGkJFZ3hYgQ3VrlqhCCIhFGsFYj5mz2VuIqHA3kwnaMknLLoyhziGMj0ed1h3DX41V9efDaL2aEFkE6uub+5v756+308VuGch2ISu7/sGk1npzKxCxdNAKOLZx/z1srSqBnB82rrIxI54vi6zOKVX0kC56hdIqsSEvZM8/+F2HPBuNNysUxFQFzAlU2rPkqiFFXmR4hFZ9ECezAIerL2gRvziJpKIZ9uHcyFejO8DcT2ZSXx8M4i4WBpfIK9UWmNhkI7f44mGH2g87Nuv7hgdORi/NlYSGGSA0GEAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "498",
+    "id": 498,
+    "sortid": 498,
     "identifier": "tepig",
     "name": "Tepig",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTH3jCk2NjZRUVFUUlHOcyn0iykyMTE0MjA1NTV1Y0l1ZEmjWTGmWjDMcilSUlHziilxYkn2iyn3jSz8/Pz/1kJzY0r1iynTYkLWY0LsknkzMTFyYkpTUlG+vr7LcSl0ZEv700H7+/szMjD+1ELTYkFqLiK8AAAAAXRSTlMAQObYZgAAAKpJREFUeNrt0McKwzAMBuBI8c6eTffu+z9ihU2hl8g5h/wG48OHhpMtK0sKS2FrPIclkK6d4YsHA8EdDyde1mdy9PhEILQ1/PZK2dYUE/0CR85LIOPozBZ8jPlwvWtJcwoAzo15PfRYThn1nw0t+s61ffaoOsxYKPcdhnCQZIModYCyenEShEZFjdWlUhx0ojCimNAC3DqbcBIS12Bp/CuSVPxPF6m6ZY35AvnQCLntdCqKAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "499",
+    "id": 499,
+    "sortid": 499,
     "identifier": "pignite",
     "name": "Pignite",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAsVBMVEX///8xMTH3jCl5WWJ7WmN8WmL1iyk1NTVRUVFUUlE0NDQyMTE2NjZ6WWJ9W2LGlTHMcinOcynziilSUlJTUlH3jSz7+/v8/Pz+1EH/1kLExNNUVFH700EzMzOlWjH9/PumWjD0iynDw9N8WWLNdCtTU1HTQUHUQkLWQkLWQ0E2NjV9XGWjWTH2iin2iyn2jCulWjD3jSkzMTFUVFQ0MjD81EIzMjDExNQzMjHLcSn////pnlB/AAAAAXRSTlMAQObYZgAAAPZJREFUeAHt0UeOwzAMBdCQVpF7kYudnum99/sfbEjvaXg3GCAfkDZ5iPjpxTF/nATmORvE8zDDhM40gvFiPO3aiFjgwcF0i0B9biqtOPGUW2fKH9gZxPIDQIRVv+peU2J7lnUXiRDD5ebi6j5cPiKG3a2KJRjeGbw+vXxpG9Q+lQdN3GG/axDpaW16Glic8iYw5dN2u2s0DdkP+ZcE7Xp4Ru6RFg9cnJYqwZz+q+yHVVqUNZBzosyMLhiOO7fOC3NaR+I9P6ebIDgvQPtdMxwyWrpmJD1tT85qCBR9SKr0BiCWoR+AD1Rj5xmx7U+0mBV689/kmF8jMw+nHoIZQgAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "500",
+    "id": 500,
+    "sortid": 500,
     "identifier": "emboar",
     "name": "Emboar",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA21BMVEX///97a2tSUlIxMTHWa0L/xil8a2pUUlF6amozMTE1NTV8bWl9bW2lWjG9vb3OcynTakHTakLUa0LWbEH3jCn+xCkyMTH////7+/tRUVHOdCnOrilTUlE2NjZ9bGnWa0FUVFTWbUT1iyn1iyr19Cr2iyn29Cn29Sk0NDTMcin8/Pz9/Pv9/f3McirMqyozMjD8xCp5amr0iynMqylTU1GlWjB8bGnOdSzOqynOrSn3jSz39yn7wyl8a2mmWzC7u7t8bGy+vr7+xSn+/Pv+/fumWjD8xCnLcSk0NDDdVEIjAAAAAXRSTlMAQObYZgAAAVdJREFUeNrt0cVyw0AQBFAviJlNipk5zEz//0XpdTmXaFWlQ47ug0t2veqZkWvHVI9Z1flGNZv73Nil+6fDD6VOQMZq+YH7RrkjdOZtGjpgznxeCjWdrEb4IOn+azl02voADrUbJgaUHe205zYBo6dxRwuSqESa94+L2w5X03pv5LWDRJFDk30lzbceV8NR/H71sFUUJZK5fLf2EiX+6Mexd7GwyVY5oYEhv0RdCek4Tv8VdU1v/C0tJCTU6KcSJYpIpM3GFkkl7mlpE3p2iZsH6DvB6QFXKSvCeZZ14YYtWGR9rmOEWqg0MVkUDlsTa3hnkTWFgzQY+yvr2bSho/AGmViAWWaLrVnxNeKf4SrqRCuh88x9FlDI4vyQI9dwIdcoIdxoMDj5noz5XERzXYohEoc1X5ZdJpYAVkNK8RrlEeL3EYcRCZTtUc1hDzeb1ipJrHHM/+cHAd0e01JVjZIAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "501",
+    "id": 501,
+    "sortid": 501,
     "identifier": "oshawott",
     "name": "Oshawott",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAq1BMVEX///8xMTFSUlJSU1P7+/v///9SlJRRUVFRivtRkpIxMjQzMzNSkpJKa5xSzMRSzsZUVFSUUiG6y9u9zt6+zt40NDT8/Wv8/f/9/Pv9/v41NTVRi/1TU1QyMjJUlZNUzsR0dHR1dXU2NjWUpaWVVCQ2Nja7zNu7zNy8zNu8zd1Ry8O+pkJJaprLcSnOcylKapr8/PwxMjL8/f1Ka538/mxMbZ39/WpSzcUxMTLUVcsTAAAAAXRSTlMAQObYZgAAAKtJREFUeAHt0scOgzAMgGGcxOwBZUChe+89+v5P1lCkHjFnxH/+ZAtipXV15QDQiPX6GFkkXeoplk2HFBQ/9yxMwsm9FUxjcmAl1xYBF0GGscAotIjdx1OQxYJ0ykzCTTjfToivzoXPVuGAMSD/t+Zy5nrcvpYvVC/tt6re0IeD43zq4O6xf435Bf0zAY1EQo+XDOqcbhrJSOUgo49MYwT6T70XZtPTVVpY1xegow0XGsKodgAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "502",
+    "id": 502,
+    "sortid": 502,
     "identifier": "dewott",
     "name": "Dewott",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAulBMVEX///8xMTGE1u9ZssNatcaC0+yD0+yEhHNKe96CgnFMfNxSUlJSVFQyMjIyMzNKdI01NTVKdIz7+/tSU1MyW51RUVFRUlQxMzP85ZVZs8SD1O2D1O6D1e4xWpwxMjLOtWM0NDSDg3I2Njb8/P2F1OyT7v6Cg3NMe9yC1O0xMjNJcYpRUlJJcoxJedtJetyEhXQxWp1UVFQyWpuU7//LtGRKetvWY0LshGz75JJZs8VKe902NjX+5pP/55SKWxEWAAAAAXRSTlMAQObYZgAAAOJJREFUeNrt0LdyAzEMRdF9YNzEVc5h5ZxzDv//WwYrVQbVeNzozrA7AwyR7fuzDnZkMGEnZyob0gq4eNeLkHR5aYlId1cJ2Bna48coxxAZhpYYcreulhb37uPiWLWpUx+OrJlRBUhQjQ27qJvDVlrdqteXIwpGdAyRdVT30vJ52CUPNO1P+0CvlRkM6QU1q+wTosvdw9WMuIDU4mc/p8HyjCmPhyDfivngxt8tT1ydO1f/7tannpsUo3LjJHjtY0/rrygFl5dQWn/4yXfhzwHhOohPMfWjLZN8XqbcdvS+f+4HxIgP8bHZI0AAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "503",
+    "id": 503,
+    "sortid": 503,
     "identifier": "samurott",
     "name": "Samurott",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA6lBMVEX///8xMTFSUlLGtWvv3ow5Y5xKjM5RUlMzMzKUhEq+vrbEs2rFtGrs24ru3Ys2NjY1NTU0NDQyMjFTU1NUVFJUVFSLu8yMvc6NvcySg0ozMzE4YpoxMjNJistJi81Ki8zt3Io0MzNLjMzv3o38/Pz+7tT/79b////Dsmrt3Y3s24tLjM5Mjc5RUVGSgkkxMTKShEwyMjJSU1OVhUydQjm6urK7u7NTUlH7+/tTU1I6ZJxUUlJLissyMzPs3Izs3I15eXmVhUt6enp6e3x7e3vzYlH2ZFL77NN8fHt9fX39/f2KusuKu82KvM4XbYyaAAAAAXRSTlMAQObYZgAAAVdJREFUeAHt0Ndu8kAQBWBmd90Lpvfe+Ut6Qnrvyfu/TuYYRYoLCjdRbhiBGC3fnvE480O1qey67rG3GmeJIhDfFSnjHjFH6ylZJ8BVcmB6Jtv/luur666sLyclZDAdjffy5CmlpK9YKpMPW00iikHP9EaluRqNB1DSYsnwfcY/McmWCSAkPvnG20xVz4liW2MPFEPXR2Sxc6mqf3S9+QUuJjl2eLqicHx5LEQNUNd1bQsZEUkINBd/DSGGk1KtK/saK7CIPHiZlBz5cNoxmHFruRwbV0jkPzFJN5g9C8c6Qm4uk6iAiO73zzQ4m8NZ8dV5MSmB/wlxWGASMrsgHCnraW7avx3aT+VdsUzFQspMgy1jaBfKlUooc0SN9raLyIQLXxq9nmhtI1w4aGgXycjgStzsEBriG4hCi8OUtT9bntlVyoyephUkIr8tzLzD0LUohm7qF+sDf0clitvwBNkAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "504",
+    "id": 504,
+    "sortid": 504,
     "identifier": "patrat",
     "name": "Patrat",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAArlBMVEX///8xMTEyMjFSUlKrekKte0K9nHPvzq01NTXWnEL7+/uDYkI2NjZUUVHzSTj+yyn///+reUFTU1L9/f2+vrbTmkFUU1PVm0JTUlEzMjG9vbX0Sjnsy6u6urKsekLuzaxUVFSCYkFUU1EyMTGEY0K8m3I0NDS9nHT3TDhSUlG7mnKufEH8kov8/PwzMzPtzKs2NjVRUVHbs3q6mnHdtHretXv2TDr3SzrTmkI0MTHFYNH6AAAAAXRSTlMAQObYZgAAAMtJREFUeNrt0scSgjAQBmA2lQ7SFAEF7L23938x15OnAGfHP6dMvtlJdqP983PRoaOL027uxDhpr2lDfL0ZBlJodq63QYiyn+IOl8L1iOuwPkKsqdlmuZsrYJ5kDt0+vJoRDaHvK6GU8v5yvaVDAcwojEKF1HMxlkmGEEsei+Fwr2xOsRhLjJhOcNMj6i6apXX4uBEnjRAPB5RSa/XEdzc5lNVMiOBs1GxgTRonSNcCJW0bpA4AFxEwzjlRqy+uRm3uewPo/Hv/+bm8AZLPDPzOC1tWAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "505",
+    "id": 505,
+    "sortid": 505,
     "identifier": "watchog",
     "name": "Watchog",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABiVBMVEX///85OTnOc0o1NTUzMjHJcUk3NjXPdUr/zSrKcUnQdUg2NjYyMTFSUVFTUlJUU1JVUlF+fXyZUTmaUTibUjmcUjmdUzm5ubG8vLS9vbU2NTTMcUkzMzPMckrMc0vNckrNc0s3NTXPdEk0MzA3Nzfsy6vtzKvvzq33ZFH4+Pj6ySn7+/v8yin8yyr8/Pw4ODj5+fmaUjiaUjmbUjg0NDQ4NjadUjmdUzg4NzeeUzqeVTmeVjufVT25mXE0MjG6mXG6uLC6urK8nHO8nHQ2MzC9nXRRUFC+urK+vrZRUVFRUlHKcUrLcUnLckjLckk0MjLMckhSUlLMc0pSU1PNckk2NjXNc0pTU1POc0kxMTHOdEnOdUxUVFQ0MzFVU1LpyalWU1Hty6tWVVHtzKztzazuzKvuzazvzKxXVFHyY1H1YlH2ZlRXV1f3ZlN8enp+e3r6kYk0MzL6yin6+vr7yir7yyn7yyp/eXo3NjaZUjn8zSw3NzX9yin9+/v9/f3+zSn+zSr+/v6aUTm8wTgEAAAAAXRSTlMAQObYZgAAATFJREFUeAHt0UOXxEAUhuFbVUG607Ztj23btm0bv3xq9lOZ7HrTT87J6j1fLS6UVwVZUtmNbl6pSclQ9SzGnA7+8WKlGeXQ0VVCP4bGzDLGXruBx7gOSPa0UMt4N37kx96m44cZngOIZb/eZVboGQ7UX36mzqc4QCV3YfCmCH9BG/vmnZOJu9SFUUNLp6uLsQiorW8vaX4+Owg6dACk0wcsqNSzlUwmEi1WgYZjHDCF9R3x3e7mXBRomIkq3KXKtLCqv41woLyIeNPIwFvrd7D3d/16TeE0Net8KHQ4n4/SdavAfjqjFbcNxntJ2w5hDQdMRf5VkrSiKOYbOI3NA2yxwLg/9yFJEXv/kwBsJO16JJbJRey1CTIoQLJMf5bpFZsAKiCn2weqkHQRVEFzUHYVP2vYKl70qMgJAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "506",
+    "id": 506,
+    "sortid": 506,
     "identifier": "lillipup",
     "name": "Lillipup",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABEVBMVEX////31pQ1NTXWjFoxMTHVi1lSUlKpYlFUVFNVVFJWVFKrYlKvjkzPrmQ5OTkzMjH11JJTUlL31pU2NjZTU1LTi1k2NjX01JP11JNra4zUi1r005LJqWKsY1L21ZP31ZP7+/syMTE2NTU4NzXJqWFVU1M4NzbLqmHNrWNsa4rKqmKqY1LHPDPOrWPOrWQ3Nzc3Nzb11ZOtY1LOr2dVVVTPrmXSiVjSiVnSiljSilvTillWU1PUi1k4ODjUi1tqaovVi1oyMjLz05JRUlJtbIn1ZlP105H11JFtbIypYVBSUVD21JJSUVH31JSrYlH31ZQxMjKrikn315b315f6+vn7+/n7+/pTUlH8+/r8/Pz+/Pp4qQDpAAAAAXRSTlMAQObYZgAAAOdJREFUeAHtkMWWxCAQAOmGhCQkDGTcZ93d3d1d/v9Dlt07LOd5U+ei6G7SdwxAX2+74Oet04JXGO+D3ySyf8J4K4Lk0fxPqVNExtu6GR1Ruhy4xeOo1IQ4DE/E0N87m/d0AalS6TxEwhTtB5C9lQ5A1lGwI5jx7HNiLwfoQrY6o0MWlu1jLnw+w/tLV1WTg/rWmH0hfL07f/j4yrN447Q+RRmzBWXrbPam8pZDWipf7lPj2c2l6vfaXK2WNBqH7aLrkKPx9MTktd7dHOeMOJBFrodbi9ysIU3QrZI9glcjxAtZIf3HgB/48xWlK5RFSwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "507",
+    "id": 507,
+    "sortid": 507,
     "identifier": "herdier",
     "name": "Herdier",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABI1BMVEX///81NTVjc5yMUjHGe0rv1ow3NTU5OTlSUlNTUlFhcZlic5syMTFzjK0zMjHDeUnEekrFekkxMTHHpnPp0Yns04rt1Ivu1Yzv1os2NjY4NjbBeUljcptTU1Jxiqtyi6tUU1GKUTHt04qNVDJicZpicppSUlJhcJlhcZgyMjMxMjIzMjI4NzY5OThjc5szMzFRUVFRUlJyi6xSUlF5eXl8e3p+fXyJUTGJUjIzMzKLUTGLUjE1NTOMUzKNUzGNUzJSU1SOVDKOVTTBeElTUlAyMjLDo3HEeUnEekk2NTTEo3JUUlPFe0vFfEzFpHLFpHM2NTbGfUzGpXNUU1JUVFHq0Yrr0opUVFLs1IpVU1FVVFLu1ItVVVJWU1JWVFP6+vn8/PypkL/MAAAAAXRSTlMAQObYZgAAARhJREFUeNrt0sWOwzAQBmA7tsPMUE7bZWbGdpmZ9/2fYpW02ttUufXS/2DZ0qcZW2M0yjCDizpDLwwLOkoLSVy3JLu3s+0BbK5Oav5Gzoy8Mgag97LeYKn6fwNc6QDw/tP3UrJtEKKiwTBgaYO9vm8RS88cNwn1Dhlj11+5yyEgcfeDsdW2SfbU7NnzLcgtt89vVn7vKD2hekXTONEGOttl35n6uaJ0d6mqLWoc2Nl79kPmHO5Yl1I1YyLQW3CnsRt6gVNeaHF5RGA+Mwjx7rcbPMoK11TE5qx8C/+Kt0R6OqiNK/ty6eIBnjdvGnG0dkqPx0oTOLF0yAmJGWertXkWRQgfxQiUUa+u3j/0A9flUaEIGI0y/PwBMH0b6Ujc3ogAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "508",
+    "id": 508,
+    "sortid": 508,
     "identifier": "stoutland",
     "name": "Stoutland",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABa1BMVEX///81NTVSUlLk05rn1pxSY4QzMzJSYoMxMTFyi6SrckKtc0K1lVvMxKw2Njb///+rcUFTUlE4ODhRYoJUVFNUVFRWVlRqUkpxiaE5OTlTU1NUU1MyMjFSUlO2llzJwanKwarOxq3Px67h0Zn+/v3///5TU1Ll1Jrm1Ztyi6P7+/vm1ZxrUkpSY4MyMjIxMTL8/PxVVVTi0ZjLw6rn1ZtsUkltVEtSYoRxiaI4ODc0NDRzjKRzjKU1NjdTUlKrckNTUlOxkVnLw6vl1Js3NjVrUktrU0tWVVTn1p3o1575+PpSVFRXVVP9/f1SYoL//v1qU0trUkmqcUKqckPj0Zjj0prj05pVVVXl05lSU1Xi0ZlVVFM2NjU1NTRTYoLm1JrNxa1SU1JTU1TKwalTVFTKwqq1lFqzk1qyklk2NjRRYoO3lVu3ll3Oxq5UVFXPx6/i0plxiqP8/Pu2lVtyiqFUU1JtVUtTZIVTZYR1OQTFAAAAAXRSTlMAQObYZgAAAWxJREFUeAHt0kVv60AUBeAMjJkdZmZOHnMeMzOXmaE/vx5b2TTjqqoqdZMjWdeLT+cu7gQuPtOAszojeS4I/J1sCoL7RwewO6dAxFFmyElfSFsME2GOetmBwCYdgQlROIIw5gTjSlNyCwlhVsYQDj+sKGEII02B9tvUMSsLGCt/KygYkeSkTSAPeaYE9UfOZrxmvpdkkydeWBI8+ITx6nI99LEMx05sM1z/1e+lhW9DJV3u8dfG8PakBItfhng3XcVOgi1PsSE6+Bz8UUXYlbwLadoTDit3pXI/sUU7n/Jk4yuspSCsnZSxQmMUevfkfwuiBi5uxmFX10NdfZ2bOI6VSfx5Q1ZIKvvs+VvdzevSTdYNweMPP68fHYopp8tz+dGAY50wE5+Pi9u35l4US7StlM/1aCFDapoWvb+/9zK7U3RULjdQLf83fk+6Gv0+M6v+c5ylsdF4vxUV74CMqt7wZ95+56PzV+BSM80xh20vVDt3l3EAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "509",
+    "id": 509,
+    "sortid": 509,
     "identifier": "purrloin",
     "name": "Purrloin",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA4VBMVEX///+Ma7UyMTM1NTWNbLTvc5xaSqUxMTExMTKNa7Q3Nze6q4L/3q2LarSJabHeSoSNarT9/P05OTn93K2MbLRaSqQ2NjaKarK8q4T+3Kw2NTWMa7PbSYLcS4SMa7SJaLGJabA2NjgzMjWJabPvdJzvdZ38/fz93KyKabP93ay7q4SLa7SNbLWNbbZcSqS9rYRbS6VbSqK9rIQzMjTscZrtcpztc5xRUVGKarXU1dSNbLNbTKKLabLucpvuc5taSqJqumJru2RtvmWObLW5qYSLarOCgnGDg3KLa7WLbLP///9wqMPiAAAAAXRSTlMAQObYZgAAAONJREFUeAHtksVuxFAMRWP7wQsMTAYmZWZmZu7/f1DlRF32qpUqZZOzSqSjK99nR3XSIL/1xvzvIvGfRfEeiMcxcSmIB1OouOtapO6YCEwh0zcxKWoTo0A7YYio+3Q6c50Az5di35xYGzOs3Fs5HFB/2doOCFSz9/hBVNzaTpf1/wgsRts+rH7uuBDl7a3FH810wxDfX2xrabgneV3Lssy4oK8uS7MMmp+9DYOvBnEt1D3dM/uh/JpL0BrzdDD1TlydnOALKl4uz++G66MIk7c3D56vFiY1DSPzyQinfUeqVTsNX7lvD9YH1gUPAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "510",
+    "id": 510,
+    "sortid": 510,
     "identifier": "liepard",
     "name": "Liepard",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABKVBMVEX///8xMTGMa7U2NjbUs1rWtVrvc5yNbLOObbTQsFhaSqXVtFxcTKRZSaNVVVMyMTNaSqQzMjRaS6RbS6NbS6YzMzFdTaV0W66KarKLarQ0NDI1NTU2NjWaeUGbekKde0IxMTI3NjXUs1s5OTlSUlJTUlTwdZv93Fr+3Vz/3lpZSqOLarMyMjOMarSMarWMa7Q0MzONarRSUlONbLSOa7WObLWObbMyMTKPbbKZeUGZeUJVVFM1NDKce0FdS6WdfEO8vbzFQ3vGRHs4NzbQsVjSsljTslleTaRrvWPVtFnVtFpsumNxWavXtFzeTITfTYTtcpvtc5rtc5ztdZzuc53udJtzWqzvdZvvdZ1zWq352lv72lr821v83Fr8+vp0Wqz+3VpZSaR1Wq1P/o7SAAAAAXRSTlMAQObYZgAAAUJJREFUeNrtkMVuw1AQRd88smMIs5PGTYNlZmZm5vb/P6KvtZKFPVZXlbrIkbyxj++9GtLjz3EAQj4QH9lCDPXyMX9gnmImKNEXSDERJPWaOtOyLtgFxByXuXTaVZrq8zz1jx1cCY0cVcSOvRBPVLuDYnuWaoWJGSnf5kjXRMRhc0p/nr+UknaG2mqHenzAKqWtk6t7eX27DD/j6CQoPXjExufI9Pn+utSjj4kE7Gq0qhkuCTLwcnpzBkevG83Wnk5NoVH6gIqE8af23cVmNDo2KvRvy6iKDEFNxnll5b1ZHzJNw7Jqg9WUisRVKB+u1a0PI2lxzuIqM0Nw+neESJqWUeOMqQY7rBwilQW+ZKTijuNdYvEAFx0oA+OWgO6LSCakepuRouhj3ZsxElK9RUBwRn6jVCKkiHgYgHn41UmP/8EX5Z4d787XUZUAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "511",
+    "id": 511,
+    "sortid": 511,
     "identifier": "pansage",
     "name": "Pansage",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAolBMVEX///8xMTExMjExMzE2NjY4w1k5mlI5xlpRU1JSUlI5xVk5nFI8xlo8xlxUVFJ754zGpVr73Yv7+/v/3ow5m1FBdEL824s6xlpUU1IzMzHmxWp55Ip55Yt55ot65ItBcUHDo1nnxmtCckJEdEIzMjE8nVI4mlH8/PxSVFL/3o3kw2rkxGpRUlFBc0L724o1NTU5xFn7/vxTU1I8nVTEo1lRUVH7bfnTAAAAAXRSTlMAQObYZgAAANdJREFUeNrt0skSgjAQBFCTCCGALCKIuOK+7/7/r9nxwI2JN8sqGo6vplOTtJr8Pm3GvlNrVwpmdJZMrxIRZhj7sS9lyg0QvRLWQ71BvuY9WLL8wvBbII6yXelx4njiU6ypzVl96XBra1f1EnDT0ehTzgg47fFuR96A9SoFtRoHI0X34bnjsE+WnxM/Dja71SjUkJY6waSP5jY+Yt1ZkkR328FKLWGJerjPlVLPIlrqy/Q49cpmRZmrQzlYnzijLxtyccwCBkY6TMK7qKZR5cDV6cy4yb/kDTdrDj1QUHiyAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "190"
+    "gender_rate": 1,
+    "rarity": 190
   },
   {
-    "id": "512",
+    "id": 512,
+    "sortid": 512,
     "identifier": "simisage",
     "name": "Simisage",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAyVBMVEX///8xMTExMzE2NjY5nFI5xFk1NTU5xVk5xlpRU1I5mlI4mlE6xlo7xVpBdEIxMjFS3mtUVFR754zGpVrnxmv+/fz/3oz////724pR22o0MzKNdDLDo1k8xlrGplxSUlI8xlz73Yv7+/v7/fz824v8/Pw4w1l55Ip55otRUVH8/v2+vr47xVvDpFnDpVrFpFk7xlpR3Wrkw2pSUlEzMjH73Is7nFJTU1JUVFL7/vxBcUEzMzFCc0L93Ir+3Yt65ItEdUT/3o2KczGlb/ckAAAAAXRSTlMAQObYZgAAAQRJREFUeAHt08V6wzAQBOCsWGZ2mCFlZu77P1Q3zVWW1UNvmfOfmW+dTx3nHELB0fUS4gRFL3GSdH2VJIo4Lf8FonSZVu1QAKzVLlHcUqe0dzdql3QTKL0czZBGnNiWN1mgPakwTLLYWpkdf3J0T1M8CMAi/cX4XrJFXU81R9v819NuVeVlfXLK5DYLCN6HzWY4eKv686883GYI4YhjMzG45xgrd3n82BdGryZIr4vL6PvivRrcrFKA319y0zTKF5ink8kKryH76xq+kuiIYTku69STuCgAXWPoMMc8eHIGjNmcz87C85DpZVFYP3k3vwXwGcI+tL9CitS8aip2f96H/FN+AD/KE/2gQvboAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "75"
+    "gender_rate": 1,
+    "rarity": 75
   },
   {
-    "id": "513",
+    "id": 513,
+    "sortid": 513,
     "identifier": "pansear",
     "name": "Pansear",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAtFBMVEX///8xMTH3Y1I0MTGUOTmVOTnOSkr2YlEzMTEyMTHGpVo2NjY1NTXLSUnNSUlRUVHzYlH1YlFSUlL3Y1FTUVH8/Pz/3oy6urL+3YuSOTnnxmvDo1lUVFIzMzH3ZFH/vTFTU1JUU1L/3o32ZFOMczGNdDHNS0rNS0uSODhSUlHkw2r3ZVT7iin724r824vMSkr9ujGVOzrOTEuVOjjkxGrmxWr+uzHEo1n/jCnFpFkyMjGLcjFcSPFBAAAAAXRSTlMAQObYZgAAANRJREFUeNrt08cOgzAQBFDWNrYhNBMgvffe+///V5bcs3CNlDn49DSMZGP981OpQEkW8TIKfMV4sYuYFAZhsWPMNkxqSnlgedHHIaTb+DxQDCOFQ8F11Ta2MNgpAqkpeEKUK4WnA99h2HBqIyaRfXby79JP0hXjtZmyzbXX5cTHN249a6fDo9j37lVuVQiZ5XGnWIiOuEkvvNUztx/vNKCjZi4Hcfx6uONnPllRM6F1aU4W52YHfGwlgkVSimR7CLRV4IQTNgINUOJ1Y6ku/Sv88yt5A3FwDRNm6MLiAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "190"
+    "gender_rate": 1,
+    "rarity": 190
   },
   {
-    "id": "514",
+    "id": 514,
+    "sortid": 514,
     "identifier": "simisear",
     "name": "Simisear",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAwFBMVEX///8xMTHOSko2NjZSUlJUUlKUOTk0MTHzYlH3Y1L2YlHGpVqVOTm+vrY0MzLLSUnNSUlTUVE1NTUzMTH3ZFL+3Yv/vTH/3ozMSkr0YlL9/f1TU1P1YlG7u7P2ZFKSODi9vbP724r8/PzNS0v+uzEzMzP+/PznxmvEo1n////Do1lRUVHFo1nGo1kzMjGVOzi6urJUU1FUVFL7+/v824s0NDTOS0n+iynOS0rOTEzkw2r/vDDmxWrmxWz/3o3nxGrDLeS9AAAAAXRSTlMAQObYZgAAASRJREFUeNrt08dyg0AMBmBvZbWA6dW92+m9J37/t4o2HHLIEnPzxZqBA3zzr8SI3qmOXYx0ZAqcw6rHFHRxyiENZAccUBlqAOTOf81hmjf0hgB4tUOGKtSGUYm3dhmrZX4dlVJKDP2FsSXx+f221GCKavAiYj4nUcQixWilUBkseNVMb5uKnc8fZ0Xq3Cy0qJZ5/pSY8cAmZ4WbFf37rxSMo9FPJ9bIbVYUiFNRUkqTgCK09EgCLfjWdbM7PhpwnIWhdCznpkDX/oBzPvdrf2UeBTKkyR8Zn2X9YO1/Tuvdzl9gVIxOhol1D9nk4mOzmdavUQUOMYHUvpzY1eV4/0KjB3cMAiVpcW/uFSFkEkqUWb9915s32ADOYMmyJ3f+v0517PoGeiQUWchuoA0AAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "75"
+    "gender_rate": 1,
+    "rarity": 75
   },
   {
-    "id": "515",
+    "id": 515,
+    "sortid": 515,
     "identifier": "panpour",
     "name": "Panpour",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAUVBMVEX///8xMTFSUlJSpeeExv/GpVrnxmv/3oy93v9KhL3///+Cw/syMzSDxf5Khb5RUVGDxP1RpOY2NjZSU1SMczFKg7uDxPy9vbWEhHNRUlMxMjPp7aRDAAAAAXRSTlMAQObYZgAAALdJREFUeNrt0ssOAjEIBVAvUGjHeY/v//9QqTHGFXVnTLxh0cUJlKa7f76bFV6fsL30Xmi5vYwLDzxI34Ju2NOW00nG2cthHEzH60k2IETYgcvCGyFuJgLxVHsLYSZ5pQ9h6Z4sviSISUw612UOeyJ1ZkJnYck5Hm7JrLuYu9zYRytVzsJovDepJqJCD7ciaFmcsSaXQDQeKMyJ1KweXEa71+lGCWAgcgcckqKa9tdQfScx/udncgeEDwYpSDz8sAAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "190"
+    "gender_rate": 1,
+    "rarity": 190
   },
   {
-    "id": "516",
+    "id": 516,
+    "sortid": 516,
     "identifier": "simipour",
     "name": "Simipour",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///+Exv9SUlJSpecxMTH/3ozGpVqMczFSU1TnxmtKhL3///8zNDUxMjNRpOaCw/uDxf6Exf2DxP293v82NjZKg7syMzSFx/+EhHNSpOVKhb5TVFWGx/6Gx/9VVVW72/y83v+9vbVVp+hJgrqDxPz9/f3+/v5SVFVSo+QK8AkgAAAAAXRSTlMAQObYZgAAAOpJREFUeNrt0tdOAzEQheGcKW7b0+iEDu//hIwDd2HMJULKL+3Fyp/c5NW5P24rVlP0vVT1PDLz0KCCi6WfcD1yIvrgoQE3BIvLGkgNub16ICwLeAaqNOhKwvsNvkrtxcuTGdvhXGUTvsK6S7s10m4QH4b7W0X3BnpBsm/vOdZONdAjCJwOmwaMGlT1MhPInHvtQoWyajbHxHxcXBwZIlkRBSIycRnn/Y9QQ+Gu40CArATgUgZnm0AHlEzy/edduxAAQsxRRAJkck8eCBKpqFIIUp+d47KNVi2/vd7jqMkT5E2sJ9Kd+Ny/6RNzkwnXmzy+MgAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "75"
+    "gender_rate": 1,
+    "rarity": 75
   },
   {
-    "id": "517",
+    "id": 517,
+    "sortid": 517,
     "identifier": "munna",
     "name": "Munna",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAaVBMVEX/////vc7vjKU0MzM1NTU2NjYxMTEyMTPla3zna3tUUlP+u8z9u858Q83siqMzMjL7usula++ma+3/1ufti6Z7Qs6+Q0SmbO7kanmKWWr70+T9u8ukau7WU1Psi6P/vs7/1ebti6T//f6ybtpxAAAAAXRSTlMAQObYZgAAAH5JREFUeNrt0TkSgCAMQFEDCu77vuv9D2liY5d4AH5D8yYDwXO55AKDycw3JQAMVqIBMnRhVFvBnQ3BKqxTzcK5QUgyBc0PhC/NQfgJxwTBfQClCg5GKPuFLtly0M8Jbsn7bCutUWHZWnXCInMV7yo201WIP00ID0+MkMv1pwdyMQWJksy7hgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "518",
+    "id": 518,
+    "sortid": 518,
     "identifier": "musharna",
     "name": "Musharna",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAeFBMVEX///8xMTHvlJQ2NjY0MjL7eZr/e5xUU1OUUt5SUlJUUlMyMTM1NTX8epr9epv/vb2NWoT9u72MWoT/u7z9u7x7Qs77urqjauyla++ma+3+vLymbO7skpJ6Qsw0MzOSUtszMjJ9Qs38u7t9Q82kau7/fJyKWYJTUlS8eLbeAAAAAXRSTlMAQObYZgAAAOJJREFUeNrt08cOgzAQBNC4gk0PIb3X///DDF4U5cBCbskhIwsJ6WnWsmHyz09EiY9YKozVYqxKTJSxbTReeGYATKvaUiyG3XNb5qGN5vfCMLGcwnnnnBC0jZ6kYaIBWyyROCHVB2n/YJQmYaQyGg+4MZkCpotqUxWbTiZ8o5oXiFzLFV+pcDZ6uy4orYwZaMrcn4sXjOMGsM/Zd3i5Lh87BuJOPI2+1dFhAFokVEZZHWXWZyc4TlLlfh6g1ezN4K5nAcrICbppdngJiUgx/NEaOkopCQ5ZrK2Ux86N/w7/fDtPmfEREXRUYG8AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "519",
+    "id": 519,
+    "sortid": 519,
     "identifier": "pidove",
     "name": "Pidove",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAJFBMVEUAAAD///8xMTFSUlJqYlKDg4OkpKS9vb3uc5z/tKT/vSn///+otJgMAAAAAnRSTlMAAHaTzTgAAACLSURBVHja7dM5EgMhDERR3FJLLPe/r3uKSS0c2/MVkLxEULTXlz3wt2C7A/ZZQwBpOEKpjJA8QDCvGEeYOzmggBg3JGAl7GPkEgwjCwj33qfPjCDN8RnCLCamnJk7qmVWhFwY6WglzCVrTrJeJpcSdKK+R0hm0Ayntxal8fiEm3bNGSporp5f+J/wDW1hCJFKwXNSAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "520",
+    "id": 520,
+    "sortid": 520,
     "identifier": "tranquill",
     "name": "Tranquill",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAk1BMVEX///82NjZSUlJqampra2sxMTGMlJzO3t7WUlo1NTVsampsbGyKkpqzs8y1tc7M29vO29tRUVEzMzPTUVmNlZ1SU1Pz8yk0MzLUUlr7sqP8s6P+xjj+xjv//vvzkimLk5uLkprWVFnscZpUVFRta2vVVFzN3d339yk0MjDO3dvO3ttTVFTL29syMjIzMjLvc5zvdJxPXHPMAAAAAXRSTlMAQObYZgAAAMJJREFUeNrt0skSwiAQBFAZpiGriYka933f///rJFw8gVytsrm+mgKmO//8TAQCnQyHQACDJAqYGUtmpu9OGPeRAnC5OhlFUcJsgeg5R8d1FJV6nzBgb+GEYrgu9Wy+lQQgU+x2x+m5Gl6ukpkkL+/OpyxOMj9o67x/ZHYnbrqFVHRTIniocX01oELrlPPUC7tKqUFhHOeVi1nZV62UfmcSZ8pKAvxus0Nm2Or+rRSAWd3k9XyEFHLcjJuw6przz+/kDfNKCYVQuYpgAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "521",
+    "id": 521,
+    "sortid": 521,
     "identifier": "unfezant-male",
     "name": "Unfezant",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAnFBMVEX///8xMTFqampSUlIzMjJra2uSo6vne602NzcyMjJSnFJra2xsbGxTUVKTpKu9SoTkeavkeqvmeqxUUlNSU1KUpa339ym1ZBK9u7xSmlJRUVFRmlEzMTKUpKrnfa7z8yn29Su9vb38/Pt1RBC+TIXEmypSm1LGnSlsa2y2ZRDmeqq6SYLme6q7SoO7u7u8vLwxMjG9S4RtbWn9/PtkbYEmAAAAAXRSTlMAQObYZgAAAOVJREFUeNrt00cOwjAQBVDGlfRGAiT03uv974btgGBjOxvEhpHi1cvXH0tu/ecr04aGLuakmYuilIhYsMIMI4CYRwNbYICOKZdDbIGJRDKUmGHCe9NrKmisqhpgr3tfyH1iAohq4Xh9mMxnI6L+YR4FnSuK7Y7zDdRrhZ4W3pbD3KOUAugDlSyZchQnUcByR+v2gYipYYb7F70bgITKnXxRVFcRxIeebuqHDtJ2VHDVSTJ29mkolzHIyu1gJJDNIdx3XWkpNjomikElJABYHkJbnlB+MGOB8H3b5gLMeUVaC/znx/MAS3cNT8nWFMQAAAAASUVORK5CYII=",
-    "gender_rate": "0",
-    "rarity": "45"
+    "gender_rate": 0,
+    "rarity": 45
   },
   {
-    "id": "522",
+    "id": 522,
+    "sortid": 522,
     "identifier": "blitzle",
     "name": "Blitzle",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAYFBMVEX///8xMTFSUlJra2tRUVE1NTVqamo2Nja7u7v///80NDRsbGxtbWltbW1yq8y6urpUVFS9vb38/Pz9/f0zMzNTU1NRUlO+vr7MpCrz8yn09Cr09Sv7+/shi7tSU1Nsa2kxvkiDAAAAAXRSTlMAQObYZgAAALdJREFUeNrtk8cSxCAMQ1c2NY207e3//3LNcg5wyyUaH9/IWCNOh3aVRR2nX02loYAaNZxvENYq0PduWlHB+euZ3FoEx3mk94WKjlBzT8MHxaSsIcNkCCmATIyG+dExQzKKAWwbMvPw7BgILc2+2QSVbMa9c1MrI8dnwduX2bVxkDsbStYnJcPcM93SR27Kg2HxXjiCYWRBJWcwC2QL5dAKyUybrOPfyBqUux4hW1VJJLj2hx3aXT80nQdMjRnr+gAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "523",
+    "id": 523,
+    "sortid": 523,
     "identifier": "zebstrika",
     "name": "Zebstrika",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAclBMVEX///8xMTFra2s1NTU2NjZSUlJqamo0NDRsbGxtbW27u7O+vrb7+/v8/Pz///9TU1P9/f1UVFQhirowMjNsbGm6urIzMzNRUVEhi7tSU1QZW3wZWnq9vbK9vbVpzNXaswncswnz9Co2NjVqy9MxMzNrzNQ8/myiAAAAAXRSTlMAQObYZgAAAQVJREFUeNrtj8dyw0AMQ0Vqe9FKttN7+/9fDOg9hhtdcsjBGA1HEt+AwHTRX8vg2YdoMsVT8bvg4Uhls3Uf/Liry1YXP830OzkX4ZbFH479m0YglWhrbrfPn9LpfZzWOK6RrbVVOpUlEpHq6IClwBY5CyLkFTH0jJEf3h5DamnNDcZpHXA5fN2/nJjluuO0bq56DbzB9vWEgeMRXDxHnYwGihUgrjkwJiiU8j9IoqsgvaFOX0tBrZDBbxBQag6TSNorpIEjzBCPEVWaGAdf3RGWQBtiPIHoGTWytyGSdxmE1jpILgWmcw44joQliiYQ3XGkvpw7YcYcGJKh39Rt99VvXvQv9A3elwu+E3qptAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "524",
+    "id": 524,
+    "sortid": 524,
     "identifier": "roggenrola",
     "name": "Roggenrola",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAclBMVEX///8xMTE2NjY5SoR7lNYyMjFZarRaa7U4SYKlc0o7S4I1NTUxMTNba7JcbbKjcUk0NDDDigjDiglRUVFTUlB5ktMxMTLEiwnEiwqjckozMjF5ktR6k9VZarI6S4XGjQjbmlnenFrz8yn09Cr09Cv39ynedlueAAAAAXRSTlMAQObYZgAAAHpJREFUeAHt0jcawkAQQ2HEZq8NJucM978iQ0Mr1eBXTPV/qmb0ew2NIbrrba/CEjRYDIpShHkXILi68snFVtg7eG90zeG8O/pzTC1xp+1y07hokww+e8y65CjMjx73CYcf+bo01Fk1O4vDOi0BWEB4MtgxTeWX/21DbwrpBUTbikohAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "525",
+    "id": 525,
+    "sortid": 525,
     "identifier": "boldore",
     "name": "Boldore",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAkFBMVEX///8xMTE5SoR7lNY8SoJZarRaa7V5ktN6k9U2NjY1NTX9akFSU1RZarIzMTExMTM4SYJ6ktM0MTGyODG2OTH7akH7akNRUVL/a0J5ktQzMjHz8yk5SoNSUlNcbbJZarM6S4WzOTKzOTO0OjM7TIK7pEO7pEQxMTL09Cn09CoyMjM6SYL8akL8a0RbarJ8ldP9NS7BAAAAAXRSTlMAQObYZgAAAOtJREFUeAHt07eagzAQBGDvLqyECYggg/PlHN7/7W58odNhlS6YhubXMB9hMecCsqRIZ7SOaouCmR9bIwo53QaYDI0C0pk2l+oecP82thOwy/sPWzQC+95XU7fuXtdSNAo4tTIjx2u0HeFEBDMp7IwURysPm/IE1epNHty5NCLFjtP7TVlvP0XV3uZ9FS5UHnbMz4d6e7AicnUdcIAuZcBVwsPTHaf2dIwoLJkf/ZjwX4ZG5CUEfV9Rl7fkE0bvD9Q6JLsKj+j7AF4RkZF/INTvhWAXWWkVYyK+3MwFXFC7FYqjpG/jf505F58v8AwOAnFQcJUAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "526",
+    "id": 526,
+    "sortid": 526,
     "identifier": "gigalith",
     "name": "Gigalith",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAw1BMVEX///8xMTE1NTVaa7V7lNa2OTFSU1R6ktM5SoRRUVJSUlJSUlMzMTFTUVFUUlFZarM0MTFcarN5ktMxMTI2Nja1OTE5SoPbUTjbUjneUjn7akE4SYL8akKyODGzOTGzOTM7SoJca7O2OzBZarIxMTPbUjrcUzvdUTh6k9X09Ct7ktN8ktP8a0P9akH+akH/a0L7akO0OjNbarLz8ylTU1P19Ck0NDC7u7u8o0EyMjP8a0Q6S4WzOTL+bUFTU1H39ylcbbIa56j9AAAAAXRSTlMAQObYZgAAAUZJREFUeNrt0ueOwyAMAOA6QCbZO23TvcftPd//qc4gnSo1qKlO97OWIoj4hDGmc4m/RALnoSTnZ7gqOBtCnvL2vFWZukUb1CDSe2xNnJqfdpVnCEjJoAXm4fK13FBKX05fkdZ/GO9wQ6r3TleO8LFi65vnz4Kr4CFNMll9jLbB3Th1xRWpL08O+WYerr6+B67vFGqY7wM5hLOQEOL4+NVK2F940NEi3Zh7duEZAoO6DNcgU5jgukHnEpJpR1PYJKK6nZnXVyOy1A1KBYQqaHROwqf77H2xvxotKULTtHolb7QuiHDJsjOrThel55sYuDtrQkz4ZpoxdFG6mXSWPxvGDchuCTo8ateypYtB5IiPGq7l+ASHAuJCVyh5aCFlPQcIUDEOv90UE+mIo6gHjv4x85a1PnW5pV7vGO8jbJOAIYq5xD/GDz/RGnV3XTNSAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "527",
+    "id": 527,
+    "sortid": 527,
     "identifier": "woobat",
     "name": "Woobat",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAh1BMVEX///8xMTFzrec1NTU2NjZSUlJqampra2tyrOYyMzRSU1RTVFRae7VcerQyMjIyMjNtbGtyq+RRUVExMjOCgoKDg4OEhISj2/uj2/yk3f6l3v+9Y3PscZpZebJSUlNberOk3Px0q+V1reW6YnG7zMxrbGy9ZHRbfLbscpv8s6P8s6T+s6T/taXD0P4EAAAAAXRSTlMAQObYZgAAAKdJREFUeNrtkkcSwyAMRZEAgXvvTu/l/udLcLLFYR+/nWae/owKW/hXBDhqZezkUVXHDuGClFIATHxLazonIClbr/FgKss6tg4iGuz6HjvPtKnKFvn2+g+YACllN8VKd5MYSONZdyDGx3NvTDwpCQTWwUV+S+/pNmgv2gfGjWUTJV2jdeZniAmbgx+GjUaD8WbN/Hgedohh8fvaY6TDwuU1OACwhQUXXnrxCOg0Vs8xAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "528",
+    "id": 528,
+    "sortid": 528,
     "identifier": "swoobat",
     "name": "Swoobat",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAsVBMVEX///8xMTE2NjZSUlJrjP+l3v81NTVLbK5RUlMzMjJSUlRTVFRUUlNqamrvdJxra2syMzRyq+RzreeDg4OEhISj2/uj2/xKaqvscZpqi/1KbK1RUVE0MzKCgoIyMjJqivtKa6xKa61Ka65xq+TscppSU1T+s6Rti/1tjf8yMjOj3P2k3P+k3f77sqNJaqu+vr5yq+ZrbGxMba5sjP37+/v8s6P8s6X8/Pz8/f/9tKSDg4R/dmwgAAAAAXRSTlMAQObYZgAAAPdJREFUeNrt0MeSwjAQBFANCs5RjuS8sDmn//+wbWy4WV6uVNHli0vPPRqzay4jAzoTqsn03ErI/6txHOhsevyAetxMuIEGbGRERrcaLuqjBMzQbYC59Tys3ROMIt0t0TG/tVBJ7YsZ5tL6zea1y6mBJqkeayHuJCqLmKlmME064ftOCLHEOkm6x8pQnX9z8DCeiTZukb4cphtWHq234c330xtgsmmaTFDzj9DB/KVdyBhXIQOsfP0T+l+vCziPmKq2426Jk4OzeZFuSpsq3zhe0YhzntxL6ZWfoYNGo1wBgfHSXjtM9S1EeZx7FBC1qE82D7vmgvIHYD0SrZX1r3MAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "529",
+    "id": 529,
+    "sortid": 529,
     "identifier": "drilbur",
     "name": "Drilbur",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAh1BMVEX///8xMTFSUlI1NTWMe2tyg9tzhN5rY1K+vr79/f2LemoyMjH///9RUVE0NDRqYlH7+/uKeWqNfW0xMTNSUlT8/Pxzg9xrY1S2VG26urq7u7tqYlI2NjWLe2z+/P2zUmpUVFS9u7zvdJz7sqNSarvucpv9/Py8u7tSa71TU1NTbL02NjaMfGxzxWgdAAAAAXRSTlMAQObYZgAAALhJREFUeNrtzscOgzAQRVHGGDdMb0lI7wn5/+/LWIgdxqwTnuTd0R17y35vPsAc1kFGaQhulyhqFjoh9sw4ONxa5nROsku1FlJ8XEl0uDjNHcnt5bw3RY2QXwtr048Ot5PUq8erVbRmOw42mB4JAYhIwMqA7Wj9LCxOvPGcnwQMITrWgAXG4PWu4URRzjcyHoXQfzRAx0mLTAxwlGccAKtlJaYhhk2WEFJNukEnKoTs7oama96yv9wX+bIJ2HcxlqMAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "530",
+    "id": 530,
+    "sortid": 530,
     "identifier": "excadrill",
     "name": "Excadrill",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAArlBMVEX///8xMTEzMzNSUlFSUlJTU1NyUkJzUkKMjJS9vb01NTVSUlMyMTGScmqTcmqUc2u7WVm8vLy9Wlrk5OTm5ubn5+f///82NjZxUUGKipK8u7tUUlKNjZWScWq+XFy+vr7TanLWa3NTUlKDYlGEY1Lvc5y6urq9u7v7+/syMjF0UkJ0U0MyMjLVbHRUUlNVVVW7u7u8WlnscpqMi5MzMTL8mrv8/Pz9/Pz+/P1RUVG2fonOAAAAAXRSTlMAQObYZgAAARxJREFUeNrt0kduw0AMBVBz+qj3yL3b6b3e/2IhpWwCaZx45Y0/IKg9UCShwTmnzMV/Xc6OgB4A/OmsBJjG8SY4RL3BQ25NamUYE3W7nO3I2Vbq4AAcEit+5JWzPypXlCXaGx7GGx24YKuML9SjVMm15tDvynLiC0z4Mcv2d8ux4otX6IEAX0JpHo7YZTXHsmGsef/6vZ0x/nuFma2EinCckWVYoOOGJpXP289qLqkyuhd8AJ2iHq1Gvm3vBTLNEx3hDgweHZhbBtQnjptkq8VybCkmZZ1tA51qrtDhaoQgV+C24Dek21aSw7Lrhhbl5LZ38qkOao09qvVTJgDAJT0APOoGavoIUeb+j2goQa6hdOG2deR8323inJPmG8tLFK0ojXeiAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "531",
+    "id": 531,
+    "sortid": 531,
     "identifier": "audino",
     "name": "Audino",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAw1BMVEX/////pbUxMTFUU1P3zpRSUlL/77XTq2r77LKuc3s0MzPWrWvWrmzehJRUUlP7o7L/prX8o7P87LP9pLT+7bP+7rRUVFP/vM3/vc7/7bU2Njb0zJL+pLT+vM397bS7u7tUU1I8fM00MjMzMjHzy5L9pbarcXk1NTX/prY0MzL7pLWudHv7/P5TUlK9vb38/PwzMzPT29vV3d07e8z+pbQ0NDTW3t7bgpLdg5NRUVHehZSarP6drv/2zZP3zZT//f3///9j6HNyAAAAAXRSTlMAQObYZgAAAQRJREFUeNrt0cV2xDAMBdBKhjBzMoxlZpr+/1fVds7pTunsZjNvff0s2SfHHDYt4n7uZQyLPWwbgfM6rpUdZhgBS6q6rgEWA25ry5glAJVywBCHpP9weQo6TlbRpa01E+n8HCAYGRyEhLPLjqVSxrD7XBvJKChdtHkh5fxjHYyaGBqXWlpr/0vR2Jn4uZTSpbbBSF2uczEprZyfkVvH0EP+HqalQPp9IpY0GqoDVu7nLi03WWMcAOsKtRxd2Rc6mZJC3Pw8UXBVmBEfnauUM+Po/+5nDEIxvX++peFbV/QSvtnd9QC0vCWuuI43mypHS9S1wvLUAaTZ36TcW/6rjFRtxxw2v05QFEIkNAKPAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "532",
+    "id": 532,
+    "sortid": 532,
     "identifier": "timburr",
     "name": "Timburr",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAk1BMVEX///8xMTFSUlLezrW1hFK7o4O9pYTGWnPdzbQzMzP+epPGW3SMY1Lby7K6o4JRUVEzMTI1NTVTU1LczLNUU1OLYlKNdFsyMTHbzLM2NjbdzLPFW3NTUlKNZFJ7e3u6uro0MjJ8fHy+poWNdVy8o4O8pIM2NjXbsmozMjKKYlGyglHetWvEWXL7+/v8epL8/PyKcVnU2ysuAAAAAXRSTlMAQObYZgAAANVJREFUeNrt0kcOwjAQBVBmxi09JKTQe6/3Px3GssQicsIWxJdX1pPH/nLvn2/JEAA6UV+jiIg86HAa2XjtUxuwTZa5XoG/MBs7cA1PsKZyO5YyNa86olPGqsT7OhcHiEVWhGHlgo+cvOtKiIwbp6FzeE1aZTc5wSKswNnjfDlD5GNfjogG4FInxiaIxUYY6Cipv2eMhSbIs4sv08ie2IDnqXVY0wBBj+i1wAog4YooSBviLadavaoUigJftkiwBXGhAjnyPvlssbJP7rRRw7mv8c+v5Qk/MQzNmpPTiwAAAABJRU5ErkJggg==",
-    "gender_rate": "2",
-    "rarity": "180"
+    "gender_rate": 2,
+    "rarity": 180
   },
   {
-    "id": "533",
+    "id": 533,
+    "sortid": 533,
     "identifier": "gurdurr",
     "name": "Gurdurr",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAwFBMVEX///8xMTHezrWMe3NTU1JSUlK9UpS9pYTec8Y2NjaNfHS6UZK6o4K7o4O9o4SLOTnbcsTczLOMOTnedMUzMjNUU1O8pIOKODi9U5MyMjJRUVHGUkrbccMyMTHbzLNTUlMzMzNUUlPezLU1NTX///80MTHezraMOjqMenPEUkrFUUlSUVGNOTkzMTLby7KjQWrcc8RUVFTdzLTdzbRTUlGKeXG8UZO8o4IzMjLzamL1amL2amL3a2P7+/v9+/uLenLQ1c7mAAAAAXRSTlMAQObYZgAAAPhJREFUeNrt08VyxDAMBuDIMsTZcLJMXSgzc/f936pKLwVnXB3a2/7nbyzwKNjmb2OB51aPL7sALEfhWNs/eubYVb+kcKwF4Fo7UirjWBvLWZdhbSeVybUQP607TmyMnAnKV3tSTt3K5uNF8c0eK2jrMcFCREWEBUnqF0Yqm7Y0eX43T/bLexy+7pETYqfZWdA2jZ5nT+Pybb2+VOSq2jWf8nB8kxip8qWowtrzO5OF2iCqPNRXVNkTO2meWuRhqPWpz3UOiipcii7J2ufiQdqsJkJF43qhMdgzeOGWdSVloFPz8JsEgDNhEIesc7ztSWBeLgTb/FPeAUXpHehViv0OAAAAAElFTkSuQmCC",
-    "gender_rate": "2",
-    "rarity": "90"
+    "gender_rate": 2,
+    "rarity": 90
   },
   {
-    "id": "534",
+    "id": 534,
+    "sortid": 534,
     "identifier": "conkeldurr",
     "name": "Conkeldurr",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAxlBMVEX///8xMTFTU1Org2KthGPMq4POrYTOzs5TUlJTU1KlpaVSUlJRUVHLq4J8W1LMzMyEQmujo6PWOUpSUVJ8fHyDQmo2NjaEQ2qFQmyaOTmcOTkyMTGkpKTccsSrgmIyMjGsgmOsg2JTUVG7UpK8UZO9U5PLy8szMjIzMjPNrIPNzc1UVFR6WVJ7e3vbcsQ1NTXec8b8/PwyMjIzMzM0NDS6UZJUUVFUUlPTOUrVOUm9UpQzMTJTUlPdcsV7WlL1amL7+/uaODiKOx6fAAAAAXRSTlMAQObYZgAAAVxJREFUeNrt0+dugzAQAOB6YrMhO4TsZu/u3b7/S/Vsokg4CW2l/oxBCJnvzufB1aX9ua3R71zV4+NigJB+eBxgkWpT2kF3rw7jEqFzDJRwSG0Ylhj3e4JAyEnXfmeUUjEIS2TKOacga8kZJwhIGBYCpiAr6WaCjqFgMsKEikazz7hOudrU03pi0rXrBJhMZeMjbva3t59zIlbgIGacp9WRZWHmO49xHN8vtvOFo510FDWhjRH6eoKMRE0L4AMwnxkwmlm2vVOL6R6cLtbv0U4uoz2zlzv96gYWrqT1EvPhOoaWVW7t9u94EIaQUKoaJRHoNKx6sjIMu7XEDXCEmbGZAFWN2nF+HXZh17MuZKzjqBxkcA2Qg32bHGKNWZdbWUaXafj8AvMzoR56D9UKZSdSZ0QmdIObCB96QXsaLk0IX+DOd+iFOHd+jT0ogGbZRdAs+2eJ1P99af/cvgEDaiFW7lXNBQAAAABJRU5ErkJggg==",
-    "gender_rate": "2",
-    "rarity": "45"
+    "gender_rate": 2,
+    "rarity": 45
   },
   {
-    "id": "535",
+    "id": 535,
+    "sortid": 535,
     "identifier": "tympole",
     "name": "Tympole",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAvVBMVEX////3zowzMzM1NTU2NjY4ODj0zItTU1M2NjVRUVExMTFXVVN1ns96e3t8e3p9fXyhyvOiyvKkzfaxgVmzg1rzyon0y4oyMzT2zYz2zo03Nzf7+vk5OTl6enk2NTN7enl7e3o2NTQyMjJ+fXuhyvJSUlIzMzSiy/Ojy/OkzPVUU1JUVFM3Nza0g1m2hVvZsXHasnLxyopymcrzy4pzm81znM70zIz0zY71y4r1zIoxMjN4eHj3zYt5eXl5entbuGhOAAAAAXRSTlMAQObYZgAAAJNJREFUeNrtz0USAyEURdEPNC20uyYdd3ff/7KSFQCDDDnjW6/qgaJIqx6SXeBIlWR2jnJRgzEGMnL4IWEDz/ddzA7RlPK6p+HtERq6xjusuINW72rrx185ZsDTWHpdIvvyao2J4Ena1RGqy8VnnvMnt7cC3fvp8hRQ4JdxVmyypBNSEKBxsluvNA2EGs00QVH+6QsH2Qpa57BHCwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "536",
+    "id": 536,
+    "sortid": 536,
     "identifier": "palpitoad",
     "name": "Palpitoad",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABI1BMVEX///8xMTE1NTViYmJjY2Nrxv/3zoxjZGX///9Si/w5OTlSUlJqxPxrxf1RUVHyyor2zYw2NjZVVFRSUlQxMjNSjP9TUlI2NzdDc9RlZGNRiflRivtrxv43Nzel3ve3hlu7u7P0zIv1zItSU1T8/PxSU1dCctFVVVVhYmNiYWJCctNiY2VCc9ZjZGRCc9dkZGU0NDQ2Nzg2ODdpwvlpw/ppw/tpw/1qwvpqw/s3NjVRUlT2zYul3vhSU1X5+fo1NjdlZWY3ODhpwfk2NTVRi/1SUlGi2vOj2/Ok3fc2NjU4ODixgVmxg1yzg1qzg1u1hFu2hVw4mLgxMzTetXM5nL5SVFT1zIo6m7xBcdNCcdFTU1NUU1L8+vlUVFT9/Pr+/v5UVVXpfX8MAAAAAXRSTlMAQObYZgAAAOtJREFUeAHt0dWSwyAUxnHkQCQpSdru1r1dd3d3d5d9/6dYeACg1538r39zZvhAaQMXwbg/d1qvPthpAS+f1avMwTa3+BwymQ2SNSegYSbjQIBt8JuCKpjIm6hPoftBlXvfoGCSZGxnXXxmhSsPh095A6xMRvzxZ8HNUiZX0sNaee+2Hd99DeUoYwZITmZbvNHYLHm9cVh91X/RxcF0i8tK3lEPYNR157TPFlHM+QtUZqb+jn+7zRrStXsVteMbp/i2stVpJol+yLI3f3k9PFLs3C/tK6aXCfIPichtY4LsqcMF1Ff+ORq80v4B1fIYGCOK4wgAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "537",
+    "id": 537,
+    "sortid": 537,
     "identifier": "seismitoad",
     "name": "Seismitoad",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABQVBMVEX///9SjP9SUlI1NTVSi/xCa9RCa9YxMTFSUlQ2NjY5OTliYmJjY2Nrzv9Si/5RUlRRiflRivtRiv1Ri/xRi/4xMzQ2NzhSU1RSU1ZSivlSivszMTFCatMxMjRUi/xanL1anL5anL81NjdiY2ViZGZRUVFpyflqy/tqzPxqzP9qzf1rzPxrzf1rzv5RUVOj2/PTY0TWY0IyMzdSU1dSVFdDatJDa9REatNQUVNSjP1QifhSjv9TVFVTVVZTjf5Tjv9UUlFQiflZmLlZmrpZm7xam7sxMjM3NzdRUlJhYWFRUlNiY2Q5OThiZGVRU1ZiZGdjYmIyMjRjZGVjZWdBadFpyfppyv1py/tqyflqy/lBadJBa9ZqzP1CadFRjP9qzv5SUVIyMzRSUlNCatRSU1Ok3ffRYkXTYkHTYkI2NTVSU1UDujJEAAAAAXRSTlMAQObYZgAAAVVJREFUeNrtkcV2wzAQRT2SDDGEGRpmLjMzMzO3//8BHWUZ20l37SLv6Nib6ztvLGGQPw6Vf8k16wFOy/10K5XUjiw366n1nlwxpOm6TrSSwfEeoKuBICH4wBdL2HI+iLsIYZKL4wwgYSndkD0QHf2MvQ9JrUVC4n7Ilt6eLNcNMYW12kMArdhHewLBtUrADGaWk69LCgPvPSDJOYAskc2cbwTb0+K85JecgClzPyjdu1NPFACGBVqozsBC2TCMEFJM0bprUjd+HoWEQLcvjRpij3E/F2qmmmqewWQkKKiFOTJLSPWYCwFJvbum6mYZyt0XBuZ2Dwd0SPM6uxzjox+QW8298NE8NvdDz06uarVkbvzGuR+Z+samsjXXOBUPDrf0MdHpTYefN6dthNj0CH8ApY58RDpPiw2HQ7CJ6hDUr4767loMm8ZaqRW0BvuDqOZnkP+fH93PJXVgnDoKAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "538",
+    "id": 538,
+    "sortid": 538,
     "identifier": "throh",
     "name": "Throh",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA9lBMVEX///9SUlJTU1NUUlJxcXFzc3PbYmreY2v8/Pw1NTVUVFQ2NjZycnI5OTl0cnJ1dXW0Slq1SlrExMTFxcXGxsZRUVHcY2vdYmoxMTEzMzNVVVU3NjY0NDTDw8OzSllWVlYzMTHZYmk2NjVTUVIyMjLdY2t0dHT4+Pj6+vpUUVL9/f3///9VUlLEwsLEwsMzMzI3NzfGxsVXV1fHxcXHx8d2cnLaY2vbYmmxSVnbZGvcYmncYmpwcHCzS1rdYmuzS1vdZGzeYmo4NzfeZW20S1r5+fj5+fn6+vk4ODj7+/vBwcH9/PzCwsL++fn+/P3+/v7//f3DwcKK16ZwAAAAAXRSTlMAQObYZgAAATdJREFUeNrt0dVuwzAUBuAcx5Q4DVO5K6Q0Zmbmvf/LzFYnTVsatbeV+t8d6dMBW1tmYWKkKnMw6nmeDYqqqtBJljAmpV9WFWsVOExi9isVnNZzsxwhwIQAVRAgjRqdRtLKb3e3a/oIEEioW/CzRA7KMXsPTqzDl3i6kVBpypj+f3Q1pcmV7Z8d6/QtuJTOn3Tmtdy1Q7dn8+3DxE1WASzgjh8i4GH5LyytMK93Yg94EzrD245047Hjf4xrae6UiB64L49p37k4pzqWMMy60z6oRN2qSDUD9Z193TKlCyZD81KolyQBAoRRPQwJ6WqFqa5t1U1sIUwIqVSMAqUuitcRFtgCZJqD0ahWLIWMZpzCa8Az4ogcyPEIZ80KVy1nWeN+9P65szHLKfp8FMfX2jyy3RbaMguQb/7VGvUiAFS/AAAAAElFTkSuQmCC",
-    "gender_rate": "0",
-    "rarity": "45"
+    "gender_rate": 0,
+    "rarity": 45
   },
   {
-    "id": "539",
+    "id": 539,
+    "sortid": 539,
     "identifier": "sawk",
     "name": "Sawk",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA/1BMVEX///9SUlJCa9ZRi/4xMTFSUlRSi/yU1v9SjP81NTWDg3JjnLYyMzQ2NjZTVFRRUVFRivuR0fmS0/uS0/yT1f1CatMxMjRSU1OCgnFjnLU2NjVBatMxMjNRUlRjnLc5OTlRU1ZRU1c1NzhRiv1Ri/wyMjMyMjQ3ODg4ODhSU1VSU1YxMTMyNDZTU1MzMzNTVFVTVVdTjP1UVVVUVlZUjf9imbFimrNimrRCa9QzNTdCbNdknLRknbWBgXFDbNRQifiEhHOEhXVQifqR0fqR0fuR0/2S0/oyMjJRUlKS0/2S1P6S1f+T1PyT1P1RUlOU1v41Nje6urq7u7u7vL77+/vZQtHWAAAAAXRSTlMAQObYZgAAARdJREFUeNrt0sduAyEUBdB5dJjeXdN77z1xeu/J/39LwMrSg2fnja8QYnF0AYEzzsgjCSG1XBsjtGpv6s/XCGGB5m0wKv4LMWWU2KFxQlDQ0OIoEEd+rQPkWFD1YIGsMPP3xu+egaQSCnNZGbKfbe0uIfUqIU09EjKE56YeFRze8bXBMITULfVgqJt3zzf16rQzECacu82MBwCMKkiTrfRtokK6GXc7DdCVCpLgJliOPaei0yOObAAoc4o8wtPE8ogyNO5K967ks4XlfZJAaWkOyk7aM8PcQeaWwISl8PM2gFjb+w/uvvuWjXtHz3zRJ2T/rFnavu+kr9NfxLs7r16tj548vRwPZ6byImILdeSS9FstZ5xR5Q8T1RbVe/6mngAAAABJRU5ErkJggg==",
-    "gender_rate": "0",
-    "rarity": "45"
+    "gender_rate": 0,
+    "rarity": 45
   },
   {
-    "id": "540",
+    "id": 540,
+    "sortid": 540,
     "identifier": "sewaddle",
     "name": "Sewaddle",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAz1BMVEX///+U50r/3ilrszE1NTVSUlKS5ElrtTFVVVIyMzFutTIxMTGS5EqT5kmT5ko2Njb8/Pz/3Sn/3So1NDH93CoyNDFVVVQxMzH9fEL/fkVvsjGR4klDjSpDjimT5UozNDJTVFJUVFFstjJCjClpsTE4NjU4ODj/3y383Cr885hFjilGjSlqszE2NTX9/f39/vz+fUP/e0HOnCHOniLPniL6ekGV5kk2ODX93iqW5krMnCLNmyLNnSKT5UswMjFEjipFjCr8ekJUVFJFjSn/95shF6bdAAAAAXRSTlMAQObYZgAAALFJREFUeNrtz8URAzEQRFFpREteNDMzM3P+MRkCkHS2959f1fSguF+M2rYe49jUcBWORUJDpk5pNkwIkVE4u856yTRzsEqmXKN7f0LNUdymog+wBDAcbEo/3zw68M2QP0T53P+wt264spW0cIjCEMCHYHAhEthuVpO5WQhRsFhj6UaPsHE2F2z3GJcpkkqPXSdHq+jyEVLk3az61CqdEVLLHc7mTaQjCVm1kI58h+L+txe+Hg0PJ7c19QAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "541",
+    "id": 541,
+    "sortid": 541,
     "identifier": "swadloon",
     "name": "Swadloon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAflBMVEX///8xMTFCjCmMxjH/3kIyMzE2Njak7kml70pBiilDjSmj7Eo6ZDFEjSlRUVFRUlGKwzGKxTCLxDExMjCj7Uk5YzFBiyn83EE1NTU4YjGKxDE0MzE5YzBCiymj7Ek6ZTFSU1Gk7UlTU1GCrDjLmyHMmiH720GErjn+3EFDjCkO5czUAAAAAXRSTlMAQObYZgAAAKFJREFUeNrtz0cSxCAMBEBLIjrnsDmH/39wZe8duNtTwKlLaKIt642CMDeeZDSGWMWQbwg0kk/I39NOUwr+iaV+p51/prKtIW2MiRsfxPt1dth4qsRDVmn6IlbS0QPyRMJLCJFh69hSTX2RxIMQe+BNXdBiUevz4yMydoYcEmxRU9r1iyMJ4KCQP2/JzOhyRGd1tlCykxbxsIz04P+zZY35AdRdB8dKtKzCAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "542",
+    "id": 542,
+    "sortid": 542,
     "identifier": "leavanny",
     "name": "Leavanny",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAnFBMVEX///8xMTE2NjYyMzH/3in72ykzMjA5YzBBiilBiylCjClEjSlTU1FUVFFiqzhlrTiKwzGKxTCMxjGj7EnLmiHLmyHOnSE1NTX83Sn+3Cj/2ys0MzD/3iyLxDGk7kml70o4YjFEjCil7UljrTg5YjFRUVGKxDFRUlH8W7P82yn83ClSUlL8/fv93SkxMjD/XLI7YzCj7Eqj7Un//vvm7bLUAAAAAXRSTlMAQObYZgAAALNJREFUeNrt0McOwjAQBNBs7PTeK4QWeuf//42suGdyQ0iMND497dpW/vly1E+x0xruVOgRhqk+1H0ICPtDo3mzuUAujC9B6c1iJItwXeZVvozwSG1wlXQiAZx/biUneAoA97WUr5YhWj2Mu9X5qhPwIyspsWPZbzKXCDJKdTIN6IokFkrh25k+TtVEkKKaR8fYzml8MR+L7G7tTh1az9KyDZ9oyruJQnZQmle+BQyjf34mbyH3CoPkHJA1AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "543",
+    "id": 543,
+    "sortid": 543,
     "identifier": "venipede",
     "name": "Venipede",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAXVBMVEX///8xMTEzMTFTUVLDSWrGSms2NjZRUVHESmpSUlKjQmIzMjLLcYLVcirz5Ck1NTUzMjBUUlE5YjGlQmOmRGI5YzHDSmpJk0nGSmlKkkoyMTHNcoPTcSlRUlFRU1FW0cxmAAAAAXRSTlMAQObYZgAAAJVJREFUeNrt0UcOhTAMBFDc0oDfe7v/Mb9jsTXhABmUrJ5mpDD09GxIAKh3m7EIAjCu28BvEaHn9YZqXaVO69jk14dhGnUXp5ErvP/Ky51FK8QFgrscgSmh3rbtFg77CDFnqJCyQVcy2ieUhE667Fcm0bKk8EzqfPh5qJmPhQplWH9umQ+7CwFEaP2/BQU9DWqnp2dD/jW0BZZEMz67AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "544",
+    "id": 544,
+    "sortid": 544,
     "identifier": "whirlipede",
     "name": "Whirlipede",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAeFBMVEX///9SUlJSUlN7c4QxMTF6coOMjKV7c4WLi6OLi6QyMjOrq8SsrMStrcYyMjJTUVKKiqNTU1NycnJzc3Orq8N5cYI1NTWtq8Q2NjaySVm0S1u1SlpTUlKsrMVRUVFUVFGzSlkzMTEzMjHEi2rEi2vGjWnz8yn09ClCDEUfAAAAAXRSTlMAQObYZgAAANFJREFUeNrt0UcOwyAQBdAMDJhq3B3b6fX+N8wQKctxDpB8iQXS0x/K5p9fzYCbLeZ8hZ2bEigZ3Be6PZzG2te+CPMZkTFIq9rHeUk+xiLU3jGwc1SYx8aotbR7cgwsykrksdIKAKNlyck+1OAL8Fo0bQvKcjAPNkKRblqABgxBTk7jnAg3oCSswaGblzFqQe62A0WQPyU9DJVdL48jNeOKlNJqqnzed0YL71hXTktSliSQwz6wn4OVMMJoqpWAec8Px8PbldXnKis0J3/9Pz+aF+J3C12eizX6AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "545",
+    "id": 545,
+    "sortid": 545,
     "identifier": "scolipede",
     "name": "Scolipede",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAXVBMVEX///8xMTG9WmtSUlKla++MQlJra2szMTE2NjalauwyMTO6WWq8WWq8Wm3LcYJTUlKMWs6kauyMQlTOc4Q1NTW7WWpTUlSjauwyMTGLQlIzMjL39ynNcoO9lGuNQlKRnNskAAAAAXRSTlMAQObYZgAAAP5JREFUeNrt0Mlyg0AMBFC6pRnCvnnL+v+f6SaYHCDD1RcLpqiiXkmazl71lHrLsHwBHLoWE2ZWfU3McQArIyH2U5NFkx9IGt1CzVAXTVH+/d7D3pwmJuhNuK0bfWSnjQQXqabi+bpRB9mNDGaM3+ajmpYPeL2g2i0M0vApzdWdKnbvQ7mHFlXmgo9Ir345cx8BImDRLATmYu3UncPg/2WFGcdAOtAqUQ2uE+nDo8mF+fZzogkmaOaknJ5iHLxMOV9W9Pn1sWa4pRrG39EMy3gln4ByvkAxwyE0Yy9nPaAJSF3FRMUiMBMg1RAwFSlwVICOLMMWphpvXbrxq55fd3IUCH1XVRLzAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "546",
+    "id": 546,
+    "sortid": 546,
     "identifier": "cottonee",
     "name": "Cottonee",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAMFBMVEX///8xMTExMjExMzEzMzMzNDQ0NTVanFprxmNzhISMpaW1zsbe9//nYynnlDH///82Id7PAAAAAXRSTlMAQObYZgAAAINJREFUeNrtkEsOAyEMQ3HbKfm1uf9txyDNMnABnpzdkwVuh8OeL4C9RSnIhZ0XD9eqbIo+wvvUooCeBbFlJUQ0ghnni0p0SVVGLVzd0Gqze/6STL+DFCYs/5mUPbMLeZfrWNiQVWWCtjDDfHxKIP1VP9OfGR1j2BpQdR6lHaDDHA57blHMBl0hCLIRAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "547",
+    "id": 547,
+    "sortid": 547,
     "identifier": "whimsicott",
     "name": "Whimsicott",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAtFBMVEX////ezoxSUlJTU1K9pVoxMTH//73//77///////2Ee1qFfFqFfVucjFK7o1m8pFk1NTW+plw2Njb7+7r8/Lv9/bv+/rxSU1I0NDNZmlm8pFozMjGdjVLbzIvczIvdzYtqw2JqxGJqxWL8/Pz9/Pz9/fwzMzK9o1lRUVG+pltanFo0NDRrxmPezo1UU1L7+/uCeVmai1L9/Lubi1KDelnTYinVZCn+/v3by4qDe1q6o1mEe1lAvHlkAAAAAXRSTlMAQObYZgAAAQhJREFUeNrtk8dywjAURf3U5Ypxt+kdAqT3//+vSMqMV0jJjg1nfebeO28k78aVGVDqDf/jZQw2Wa1sN8OMMQblvmA1dXoPbcGMKgWvHd694FAygzYdvaFJ/FsMV+JUsp7a4s2qXArBjWMW1BbvWOVaedc7ZVrYxMHs8IlyBsGT5OGK7wsg3eXEplqmGL20OIcziqeO7t3rlmgwahZ6BWw8ixgra53ippqbuVLcXRY/gpaQty2eHxbH3wPY7vPlPyck+kYqcAylq3vJQ9+fBAiNQaE9S/dozQFGCcFaJJ39Me4eoyhKfBVIVLIJtK0kCn9iet0PklLl4nja73OmdrT/Cu5U78b1+QEdxhU7iTCG6wAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "548",
+    "id": 548,
+    "sortid": 548,
     "identifier": "petilil",
     "name": "Petilil",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAeFBMVEX///8xMTExMjE2NjZSU1JZmllanFpbnFlqxWKUvUuUvUyy0zi01Tm11jnO1t7O95wzMzGz1TlrxmOUvUnL09vN9poyMzFqxGL9/vuVTBs1NTUxMzG00ziSukmSu0qUSxjN09pRUVGUvUpqw2LO950zNDL+/v7///8HjULWAAAAAXRSTlMAQObYZgAAAI9JREFUeNrt0FcOgzAQBFCMe6dDKum5/w3jyAcYfyNGO39P2tVWezYXmovd85RLIBQ1V4wkC2BSc8dmUVdQJsV4cijHO2fXCTtq+8cY9VTgRu2yRC5GnfouhEkCuLyidgXwsp79EkzBkcPne7gZ5xv4xiEE4/qC90glVCdqAqGXrRQtXk2J9Y3NDtL/7Nlcfr59CL2eIEzLAAAAAElFTkSuQmCC",
-    "gender_rate": "8",
-    "rarity": "190"
+    "gender_rate": 8,
+    "rarity": 190
   },
   {
-    "id": "549",
+    "id": 549,
+    "sortid": 549,
     "identifier": "lilligant",
     "name": "Lilligant",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA/FBMVEX///8xMTE2NjbnjEL+/fw1NTXOWhhCejlJmjhKnDlSUlIzMjF6xEp7xkqSukmUvUq11jrN9prO1t7O95zkikHmi0FTVFMyMzH///+Su0o0MzCUvUu01TlTU1HMWRhTVFFCfDlUVFExMjHki0JRUVFCeznnjUT05Cn35ymUvUlSU1GzpFkzMTC01Dp6xElTUlG2plnLWxjL85rL9ZpKmjnM09vM1NzM9JqDg4OEhIPOXBjOXBuEhITO9p2FhYXO951TU1Lki0GSu0nljEJRU1E0NDRLnDnz5Cl5w0n15Sn15Sr15in25CiVvUn35yz9/fz+/PuVvkz+/v6yo1mMKKSgAAAAAXRSTlMAQObYZgAAAP9JREFUeNrt0NVywzAQBVCvZMvMtmyHGZyUmZm5/f9/qTR5zvq1nckdPZ7Zu1pllT8QDaoNUQgoJLGhYhIkdqLePRynuNQeyz6llL1OhMShedunLFXfJ128mwjZStURY58ncxQO9OGVLE8ptVG4HdebonyjVSU17+OraVnF/Rab40t6N2qeR2fcMc0eWs33vvOResH1ddfNUHi4H0XnayHXewDYr53O7Oj0uXvAiww9o9u59l82L52y8P0MPeNOPYyDtuOWBQKJYUoXL6S+/NeaMVxAcXVrFzkPAfAaUyGDaRi0pcS2HL/5DenAwKCcOhjXfp5qIOdjUFL5Vvk3+QUpuxn9L7Td3gAAAABJRU5ErkJggg==",
-    "gender_rate": "8",
-    "rarity": "75"
+    "gender_rate": 8,
+    "rarity": 75
   },
   {
-    "id": "550",
+    "id": 550,
+    "sortid": 550,
     "identifier": "basculin-red",
     "name": "Basculin (Red-striped)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAgVBMVEX///8xMTFSUlI2NjZKdEI0NDRSnEJqampqu2Jra2trvWPcWiL7+/v///9RUVFRmkFqvGIxMjFSU1Jsu2FMdUTeWiFUVFT8/Pz+/PtUmkFqumIzMTBRm0JKckJrbGpSU1FsamlKc0K+vr7bWSFSmkLcWyJSm0IzMzMxMzE1NTVRUlHQX3jAAAAAAXRSTlMAQObYZgAAAKpJREFUeNrt0UcSgzAMQFHLvQKmp/d6/wPG8R4le/jevtGMZLI051h6fzkvvCAMCO6T8CEI+FoFGHz5nlI6hPNDuQ06sVDGmEQFDlliOapc8/zpXNcdzTRkAIXKbFXZ2yqWcQr6Prux1XZ/j4Thi7hubLdVTQE7dU8VhUtj+XsIArthoetrxbXluCNsbW290/w0hJAkClNSHsALAPyjSyllBMIyw2katTTvPr+2CRi0ywXCAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "25"
+    "gender_rate": 4,
+    "rarity": 25
   },
   {
-    "id": "551",
+    "id": 551,
+    "sortid": 551,
     "identifier": "sandile",
     "name": "Sandile",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAY1BMVEX///8xMTFSUlJqamrnvXtUU1I1NTXGlFrkunnku3rlu3ozMzJsbGvDklnEcovEklnGc4xTU1IzMjFUVFRTUlJra2v7+/tsa2rEk1o2NjaSakmUa0qVbErDcYrmvHpRUVEzMjJJ83h1AAAAAXRSTlMAQObYZgAAALJJREFUeAHtkseugzAURD3uhV54j/T//8pce5XFdcQ+HAmBxLFmNLIonJzsOOipmmgBfHz7BrWk1rmpyDvUGrVOFXGb+2vU9B9eN+saU71T+zAkaaMimbKW3E5PiW2Gd2MONiHxXqmVlIS/xRxsAtvRquj+sokL9Wyk6oalnzjRU5Ym6EVeMN1LAYI3HZWUsnejDNpA2OqMoOc+LADyIfEdC5QFWJFZ9J/x+Klw/IKd/ChvObcHxcMRF44AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "180"
+    "gender_rate": 4,
+    "rarity": 180
   },
   {
-    "id": "552",
+    "id": 552,
+    "sortid": 552,
     "identifier": "krokorok",
     "name": "Krokorok",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAh1BMVEX///8xMTHnvXs2NjZSUlJUU1LGlFrku3ozMjH7+/vlu3pzc3N0c3IyMjLEklnkunkzMzJ0dHPmvHpTU1I0NDTDkllxcXFRUVHbepqSakpUVFSVbEq6urqVa0uSaknFk1lycnLGlVxTUlHcepree5w1NTVTU1NUUlMyMTGTa0qUa0r8/PzceptRiarJAAAAAXRSTlMAQObYZgAAAORJREFUeNrtkscOwjAQRNl1S5ye0Hvv//99jJEQHLDJDSExB0uWnsb7sun889XsiFpxomAdUQuuV7MyOmpTOLHMH0kRj42uWTcUpKgj+lLKy1hKU4Ze1RE4o5YSJ3tJtGE4rhKrHBcAd4WuKyeCNBAPmXQLBoQh8wcn3nc6azncHvIGM97v/YzIY95LEzcjKkENAv5iYLiC0OjoKJ1mXvfTeonOkVWgElv6v+Zkc5DDGfSVqZLMy033eXrdzhYoU6akwN8YryKiueXPCyd3zhfndZB7uuevuwluKe62Agnb++dHcgPwoQup25ZihwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "553",
+    "id": 553,
+    "sortid": 553,
     "identifier": "krookodile",
     "name": "Krookodile",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///8xMTE2NjZSUlJUUlJiYmKESlqtUmPea4RTUlJUVFQ1NTVjY2NkYmODSlkyMTGES1urUmKrUmOsUWJSUVKyw8uzxMy0xMy1xs7baoLbaoPdaoMzMTL7+/v8/Pw0NDRlY2R6enqCSVncaoMzMzOtU2RRUVFkY2P9/PyFSlpkZGSDSlqsUmMyMjJ5eXmuVGXebYXkkqvmk6wzMjKrUWJTU1P+/P1Um+lUAAAAAXRSTlMAQObYZgAAAS1JREFUeNrtk0eOg0AQRSk6kkw2GZztyXnuf7SpbnbYgBeWZuOvRoiup/oVhHHX7WWCYTgAV4AfX1BIWc9yh1JUElXPJHUOpdSiMMO171JiTsoAS51yXj9XoqKEuZH/+jIBFpRFVmsz191OuZtMxdma4Hu8cxNwLkdFUM09+HjVB4YTXGFckeJkkwWPq5r1IINBffJztT26hLT2giOnZ2TCOaiNKVkkZJkHPCElfgMD+PYG3k6B+9jEFlvmeR7EHsGe8ImE8M/bad6yH+RQj24kLIYsTvRC503X2Jix5zx0p6GnwHPSMDcZcholCOplXhaSGntKcO+i+u3GuHTPeaa6wVWGJ7sdBSHdpTtIg1hYodV2MPUzOKoAHgvBfWNWTrofcJMlGFeR6tz1j/oDSj0Wl/a5NtMAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "554",
+    "id": 554,
+    "sortid": 554,
     "identifier": "darumaka",
     "name": "Darumaka",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAeFBMVEX////WSlKlOULVSVHTSVH3vSnVSlExMTH2uyk0MjH/hDkzMTE2NjajOEEyMTHWS1G9ekK9fEH7gjj7+/v+gzlUUVL///81NTW6eUHWTFTzuilUUlH3vCk0MzCmPETTSlL8gzn9+/ymOkH+hDj+/PymO0H/hTzWSlF21575AAAAAXRSTlMAQObYZgAAAJxJREFUeNrtkkUOQzEMBeswfMYyw/1vWDsHcLpvRtll9CQ/e1P4XyqLz9q8t9cnBQDR8hqKvWtBCAmR8wavnNaPj9MvzlyH4FUc3+HYOxKZRAXitqCoKZExqxq/YQp+PEuYL3wk8Vx2MF8PlhNx5ISQGMzNvTWuJRn7mTzXz112pjMps+EXWAuZNIEiy4oq0eTXTTeB1f98Q4VCji8PMAdLjyIMUgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "555",
+    "id": 555,
+    "sortid": 555,
     "identifier": "darmanitan-standard",
     "name": "Darmanitan",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAArlBMVEX///8xMTHOSko2NjbNSUk0MjH7ilHOS0pTUVHMSkozMTGlOUL39ymmO0H7cTjLSUn9/f3+ilH/jFL///8zMjFSUlLOTEzWc0L29Cn29Sm7u7u9pkG9u7u+vr7+dTg1NTX+i1H+/Pz/czlUVFT/jVSjOUL09Cn19ClUUlJUVFH39Cn39Sm9vb00NDCjOEH7+/tRUVE0NDTNS0umOUGmOkIyMTHTcUFUUlH//fzz8yk/26nwAAAAAXRSTlMAQObYZgAAAPpJREFUeAHtz0l7gjAYBGC/LyEBDHsVd6xK933v//9jndgek7RPL14cHsLlZRgGxxwy4q8uj/4BBflhl28gOyLCEWwX+dUtFcyc2ldC8NNkEm6y2rxTGM6nmZwYs3qWnAY23sVnJjufT63j4asfqo9HVV+by4RtUq8r+LTZ1XV0v9MhCbh44kpDjzkEsXBWjsFwbxNslB4oijhZlE2zLJvtKIFDpdsxx7ObcokLhXEv8d9e2EvbCcfxqB/KKnI4VesqIqUZKLEHva3bExds1xc0EKRe9g77BJHz00T0/Xz4gb9FKF1p3s8Lp8OI1jHPNQLUUejeOzhsjvkCplIQuBWJ73MAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "556",
+    "id": 556,
+    "sortid": 556,
     "identifier": "maractus",
     "name": "Maractus",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAxlBMVEX///8xMTEyMzFSUlJSVFJztWOL5GKL5mOM52P3pdZSg1JShVJys2JBmlmL5WJRUVExMjGN5WLOWozmcpv2pNU1NTX35ynzo9NCmln05imK5GJRU1KK5WLkcZrndJpUVFFSU1JytGI0MjP25Sk2Njb05CnOpTFxsmL25SrMozHMpjF1tGTOW411tWLOpjBTg1LkcpozMjHnc5xUhVFDnVrz5Cn0o9NEnVn05SkzMTL2o9Q0MzD25CqN5WSN52LLozH35SvMWYvvzYRWAAAAAXRSTlMAQObYZgAAASNJREFUeNrtksd2gzAQRTMqIDqYXmxwwU7vvef/fyojsslmsBc5Jxu/w4ajy9MdiYN9/j4r2BHLrQXswOXW9eTZWmzlppPXbDa5CH9eU7I6za3TOLHeJAONaQugFU9MwY+u0AI/ojUQrZToW5fBNLE+0eOJ9Nx09mN2My/br/gwmyVU5equNRwE/dv6Xu8dJxQIH5GS0lSOL/gl9gGBYeV5pDCiaGTHgRL0wqDX4PE6wtmXL9Q5BtwQroncMkNcAF3Y4J6GNAdQspE73JhKsgrJdSQ7AEBrUhIXAxfn4PbcVMwLCRAGuuZFbftKcLc80/dOX6PghuMPR1Q+hCOqlcJosn/XI20hJYOgCFGSTuo1whAG079uOloI4P2qGkf1s88/5xtr1hki1uHNbwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "557",
+    "id": 557,
+    "sortid": 557,
     "identifier": "dwebble",
     "name": "Dwebble",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAeFBMVEX///8xMTGtnJxRUVFSUlJUUlFrY1psY1uEe3Ormpqsm5s2Njb/jCk1NTUyMjKDenIzMjE0MjCrm5pTUlE0NDTLcUH7+/v8iyn9iylqYlmtUjGFfHSuUjDDurrEu7urUTHMckLOc0HOc0L7iimrUjGCeXEzMzNsZFtsd1KaAAAAAXRSTlMAQObYZgAAALFJREFUeNrtkMcSAiEQBXeIQ5DNybjm//9DwSr1BO5Ztw+cmq4H2cKPYgBglrfbaOJm5OgoKkT3zbtqglpWyeQKMqMQURMiBaTErqG5Jh7U6BIeBaocKO/t73ncNGfecwZdM1ZE5ogu6lnLe8sBKFMEE+Jh8J4NVaakEAKiwW09rYdnlY3Bi4nHAqA91b4aTIg/pfTnDeglVKci8TmfCUPZvsSEHyb4W29SE+ZhsoW/5gHI/AmkuzPUKQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "558",
+    "id": 558,
+    "sortid": 558,
     "identifier": "crustle",
     "name": "Crustle",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAolBMVEX///8xMTEyMTFSUlJTUlKEY1K1hFrWpXP8ekL/e0JzSjlUUlG1hVo1NTXuxYvvxoz7eUH7uin9vCmzg1n/vSlUU1HVpHKCYlHuxIuFY1GyglkzMzL8ekG0g1lxSTg0MjE2NjZSUVHTo3GDYlI0MzDnjCnnjSzsw4ozMTAzMjG2hFlySjkzMjJTUlGDYlH8uyn8/Pz9ekG7WRi9Whj/uym+WhhFe13xAAAAAXRSTlMAQObYZgAAASRJREFUeAHt0udOwzAUBWAcD8dx2uzuwR5lD97/1bjnIkAmjvoL8adHam8qfz22rBwd8lc5Fpz96HRcUOzdoAVbzIoin4wLa6GXA3ZELDeGLGLxRDbirnI2Xw7/mtnxsr8x9v0JGEYETvU6pMxvYlCvTUBx0AhcaEhD1lpLgz4xB0kLTCe4nRxOJzFY7bDEtQg/RnYWompZMuXv2Naj0nnZ1N+UXd2e9/rIPV36xpga1HyythM9uMlORNU1SjYEdkpyu0q3kTuUjxev99xad6lzNJVM58lvmIipfHl226ojQA5Spf4MMJCwpXNv1Nqo2yxbOS9RGHt76IZK934txOZB62zlUy+DwgALwQemJKKcS/wczggHzhLMOAgPjIm+vfZ/c8gHNIoaxUdoCooAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "559",
+    "id": 559,
+    "sortid": 559,
     "identifier": "scraggy",
     "name": "Scraggy",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAh1BMVEX///8xMTHGhBj/tSkzMjD7sin7+/v9tCn+tCg1NTXmSiiUhGOVhGL8synDghg0MzDGhRn/tiz//fs2NjXnSik2Njbby2rczGrezWnezmvezmzezm3kSSlTUlFUUVHz86v09KtUU1GUhGEzMTA0NDT9tSv9/f2VhWT+tSq6urq+vr4zMzH////558LWAAAAAXRSTlMAQObYZgAAAIlJREFUeNrtzUcSgzAQRNEJSiQJcI44gPP9z2fKxdqjPfz1q26YGnMLxDi1n18jnHeUxjjNTORChPtFSoJm9+D6U7E0OTOvrm6NDCF53qp+cf0GUS43fRGuuWerkhQkKEmfHk/bUmlSKEhNl8yeCyYXBOeYObe5Dfh/Eb2jQzE8C1TzsCZTmBpzX9gCBwlH9+MzAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "180"
+    "gender_rate": 4,
+    "rarity": 180
   },
   {
-    "id": "560",
+    "id": 560,
+    "sortid": 560,
     "identifier": "scrafty",
     "name": "Scrafty",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA3lBMVEX///8xMTH3lCn/zimtQkL9zSnOUkqEYyk0MzCuQ0G8k0G9lEK+lEHNUUk1NTXzkin1kyr2kyk2NjZUU1F7e3v1kinGxsY0MjCFZCnUgzLWhDB8e3lUUlG6cSn2lCsyMTD3lSz7yyn7+/v8zCn9zCm9lEH+/v4zMTHDw8NRUVHFxcN8e3rLUUnMUkp9fX2CYinOU0nTgzHUgzCDYikyMTHkeYLne4RSUlL0kimrQUFTU1EzMjA0NDS6kkG7cim7kkJ5eXm9k0H8/Pz9yyl6enozMjH+/fu+dSwzMjL///+NCqiqAAAAAXRSTlMAQObYZgAAAOxJREFUeAHt0cWShEAMxnGS0M3gAuPu6+7u8v4vtFkue2oyt62pmn9x/JGvCqx/blMGVgSruPOLL35WgdoO9VK8GV2HWpdUcE/7zGwRZpPRkV1HRNcOK2UGsVvHbpGgK8C4k7IrisQ9E6Ybg0735fsgaUofZ2vRGHzcTT5vJXjo7SxGOHdmtSoWQX8WOJyniCpkFCPOmZT5778vGmA/bW5PiVonz4qcoQV7S+M0/5qi3TtO81NPAWgwr4/zN5ZXmE/JIfu1ZnSBCnbbvYeUIcfOOA5jouDm8tFXPpTLgm0NBVbSe/U3Kh21Nq1NP2+3E5HgW/GCAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "561",
+    "id": 561,
+    "sortid": 561,
     "identifier": "sigilyph",
     "name": "Sigilyph",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAqFBMVEX///8xMTFSUlJRUVH/tSn///8yMzRKg0I2NjY0MzBSU1JUUlFUU1FZrFmCw/u7ekLTYkL7sin8syn9tCkxMjFarVo1NTVKhEKFxPwzMTG7u7u+e0HTYkFUVFTUZERZi/z7+/tMhUT8/f9TUlEzMzNZq1lcrly+vr5RUlFTU1MzMjFSUlRJgkGFxfv8/Pz8/fy6eUG6urr9tSz9/f1Zivv/tiz//ftSU1Tc+YUzAAAAAXRSTlMAQObYZgAAAPZJREFUeNrtkMeOxCAQROk24Jw9eHLenPP//9kWIx/H2IeV9jKlllCLp1fY4pI/TkBjwUwT0ShyOX2X4YiSwOO8DnHbQUSZPl+9tkbwp62UT+vZ+WpzMuIgu5SLA1MPaJUJbdWKwEkYp7qHJC+vk80eYGCFMDqUFsjvqeyEvcpqUScga5cQHF1FOcAK4xLa755/fEkpv2/u/IZcHPvpi1Jql04iQhzd2+tJm2IiJs/BCfP5wMzPasV+4zFIZz1v9ru2EcbJvR0fW+QWkJM0hLHS+VEMxrwe8CNpmFvGRVwlVTgIZjr7KeJiNqzEMwHrbh2ExSX/ml/Z5hF1ZJkJfAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "562",
+    "id": 562,
+    "sortid": 562,
     "identifier": "yamask",
     "name": "Yamask",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAXVBMVEX///8xMTE1NTVRUVFSUlI0MzA2NjZUUVFzc3P25Sn35ylycnJUVFF0cXG7Miq9MSm9pVrkSilxcXEyMjL35yz7+/u6o1nz5Cm+plzkSSkzMTDlSir9/fz+/vv///99f0xBAAAAAXRSTlMAQObYZgAAAJBJREFUeNrt0EcOxCAMBdBxIbT0ZHq5/zGDR6NkMzLsky/BAj192ZyO7DgVQCEc3VRWOLoSWVF0JRBTXduIzMO26xoGXYHA5+NuWZUo6yLxYAfLoDlOASC51UL6AryGUHOcEsW//veO5/n9mQ2kMdJRJsDL69Z7I/3RcQb6YKSfNCey9zWso+hLbSD370d2nQVIMwUlViMj2wAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "563",
+    "id": 563,
+    "sortid": 563,
     "identifier": "cofagrigus",
     "name": "Cofagrigus",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA51BMVEX///9rtc42NjY5lL0xMTFSUlLGnEE1NTVUU1FqssvGnELTYkLzwzj3xjnFm0JUUlIxMjM5k7tqs8wzMTGUe1GUe1KVfVSj0/y+vr7DmkHDm0PEmkJRUVEzMjFSU1NTU1HWY0I4krr0xDn0xTv2xTk5W2z3xjz8/Pz+/fz+/vuk1f45Wmuj1P1TUlKl1fyl1v9TU1NUUlE6W207W2rEnERUVFQ7lLs5WmxqtM1rtMzkgmrkg2rmg2pRU1NstMtttcv1xjz2xDltts6SeVGSelL7+/v7/f0yMjH8/f79/f02NjWVfFH////pW6JjAAAAAXRSTlMAQObYZgAAAVJJREFUeNrt0edugzAUBeAYDwgjkD3JILt7773X+z9Pj53QRqkttVJ/5sgYgT4u90Jmlb/GZux3KktoxMwgY2G3WN3d2iZkuG6Q1gxavb64ImRtL08jA2QITv50dI16edpw41kBS+t6GzeBwwu0HwhXSWuZQso9S9p8PHKag+lIHEVpheVpcWTbXvdWdADvKKURGreXIRSW73hFX3Q4LxCiINNXBOTnIeded7dKaCNWr/4xt+qx73C44llYJQeugrovpKZ5qe14FyEfz6d500lY/L2n2ushT+Q0RsjwwYP9AqEn+DkEkKWv1uAWTwQsQo/NDrHvT8kQRS85YwbB5rBc3kwC5yEXG2spbNdLkNzkQFQUzJVybklCM5XbN8SFvK2pKM+PFSis8rN8DkvToi13X0wUjRca0jbQag7E5KMCmEpjq6DBO+CXNFOZhYZW+c98Ain8GhFThfwhAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "564",
+    "id": 564,
+    "sortid": 564,
     "identifier": "tirtouga",
     "name": "Tirtouga",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTFaWnN7te9SUlJSU1QyMzNjhL1ycpNzc5R5sux6s+01NTU2NjZRUVFxcZJycpIxMTJSUlMxMjNig7t6tO5cXHUyMjJZWXFyc5RigrpzdJVZWXJ6s+xaW3Rkg7t7te5aWnSTxNTDUXHGUnP7+/v8/P3pScXaAAAAAXRSTlMAQObYZgAAALJJREFUeNrtj0cOwzAMBE1SXXFv6T35/xNDOT5age7xXggQgy3Zqr9WDomcU0ncxpFKsWZQCgD4YZ3PYFFZRKyZI7XspKZTBsxYrPf9Mld6CXygEEczsQ0sVytORAocEUkRws0YHUu66bTuw2XTCBdCoag8Uzv0uhHwfUXYraeDfQ9edj3XgMjsMAg58jV0raOgM0IMtBbvV91yqCN9M5DFos34eF7auTI3jA+aBqxalaQPy8MHz2nDt/EAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "565",
+    "id": 565,
+    "sortid": 565,
     "identifier": "carracosta",
     "name": "Carracosta",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABd1BMVEX///82NjZSUlNaWnNycpp6s+x6s+17te9zc5xaWnRxcZkxMTE1NTUxMTN7te5ZWXNjlb5SU1Q5OTlbXHZjlL0yMjNxcZpycplSVFRycptycpxZWXF6tO57tO5aWnJSUlJwcJhxcZgzNDRTVVZ5sut5sux5s+wzMzM1NTYyMzNaW3VaWnE1NjhcXXVhkbh1dZ55selaW3Rjk7txcpxZWnMzNTY2NzlzdJ1jk7x4sOlzc5t5sep5sukxMTJaXHRaXHZ6te97s+xbW3R7tO9bW3WDsbODs7ODs7SEtbSFtrai0bp5supbXHRbXHU2NTV6sul6sup6suxZWnQyMjJ6s+5RUlJRUlMzMzZikblRUVKBsbF1dZ0zMzRjk71SUlRSU1N4sOpTU1NSVFYxMjM2NjcyMzQxMjFikrlikrtRUlRyc5tik7tik7xTU1RTU1VTVFU1NjVjlL8yMjFklb04ODii0rqk1Luk1Lyk1byl1r36+vr7+/z8/P2MeEXXAAAAAXRSTlMAQObYZgAAAXlJREFUeNrtkkVTAzEARhvZZKUrFepGCxUotEUKFHd3d3d3/fFkr5BSbr30OySZzJuXL5lYKilvrNGo8g8sqdRS6jw8MZeJv3QuQs04ulUFi2pxTr90BvoYOJjDooiqioJpgVKjv20gRJwQY6R3FxPuBSjRmr82pUnNhhHCvq1iDeeDba93HxkRCg43QjojE9yTqwuiOPGZETEUqOMW1jMSq7yGsWqfa99VcKFzgQia4anXvX7Au0lNXoYyxHCl6SwXFigjvYu/C7KXTlnsQFl22xiHr+c0akBcxQfNudHT9LjglUJMSWMyevgJ2rNEM8G0f2RsXMKiZILUJqu/leudraa4bvjlvWG6peVmVmNKzmWe5J3aFBPfI6Yc7dlu32VKsw2HXGLbya7e4ee3qaugARkYX+WAzHZssUb0UwQ2EKHEI8SDQ1jlksBin7ECNoJsoP2A1IV0Pyj1g9dsAr3Q3UclOGsEhkmNBEr4zBJA6chzMH7hSsqZb7B3L6WPABAbAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "566",
+    "id": 566,
+    "sortid": 566,
     "identifier": "archen",
     "name": "Archen",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABIFBMVEX////WWkpanP/TWUk1NTX/zmsxMTH/zmozMTGUQjk5OTlZmvvWW0o2NjY4ODhbmvz5+fnPlSMyMzUxMjRanP5TbKfUWkvRWUk3NTXWXEzWXE37ymn+/PxVUVJVUlHJkSLJkiPMkiPNlCLOkyDOliVWVVNXVFJXVlI0NDTRWUo4ODcyMjP7+fn7+/vQliLRWEo3NzhRUVFcmvnTWUpSUlLUW03UXEwzMjFUUlGVQjmXRjpUVFL5+vtZm//7y2nTW0vUWUnUWkpUVFRUa6VSa6TVWUnVWkpcm/1cnP1cnf9dmfn4y2pdnv9env75+vz6+vxfnfuTQjlTUlFVU1D8y2n8zGr8+vn8/Pz9y2n9zWv+y2r+zGr+zWlWVVK4uLjJkSFBBJ/cAAAAAXRSTlMAQObYZgAAAOVJREFUeAHtz1VuxDAQxnHPGJI4cRayDGVmZmZmhvb+t2hayVJfxhfY/JUXS7980rCsTk2oovr3UASrJSEiJpaFmBBz/OwYcRPV3yNEytU4AOQ2LlMofv/KkXtwCNAamTwNlrmv0o9RcPWIN1ozVydwPx+Az6jiap23n+rXN/uV3n4IxhmZzu+NVtpzi9HQXc/CdFnRMhazK7vRzpssfHrDWGSOdDV6X3v1pCw8lErKJU1TyvXzD8+bKh8YhxNf2y+PfV3fWwPNC+egNqZ78Lbhi3z8bAfp25cmxphmLmdvd5usLNsPCe0VK76qwRoAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "567",
+    "id": 567,
+    "sortid": 567,
     "identifier": "archeops",
     "name": "Archeops",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABdFBMVEX///9anP//zmsxMTE2NjY5OTlSUlJZmvtZm/3OlCL+zGoxMjQ1NTU4ODg4w6M4xaQxnHM5waE5xKI5xKM5xqUxnXRSU1RSa6VSa6ZSbKdTU1FZmvw0MzExMTJdnf3LkiHOlCExMzLTWUnTW0vUW0zWWkrWW0r5+fn7y2r8zGr8zGv9ymk3NTX+zWk4NjZUU1IzMTE1m3QwnXVSaqM2Nzgym3M3NzZTUVFTUlExmnI4ODdUVFRUVVJUVlNYmftZmvkzMjAzmnI4xKNZm/5am/wzm3Fbmvxcmvlcm/lcm/pcnPw4xqVfnfqWRDu7ubk5ODjMkiHOkyE5OTgxm3PRW0vSWEk0NDTTWkvTW0o5w6LTXUzUWUnUWko0m3PUXEzVWUnVWUrVXEownHU5xKTWXEz4yWn5yWk5xab5+vr6/Pr7ymk1Njf7zGz7+vr7+/v7/v07x6ZQUlL8zW1RUVH9y2lRUlJRU1L+zWr+/v7/zWv/zmpRa6QpCUwjAAAAAXRSTlMAQObYZgAAAU5JREFUeAHt0sVuw0AUheGBmB1m5jhcZmZmZmZm6Mt3rCpSF7dNlq2Uk01kffotjQf9nVWnIpXSSpygCFhB8L41VCp4RIX+xB78SqmHE8lhDCcv/B4Ru1hTpUzGagWPO0iBXGA0hLHLjxVqiuqOVaGeGn4hhEgjzDYsfASZY8+gXpq8p0kN/9RzLxWIVEjpEOrF5yLnnXybrf6Zz+hl32wvhU6R0w7lribzreXAssWoLu0ORxQB8rrD7rCcvtatppIyc5HIkDkKv/xubeJmWZvayDFWIGT8BCwyaHLazvLTK8mULPkyLOnjKYJhv3N9Z6lIjwJhBol+phSi89b9vqtEHhlVpLZmyWRowCvClLMubhZLZ0rIZQh73SL4rTmD4etPc+bxTU92Dyq/3seZY3lvN5fOjjUayl3ZeMt2rMj65cZp7ZoRVTKO/f7JqvsE6w0qDnKMAXYAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "568",
+    "id": 568,
+    "sortid": 568,
     "identifier": "trubbish",
     "name": "Trubbish",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA+VBMVEX///9jlGOEtWM2NjZSU1Jjk2MxMTGDtGM1NTVikmJjk2I5OTlRUVFklWNllWWCsmKDs2M3NzdikWKEtWT6+/r9/v0yNDIxMjExMzFSc0pTUlJTU1JTc0tTdUo3NjWFtWWFtmWLakqpkXGqkXGrknGrknKsk3KtlHOuk3O5urm+vr43NzYyMzFllmVmlmZml2aCsWJRckuCs2KCs2NSUlEyMjE1NjQ2NjUzMjEzMzIzMzOLa0qMa0qMa0uNbEpUUlNUckphkmIzNDOrlHM5OThilGI1MzM7wqE1NDTpcZnrcpnuc5v5+fn5+vhRUlH7+/v7/Pv8/PxRcUlRsSWvAAAAAXRSTlMAQObYZgAAANJJREFUeAHt0NdOhkAQBeCd2f6DdOxFQbGIvffeu+//MBITLx32mnCyl1/O2Qzr08UYVxfWjg5dIYy4wU2hmFFKtTl/K8I6xLb92GrQsI3k/LRi8evszpDGqV1FbO4tLB59xCFoRASi0SuWJmyWzzSFmCIMs//l04WEdCNCfFtJqUp2axLI8vUI978COxhlRLxELn+uNToYv7ynr/hurwZ3AGLu+eXxmKwc49+JlKI8q+ZvDinJm+eLSb+szh+uCfj3Vc4PitOT1VZpfss569Oh/ABviBFUf3NXmAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "569",
+    "id": 569,
+    "sortid": 569,
     "identifier": "garbodor",
     "name": "Garbodor",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABPlBMVEX///8xMTFjlGPEo3LEpHLGpXOFe2tTU1JTU1NUVFNikmJjk2MzMjJSc0o1NTU2NjbFpHNSUlLuc5tik2JSU1IxMjFklGRllWWCeWqDe2oyMzKzcou1c4u5ubm6urq+vr7BoXHConHConLDo3FUU1NRUVHFpXLGpHNUVFTscZorrIvvc5z7+/s5OTlgkGBhkmJikWIwMDBikmMqrIs3NzU3NzY3Nzc4ODaBeWmCeWk4xaSDemsxMTKEemuEe2uFems7xaSGe2yGfGuycYo8xqW1cowqro21c4xRUlFRU1K8u7u8vLu9vb29vr1RcUlSUlHBpXQxMzExMzLCo3JScUrDo3LDpHMprYwsrYwzMzNUU1LFpXM0MzI0NDTHpHQ0NTRUdUxVVFT5+fn6+/pVVVL8/fz9/f3///8wMjI1NDNyTJAdAAAAAXRSTlMAQObYZgAAAV1JREFUeNrt08VuAzEQBuA1LXOYmZMyMzMzM77/C3RcVb3UUXrLJSNrV7K+ndlflqVedbVshP6BYNUalc+OLn0p2cv+HTM7zeSwwBgzEZ/Pd4TtdlQPwTtKFR1bgRBC8I0pkiXyvW83I+AwDhLmi6CNapX6+Qe4W936gUnXFExWE2596ghg5u09gvFrRiXiyYjHUNBeAAe9pwi+bz4Y1lBcakMhBzSrejp+3g3joKaHhLKgEHnO4GPD4PUrcl2cETqmECYbOMaz8DT+6qJniqDsEe4oaA6PK0vpRyqUSmLWiFG/MQ/cAOkWc2VTcgb/xikRmSYBApdBeurk6U28b0x8PCy5zvsy/iNb6oahHwoDvWiElZk8vHagEFKWvYF+y5FEMkvNaJ6yhZWLTSKfMeXEASeqlgPLmchTtxjdns6N/7I2HO1rWilV7XwtWllKR5zUqNRZ2jY8pF51r74A9bEl++cx4L0AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "570",
+    "id": 570,
+    "sortid": 570,
     "identifier": "zorua",
     "name": "Zorua",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAq1BMVEX///+MjK02NjYxMTFSUlJTU1Rra3OMjKwzMzNra3JTU1M1NTUyMjJsbHQxMTJVU1PVW2XUXGWKiquLi6xSUlM5wqONiauNi6q+OluJiakzMTHWWmPXXWb5/PyMiqs2NTVUUlM5xqWNi6y7OVrVXWVta3PQWGFpaXFqanI9x6e9OVq9O1xRUVFRUVLTWWLUWmMzMzQ4ODiKiqpTUVGLi6s5OTn5/P3+/v7///9oo07WAAAAAXRSTlMAQObYZgAAAMVJREFUeNrt0UlywkAMhWE9qbvlAWxjQ5hnyDyRQML9T4Y5APIe+BdafVXdKtG9ayxtFtl5yOeoEZbfFI3Hr6MzFwOKooXibdYVKdEyILsfB0D9HgiZ+fZ7HlQXK+06IRP+Fj5PBgPvnjNrefnoAMVDZwIv9WaXf8nDPwCb5RGIKDIgpT0A05d/qEaAAXfDNtCrXeJDFVsXEqg6RRIAsRxxnNSF4AAhM9nGcWg7fuo3wTVLXjGlj3MbMpN8MdGBqa7R3rvpTkLjCeFpAGnBAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "75"
+    "gender_rate": 1,
+    "rarity": 75
   },
   {
-    "id": "571",
+    "id": 571,
+    "sortid": 571,
     "identifier": "zoroark",
     "name": "Zoroark",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAeFBMVEX///8xMTFSUlOMjK3TWWI2NjZUUlKKiquLi6tSUlIzMTEyMjJRUVE1NTWNi6ucSmNra3NTUVLWWmNqanI4w6MxMTIyMTFsanJRU1IhrYSMiqsxMzI5xKONja6aSWKaSmKbS2Q5xqW6xsVqanHUWmTVWWM6xaX7/v1WACj6AAAAAXRSTlMAQObYZgAAAPBJREFUeNrt00duw0AMBVCxTFV1i524lyT3v2FICYGL7LF23vgDkgDigSQGmuydl8aAZAjjsQ2D2Ng+a1hmRlibmLLG5a2zgfUFCYiszqPCVMdCQD3yJ8viOD6kZcF1/UWkUPJ4unE7ZRXy/LylAbgDiX5+14STC1cE+fZdPj2IaxQKhdb1pOGKiDBMwlmCQo5XrhujyKPH7bcOD6vPRV9qx2YG4Ag9dScK0/0S5NBuIABHXVUcacsIUtP6rcxKkMeh7oo+h8t6L+bY7sTW5+m/bDPyhDrSUUoK4KqbaZ5K+D+CZjbs3nD9MfiGZe+8OH94JQzod8o8XQAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "572",
+    "id": 572,
+    "sortid": 572,
     "identifier": "minccino",
     "name": "Minccino",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAYFBMVEX///8xMTGMjIytra1SUlLExMTGxsYzMzM2NjbFxcVTU1P+/v41NTXDw8Orq6s0NDRRUVEyMjL////GxMTGxMWLi4v7+/vGSmPGTGXtc5uNjY3udJzFS2P9/f2srKyKioohGgkPAAAAAXRSTlMAQObYZgAAAM1JREFUeNrt0scOwyAMBmA8MCMhu3u9/1vWtEpvoByrqj4h9Pm3sDD/+v5qATY5n5qp3wT30/SRHgDK8Bya3vg1vRjf7o+HWVxyYFp1ZejTZUFmG3fjYBFvZdhhQLaEIVq8HmYaTUUK3oOIdpwWpzcFONhGXkVBW5w+ry/I5JIy1Rh0cA1Gq1A1Rciu8nDNkmgJR1OFph2sECHDu0sPpcgHM+84zwXK6a68IsprHKELIoL1VUrkzJBr384DdIQ5cR1bs13e4RpXp+ZfP1hPh40JM0vp8QMAAAAASUVORK5CYII=",
-    "gender_rate": "6",
-    "rarity": "255"
+    "gender_rate": 6,
+    "rarity": 255
   },
   {
-    "id": "573",
+    "id": 573,
+    "sortid": 573,
     "identifier": "cinccino",
     "name": "Cinccino",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX////GxsaMjIxSUlJTU1MxMTHExMQ0NDTGzu/+/v7///8zMzM2NjaMjY3EzOzFxcU1NTVTU1T7+/v8/Pz9/f1UVFTDy+zGxMSrq6vDw8ONjY2Kioqtra3GSmPGS2Surq7GxMWMiotRUVHtc5vExMNkSzsyMjLFS2OLi4vi0l2+AAAAAXRSTlMAQObYZgAAAPpJREFUeAHt0dluxCAMBdABQ3BM9iWzTPf9/7+wF79VCqhvVaW5EhKKDgTbhz/OLY33v1OTSNBd6cBwNq6rhaN6CSVo3AyRGI/k89D2gKaGW6kyJmbhwzNkgmtlrO0L8GjpaxFue2M/j7kbm22sjKvscrHJ3edgM/FYObwMDMu+PuWcMGRtNMqjz0ABfH8DqtWhp2HXBf9C+m+TtCP0XsIODFrO6Q53QTu/cQ7CtYuIPKIS8hj3Vu+NcTgME7fLBZRbmkHwQeH+M88WUtYOlwFy6lDmmaiI5pVmjoA+M0LlV4sxUhf1YCnN6eOKYrDBKkKfbAH8tLf8l3wDhkIOy5QZLzAAAAAASUVORK5CYII=",
-    "gender_rate": "6",
-    "rarity": "60"
+    "gender_rate": 6,
+    "rarity": 60
   },
   {
-    "id": "574",
+    "id": 574,
+    "sortid": 574,
     "identifier": "gothita",
     "name": "Gothita",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAilBMVEX///8xMTH///80NDRSUlJTU1NUVFS+vsbGpc7Gps77+/v8/PwyMjJ6enp7e3t8fHz9/f7+/f5RUVGjcbo1NTWlc726usO9vcY8ZZXDo83Eo8zEpMzEpc7FpM3Fpc3Go8zGpM1kxfZlxvfNU2zOUmvOVG32epN5eXn7/P02Njb8/v4yMjN8e3w7ZJQBrhpEAAAAAXRSTlMAQObYZgAAAJZJREFUeNrt0lUOAzEMRdHaYRoqM3O7/+3V6gLifI/mfh89KTAa6mVPKHT3KpasFcEJeBTQATvn0dSSAhaanVUykQTIQx3cZ23VSgUUeXnaWKpF5OBiSUwHNE0ejrfn2+H40kEAd5zrZf99uOmbuUePrkVnyXHQNIgagH/BLgXUMkVezuZ1JaHk60SiNMhLsn9XZId62A8qrgnWERLH9AAAAABJRU5ErkJggg==",
-    "gender_rate": "6",
-    "rarity": "200"
+    "gender_rate": 6,
+    "rarity": 200
   },
   {
-    "id": "575",
+    "id": 575,
+    "sortid": 575,
     "identifier": "gothorita",
     "name": "Gothorita",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAS1BMVEX///9SUlL///9ra2sxMTHGpc5qamq9vcb8/Py+vsZjxvfOUmtsbGw5Y5T9/f67u8Q0NDRtbW02Njb3e5RRUVE1NTX7+/szMzNUVFRaVHE0AAAAAXRSTlMAQObYZgAAALNJREFUeNrt0MkOgzAMBFA8HhP2pfv/f2ntimMTuCIxUW4vE9nVlTPkxkOMBJbquYudqSpfjsvtRFJgbbCQzvxBBhMqQBKpo7edsAT+KwOKRqRBO0jd5KCKuw2ufpGBoqLY5DxE6zszjjjs1Pyo1DJPH2agkjaaoYND9bFykH6ttzRCyRi+uPV7bxaEj3B5mACRIHRdkvrbJaOy3AgVP1vb3tdRuBcyYLh9esyFPAxZXTlRvvedBPo5FUQFAAAAAElFTkSuQmCC",
-    "gender_rate": "6",
-    "rarity": "100"
+    "gender_rate": 6,
+    "rarity": 100
   },
   {
-    "id": "576",
+    "id": 576,
+    "sortid": 576,
     "identifier": "gothitelle",
     "name": "Gothitelle",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAYFBMVEX///8xMTFSUlJra2vGpc7///9qampTU1O9vcY0NDQ2Nja7u8Q5Y5Rjxvdsa2xTUlOlc71tbG2+vsZubm7EpMwyMjIzMzNRUVGmdb7OUmv7+/v8/Pz8/v79/f7//v9VVVUaeODCAAAAAXRSTlMAQObYZgAAAMxJREFUeAHt0bmSgzAQhGG6e1rA+rD3vnff/y2tCQglhU74yyb6iq4apr079gDkI/8DWAR8eUXpQuCdRfx+mtP33ieRhYl5+F078lVSZRkPb51pcWa6jAVAaxoSn+O8SaklQc6OVC9nFrLlUsqnqC6uFxZ15Pofx3j8O/3UE7HShgQWM2pHf1zYOSbCJOMz4krk9ZvTMODFIrYP35T1JxtVJusFSyQEui9zesEEOmIgZeeyAxhNi5UkG06nHAXKlkYwJShtckSzae++3QBOpQVh2tG88gAAAABJRU5ErkJggg==",
-    "gender_rate": "6",
-    "rarity": "50"
+    "gender_rate": 6,
+    "rarity": 50
   },
   {
-    "id": "577",
+    "id": 577,
+    "sortid": 577,
     "identifier": "solosis",
     "name": "Solosis",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAflBMVEX///+M1mu976VjvXtafGu87qRjlHO+7aT8/fz9lYxiu3oxMzJjvHozMzJkvXo1NTW67KO77KO77aQ2Nja9pVq9pltTVFNae2u+76YxMTFiunn///9jlXKN1Gtbe2plvXvUdHLV1WrW1mvW1mz09av29atyrXN1rnX/lIyL1GuuGJL5AAAAAXRSTlMAQObYZgAAAIxJREFUeAHt0skOg0AIgOGBWdwXa9Wq3fe+/wsW0juk9/nPX0ICGLVYrJ85lTXzYrlCof1i0/U15UwV+EzXHbjpfpIkObdBRPDD41ZrcOyIDpdrbQsZVi2y3B5zEQYanSU4duAU+PGYvZOqhX0pQNOQhPPBIyiQ9hgCWcX9pGUbSktQlMoN//8KE4t9Afa8CYnB830bAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "200"
+    "gender_rate": 4,
+    "rarity": 200
   },
   {
-    "id": "578",
+    "id": 578,
+    "sortid": 578,
     "identifier": "duosion",
     "name": "Duosion",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///9jvXtafGtae2tiu3pjlHMxMTGL1WuM1mu976VjlXJiunlSUlJbfGtjvHpSU1JzrXKL1GtTVFMxMzK67KO77aS87qQzMzK+7aS77KP9lYxyrHI2NjZ0rnN1rnVik3K97aQ1NTUxMjG+76bVdHNzrXP9/vz/lIz////aOkehAAAAAXRSTlMAQObYZgAAALRJREFUeNrt0kcSwjAMBdBI7um9AqHD/U+IEvZytjD5M969+bI9Cvb8Tg5a600sAoBKex0xFEJC5XPGYtFaJOlxz/epcS6RNN4Hb4kQEz/8EgFSnW3pIEmmEJtyIEc5CsnDrh57tyThYdG68dWXgw8CTs397LraWSTIVuZmfUzO3zGTOBc2f5hQSOAhKIImVCnglfvHrwxTgEzzGxYBKJVmcexdC6JLLyzQR9devXXLgz1/lg+rgwunYX2pBQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "100"
+    "gender_rate": 4,
+    "rarity": 100
   },
   {
-    "id": "579",
+    "id": 579,
+    "sortid": 579,
     "identifier": "reuniclus",
     "name": "Reuniclus",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAsVBMVEX///9jvXtafGtiu3pjlHNjvHoxMTGL1WuM1mu77aS976VSU1Jae2tzrXJ0rnOL1Gtiunk1NTU2NjbWc3P/lIwxMzK87qRjlXJiknFjvXq77KNZeWpyrXO97aRSUlLUdHNTVFP8lIuL02r///91rnVUU1JRUVEzMzIxMjKN1Gu67KNbfGsxMjFklXNku3plvHu+76bUdHJxq3HVdHNiknJik3L8/fz9lYv9/vxzrXNUUlJlic+MAAAAAXRSTlMAQObYZgAAAR5JREFUeNrt0kduxDAMBdBQhSq2x1We3tN7b/c/WCgFCRBENmaXLObDGwNPFEXwYJ8/TIm7uaoAtyNk6SX6hD/shlNjLzhQHIbyfVBnEgKd8p4+ynv1uj1MUw4zXzsGK6QPC5g9b2+1Zmneehh/bwEJZwS0bq0dqEy62J0FADlgxlpyBN+Ci5VcN0ecmdUkOEsXd8FlfU0FT86/IbioAwA19i0+zK1dTQKMDb1CesuG5F191lqqywhGh070mIs8Uy9NPbfesQUdhgQxdr8wA6V1prx7kmESQrqI9CV1ZgbmihQl0N+wHEmRLDbDfCgkPU2N180NOIzOnYaePBIDcTqSsKzfu8YZ+uefe4ZEe1at8Aq/jnVDv0Q/lmqf/54Pr2IUMcY6lHcAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "50"
+    "gender_rate": 4,
+    "rarity": 50
   },
   {
-    "id": "580",
+    "id": 580,
+    "sortid": 580,
     "identifier": "ducklett",
     "name": "Ducklett",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///82NjYyMzQxMTFSUlJSUlRShPd7td6l1v9RcaOm1v9SdKVSg/RRgvNTU1F5stt6s90xMjSNjXGj0/uj0/yj1P1SU1R6s9vLq0H39yn9/fz9/v+k1f5TVFRTdKZThfc1NTU0NDA0NDQyMzPMq0LOrULz8yn29SlSUlP7+/uNjHIxMjIJ/1I4AAAAAXRSTlMAQObYZgAAAKpJREFUeNrtkMcOwyAQRE3HGPdeEqfX//+/LMqd5ZrIDy4rPY00E238DARekFfTmoaJWoeJcbtraFAgoM6Yd8gX7aCo6AJng5skLpb59DQgEq833MdqcqL2jkRuI1BNRnW88RYibLhmvE8e8DmM5FXjQiVF0qLVSd71SrmR1tLrpcKKvmu03r/9Q6ZSCisFYwwuLFI6SkwcXpxfMot5rjeDOY/fA3ejjb/jAxO/CYGQwfapAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "581",
+    "id": 581,
+    "sortid": 581,
     "identifier": "swanna",
     "name": "Swanna",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///8xMTE0NDT///9SUlJTU1OMnJS1zsa2zsb7+/v8/Pw2Njb9/v6NnZW0zcVUVFRjdNZ6enp7e3syMjJ9fX01NTWLm5VRUVFicdOyy8OzzMSzzMa0zMRjc9bz80l5eXlSU1P390p6u/Y0NDH9/f2LmpJUVFH8/P55uvNkdNVlddYzMzNstL6CAAAAAXRSTlMAQObYZgAAAPhJREFUeNrtk8euwyAQRTMzdGPjmt7rK///fw9QpCdFtvEumxyxmMXhSpcy+/BGMggrSQegUeOEPO2MsjjBo3ZriRCSYmvI0xpMR3ryq7SYFlHnFMS0R8oSOYAxcWEQtOJrmxf81sCQ3O3vzPjKC1ZtJWeVGeif7U+niw/JVpIbxQ1FsM+7hP3RI/f0SP0CvHhBi6K4ErVPMU748hr+u8cLcizKeSHqprf68hHOnNxNHE2ciLBX/CofIUgU0ptKiDoE9kdu7M9uXkgp+VoMBnq61fe53G2kFA1oIoCRZ748l3NxhDDC+K0fasaqZtLfgUNsMc2dfXgnf3bNDZbT4XgOAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "582",
+    "id": 582,
+    "sortid": 582,
     "identifier": "vanillite",
     "name": "Vanillite",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///////82Njb8/f6N1v8xMTE1NTX9/v80NDSK0/t7te99rtZrhd6L1P4xMjPU/v/+//9jjM4yMjN9tu9ZaoJabIV5q9OL1f6M1v96s+17rda03fZ8rtaL1P223vfT+/vU/f4zMzTW///7+/tiisv9/v4zNDRjjc5ljc6bwLe4AAAAAXRSTlMAQObYZgAAAIFJREFUeAHtz0USwzAQRFG12GyHmSH3P2FqcoD07O2/ftUamalRZ4POxXvWQmSdq/ZPhbSrSw/wTSt7wO0wY7BIIiuXmasd4JM8zqGvm4TT9T889/hB373ojfI0/4yJj6Hp/I46W7wd5u7TGioX23W5PMqJdHNTDm0wvBiCsNE29QVk+QZGALmXPgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "583",
+    "id": 583,
+    "sortid": 583,
     "identifier": "vanillish",
     "name": "Vanillish",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///////+N1v82NjYxMTGK0/t7rdbW///9/f79/v8yMjN9rtaEnO+Fne81NTWL1f6M1v8yMzTU/f5rhN77+/v8/Pz8/f55q9P9/v40NDR8rta0ze61zu+2zu/T+/uDm+6DnO5rhd5thd5RUVGL1P5SU1RSVFT+//8zNDTn/zWBAAAAAXRSTlMAQObYZgAAALBJREFUeNrt0jcOAzEMBEBRgQqXc3DO/v8LzcatxNIGbgtVgyUoUGz5gSitWa7sARaO0z3LKeqzb4a7DUBZGH2HOVlJ2xovPbn9vESheQ7yMhJNDFfTbiZ4vXuy8cq+cNITBMiCjv500Y0gfeGyqm4ihccXyLzrTg4kBiGiMjtXuYP0Nq0l2tIuVjYiKrG1dqVnDYmLMIhY1YghfTumxgfnIMvpW5eWPCcUQaYUW/4oH11GCR83pCz3AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "584",
+    "id": 584,
+    "sortid": 584,
     "identifier": "vanilluxe",
     "name": "Vanilluxe",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAnFBMVEX///////8xMjNljc55q9N7rdaL1P5jjM4xMTFjjc4yMzQ0NDR6rNU1NTWK0/s2NjaVpq77+/v8/f7+/v8yMjOUpa2Ua+/UxP7Wxv/O3ueVbe/9/P79/f3+/v6L1f62le/Ly8vM3ObNzc3N3OfN3ebOzs59rtaUbO7Vxf5iisuVbO9kjc4yMjKuxuf9/f79/v79/v+0k++1lO+M1v+E/S1yAAAAAXRSTlMAQObYZgAAAP1JREFUeAHt0EdvAyEQBWAGlsIWvN3d6b0n//+/ZZhVboPWl8gXP9t6PnyA9MQ/5ZyFc8e5BqCY55VroH4lP/GUa+odRFGRr4KXyWfrYYcy/oMi6EOehJQi3qyM1j3vLofrfXSoMKpEx67S1LcP2zvEBFFKzmUH30a4uRkioxQcDNq28PYBBFfPyy7+ePkJsFl2iLG304eBNB2KcRy/3uEvSrrUNqvvxw7rgg4o8+MlJ5VtgYIS3b3W/OKLzF7tia2nUibHp1Ny/dKCmpr2SUlrS/zq2L0TSRhyl9kSTaatTCmSONOT8TIeETOpgjc5lpgNfxkHs14cKcXpc84vL10SnGuEMAcAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "585",
+    "id": 585,
+    "sortid": 585,
     "identifier": "deerling-spring",
     "name": "Deerling (Spring)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAsVBMVEX///8xMTE0MzA2NjbOhKXOxqX3pb3398b+3Sv/3ik1NTXz88MzMjI0MjP0pLv29sUyMjJxcXH72yl1dHGupoX29cTLgqP3pbrOxqPLw6Pzo7rOhaX3pr3OpVs0NDN1c3T+3Cr+3Sn19cT2pLwzMzKro4L0o7uspINUVFFUVFPLo1kzMjHMg6TNxaRzc3NUU1P39cXOhaN0c3P82yn83CrOpFt0dHP+3SrOplz+/f1RUVFO/MDeAAAAAXRSTlMAQObYZgAAAOVJREFUeNrt0rd2wzAMBVBR7JSo6t5bintJz/9/mAl7yWIgmxe/CcM9AEEyeuSe4f91PX8tHAmVB+R6HmMA1J5VMQNPdBST1zd7nA/XEdGy9TG1dTacxsRmrrL1e50ZGyBHDspbp102zsQkOIDYMuqgB2pcgFPKI/DnuxmkB3jb8UTrUSLzgUgj/vuMTF41Acp+Cr2DvhnOEi37QqThyk0bJELLjZirS0xMvI5pK2M7X7azwGEFRuaNbb7E4dNMylw3CpbIBSW1BsO7BOx+vsxGUJQFCl0ZpgJ0jPiU7G8v0j5y75wBGNoPJEg09tUAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "586",
+    "id": 586,
+    "sortid": 586,
     "identifier": "sawsbuck-spring",
     "name": "Sawsbuck (Spring)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAn1BMVEX///+9e1oyMTE1NTU2NjZSUlKLUlKMUlK8elkxMTHdu1r/55RRUVG6eVkzMjFTUlLbulmKUVHevVrscpr+5pMzMzFUU1L75JKNUlONU1LscZpUVFPz5Cn2k/S7elk0MjRUUlONVFO9els0MzC9e1zvc5zvc53vdJrzkvO+e1m+fFr2k/X3lfP35SwzMjL7+/v9pDnbu1n/pjzcu1n//fugnQxxAAAAAXRSTlMAQObYZgAAAO1JREFUeNrtk8cSwyAMRC0wmOJup/fee/7/2yLGyRHjQ3LLzjDi8GZ3JJD31/fly4aUnxE3baiQE1McXH/KGUPX4XEiZX10WBwmHu2vptxhSrenhUczxllxrrWMkqJLhpsuMdEOkjNkI4DYRQIEbBwExHOCqGbc9XnfYa47mFwq0Jco69MIVeq8JyCWMoIAqwWlHT1gXADAaD0HSMbW7v3wVu6h0miZcBHbwtNS6w8J1mRDdrSemWzVrnKtjnmpB4ioHHtSrbo/+WjLTIBqYd8qryWJmWc1ydQFpj3yuVtFJZ63E22wPI2X9q+f6QWWyg1qDXhU6QAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "587",
+    "id": 587,
+    "sortid": 587,
     "identifier": "emolga",
     "name": "Emolga",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///8xMTEyMjJzc3NSUlI2Njb39yn8/Pz///++vr40NDQ0NDB0dHR1dXF1dXW7u7s1NTXbmkLdnEP29SlUU1H39yz7+/tUVFH9/f1xcXFRUVHz8ynenEK9vb309CpycnLenUEzMjF0c3L09Cn+/fz+/vvbmkFTU1Pcm0LueaxfAAAAAXRSTlMAQObYZgAAANtJREFUeNrtktcOwyAMRWtMWFlts5s23eP/v7Am5JGUvkbKlUBCOjrGhs2aRSSC/7hth+wv3+FMYAQQBDtEBnYLGjlhn+PxGq6MfPeoRDx1BuDl6kxmiFJVIxeRnC7h45RSmdTJ4LgRA+8IiaToBJnjOPhnWOtWKVMTyexAcSrsr22gfxI4CcHP9U3eqkpcShjfaF7YX26Yn/YllwYItJ34wVeR5gnn0jbP5h7dKUVKxZV+7wrRON2csySdFQ5CxD9/GRyc8h4A7TANQJfvizj40+wi2p3C9JoF5QsTQwtCrTaC9wAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "200"
+    "gender_rate": 4,
+    "rarity": 200
   },
   {
-    "id": "588",
+    "id": 588,
+    "sortid": 588,
     "identifier": "karrablast",
     "name": "Karrablast",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAflBMVEX///9ra2s2NjZSUlI4guQ5g+U5hOc8heRRUVExMTFqamoxMjP/3jE1NTVSU1RZo/sxMjQpWoRrzv9tbW382zFRUlRqa2wwMTJqzP45hec5g+RsbGltbGorW4JtzvvTqxjUqxnWrRjvhUH72zH7/f5ZpP783DH8/Pz+3DEpWoX5KlTSAAAAAXRSTlMAQObYZgAAAIRJREFUeAHtz7cWwzAIhWEhVISKu9N7z/u/YLJlhDn2P3/nwFV/2FxRWuR03dSNCJq7S7LTRubEsBjnksit1hKpr4euqzbvpQRW8eET50JEHC4vzx3X5tYDnLZ2jMTABeKzBzsicT/uAMDyu0sYcs6eX/2Vx/O+bXmoNBGF3xQOq+k29wGr+wZVP9ytOwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "200"
+    "gender_rate": 4,
+    "rarity": 200
   },
   {
-    "id": "589",
+    "id": 589,
+    "sortid": 589,
     "identifier": "escavalier",
     "name": "Escavalier",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAKlBMVEUAAAD///8pUpwxMTFBg/9SUlJ7e3ukpKTFxcXVOUHVpEHuc5z29in///97yI9BAAAAAnRSTlMAAHaTzTgAAADRSURBVHgB7dNBdoRACARQY1kUrcn9rxsYkt2AHmCqX6/8jwXVbl8P8xB+4PYXvLL9p4PAdV1rLWCGSFXBBFGsgh6WI418AGmKU7KB6QAPZkbOML6FNEkzLCdXSnQwEMJl0pk7poWbxzFj6gGW+w4ns3BAB+XOddLdciC8hS6SPzlQRLiuwhXsPBlQcckGhnN3O8+dstRo9ujpJNuPI5thA2veq8Fjp/vC+/VgAeUkgJe611O1yGov183DVYThXHe/QiRm5Z1h2nL3sOwA53zgnF9CAww+ZT2yPQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "590",
+    "id": 590,
+    "sortid": 590,
     "identifier": "foongus",
     "name": "Foongus",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAb1BMVEX///+Ea1r3Y1KCalkxMTGFbFuFbVzTuqvWvq71Y1L////Wva1SUlI1NTU0MTGujYUyMTH7+/v+/f0zMzLUu6s2NjX2Y1IzMTGFalnscZrtcprvc5w2NjZRUVGsi4M0NDT9/Pz9/f3+/P28Y1K9Y1ILdwgcAAAAAXRSTlMAQObYZgAAAJNJREFUeNrt0kcSwyAMQFEkenPD6cVp9z9jgAMgrxP/9Rtp0MC2fq8oSiS7ilEBgO0E4fhDzZPrwR6HNhyduj+dkRY7wjlXVyNiR8BcT0M9FWjke4+fQwPu+FylAsT2ayKHTI0EAEGdm0NJZEfJWwhBMNLppL33idGSn1+LlgMNT5cMV8yM9ZSqTqSlSWs/JNv6474wAgd0VuXoGgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "591",
+    "id": 591,
+    "sortid": 591,
     "identifier": "amoonguss",
     "name": "Amoonguss",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///8xMTGEa1rMzLvOzr3WWmvueqTve6WFbFutpZzLy7pSUlKCalk2NjYyMTHseqPteqM1NTVTU1MzMjIzMzOFa1syMjIzMTGEa1vUWmrNzbxRUVGro5qspJrOzLvTWWpUUlPVW2w0NDTW1taFalqupJzOzLyupp2Daln7+/v9/f3+/v05AisUAAAAAXRSTlMAQObYZgAAAOhJREFUeNrt0jd2wzAQBFAtiECCNJiDqOQgOd7/fh4AVueF3anRFKz+W27A5p5b54F8/sGslLJYHP3JchGynSnhqgwuQ0HRGDM6zrVwgIcVH0BetrE9gXindM/8eL9KX3GrzTX97zAWRDWltNJpGLqLDFEzO3MseHVnxzS5e/cL1BEJwS+93ZUlLOIVGOf2iyh/4hUPbZ519PFWIFMayryszeXzGXgiooTs6sfavH69FEVXY428pJM26oh9wo2iSUj7BOchps9yx0PcO2Sw/sENiYGqwxou7ix0cnSqRDhKG6ZOU5B7bp1vLOAN3kAnmEYAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "592",
+    "id": 592,
+    "sortid": 592,
     "identifier": "frillish-male",
     "name": "Frillish",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///+c1v8xMTGd1v80NDSa0/syMzT9/v////97pf/7+/tZYqsyMjR9pv+EhLWEhbaFhbYyMjM1NTU2NjZRUVGb1f/9/f1SUlKa1P2c0/xTVFSDg7MyMzNbZK6rw8OrxMTTUVnVVFz8/f/9/v6b1P15o/v8/PwxMTJUVFRsMkkAAAAAAXRSTlMAQObYZgAAALFJREFUeNrt0ccOhDAMBFDGDin03raz9f+/cFEu3BKuSMwhp6exFQdHdpR6I6PrmbbAKio6scU1t2dRbnCh0lqz9DsoBpRXVvEAmBZwwpqC6j7iMsAN64glhcBjBEzihsB0egHIS88PahFxnmVZ9yNySqIonVmxEiGkxzafdE6TpZ2hhGs6T30ff+0eWri2ZJO8W5PYPVyFi7PnEb4LSgos1D5pX2/l6ilcb+irPrKT/AHsMAgYi958ugAAAABJRU5ErkJggg==",
-    "gender_rate": "0",
-    "rarity": "190"
+    "gender_rate": 0,
+    "rarity": 190
   },
   {
-    "id": "593",
+    "id": 593,
+    "sortid": 593,
     "identifier": "jellicent-male",
     "name": "Jellicent",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///8xMTHe//8zNDRrtf+a0/ua1P2b1f+c1v+d1v/b+/syMzRstv9SUlJSU1RbZK7c/v/b/Pxqsvvc/f9UVFQxMzT+//81NjY1NjdcZa6rw8N0hY3UY0PVZERbY6syMzNTVFRqs/3c/f1aY62c1PxaZK77+/tttv//////68AVAAAAAXRSTlMAQObYZgAAANxJREFUeNrt0dkOwiAQBVBnoJSl++q+b///hU6pMRoBffPFm0DScHJTmMk/v8/0SwbzDXwF9WLPPrMeyJGET66KZYGIirdhF0lyijYlTbgvF/Ie3oYK8+VR5mLUxu/Ol6FxtRahyh5Ad1dMYn7a8djCmrmcxqYkiEmNSHxwyFxOyW2J2OGYhJNzQ7TyJUnrnggyWs0TZr7hDavKHpLZG/rfPEstnR2EAe2v1YrzLE0BIJJDCiudd8oFTdrYv1bkfFBJE9GxMvaLGHiGbYC2sTJ8l/E8Mj7w/lT//Dg3k0AMp3FK63wAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "594",
+    "id": 594,
+    "sortid": 594,
     "identifier": "alomomola",
     "name": "Alomomola",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///8xMTHvc5z/tdbvdJz7stP+tNU2NjbtcpuFa4Q0MzM1NTXzkrrzy+Qse5z3lL2Ea4T7tNX8s9P9s9T2k7yFbIX/ttb+s9VUUlPziypUU1NUU1T1zOVVVVVWVlb3zueCaoI0MjP7+/swMjIpe5zscZrscpr+tdb+/fszMjJSUlL//f4VmgJEAAAAAXRSTlMAQObYZgAAAKlJREFUeNrt0kcSgzAMhWEkF8BA6JDee+5/v4gTPO2SBRovv/nHGjua5w8mJqVzJiidBsbkTMkv6DK3aSwr4K7pE1YFJcfLN8Eb5sxp1VrYjG+ctsYYkQim24dAuPeeCnG28xYVi8MEeQxo6ym4qO0oReyudekVcHE5D3CZzElw9RzMFITyI8H1HUoS2leJ5rmPwpi7E4Tyigl3PuBk7oPuk2ckh6J5fjpfwKAKLPf/4cgAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "595",
+    "id": 595,
+    "sortid": 595,
     "identifier": "joltik",
     "name": "Joltik",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABPlBMVEX/////51L+5lE1NTX/5lI5OTlXVlLMoxnMpBnPpxn54VH85FP85VP95VA0MzEzMzExMDAxMTH95FHKohlRUlL+51T85FA4ODU2NjY3NzTMpRnJoRnN3PT44lI1NTBTU1H85FH85FJXVVD95VL95lH95lR/nvmFbBk2NDEyMzRRUVE0MzPKoRvMphz54lD54lExMTI2NjHOphzMpBpUVFJVVVBWU1LLohg2NjQ1NS82Njc2NzhWVlE3NjJXVVLPpRjPpRkzMjD44VBiasz4+PpkbMplbMxlbc754lL64lD65FL74lD741D741H75FH75FL75FP7+vj841Flbsxmbcxmbs1obcr85VJ4mPh5mfl8nPn95VF9nPz95VQ3ODUyMjX95lX95lf+5VH+5lCGbhv+51H+51KHbRiHbhmIbxoHTpQcAAAAAXRSTlMAQObYZgAAAPRJREFUeAHt0dVyAyEYBeAeYIXdZYm7S+ru7u7u7u//As20V50JTO6TM1x+HH6go7XTzkOgKZb0C7lmcNIi4NN+wdcqKodsAoAT5PR1J+YAEMNhmfFljZuySfUzFPseNCNFTSWVnbfIjJC3kHk5ni0vdgVUcJu50doTMlWAz0VsMq96vvTLxloUqD177xATO8yVjQ/eW8iePR4AON70wL/Cu+szjaDh9E/mb87vAfSuuvV7l4JUMeLVbHDlQzCIizuvWBobHVaMaCTqy0lVhLVfsfLhpaNX3ecY1EnFE2lJe7ZO++Ia+Fv8V37drXX/d7TTivkBGb4bm7p2EwoAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "596",
+    "id": 596,
+    "sortid": 596,
     "identifier": "galvantula",
     "name": "Galvantula",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABVlBMVEX/////51I1NTVSUlJUVFIxMTE3ODWzkqu1lK3LoxjOphjPpxn75FH85FL95VNTU1E2NjZTU1Nja85ka8t5mvuDa4MyMjS1lKo4OTa2lavJoRk5OTlRUVFRUlL44VD54VH741AzMjBSUlP85VL85VQxMTP95lX+5VH+5lH/5lJXVlJiasz841H95VB+nfmEa4SFbBmxkKuxkqqykqpTVFW0kqy0k6y0lKoyMjZUVFRUVlTJoRgxMTLJohvLohdVVVLLpBhVVVBjaso3Nzf4+PgzMjL5+vxla8l4mPjNpBr85FE0MzH85FX85U/OpRiEaxh+nvyCaoKDahj+5lL+5lT+51E5OTiDa4RiasuykqyDaoNTUlD641T65FRWVFP75E9jasvMpBjMpRl9nfz75VN6m/x8m/z95FVXVlP95VLMoxg3NzT75FJVU1T+51L+51U4ODViask/nMg/AAAAAXRSTlMAQObYZgAAAXNJREFUeNrtkkV3wkAURvMyM0mI4RDcXequUKVC3d3d/v+mE3oOiwR62LULvtU7yZ37zcsJ082/CEs6xFyezkCXw5HqCDyMI9IYfr8cG+RrGTFGqNlD2nGWGCEWby0D4BMW2t6Am5y2OOOKT1B1ThWtqNASZIt4yopCvKD61B/YTlrXrr99xZX8DC/YEaUBo0Krarb3QnSOnQFAHimYV0WvXcFmI0dkkOqPSjmZzAJIVqrsQYroNBrZsEjf4/nNNJTTQIN5+zFSYNUoDBA5B684JcNNOvkBe+IGrd++ol/TRFpu5XyourYDpftFx+kIqgN+zgCYSXZ5PFHpH3rYvV4avTxy01qkg+byfX2bk62B4fNQte8AYQUknRQzJpJbgahmC+JExT1HrJK+m/9TxogYq+XoOz38UgSJMIFILgcgxRib+cdkw1pEY9jZLEQ5upu/9EQL6GAzgvRJoOmlw8RgQjMgRi/XOBe8M7jM3ubUzV/mGyI5Koec812+AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "597",
+    "id": 597,
+    "sortid": 597,
     "identifier": "ferroseed",
     "name": "Ferroseed",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAyVBMVEX////OztY1NTU5OTlzc3N1dXWpqamtra0xMTExMjGsrKzMzNR0c3F0dHSqqqozMzPLy9PLzNNRUVFJgVH+/v5lrGo2NjY4ODhjq2v5uyk2NzZlrW1nrWxwcXBycnE3NDFzdHM0NDQyMjJ0dnVJgVB1dXY1NjVKhFKrq6tMhVStraw2NDHJydHKytLKzNJRUlJSUlJUVVJiqWn4uCliq2r5vCr7vCz8/PsxMjJkq2zNzdVkrW11dXL5uSpycnJyc3I3Nzc2NjVjrGtqgLQ8AAAAAXRSTlMAQObYZgAAAK5JREFUeNrtkEcWhSAQBEFABHPWn3POOaf7H+pzAnCvta7XPT2gosxoRlHvwIwCGltEUx+6SvWTvU0I7R9TBU5g1McC01UEehHJxj6E0JXv0L0zHJr0ZlLck4hotw0sLm6cEUW3tp/nDwtvxCB6ZTLx9Yzvx3beWFFidGXdOsbL+in2ia2n8vc0HWILHOoq/jio6Zw7vNNK5CJKAArWhhZegBoUjgD6ggKkoKLU/AHhBwvyvCTOXQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "598",
+    "id": 598,
+    "sortid": 598,
     "identifier": "ferrothorn",
     "name": "Ferrothorn",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABEVBMVEX///81NTUxMTFKhFJirGpjrWvOztZ7e3tKg1IyMjJRUVFSUlJiq2oyMzIxMjF6eno4ODipqamsrKytra3MzNQ2NjY5OTljrGtKhVJlrWl5eXlNhlV6e3ozMzN9fX1RUlKrq6vKytLLy9PLzNPMzNNTU1TMzdTNzdU2Nzb8vCpJglHNzdRSU1Jiq2k2NTVKhVNjqmpLhFNMhFNkq2xkrWxMhFRmrWxwwXhyw3lyxHpMhVR5fHpNhVU0MzBOhlZ8fHw1NjV9fX5RUlFKglKrratRU1JKg1GzbBm0bBjJydHJytFSUlM3NDHLzNJTUlDLzNRTUlFTU1M3ODdTVVNUVFRgqGj5uyn5uyr7uin7vCxiqmvWBACjAAAAAXRSTlMAQObYZgAAAUdJREFUeAHtkMV2wzAQALWSJTPbYWYoMzMzQ///Q6rouYfaTZNbe8hcpMNYux70X5gAGOOxPINSao20uEcs3JOs4dOweM3SFO7AzyaYz+nBOMxfImU9+iLpdYzphzDUDiVSbyrlBvNVBJrCF0gsT/YGR3GBm77fZowVexIlieEdMQVy1f4WqTO2IdEWayqEkJgotgF8cnZnXweMi4RItKBXfPW7Zh0YxybGteXX7ZfsZnDL1V2FSFPx5rA6K2XWTAT2XHeltXR6Y8uy5/vziQXh8oPSR4xSbkmtthe7V2/Zgq5XZD2eJ3W+Q/IXDkKO294vgfGePZIr97anxkVuBoEjLm6jz11ZfhI/kizuAEQXTXZrQeB5pRxEMYYArhPOAIRuEf0upsKvU1RLFEoiqqUz6+YYYlRtJLxaXlQbSVRtHBMA/QkTPgEHfh8J6CPwwQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "599",
+    "id": 599,
+    "sortid": 599,
     "identifier": "klink",
     "name": "Klink",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAnFBMVEX///8xMTEyMjI1NTU2NjZzc3N0dHSUnJy9xsbL09PM1NTN1dXO1tY0NDQ5OTm7xMRSUlLM09NSlJxycnIzMzP9/v6Tm5tSU1M3NzczNDR1dXV1dnaRmZmSmZmSmprJ0dFSkpqWnp66w8NRUVG8xcVTU1NTVFRUlZ1VVVVqzdxxcXFRkprs7Ozs7e3t7e3u7u77+/v8/f1ydHT+/v7lD9cyAAAAAXRSTlMAQObYZgAAALNJREFUeNrtkUUWwyAABXGPWz11997/boUDELJPZsFqHsz7gJGhgiHsIwEsDUdBT5pypXuJoprRWnOEQuY7koxSZS/trsXb6nT5Ji8rQkBcrbfxuM6bu+CHzJRLpXnkFVmaFlQ50TC6f2ww8swjGboqY6xpW59Cd73OubZi4mqpUvXELyIId9kvuuVNofybYkLsGUvxOafFNOPBRWE7d4P2+0++kK4xQNxaibiQoIkxGBkof70yCwW0uzg1AAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "130"
+    "gender_rate": -1,
+    "rarity": 130
   },
   {
-    "id": "600",
+    "id": 600,
+    "sortid": 600,
     "identifier": "klang",
     "name": "Klang",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA3lBMVEX////O1tY1NTU2NjZSUlJTU1NUVFSttbXM1NTN1NQxMTFzc3M5e3tse3tUVVWUnJyrsrKrs7OrtLSss7MyMjJSlJzM1dU8fX1RUVEzMzNSk5uWnp45OTmTm5s6fHw0NDSstLRqenqutrbJ0dExMjJtfHwyMzPN1dV1dXWUm5tpy9qVnZ02NTWqsrKqs7Nqe3tre3trzt0+fHwzNDSttLRycnJydHSvtrZRk5rK0dHL09PL1NTM09NzdHR0dHQ3NjZVVlbN1taTnJzu7+/v7+/6+fn8/Pz9/f1seno7fHx/DGaBAAAAAXRSTlMAQObYZgAAATBJREFUeNrt0EduwzAQBVANOymqV9txjVt678Xp5f4XCk0jK0neJ/BfEeDDn8E4m/yBqH76+0RKqSbktACC1CIHhZx74zqHQKBgBp2WY5A3LiMLUbV1a3v04bqB6KCUr7KUYU0rekcPl24ggQyUKgkZxhZXZX/0mZ24r1fS91N2DwEdHsd1UN0Cbbfp+RsD8F/AwIh7sXHVHcWclq4rnyTAXZ4bSSIv9saqIrGYo8fZMxDIi57OYTk9rj2SMn8XN8IHvZv1NECXmso6iIXoYlwC6Oss0xAQPlWhhRWJsVlByEJnuoA9OmiCq5wxeVp8z8BUTvjBVDU5xTkxyJVyh3HechqDk4RJ2aWUMXvvNRInhLDJJDxMeHS0aHSWElu2n3xVXHX+EiG0Vllp4mzyz/IDv/QYeaVlrgoAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "60"
+    "gender_rate": -1,
+    "rarity": 60
   },
   {
-    "id": "601",
+    "id": 601,
+    "sortid": 601,
     "identifier": "klinklang",
     "name": "Klinklang",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAtFBMVEX///8xMTFSUlKttbXM09PO1tbN1dU5e3tRUVExMjJTU1NTVFRse3txcXFzc3OSmpqUnJyrsrKrs7OrtLQyMjLL09MyMzPM1NQ1NTUzMzM2NjZqenp0dHRre3vL1NSTm5tSlJzO1NRycnLWY2P9/f1Rk5vVZGQ7fHxSlJ1sfHyutbU0NDRSU1NydHRUVFRUlZ11dXVqeXnTYmJqzdxSkprt7e3t7u73jIz3jY37+/tqzNz+/PwXlvv+AAAAAXRSTlMAQObYZgAAAXJJREFUeNrt08duwzAMBmBTw9uyLa84e6d7777/e5VUgsKwgiKX3kLAgA6ffhGU7Jzr5BoAdJZwHA3BGVYyKw/LnPM4OMIItalLEFEc+JogbbEhXz+omZuVkHNTJHGLLT+vE4VSRroGn7FRccAWzNf3z7evV27EwBcyC0eTwkC7x+hlfqPf7oSMqNlQ87ggZ8MxY0vVREJSoWQ6LuIA7BlW4zJppES587wpUerTzjRjVA3C3dcFSoQYeRzSeQwDN/O5N0VXQ07Qlj42WVZ48sb7Aw4hUSWAM/BFp8ca+gpSZGaePBTUrJlQ2HepmqnSrOhWhGmW0X0zK7Fq90xIo8y9ENR1b4xJ0zqD1OXb1WqBw2QaZ03PaNm09jvDuO33x/tqkU0mbBTsH6bb9q+moiD2RIm4AjCt5G4E/cQWkPKQYYmspJ8B2SUDa4z4EZVGE6Jg8Xtwn0PFQ+0aXmPmY9OR9qTA1GGnJTrdnvp7O+f6t/oBUMcckR+P9DIAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "30"
+    "gender_rate": -1,
+    "rarity": 30
   },
   {
-    "id": "602",
+    "id": 602,
+    "sortid": 602,
     "identifier": "tynamo",
     "name": "Tynamo",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAWlBMVEX///+lxv8yMjMzNDSFnbajw/sxMTGmxv/N/v/O///39yn9/v/+//////82NjbM/f0yMzTO/P3O/vulxP3TYoLWY4Tzior19iyEnLb39yz7+/umxvs0NDTL+/tDy0UNAAAAAXRSTlMAQObYZgAAAGVJREFUeNrt0bkOgCAMgGHKUW7FW1Hf/zVlcC+DiQv//KVNWtZqfVyHWMdytAJrWElDItwdogUAIwinwGvY3EnNy2WpP9wIiXRFGis5PVD2YIoj4DyES+2cPs26TC+jX4Ks1fqrB7aIBDR8kGCYAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "603",
+    "id": 603,
+    "sortid": 603,
     "identifier": "eelektrik",
     "name": "Eelektrik",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAw1BMVEX///8xMTE5SoxSY73Dq2PGrWNRYrw0NDI2NjY4SYoxMTI7S4s0MzAxMTNTU1JUY7q2MTkzMjHGrmP1UVn3VFz7+/v8zCv+/YNUZLpTZLv/ziw1NTV5ivs5SouzMTo0MTHDq2IzMTH7+4JUVFJUVFT8/PyyMTjzUVn0UltUYru7u7s8TIu1MTnEq2JSYrv7/P1RYrr2U1v3Ulq6urq2NDw6SYpSY747Sos7S4n+/ftTU1PTmwL9+/v+zCnWmgHWnADWnQM4Q7LVAAAAAXRSTlMAQObYZgAAAMhJREFUeAHtksWWwzAMRUcyhMFhGEgGMszM/f+vqt19bG/bk7u+9pOO3t6WsOAC2HlDnQkb7zizFlnt2ET38str32YVjwacRGDS9t8QOZFEWu/86ZIoDKY7/bzkf59dI7Wq0Ynl6dXjb1h2/4nhx+evs+L9fpUYklV0kb7KVZC2VahWm7tmP91ID5GyNlLv8jQ/mjEBPKTxbcCV+EAu0lFTCsbiu+8PHzyOh6O+FScHalCkAvQ1c4YA1aDCdMZNPBNg13Kp7RoLay13Dk+TiJOIAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "604",
+    "id": 604,
+    "sortid": 604,
     "identifier": "eelektross",
     "name": "Eelektross",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA/FBMVEX///8xMTE5Soz3Ulr//4RRYrxSUlJSUlNSY717jP/GrmP8/IP8/Pw2NjZ5ivtUZLoxMTL+/Pz+/YP3VFxTUVFTU1JTZLtTZL1UUlJUVFQ8TItUZbtUZbwxMTN6i/w8TI22MTm6urrDq2LGrWNRUVLzUVn1UVkyMjT3VFk4SYr7+4L7+/v7/IT8/Es0NDRSUlT8/Uz+/EpSYrs7S4v//0pSY77Eq2I0NDI7S4zssgDsswLvswHvtgE0NDH0Ulk1NTX2U1j2U1t6i/1RUVF9jfx9jf+zMTmzMTqzMTu1MTk7Sou2NDz9+/v9/f1UYru8urq+vr5RYrrDq2P///9qWBNIAAAAAXRSTlMAQObYZgAAAUpJREFUeAHt08VywzAQBmALbMugMDMzQ5mZ27Tv/y5d2ZlmxrInveWS//yt9Y+0VnadfTgS+QdbMZHin+XIl3Uxxt/1GDVTwoLhobaP66oMAhRkPeV8mDEkO+dUlw5M6loU7IZ5QQcAY5T6FbwMLdfsJAwygnr00M/xkLFkw8UZIJGioiBgvhDceXOaX8PA2xEVhx1yGta12QbyVdHrmuTDOfkpcTBX146jXkGC/TghpPLcIhkr1yi1HVaLFZDX3drZi2icROMZy5w3SkYbARPv47maalqf6Xb24e01YeVUppeMsUUlB7BfVrGqI0iPAnSkps1wxPvIj63K55EK8xwgduXkbiw1rF5PO9EyjAsopIDGZCHB/uj46kU4V5pzjBv2/WQhdeQK32xqDZYsqdlf6RvjZ7TtZ6jVkwhV393pLVg0CnRSo312lV+sLCIfCZNh1gAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "30"
+    "gender_rate": 4,
+    "rarity": 30
   },
   {
-    "id": "605",
+    "id": 605,
+    "sortid": 605,
     "identifier": "elgyem",
     "name": "Elgyem",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAARVBMVEX///+l5+cxMTFrva1zlJQQxhA2Njak5uYyMzMQhBAxMzLvc5z39yn///9SUlJTVFRylJRquqtzlZU1NTWj5OSk5eUyMjLosyF1AAAAAXRSTlMAQObYZgAAAHtJREFUeAHtzTkSwlAMBFG3pO/d7HD/o6IC56MUyh2/mumOfqberOTu14GxQPsH3J4+K2dAQs4l6AOMygVByhoM/PIS8OsoXO/QZ7n4KcI6IbcWGS7h1NhawS0BU8tjBVciAzNhEzicgEWvRkraqiHh8nq/B8122h39X29AlQKk6qySEQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "606",
+    "id": 606,
+    "sortid": 606,
     "identifier": "beheeyem",
     "name": "Beheeyem",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAXVBMVEX///8xMTH/tZTelHO9c1p1dGsQxhBSUlL8s5Nzc2sx/ym+dFozMjH3Y1I0MzKEUkr/7+c1NTW6cVm7c1o2NjYzMjLbknHck3IyMTF0c2r39yn7spJ0c2s1NDN2dWyfMQmgAAAAAXRSTlMAQObYZgAAAKJJREFUeAHt0rcOwzAMhGHfkSpyT+95/8eM5SGjqM2L//kDiBPUbN7eAUCNO79IjpWOcjHd8RFJd+pNeH1Huthpb192KdKEYIou0t0s+GGiy7TrTcdvhmUJMmW6nh9LUMgVcoFlqW3gmugypyy9D61Xne7G+0A1u4p/gUkkVDDMXILpBhVmChjQS2aBz8GSQTlTAj2s49RJ61YD/zG2bbZu7wdPwQV8k6hV7AAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "607",
+    "id": 607,
+    "sortid": 607,
     "identifier": "litwick",
     "name": "Litwick",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAclBMVEX////////9/f6tpc6utsYxMTEyMzN9fX2cvc6EnNWSecuSesyUe86CmtMyMjOttcaups40NDTOpiz7+/v8/Pz9/Ps1NTU2NjacvM5TU1OrssOspM6spc6ausumdSR5eXl7e3syMjJTUlOau8z+/fubvM42J7toAAAAAXRSTlMAQObYZgAAAIFJREFUeAHt0ckSwiAMxvEmBFoXu2it+67v/4pCxvuXgyeG//k3QxKqHCvtrG7emqHRnZbtX+G0+swMcPKXw+L5Ch69u+ndvmnOjgfgiHoXY6IBwF8mKIzhkZNLUgIaUvi6la4L4Dq3+0jrdz3WD3gfndDgLEur9LoP/BmlsaqUX1882AZ9i/YZdwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "608",
+    "id": 608,
+    "sortid": 608,
     "identifier": "lampent",
     "name": "Lampent",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAVFBMVEX///8xMTFSUlJqamo2NjYxMTNRUVFra2uEe+eUe841NTVZasuktPaltfemtfT95nXUzP6Tes5aa86VfM6jsvNbbM5UVFIyMzRZasz85XT95XSFfOUISRkDAAAAAXRSTlMAQObYZgAAAI1JREFUeNrt0rkOwyAQRVHeDLv37Mv//2cGJCfd4CKV5dshneYB5miP2a2O8Vdo4ZmANuNARBx0moWtadRW9gst15bw9MWkLrLonjcqPRz01ZfpHWM/jVenIEDgIC6+xuFutNFVpvnci1PKnmFyt6R0cnICoLxLGeuB+pJBnS1OdLkmoP17als+7tEe+wCrkQTLbj4sbwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "609",
+    "id": 609,
+    "sortid": 609,
     "identifier": "chandelure",
     "name": "Chandelure",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAkFBMVEX///8xMTE2NjZSUlJRUVFTU1RqamqjzPTEs9OSkuyUlO81NTWlzvcyMjPEs9Tz8yn39ymCcewxMTNsbGylzfZUVFGjy/P///9TW96kzPRRWdv9/v7+/f5VVVUyMzQzMzNSUlRWVlZSWdukzPZra2trbG3DstNSWt5tbWnGttZtbW309Co0NDCDcu6Ec++EdO+qsKJSAAAAAXRSTlMAQObYZgAAAPZJREFUeNrtk1lvg0AMhDP2HkCA0Jy97/v8//+uHqoENUFkXyr1IWa1WN5PY8YrRof4q5BU7qhKA8cE0xQ/q1SQZAq3D5QN9zRNAE8/7r6qAWgzFlmWx9MEUFz0t9cYmt14ecksqD1Ad7R7G8Ik9wZqLKr+CxVTE8DeZ6sXn81OSpLdB3WgAxDu4bLz1Ws9L32ko12QJQmjG0ya53pWzx80UpIQe21JBtsnzfujdX5rFnENAr9AFhytwDyb8CIvWjW0ZrZRp8h95rOroOTYxgF902Q9L7wt5fkFuPqDMqoAbG/zAfCnnRBVZgOSWNvDvr/wEP8gvgE9HgwT0cjxQwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "610",
+    "id": 610,
+    "sortid": 610,
     "identifier": "axew",
     "name": "Axew",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAgVBMVEX///9arUo2NjYxMjFSU1FSczFZq0oxMTGCy2qDzGqEzmtZq0lUVFNSdDFRUVFZrElRcTFimjF7/xBSUlI1NTWDzWoyMzHW963+/PximzFSU1JjnDF6/BF6/RBUdTRSVFBScjEyNDBSUlG+vr7T86vT9KvU9atbrkvkWUnlW0pTdDOxLtm5AAAAAXRSTlMAQObYZgAAAKxJREFUeNrtkUcSwyAMRQ2iGFxwAzvV6e3+BwyZCVvE1jP+6zdP+lK2ZlmhqVwDaVzLIZFLAals+eUEKTrPcUjhuLEEA4fGc0prjZG08brq53TxHnm1se/p+uHKxbhb6afu4DUduQHE+AfNoTvH/khzYjV5PNm+mwXkLuaU9X0cx7JXW6Ud8pm675UmTGEnGgrCvFAwiZyyYMKTIviie8qCoFyoH5rg2mzNMvIFFoAId5sDNF8AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "611",
+    "id": 611,
+    "sortid": 611,
     "identifier": "fraxure",
     "name": "Fraxure",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAflBMVEX///8xMTFSUlJSU1JUUVFimmJjnGNra2tz1mN6enp7e3u9vb0zMTHkOEHkOUJSe0py1WNSekp5eXkxMjE2NjbnOUJqampim2I1NTW9urtx02IyMzF6e3rlOkLmO0NRUVEyMjJ8fHy7u7ty02Jjm2NTU1NReUlSUlFsamp6fHo8BknsAAAAAXRSTlMAQObYZgAAANlJREFUeAHt0cluhDAMBuD6zx5I2GGW7nvf/wXrcKs6CdyqSvMffECfbOzcXPPXOex1p/NeqIc9bjxp3eyQI62QNp1qNUeoYWuutXZLjkT08JLgrX8twEOYjm/J2S+QEkrnJfVYG4pYKwEQFYarNvUL8rmq7qepXr9dpr33iMeqegKQyBhYX5bglbrmo2uWIbmpzo5/bxYt0C2tPVPv7+rCzdk5KBGl8/4x72YALBAlS0P5c8oZs3HgwrV0ovBpeB/njVlPWXxJrkG6n/+Xbyzj74Xzna/5B/kG38ELy2LemWAAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "612",
+    "id": 612,
+    "sortid": 612,
     "identifier": "haxorus",
     "name": "Haxorus",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTFSUlKljBhTUlFTU1FUUlJqampra2ujixgyMjDDqynGrSk1NTVtamqkixekixk2NjZra2nEqylRUVHzYlH0YlI0MTEzMTFxYhByYhFzYxDFrCijihiyQUEyMTB0ZBDGqylsbGlTUVFramn0Y1L3Y1KlEF3dAAAAAXRSTlMAQObYZgAAAQxJREFUeAHt08uygjAMBmCTlF5oqxQUvBz13N//Ec+vR1ZS6sKlGWbo4pu/SRgWT69XJXrMxc3wWN5mSeOxHBipGI1AJvJSE44l6N5CeF/V5meYc7+6CyHIYaUKcGkZsnLKWMDSzaJ43gEO5BHYa0CNgWbgIvmK0AGgq491TkY8CFuygVPsbjDSBPWVYVoDotlqf75eZO5h8vK/be1EdaGCSGTsBDxtT1u81sbaRnWIJC8tTXaZbs4yI7ILn43kZkpHBcj9x2X1IoqyrrXspOVe92j1cM452n3bRqRtlGGn9jkXT1+MBe5WUiO5yd6LwOvgkegyE8Pl5fiDQfKdzHz6je6Hghqz0cKz61V/bCoQd8NoFnYAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "613",
+    "id": 613,
+    "sortid": 613,
     "identifier": "cubchoo",
     "name": "Cubchoo",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAgVBMVEX///+E1v9SVFRTU1NjlP9jlf+C0/uD0/yD1P8xMTG97/////82NjZikvw0NDQ1NTVikvtSUlJSU1QzMzO67Pu7u8y7vM687v+9vc4zMzS+vs77+/v8/PxUVFS77Py77f+8vc5RUVF6g4u6ust9hY0yMzS7vMz8/f39/f79/v8xMjT4QALCAAAAAXRSTlMAQObYZgAAAKlJREFUeNrt0scOgzAMgOHaCZnsDYXu/f4PWIve454R//mTY0vZba2t2P7pajcQtrwDQFs7NzA2VoC6cw7w4IYgzEsN3eIA7uGRkTQA0RE4mEuCFAMzciTfqWIHlkUiDVqFdHVYGkzMSWgaGC5TqIGu+TAuVgA0MpJtxcC993Mi25f3adBdxXR7+rEXEwPPjWh6UVwelWVusRQ9P/5W5PacG3J8y3/cWl9fRBgJGzkpU5sAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "614",
+    "id": 614,
+    "sortid": 614,
     "identifier": "beartic",
     "name": "Beartic",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAilBMVEX///8xMTH9/f7///9UVFSrusutvc6uvs42NjY0NDQ1NTWj3P6j3f45c6WsvM0yMzNSUlL7+/v7/P39/f1DldaFlZ1ixcaElJw6dKVRUVH8/Pw8daZDlNWru8yj2/tTU1Ol3v86dKZixMWru804caNjxsZkxsaCkpqDkppEldb8/f5CktNRU1RClNUwWRUMAAAAAXRSTlMAQObYZgAAAOVJREFUeAHt0cdywzAMBFABYFehiuTu9F7+//cicCaTHExYN1+8ur5ZrIbFNRePA1jGOiK/wHUWiWw8L0NHM0QvX02V592WrUbyHXn5pgd9+GqPSCRIPklTc1g9V+NHgg6yP6Haz3JcVS/fkgwaubAc+Zsh70B/WpoIN/cP1VjeJal2makBivBU9/Re9/t+GlSbgxynN7Pa1716awySjfkHNJtH5Le5BdAm78gipXCZg7yjP8nzBDgNvzjtEyauB4tqJ0OnjTERdNwekawRGgPMKUIRXteN+Q+FbrRoF0gHnOKCueYHBssMUuuBNjMAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "615",
+    "id": 615,
+    "sortid": 615,
     "identifier": "cryogonal",
     "name": "Cryogonal",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAgVBMVEX///8xMTFSY9Y2NjYyMjRSZNZTZNZ5mvt7nP99nf+jw/ulxv/8/f/9/v9RYtN6m/5SUlIyMzQ1NTWjxP6kxf8xMTOmxv9UZdZa3N7///+jxPxa3t5RUVFSUlR6nf78/Pz8/P5Z29tZ3N1Sg9NUVFRc3t5SU1RSVFT8/v5TU1Q2NjVsbdJnAAAAAXRSTlMAQObYZgAAAOJJREFUeNrtksdywzAMRAmITSzq1SXuTvn/DwwkT46Ec/WM9/xmsQBWvPUqagD+RYnGWQlPYIJqIbKi7HzNchkYMnMasec5ZxFb7+M8kGMGjGGxYiQiwdVcRsJyawORupSQBk0Yafgf2aU9f3an7UcYVlJjD2nH++X8Nc8jloFippcBF8d9dZhvW3XkQPe9iXkXr9Xl/HkYrEzfx2Ab87CM3lcVBWRI6eyksKVlOMflG9lJlZM60nm87oF/ZMwn1XqNdEcW3G38UrSCPsM3zT7K0xj5pGoAxso170M8LN56Gf0CyXUNN5zLVT8AAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "25"
+    "gender_rate": -1,
+    "rarity": 25
   },
   {
-    "id": "616",
+    "id": 616,
+    "sortid": 616,
     "identifier": "shelmet",
     "name": "Shelmet",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///+MjIy8vLy9vb1SUlJTU1MxMTG7u7u7u7wyMjIzMzPvhJyEhJyKjIuLi4s2Nja6urpUUlNqaoJra4RsbIT8/PxMnVxiYmJjY2NjZGO6OHFRUVFqu3o1NTU0NDRtvn3V1dXW1tbsgprugptKnFr7+/uKiooX9UrdAAAAAXRSTlMAQObYZgAAAJVJREFUeAHt0kcSwyAMBdAIyWDAvaT3kvsfMcJZR7APf1i+0WcEq5y/T6u1TnLd9YYuySHHxWvfCkBF4EmH2qJRoJw4bSjZIRZGgNw5jOU0lrjIn9Vth1Wlpi8FMk7oXSgfLGjTWOmKBzKIQHTcsZPg3fc0n1+XZw1WXs7+4X0/r+utcTIMIw2CjT417zuwtI+TxHJyPn5BB52IzN83AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "200"
+    "gender_rate": 4,
+    "rarity": 200
   },
   {
-    "id": "617",
+    "id": 617,
+    "sortid": 617,
     "identifier": "accelgor",
     "name": "Accelgor",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///8xMTFSUlI2NjYyMjNTU1Sao9ObpNScpdbWY3v3e5SVzGtRUVFUUlLTYnpqcYLzeZL0epJrc4U1NTU0NDRqcoP7+/syMTHUZHoxMjJTU1KjQWIzMTKlQmNTUVLFnHrGm3vTYnmUzWuUzmvVY3tUUlNUVFQ0MjL2epMyMzFrc4T8/PzNA+/dAAAAAXRSTlMAQObYZgAAAORJREFUeAHtksdywzAMRAOAXVZ3d3ov//9/WTI5kqaunvEOb3qzi4Vwcxm6SoiWYDMNIXzUURkC1Lx8LeMeXpsKKasxckfubiuGb2N4fN63nQcohFcyZB4R7FsAYpwy6oxjs/cehtJbB+VJefrEiEi+28FQETwL2fMQfHP8WZ921B/iUsvb8S3Tdr3a2P/MfB053WMx23dGLF5qpHKc0R0cGVAq7YBn6+CbZjNZNx3ivIAiSznLno0D6DTRH6mKvxCGemN1Gm0uH9xsNCdTXTu0GDd9W6Cqet99LEMLzlwidFG66hdJPAuAIOUvPQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "618",
+    "id": 618,
+    "sortid": 618,
     "identifier": "stunfisk",
     "name": "Stunfisk",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAnFBMVEX////vlFI2NjZSUlJTUlGSWTGUWjGVWjHLainOpikxMTH+/Vn//1rNu5rOaykyMTHsklHtk1Huk1FRUVH9/FgzMjH+/fw0NDSVXDGVfVQ1NTXMainMoylUU1KKahDObCrObSzOpCnOpSmLahHOvJqMaxDsklKNbREzMTDulFGUWjDvlVL7+1n8/Fk0NDH9/PuUe1KUfFP+/f0zMjAPJLU3AAAAAXRSTlMAQObYZgAAAKxJREFUeNrtkUUSwzAMACtjDA04VGZm+P/fGo97VSYPyF582ZG040FPT0eI1rqTd1PGPnSr8hePhVdxb5KW4dWLwqrNFz8tiIQLtt0X+EiSgkyajnxmRuxuFT4xp3TqYG3sVTI8nOjIgcdYdZYJHsKfdRQHFaRoTkCLq/FruHRBZJSLBBEjJ4dvkVV1CnN6ACjR3VF8ERnsPivGMyj9Zrwm9py0p/2Tg9LT04UfSs0KlGm8P6YAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "619",
+    "id": 619,
+    "sortid": 619,
     "identifier": "mienfoo",
     "name": "Mienfoo",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAmVBMVEX/////93szMTI1NTW9pTHezlL783n99XkxMTFTUlJ7e2u7ozEzMzG+pjLEUnLGUnPGVHPby1HdzFI0NDLkaorna4znbYszMjH89Hr89XpRUVFSUlLGU3J5eWp6emrbzFI2NjbdzVF9fGvezlS6ozHkaovma4o2NjW7pDFTU1H7+/tUUlLDUXFUU1L9/fv+9Hr+9npUVFL/933vnS70AAAAAXRSTlMAQObYZgAAALxJREFUeNrt0kcSwyAMBVALg8EF9+707jQnuf/hoskqK+RtMtawfKMPSNZUP1K2GukcyJQaAxMuQQS0Xc29BuBZQ0Y4Z+M1eICEOwmAUFdU8nn7AMGlCAjXhgPo+0vwyuzyaACAOCWcdXR070shbvho6rfLS7c48T5k5iHZ18hdYsd9UTDLzplBtjVgsj5ETDklakP4Zy6xi3edoTOEpxjddf4aB25yecGUStAqRa8j3jT8SiX6jl7zqf6v3jQYC6JqJrT/AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "180"
+    "gender_rate": 4,
+    "rarity": 180
   },
   {
-    "id": "620",
+    "id": 620,
+    "sortid": 620,
     "identifier": "mienshao",
     "name": "Mienshao",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAk1BMVEX///8xMTH///80NDQ1NTVTU1OUc8aymsu1nM4zMjNUVFRSUlK6urK7u7O9vbW+vrbv1oz7+/v8/Pz9/f2ScsRTUlM2Nja0m822nc4yMjP9/P0zMzL9/f68u7U2NjWKeYIzMTKUdMW2PI2yOIrs04rs04vu04xRUVHv1o2zmswzMzOLeoP9/P6MfISNfYX+/v2SccM8WscmAAAAAXRSTlMAQObYZgAAAORJREFUeAHt0beShDAMBmAknAETYDOXc773f7qTmLmt0Jpum/0LD8U3xr+UXXLerGGhezwswuwUtHkatjm0W+d8CqqXqkdMS/Xw3PwgJ4fEn6frxomecjdFh3h/a8eEK2PURCn1e3YSkquI1rr4nz7MVil1h6GKdL4emKytMzupC4aPfSiemoYmb52fL3/NEL/39EQgoaQNKXKh6pmSkB3D+ourdFteDIgXWvMZBrMq3txIY4QIotuY1WDM1bRtLzs9bHx5Z3ZgHUWTEyRYTwe3Jcnzk+Xx61dwMzvq84USsjPnkj9FcwyMV/dvCwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "621",
+    "id": 621,
+    "sortid": 621,
     "identifier": "druddigon",
     "name": "Druddigon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAjVBMVEX///8xMTEpa70xMjNBittCi9tCjN5UUVLTSVHWSlKzMjswMTMzMTFRUlNRUlRSUlJTUVE1NTW1MTkparvTSlLTSlPVSVFBi937+/s2NjY0NDQparpEitvWTFT+/Py6o0GyMTi7o0K9pUK+pkREjd5TU1FRUVHTS1QrarrV1eSyMTuzMTlDitv7/P0ra7vEzxLrAAAAAXRSTlMAQObYZgAAARVJREFUeNrtkcduwzAQRLWsonqlFLmk2Onl/z8vI4VwDjQNXYJcPCC4BPh2ZkFGV/2JbmgtuEmjmtYYblgKdoUhm7WaTJdjEKqxnCPhKDimpXNcnP2S4JTiQvFzqbHJKNYtuFxywQYFcY8iio3ujHGgWjg4+3a6050j81KCc4Z+7mII6bJ0hpx8jgAax8kChqdcP7mx+51prJasnwfNO03+W9Z31uwPr7slN2kqqYr2reqyOCPvEY1+t6ap7r8GVUgE5+2QfCQvqedJQIluHx7hNjNFG/h1oITtSaoEcyZ2CzI9BfuwULgmwfptgcYgJ2CXLZX1qEFuPLrPAPl8CaRxGifXwT6nS2RU/1S0eCMGe676T30DllsQ8NmNeoIAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "622",
+    "id": 622,
+    "sortid": 622,
     "identifier": "golett",
     "name": "Golett",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///8xMTFChK2ExtZDha1RUlNSU1SCxNWDxNMxMjJKnLVCg6tRU1NSUlFSUlI2NjZTUlFBgqtJmrKDxdVKmrOFxtSLbDuMazm8i0m9jEr9/mw1NTWCw9MyMzMzMjG7i0q7i0sxMjNEharc1RPe1hFMnbP//2tEhatDg6v7+2r8/GqFxtIwhA+HAAAAAXRSTlMAQObYZgAAALVJREFUeNrt0kcSwyAMBdAgUd17ix2n1/vfL/IqKwPrjP8MuzdCIO22/GP2zNONOPm4NFfceDmgGOa+lwMoDmqyl2Ps9QB1OTtgOnLxrhGHGuV8sDo4ZhqHey3nPmO2/lTTZQmFnMbJBrnQ2HT94pCbVRiA0MOtbLo21sjVesligdePDEFUJUHLlItII72kfYoKCNrmLJNQkIxDMPaFCE45NRBEjDlWjNFZuOei/T7RWXfLv+ULj1cLwRuomB8AAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "190"
+    "gender_rate": -1,
+    "rarity": 190
   },
   {
-    "id": "623",
+    "id": 623,
+    "sortid": 623,
     "identifier": "golurk",
     "name": "Golurk",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAArlBMVEX///8xMTExMjNChK1KnLVRUlNSUlJSU1SDxNOExtZRUVFCg6uCxNUxa5RRU1NSUlEyMzNDha2Cw9M2NjZJmrJKmrOMazm8i0m9jEr8/WxTUlFBgqsxapI1NTWFxtKKajhEhaqNbTm7i0pEhasxMjLb0xHe1hH8/GpJm7T+/mn//2uKazozMjE0bZOFxtTb0xCCxNTb1BLc1RNLm7P7/GuLajkyMTH9/myDxdVUVFJHA2MLAAAAAXRSTlMAQObYZgAAAUBJREFUeNrtk9duhDAQRRncseksZXuv6T3//2MZb15nF0XK414h20JH1pkrCG75ayYA/YhfKp70kWUV+nXE1j1cZAUEZaGkzq5yI4ZZP84ZcyaDy4Kj58OKCbmZdyvm1AAtSgCgwG47VVpZ1h1XQuNEUBgeUlcWBimnJEbjUWia88UkWsnBlzGGJ7jl+5AusUqseG+G4zh+uxf6czslyXJWN0Otlm073G3nsdAvhwcKLKPdcZHqXHjSxk8KNXNGgUXO2CndHL6XdYogDyO75yTncpdBhHfKcYwIvjIZYQgFct4Ap8UogFnT3tHfFvjSsUYf7L07LppfksIjHMHho6zzzh/BZVLaM6jPzpe56lSnEsDjSK6vXDjgPPSuAlEFV/8XOPNsn+CpLxOspq2JSSjV+jXsB31LhjCkVSG45f/zA3PbGSuNuDg8AAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "90"
+    "gender_rate": -1,
+    "rarity": 90
   },
   {
-    "id": "624",
+    "id": 624,
+    "sortid": 624,
     "identifier": "pawniard",
     "name": "Pawniard",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAjVBMVEX///8xMTFSUlJRUVE2NjZqampra2u9Skr7+/v8/PxTU1NUVFQ0NDQyMTFsbGyFhYWKODiLOTmMOTm6SUm7Skq8SUm9S0u9vb3skzEzMzO7u7u9u7tTUVFUU1E1NTW+vr5ramqLOjq6urrOcxjskjGMOzv0i4v3jIyNPDxsa2n9/f3///8zMTFSUVEzMjEbzkNTAAAAAXRSTlMAQObYZgAAALhJREFUeNrt0UcOwyAQBdAMmOYa9xo7vSf3P16GhbdMtpb8xQo9fWDYrFlKPFwAfzgdQq7Um6SjDq63SiGl3OQXyEiJsEZJQw9hfSmVyrI9uJwwCP0UmZRuKM0USxsCAhdSNt/zjgknRMq7Om5ODwnghGOuBmYDxBiP1SDwVCYKaowh6ISx7nkvCYmLM/NKDiX9idjITFD0LQG3H2wMGOiQek7fAk8jewu3BLC1WTRv0L2kmnvXLCM/QN8MiHu5z+MAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "625",
+    "id": 625,
+    "sortid": 625,
     "identifier": "bisharp",
     "name": "Bisharp",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABRFBMVEX///81NTU2NjZSUlJra2u9Skr5+flVVVVpaWlqamo0NDSJOTk3Nze7u7u8Skq7SUk2NTU4ODi6SUkzMTEzMjFWVFEzMzMzMjIxMTFUVFGMOjqPOzu5SUlTU1M5OTm7SkpRUVFSUVG8S0u8vLw0MjK9S0vx8Snz8yn39ylTUlH7+/v9/f3+/v5ubm43NTWKODiKOTmLODiLOTmLOjo3NjaMOzuNOzuOPDlTU1GPPDi3SEg3NzC5Skq5ublUU1K6Skq6urpUVFAyMTFVUVG8SUk1NTFWUlEzMjC9SklWVVUyMjK9u7u9vb2+vr6/v7/DiUHEiEDEi0LFjULGjUHGjUTHj0fIkEg0NDDy8Cnz8ilramr08yj1iYn19Sr29Sn29ilTUVH4+Pj5+Phsamr6+Pj6+fhsbGz8+/v8/PxtbWn+/PxtbW1YXpErAAAAAXRSTlMAQObYZgAAAUBJREFUeAHtkcWb6jAUR0mT1Etwd4rzeOPu7u7uMvP/7+cWtk2zYsev/ZLN+U6u+AbpQ8zuidZFHGrqzll7nBWCZ5FNuKr3l0Lw4TSSqEWxLQbr9XrST2nYE8zJ57fA5e8qQIqV0TylLBUXKpN5ymjqlSS8lc8XjbnQxNANEYCBgqxM6bJCNNX0FIZW1e/jd0UjyRVPoTTDNqonC1m8fDVp2/xFS6ppHDUKhODraT9lnAkhWSrHfDmjSIiGD7cYG+lwQKvV1uHKLn3g7Pji/+IOd9gHlgl9v/xqSvmLSKgQ87l2HpQdYSCzrWG5/S/uPGE2dfe1BJ35dI2faRuKbu/H3BcIf6b0pOK3n7SfhtH8HrzBi2mNdiRjeK0SGoOqm0H+rssSeI3SLurVwksOod4ErJberUUQcPVsYhK+QfqRP94mJhqgN2N0AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "626",
+    "id": 626,
+    "sortid": 626,
     "identifier": "bouffalant",
     "name": "Bouffalant",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABCFBMVEX///8xMTE1NTU2NjZSUlJ7Y1qagnmchHubg3pUU1FRUVGMayE5OTmtjEK7u7vOpXHOpXP+xSoyMTAyMjF5YllUU1JUVFIyMjKsi0J6Ylm6urp6Y1m9vb1TUlKLayL004v31oyti0EzMzN7Y1t7enl7e3t8ZFt9ZFl9ZVyKaiKKaiOLaiE2NDFTU1KYgXiZgXlTU1NUU1CbhHs2NjWdhXmkhFilhFmlhFqpiUKrikGri0Ksi0EzMzEyMTFVVFKtjUWujUS5ubl4Ylp4eHi8u7q8vLw0MzHMo3J5eXlRUlLSojLUpDLUpDTVpDHXpjHz04ozMjL21Yt7Y1n5win7wyn8xCz9xCpTUlEiT6oBAAAAAXRSTlMAQObYZgAAARNJREFUeAHtz+VuwzAQwHGfYwg4XOYxMzMz8/u/yZwmU6Us8fptqtS/4g+Rfjrdof9uGAb5QR+O8TLj9ADUGAPjnOrykV07VLiCNFGUquUaS5zOIxkq9usVj8SZ+13GMNlSSivYCdNq//nd9ad6Mt7S2ktD8eR9Sjj5cwwh1Qjavw/ChduNZsI4a7Y7JRJBK0DpBNZgcTWGy+2O57u+QchckHm12R3J6MJVF7ovpWyIxJJO2Xr98fXL27rbfDCIM4qyE+bY9Mf8m1ElN0UCUGvkQYRrDed+3Dilht0ChK/LeVCcOBMXh7MrxYoN8k++XAkmmalXjkdaGlKHz7CmbZ8fAfojgeMNUjB/rtYfFNINRMO+Aa8yGQBvExzYAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "627",
+    "id": 627,
+    "sortid": 627,
     "identifier": "rufflet",
     "name": "Rufflet",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABQVBMVEX///81NTVUVFPWxqX//85UUlIyMjJZWZFze6WrmoOtnISunYU2NjbkUlL8/Mz8/M38/Pz9/cw4ODhSUlQ5OTlRUVFyeqRze6R1faV1faZRUVI3NzfVxaRUU1P7+/v8+8wxMTFUVFRcXJX+/s1yeqNzeqJUU1E2Njg0MzE2NjVVVFKqm4SrmoJVVFRYWJCrm4OsmoSrmoVSUlJyeqWunoUzMzL8/P26uro2Njf+/804NzZ0fKSsnIWsnYVSUlNZWpJaWpRaW5S7u7zQmCnRmSrRwaHRwqHSmSjTw6PVmyjVnCrVxKRcW5JcXJPWx6XXx6Y0NDPnUlLnVVX4yVj4+Mr5yVr6+cn7y1n7+8v7+/pdXJD8zFr8+8teXZNxeaFxeaJxeaNxeaT9+8tyeaT+/PxSU1NTU1L/zln/zlo0NDT///9ZMb+oAAAAAXRSTlMAQObYZgAAAQRJREFUeAHt0cVuAzEUhWGDh2E8DjMkZWZmZmZmeP8HqKMq6mpusqsizb/+dKRro7B/DhdlzbBen9HKYSOKLxkjw26NNnCWT/h3yWWMgTLjsrqzfEDi86k6lEFwoED48esvtEw1GJ4m550jxU3qnjwHmBTaeMlxlKq+6NUmVegV047CeVk6apoAzEzc9T2pxXxK98BjxFru5vN62c6npCPQ5+CTj4vt9quyd0BzRnYMgOmz7ncjS+nOfoWs02Ap7iNvm7PPo7dzBRJXv1BwUS3eMzM0aCT0l4cOBIX72x5HliLVxMIkAovGVqe13T0Ss2EnpY3wytZGJ6z+VrtQMwmMWqewH06XIF5Q2nfPAAAAAElFTkSuQmCC",
-    "gender_rate": "0",
-    "rarity": "190"
+    "gender_rate": 0,
+    "rarity": 190
   },
   {
-    "id": "628",
+    "id": 628,
+    "sortid": 628,
     "identifier": "braviary",
     "name": "Braviary",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABiVBMVEX///81NTXGUlr////7+/tUVFRVVVXEUlkxMTHne2tSUlI5OTkzMTExMTQ3NzdVVVZWVFRpcbFrc7WCOUKDOUKEOUKFOUKFOkKFhY2Gho7BUFjBwcHDUVnDw8PEUVk4NjbEUlrEizHFUlo4ODjGVFzkeWrleWrmemrnemvne2oyMTHz01n101n5+flEZPz8/Pz9/f1RUVFrcrPle2tvd7aCOEE5Njc5NzWDOUSDg4o0NDOEOkOEhIxDY/szMjCFO0OFg4uFhIyFhYxFY/lHZvmIiI+IiJA2NTbBUFvBUVnBiTHBiTJRUlPCUlnCUl5SUVHDUlk2NjZSUlNTU1NTU1TEijFUUlLEizLFUllUUlM3NTVUVVbGxcXHU1o3NzXieGnjeGkzMjHkemozMzRWVVVWVlVXVFRXVlRXV1fx0Vk4NzX001lpcbL11Fj21Fn21lr31lr4+PhqcbL6+fn6+vv7+fj7+fo4ODb8+/trcrT9/Pw0MzH+/PzheWn+/v7//f1sc7LDizE5ODiK72hWAAAAAXRSTlMAQObYZgAAAU9JREFUeAHtz1Vv60AQBeBZMKwdZmZmuMzMt8zMzMzQX9646lOzUfLaKkeytQ+fzszAI0g7SNbSlI3InlAIY6xrQpEHB+XesoSxI3Pfz4dqbaihKEhdEa1UBpQt6Bt1I0oEaUEUZxjDuuf2/o2CnqcADJS4xCKhxppkzoDDnuNIRA0yJeRHiVDhdTXNsKNTsdlzp9yx+8RVImTO++VdFeMkYwOKLVN/i//I5Dv7fnAZ+zQvKv9rTss0b0ffqwDejUU+jl1QoU+xxVOM4SRHqr+/dgyZrG/9eyVjxdKjWBOsgUTX73+djH52K/8qFsvaT3SewkkunFj9Nrv9jJIl8/HO1RsAFB9PpJ3116Ds1vrgotedL0bNw3/DH0DVKnk7Lm+GV0DNR7sB/XlZRlolnnoBPHmo/bWvDDdwB3XAi/rghSalILQS5GnNgYrgKaWdWzECLj6z3qmkAAAAAElFTkSuQmCC",
-    "gender_rate": "0",
-    "rarity": "60"
+    "gender_rate": 0,
+    "rarity": 60
   },
   {
-    "id": "629",
+    "id": 629,
+    "sortid": 629,
     "identifier": "vullaby",
     "name": "Vullaby",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABCFBMVEX///+EY1o1NTWDYlkxMTGEhISsrKT/771ZQThaQjlcRDtsbGsyMjIyMTGrq6M2NjatraXetXz7mrJSUlJRUVH9nLT97Lv+m7T+7rs3Nzesq6MzMzPWc6U4ODgzMjKEZFuFY1v/nLWCYlmpqaKqqqKqqqNcQzqrq6QyMjFfSDytq6Nsa2o0MjPTcaPTcqHTcqM4Njg5OTmFg4T56bjbsnnbs3rTc6TUc6TVdKWurKVbQzrXc6XZsXnWQkPWQ0Nta2yBYllTU1NUU1ODY1rcs3pUVFM0NDSEg4P7mrP7+/v8m7P87Lv9m7M1MzUzMzJbRDv+nLT+7LqFhIX+/PyGZFv/nbb/77ypqaGSLKBQAAAAAXRSTlMAQObYZgAAAOBJREFUeAHt0bWSBCEQxvHuoYHxYd1l99zd3d3l3v9Njuyi6SK9rf0XRfSrjwD4V43zyNENE3KEmDi9OwzIxRX7j+0uv0Rk77uv10HxYDGfeqnpYUJLR/OVwfnt503MSIlYWqmd3B9/7L5fA3CbZ6ncqe1V2usqbXGS/CA1UklljGx1kzgfe34gmr1mNBNdIC6oyU4u3KwX6vpKlAQiTqgO8yfVUFS11qFdjgmAk3MPOtzfKDxnwNUob719hwJ9Ara1n+3Vw8vp0/4s76zM7Cm/LD+x6m83mmq4ycyDUWvcL2FCFKGGtdT9AAAAAElFTkSuQmCC",
-    "gender_rate": "8",
-    "rarity": "190"
+    "gender_rate": 8,
+    "rarity": 190
   },
   {
-    "id": "630",
+    "id": 630,
+    "sortid": 630,
     "identifier": "mandibuzz",
     "name": "Mandibuzz",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABF1BMVEX///+Uc2s1NTVSUlIxMTHmvIznvYz/nLX/7727u7uUlJSVdW2VlZWWdWw2Nja9vb3Wc6VUU1P+nLT+7ryTk5M0MzNTUlJra2tsbGx7Y1qmfFp+Zly8vLyScWrVc6WTcmrbs3oyMjFUUlP87LuUdGz+7rszMzOVc2z/7r2VdGuVdGxtbW16YlmWdG02NTaWdW2WlJWke1qle1qle1t9ZVumfFunfVy5ubm6ubm6uroyMjJ/Z12RcWnUcqTUc6TUdKORkZHVdKXWQ0Q4ODjXdKbbsnmScmrftn3kuorlu4tUVFSTcmv56bn7mrL77Lr8mrNVU1P87bv9m7T9nLT+m7VVU1RVVVSUk5P+/Pz+/P1RUVEyMTFtbGyWjuYZAAAAAXRSTlMAQObYZgAAAQNJREFUeNrt0cVyxDAQBFCP0PbaMnuZOczMzMzJ/39HnOQ+ym0v26Xjqy5JbYwz8hCWHfYPd9xNqgBNPbyZAICUMp37oCfF9lJd10mupfRbja6Z4I0sc7K/02onBh61/+i/X9wGTOfW7cLBmx4yz7bj2txD/7zUxAtjO//8tTvNhdDImb3AP3qSIEopug2rpm5NytDldKpe/EShcMPQFfMBoB+utu64GA4Fp5AFqySNZb5yxhd/YQepPLw6nTU3F4Dm4LXjoM8xI9Msl6lXsByLIFDdwyAyo5eKE3s9fJzcdi6CQbA2WXE20HEsZV1mmK7mLYXPaKgf3CPk74pabIwz2nwDDFgZfBzMc5sAAAAASUVORK5CYII=",
-    "gender_rate": "8",
-    "rarity": "60"
+    "gender_rate": 8,
+    "rarity": 60
   },
   {
-    "id": "631",
+    "id": 631,
+    "sortid": 631,
     "identifier": "heatmor",
     "name": "Heatmor",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAulBMVEX///9SUlIxMTFTUlFTU1KaemK7mnq9nHvEWULGWkL2uyl8ZFmMUlEzMTGce2MzMjK8m3pTUlI2NjbFWULGWkF6YlnGW0HLghjOhBh8Y1qbemJUU1FRUVG7m3p7Y1p8Y1gzMjAyMjHFW0KLUlI0MzCMUlKNUlHMgxjNgxmaeWLzuin0uyn1uykyMTH3vSk1NTXEWkK+nX2+vr55YllTU1O6mnnFWkJ7YlmNU1H2vCj2vCqKUVH7+/v8/PyqmEr2AAAAAXRSTlMAQObYZgAAASJJREFUeNrt08eygkAQBVB7EjPkLJgxoYLh5fz/v/Ua2WFBsbXKy4bFqQvT1TN45B7iE0wf9qZpmp0RfOt0Favku/UyddrdGV2d71NMedbVZ7tXuFT6yTgS0lro/D7VjbHSE8pdp6WQ/T2/AghtqZ9iRSUVmnMdw+2XGXCPe0XVF1KpKvkTKPN40yhN4LZXJKHSsZK7TKQXCtJqQJZvA3Pk5aEeU6giGJ9dlFJWc9rDefkJfBfqY5GOXC0FSVE2IcqDUa7JfhdSwQDQei0Q5Xrg7+0NgFSKRiOXrT5q18yZDFDOQJqbAM+cAkKrZez+cA558pVsAxpN2epIOvZsUhilgccS6LqX7VDBsWBRi2scf8LtrMee488uhot+twKfR+4i/2QLGeEJgwy4AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "632",
+    "id": 632,
+    "sortid": 632,
     "identifier": "durant",
     "name": "Durant",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAY1BMVEX///82NjZSUlJTU1O9vb0xMTEzMzN6eoN7e4SamqObm6ScnKW6urq8vLwyMjK7u7u7u7x8fITV1dXW1tZRUVF5eYI1NTXT09PUUlLTUVHTUlK9u7ucmqPU1NTVU1N8eoMzMTEdDYCFAAAAAXRSTlMAQObYZgAAAMdJREFUeNrtklcSwyAMRI0KHVzT6/1PGdnO5MvYB3CWAX4eu4Ok6q99Sn0vZl4HjxNwjF1PesNRyRE7wpr0hq0SEAFqapuu12sgD4JhHeyDiHSZG06Si856NA0FmwtuHCmktiEhwXjrbV4O5YPviEJIaMBYH/IhL3N8uYUU0vOOwmWHwEs1HJdLJHbXF4ABYHla+ElEKcv5HdssjNipAqlOpN2UOiJjrgJeBnWlXMLZiiemYClsrydu7vxqZ8bNv2nanI2/dqwP0TYH+o0sJWIAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "633",
+    "id": 633,
+    "sortid": 633,
     "identifier": "deino",
     "name": "Deino",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAaVBMVEX///8xMTFaSko2NjaDcnJahM5rWlprW1wyMjSDq/SErfdqWVkyMjJZgssxMjNsWVuCq/NaSkyDrPZZSUmEc3OcjIy8QqRag8uCcXFaS0yErPY1NTWaccuaioqbi4ucc85SUlK6QaOEcnP0VLGiAAAAAXRSTlMAQObYZgAAAKRJREFUeAHt07cOg2AMBODY/ju9k17e/yHjsGT77RWJmxg+oTsLTrvKEQKlW0ulGxWQADSOYCjMiGLF6zpucZKk+6SSvOIxTZstBei4oGEsQV6C0WNhpN3U+pjO0Rt2BFmYON69AKANWXl7XmyHxmG0fcheEoZfxbnBGISa78bMH8SYbC0txwIX26cU8rtTqDpcauAH6Zulqg/Cef5vVf8Ju8mRL5AlCFdiYAPRAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "634",
+    "id": 634,
+    "sortid": 634,
     "identifier": "zweilous",
     "name": "Zweilous",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTFSQkqDcnJSQ0xqWVmCcXE2NjaDq/SEc3OErfdrWlqCq/NZgstahM5RQUmcjIw1NTWbi4s0NDSErPZSUlIxMjOcc84yMjKFrvf7+/uDrPZqWltZg8yaccuacsuaioprW1xTQ0uEc3UyMjT8/f79/f6BmeOLAAAAAXRSTlMAQObYZgAAAPtJREFUeAHtk8mOgzAQRKerAS/sWUhm3+f/P3GqUTjFJrnlkpKQLevxVLbh4Z5bxl3DCJ/qaOM6V4WjgWLsRbJXaCC77nW91lDI4s1yH8FC4exdAwdiIFMvnJNEgbEKYTN86UlrK1KZ/0xYzg2ptdRiC8GSIOELpXUwFkIOwpx3bJ8jwYBSN0MAZ3vJ7ObtsCsU/lNhLcL+dcqRPUBtLPw3ObRdN+WuBiXeD7tYlARJTvmbIcnYPpTGNDg2NNWM2SzwSdI9PcaZXDBr+5MA7Xj+tqVUUPDsueUm5kgRfomuKXz3IjZvyGUzsgFFcnpxJU7a3y3HK3+ee26ffxDTDX17yCAEAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "635",
+    "id": 635,
+    "sortid": 635,
     "identifier": "hydreigon",
     "name": "Hydreigon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAS1BMVEX///9SQkoxMTGErfdqWVlahM5rWlqtQq2EOYxTQks2NjZ7c3OrQqt5cXFSQ0yrQausQax6cnIyMjIyMTJSQUt7c3WDOYoxMjO1tbXrQpQMAAAAAXRSTlMAQObYZgAAASlJREFUeNrt0tuSgjAQRVH65AYGUJnr/3/p7MSirKLLcuZh3mwIoC4OacPwqj/V6VdIwynquVLMjOfwXCaLbOJ6v9fdJanJ8T3a/Daclq2zpdbtkFZKkc6lTMBJ8brxHcx8InK0GdnG7qjNybEU49Gflw5vLotELy1YSmmdJzMB8868CyGxr4ROaq63LTdHa84srDMt5ZzJ1eJnKUsk5mJEWnccrr5vEUU1Z2TFvmOh2+F/RJLZHX33x0P9HAlEfpvlfJMsUqZ0XBnmFwxmleMYwniZpIg7lIIBCcvVCo78qPbaechPVbJKo619PgrmqZSrOFUDtvjW3JcWmva0N9VWsjVvKVAfd+dfDgIbS0jyHsKAbINUSQ8dEoAGeuXnCtUOn3G2V/1D/QDaVQqUzgQFXwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "636",
+    "id": 636,
+    "sortid": 636,
     "identifier": "larvesta",
     "name": "Larvesta",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAXVBMVEX///8xMTFSUlK9vb3///97e3vWUkLehCGchCk1NTU2Nja+vr7TUUExvf9zWhA0NDS9pUIzMjEzMzMYjL0yMTAyMjC/v79RUVHTUkLWUkEzMTHbgiHdhCNUUlEzMjDDeLHMAAAAAXRSTlMAQObYZgAAAK1JREFUeNrt0tsSwiAMBNDuJhRae/N+9/8/06D1EfBVpxsezySEoVryQ2m/dE13+a5fV5cgZlh0tUkAV/8oQT82oqqrm8kWOXlQS6Sb4yl3U8zOe3/OOtGPrO+ocg1FZ0vRsei25AuP2ckkehehcNilIEg61/c05jiFCen3UeecxLVrBpPrlPOVxrzlFMI+PVxF7QiHIYQB6cUhEBoLVkD+B4GwQ2OFRAGrJf+WJw/8BdEsbWknAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "637",
+    "id": 637,
+    "sortid": 637,
     "identifier": "volcarona",
     "name": "Volcarona",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAw1BMVEX///8xMTHWY0JSUlJUUlFUU1E2Njb3lCn8/PwzMTGcSjH0kimaSjEyMTHTYkHTYkLVYkF7e3t8e3lUVFT2kynWY0FjY2P9/v////9RUlMyu/ydSzC+vr5ii6uLxPxkY2J6enp5fH1RUVH0kyn1kypSU1QYi7vUY0KNxv+aSTFTUVFlY2Jlja6dTDR5eXl5e3wYjL4yMjIxMjIxu/x8fHzzkil9fX1SUlP1kimLxf2Mxv9jZGVjjK78/f39/f01NTWbSjF5kfuaAAAAAXRSTlMAQObYZgAAAS5JREFUeAHt08dyAjEQBFCPtELS5kDOOYBzzvb/f5V7wS77oClz40Jf0OFVDyPEyeFyTIVoL/cRCz/arzEWlv4OQBjoJcL+9FMsEOtyq1R4YWq3ZzDOlZPR6EdEu+NgwcKqCtPBMMuuYn+dCEA4BiZwSH3hBbrGFELeaTW/KKFMBOTmM3LfI40DdTPKsvZIhv4alczk1aNKPDS2L1uJAOxE3DfcTJQphnLeCv3UM4Uk5m6q+TSXpjBnuE5pmkVQs8RIrUwTKeSwdFrnC+uSFGPeVnbfS461J+59KuN+Y9koG033VgYaqQnrfBO9p5m5N81l4/QNhfkUzv0evf4Lfpl6//n1IVCBZrfxo/HOzTC4ExHx/4QKpOxdU1z93ZjR53X47dsU/0j6/oA/YI75Agu1GH+ibHL+AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "638",
+    "id": 638,
+    "sortid": 638,
     "identifier": "cobalion",
     "name": "Cobalion",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAvVBMVEX///8xMTFarf9ra2ulzs73vXv///9ShLVShLZUU1JUhbZZq/tZq/xZrP1aq/wyMzNqamo0MzJ7lJSjy8ukzc02Nja9hFK+vr7zunn0u3r2vHpSUlL9/f1SU1S6glG7hFMzMjG9vb1qbG0xMjRtbGs1NTUxMjP8/PxTU1NRUVFThLVThbWrWgkyMjK6urpUVFS7u7tSg7NrbGxRgrLzkil5kpJ6kpI0NDRSUlP7+/ujzMz9/PujzM3+/fukzMwUkyW7AAAAAXRSTlMAQObYZgAAARlJREFUeNrt0cdyg0AMBmC0hd7BdFywcUlvTk/e/7EiZ4dTRjg55GYddobRN/q1i3aqv9YEfsmKSOljTEZKj7tpJSNk02rc9UU2Bzwl6vGBhRXywzg45lac12U2H/aFEVdm1cpffrNEBAQMOb94sw3PXONHIijXJ3EaPHzYHlsqtwUgoIjjVJx7B7d7TIUgo/epuLvFgQAOY+Y75XDmrkZnPpeWyzqflpNwo+OGbSmt2u387pNyL3mj67Yxq6SUOBNX0Cip63ljG0jRIdQoeNXo+ZmH95hVkcPa14CWi0Vz7TJzDfhANQ2xeYNQheKTx5cUTLabJ7j3FNyn5D9Urd5pAc+QE9lDa9gOsKhkbNGZPzmRSQw+1T/VF+gfGdDYn3y0AAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "639",
+    "id": 639,
+    "sortid": 639,
     "identifier": "terrakion",
     "name": "Terrakion",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAJ1BMVEUAAAD///8xMTFSUlJ7e3uLamKUlJSsg3O0tLTeWhDetIv2ezH///9M87mWAAAAAnRSTlMAAHaTzTgAAADWSURBVHgB7dPBboQwDATQdMZ2IOz/f28zWEKNvFS9dQ+MyMV+jBCC9vXHPPB/YPsZoC25gYATl64wF2hw57ZN7XgLcwFPR5/JXlTowASkrnnO3nlWCFcSeFI1h0WBWXixhJtchQ2UEbtgaZQTNH/RYvp0BTaocPQ+9tewiBOSjDC8hWPoWLrj4FlZXzh6P6lRbt8ZFWYwVSfltiDtDiI4IxoxGw9A/ahQ84AeQF2EJhEFykVoCwgaGszGqFDjjqs7bwFahcrS/euHu3bfw6U789H/9QO/ATSOCwBJvfEZAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "640",
+    "id": 640,
+    "sortid": 640,
     "identifier": "virizion",
     "name": "Virizion",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAt1BMVEX///8xMTGU90o2NjZzzkqS80mT9koyNDHv78ZaWlpaW1paXFlimllimlpjnVlyzEpyzUpzc3MzMjI1NTWT9EqT9UoyMzGV9kvsgqvs7MNaW1lZWVljnFnu7sXGvaVzzEoxMjHthavvhK1xy0llm1uV9UtycnJbW1uU9ktjnFpcXFxzdHLDuqPEu6PEvKPEvaNzdXLlTIMzMzPsg6tlnVt0dHPt78R0zEtxcXHvha0yMjL+/P3+/f1BXpPPAAAAAXRSTlMAQObYZgAAAPtJREFUeNrtlMd6AyEMhC2WRWzvNe6OneKS3vP+zxXYQ3JaQe6e84/0aUZicpa1HLDkXIaWYLy0BDG07MwQwAwWbuDtsuxzYAvihXOhsIVgfLoECFOBo+B7VrI/8ZriAi8RGtJVxwuW/OHr1ovSoTcxdCcf22/5nPYApgA7qbh9uVrnxqzDKq4UZ8y9UJ7HPmgbXQQ6nPuF4LWqzAVS8zS/Lk59IMHXhsU3qdAssUrOYSYbLliQ3L3oMHE87eP8mvE+Os3k/ArAJUgvqvSydfIjpyxy2ks/Eat8UrRvNb2Tm/5pvUVtKBrAeiNwcNQAgkasLleD1r/AWf/WD9XPEDqvZq11AAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "641",
+    "id": 641,
+    "sortid": 641,
     "identifier": "tornadus-incarnate",
     "name": "Tornadus (Incarnate)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA8FBMVEX///8xMTFSUlKEzlqaYtucY961tbX////W1tYzMzNTU1NjnEqCSbqDzFmESr2FzlxSUVObYt0yMTOysrKzs7NSU1G2trbT09PV1dVSU1L8/Pz+/v5TUlRRUVHGnFr7+/v9/f2bZNuEzFximko1NTWDSrs0NDT+1VpUVFT/1lo2NjY0MzFzdHLFm1yCy1n701mFTLv801mDzFqDzVlimkl0dHTDmllyc3JzcnTEnFoxMjHFnFtUVFKFYznU1NSFZTyFzVqFzlp1dXVjmktjm0z8/fz901v91Fn91Vr9/PubY9tTU1KcY9uDS7v//vxlnErkD6nOAAAAAXRSTlMAQObYZgAAAaRJREFUeAHt01Vz20AQAGAf3wlkMctgyzI4kJSZGdr//2+6F00fmpObNs/euTnp4ZvVwmh02zjG7l8MGo3aaXezm4oOIFyH88CtnRBdNBNSDbvz7R4wDZtSpLMU3EE4We/R2Zw9elGlVjw74HbI8QLG6uX3oI65Res4H5ItOr8IWIiQ41++JgWm7F2CcWZIKG/yLUT6LXr6ihAy93yXFHGuDLe9CPsCpi8/j8mn7c/3YzuJ1VAbvycoxPjx848/xLiIuQEfrJ/1M2xw+aYEC9q2E2S23NBQP86InWgqZSU22HAgnA9Q4+7eXUKKJdD0frnBrv1kCG73AL+wBSlWfrlxT+6QOfNCY4z0dA2ydQKArj4E3BVs0R8Z6ekE+kHNEmq8Ugu47CRTaNpd6+Zy8nUVMFgct9w5WwA9wbr/7nqRPoa9wa4zKTcr7+1DWGAFLlVGO0FNawqwEqmFcTwTEFKhgcY9H1PP78ctYJAwTMhnRoscz/P7TFpKbmWm62mDY87zSqcD2H93WEZcRTyXPFeZ5OqvvymciIPZITS6KVowx/i/+AUJCyoUfiwkuAAAAABJRU5ErkJggg==",
-    "gender_rate": "0",
-    "rarity": "3"
+    "gender_rate": 0,
+    "rarity": 3
   },
   {
-    "id": "642",
+    "id": 642,
+    "sortid": 642,
     "identifier": "thundurus-incarnate",
     "name": "Thundurus (Incarnate)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA3lBMVEX///8xMTFSUlJUVFTW1tb8/Pw2NjZRUVEyMjJTU1QzMzNycnJzc3Nzped1dXWlzv+mzv+2trbT09M0NDQ1NTX9/f3+/v7///+jzPxiQrt7Wve1tbWzs7N6WfR6WfZSUlR7W/dTU1MyMjOmzvyysrJ5WfNjQr1kRL5xcXH7+/syMzQxMTNSU1R0dHQyMTSjy/1SUVNxo+SkzP7V1dWFYznFnFxzc3T91FmkzPz9/v9yo+T/1lr//vykzf6jy/t6W/ZzdHX91Vz9/PvGnVxiQbrU1NSlzfx1pueFZTz701lgf0V5AAAAAXRSTlMAQObYZgAAAYJJREFUeAHtkmWu60AMha8HwsyQ25QZ2tfHzLD/DT2PIrVSJq2ygFqj/qi+HJ9j++laj1KgHxet0rAnh2AEvUBHQ9UeXOrHqAp3YyBIuX9OUrbj4e2gyuc1qM91NSJBGacUOsClBiDAxWExKOpMr8q4W1NRTYJk9G+ymB9c194SFD0bHRmWlqWhwR+/XVF65uqVMe0gI1TMN7D6+91zv32YvPPsMcjDVABmewBQOY7Ge/XyzcfUW3clbvyhT8IdZLH+2PZYDkxM9CciuzqniDKWpA6BW4rK6ROGeL8l3N9ZlvVWlhQ9hfHTl+KFq+dHTjPMPSzmmw5ytp/GNB8giHNpOATl04x+HjEEJdhYUKgsZh4YsAqlMXJxMs4vRrNhIdCvROQP5b2I/0Uxms/t17jARJybIe/vQvojQqrmGwPk/VkEQXqRxceSth4Kaip5rgNqXg2wchRII48AH8xqszHAEgHKfa/9iTAQMDxD/Gm1bRsAmJbIRNCSkww8dTL361H/AWALJlv7lqm/AAAAAElFTkSuQmCC",
-    "gender_rate": "0",
-    "rarity": "3"
+    "gender_rate": 0,
+    "rarity": 3
   },
   {
-    "id": "643",
+    "id": 643,
+    "sortid": 643,
     "identifier": "reshiram",
     "name": "Reshiram",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTF0hcZUVFRSUlK1xu+2xu/7+/v8/Pz9/v6zxOxSUlP///+zxO4zMzOyw+zb2/Te3vdTU1Q0NDT8/f5zhMY1NTV1hcbd3fYyMjNRUVHb2/P+/v7c3Pba3PZxgsNyg8T8/v42NjYYbM5Uxs4zMzRRw8vyT3hMAAAAAXRSTlMAQObYZgAAAVFJREFUeNrt09lywjAMBdDKu519Y6e0dPn/T+y11Y6nhBT6jpLBM3B8sQR5etS8VnSn23cf17fjxnrL2YHskNY/4dmux3LACs1v4Ia86iQR2RKcfYSXctX4spSuRMGt2BPcDFp2UjlTQ6FM38oWcBYIA5uWVLKN19VAqYJnA4zATveKR5ad8YC4kpQBQrWdVMrJ2FSGp9GIsUTfRkwj4EaLY4d96TAZni0+LxxSh108ZBDTsROFW2Nv5TOMMzM9TuWHz1fE9SpoUXBPhl2W1Hjj39+eDz8nBGPHMFO0w/0iTm/gvyu7HMrnS/0ejNb+0uXedw79iqMoghj5a009Z4BN/1LpTad175AoKrGluWIZwypAhREOtMSoEdNUBLg4oRpsKQ5Zomh1HWel6+UHbi8Koj1E+kkXISRRfOEBBL0sf/+bDORtSHa9JbonEupR/6gvfqAY7FCmSAwAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "45"
+    "gender_rate": -1,
+    "rarity": 45
   },
   {
-    "id": "644",
+    "id": 644,
+    "sortid": 644,
     "identifier": "zekrom",
     "name": "Zekrom",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAPFBMVEX///8xMTFSUlJzc3OMjIxycnIyMjKLi4uKiopxcXE2NjZRUVFUUlIxMjQ1NTVarP1iirLbUWLbu7veU2QlcyauAAAAAXRSTlMAQObYZgAAARFJREFUeAHt09tSwzAMBNDuyrKSttz//1+RhFMmQRn8DuYFT0502Uwvf/lc4WcKriLSJ/DzjSpC7eMKnMooKX2w15en8+ZRM+F1aR2/TJljutvtiGNzYCXVmvPNrNZa69VGNBHiawCGalK4hdzq5Wt+IVHV8xKjYOZg7bQx3z/uGWZcVbJ+CfF216gJT0tFys7jUTykEhGWFY1zS+pg23/0yvjh/PVILo3GX86wduDoMuaAJI2P+tL3UKxfUgYTczAk9ln3pY/0JGN3SaqFO0BgZJSgtRzU3O3h42uEY37lhEU831ATisVKqBkWEp47TXKfM7eaO+e4BSRRuxDA2G3kMvGbpMqU9O6sVy7HmD7/5xNPKQjTDPpJcAAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "45"
+    "gender_rate": -1,
+    "rarity": 45
   },
   {
-    "id": "645",
+    "id": 645,
+    "sortid": 645,
     "identifier": "landorus-incarnate",
     "name": "Landorus (Incarnate)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAACOlBMVEX////+/v7////9/f2zs7OUc1I0NDS2trbT09PU1NTW1tb7+/v8/Pw3Nzc1NTX/a3P/pSk2Njb8oymxsbGysrIyMjG0tLS1tbU4ODhSUlJTU1PV1dVUU1HX19f5+flUVFRVUlL8pCpVVVVWVFKRcVGSclH/oymTclExMTH6+vpWU1BTUlHR0dHS0tJXVFDUMjpXVVNXVlTWMjhXV1d2dHJ5WTkzMzJ6WTn8anKScVJUUlD9pClRUVH+oyn+pCmTclJUU1L/bHJRUlH/pCpSUVL/pStVVFJSUVE5OTnUMjg1MTB6WjmRcVBSUlGScVE1MjKSclA1MzOTcVFTUlJTU1KTc1KUcVEzMDGWdlSWdlWwsLBUUVGxsrJUUVI2NTVUUlK1tLI2NjUzMTHFnFnHnlzJeRnJehrKeRnLeRfLehjMeRrMehjMexnNeRjOexjOfBnOfRvPexjPfBrPfhzPfh7RMTlUVFPR0dI3MjPTMTnTMzk3NTRVU1HUMjlVU1M3NzXVMjkxMTLWMTlWUlA4NzZWU1T4+fr5anD5anH5oiozMzP5+vn6aXH6oytWVVT7anH7a3H7+vlWVlb8anFXUlH8anP8a3H8a3L8oir8oyhXUlNXU1L801k0MTL9anH9a3L9oytXVVH9pCr9piz901n91Vz9/fw6OTn+anD+anJXVVX+oyr+pCg0MjL+piwyMjL/anNzc3P/bHB1dHL/bXF1dXX/pChRUlJ3dHB4WDj/piz/py//1ll5WTiAzGT3AAAAAXRSTlMAQObYZgAAAjJJREFUeNrtk0WT4zAQhSPJjjGmcOIwDzMzLTMzMzMzMzMzM9N/W8XJYRTvTtXc51XJ6sNX73W3ypYhDUZSGit3Dcw5EITQmhaM70CcH0DIIJiT7V/M3DocJrFuAxIQQRJYgqZp5wGWDzVRvuDLriBGjXiJjBxLT0040/FJlD+k6Q3h0+E5XRkAsihQCcMEvX9adtYWyqcpVUU7ihpuUcZcjNt9kjCkjx02qha77/a6trVtVWvmx7zfRMYNmALQmSttIW3RWwVrQ3FE0SkXwn32A0en8uCzIFg//enP5se/MbsqxrkRIMA/qca6N7kyA0Twa/GMJ49eK2Xb/Iwj4+q3o+G1qY72e9txta9pNviARIBgYPOmFfrMUpskFayHPiffsey6oejBiqNfkF8EAqoszm+RbHLnpXHvlrf2PuhbemiMSNVcONt3feNIgjKyx2My3LPs6vtuRR9x+VRl5PvDZKd8cCHJGePgJ5wV3nu8VdutKWWRpKJ87LxbPgEvLG2ypPe8kG8uiflOfE32fu5OKtrqCs4mBT2k5Y+J2TZleR7LXDzzXH7VfP5+TVSEEFkLsofVpzB57coRlg9Ubylf+Ska5QBEAl4jIU+8fhROb5zs4gGE1dEohSCC0G+1mgZX1doU3dEjwpwCCPKs6FJJKs/G26dsFQCmED48z3hLPP/5ZbwhysEhAHkkgADHevJ+Zks7Ral2iuOZUk8JR4xhalTCB+M2fJnszPgC1TKkwekvxLVntr7n8aIAAAAASUVORK5CYII=",
-    "gender_rate": "0",
-    "rarity": "3"
+    "gender_rate": 0,
+    "rarity": 3
   },
   {
-    "id": "646",
+    "id": 646,
+    "sortid": 646,
     "identifier": "kyurem",
     "name": "Kyurem",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABiVBMVEX///8xMTE1NTVSUlKDi4vW9/82NjZqampra2uCioo5OTmEjIyMrdaNrtaV1v/U9PzU9v84ODg0NDSFjY0yMzRRUVEzNDRSUlOLrNRTU1NTVFSS0/uS0/yU1v9UVFTT8/vT9Pw3NzfU9f1qa2vV9v4yMjL+/v////83ODj1xSv19iyT1PyT1f6U1Pz8/PzQ8PjR8fmEjI2FjIqFjYrU9f6JqdDV9f6Lq9M2NzeBiYn3xin7+/uR0fkyMjNTVFUxMTA0NjeDior39ClSUVH8/PuCion8/f38/f/9/f3z8ymLrNX1xiv1xiyU1fyU1f2Di4yV1vuV1v6DjI2W1fuW1/u9vb2+vr6+v7uEi4tVVVTR8vtWVlZpaWlpampqammFjo/U9v6Gj4+Hj4zV9v0zMzTW9vvW9v+Kq9M1NTPz9C70xiv08ywxMjJrbGyMrdX19SprbG32xyz29iuMrtaMrtf39Sn39yn4+Pj5+fn6+vtrbW6Nr9eOrtSOr9dtbW1SU1T9/v85ODg0NDC/DEUmAAAAAXRSTlMAQObYZgAAAdRJREFUeAHt02WP20AQBuBlMzjMyQXsY7geQ5mZmZmZuf3lnT31VHnrSNZ9zihRFPnRvjOzMhrUlotg3O+JwpqFPgdUc/8saXKe7eGEQ8nq+Tu8sJrZ/KvpYz4vJB1KHsxxHv6FxLDa7kvPzSVF52t1f1MCLD1j+hjApGi37gOUc+Q1pjNKa7nkYXwOtIA1ZllUo7TlrPdZT7Vu2z+AgWs1JiPHttdx4gpNyAQmXRhFrj1jtcNMzA1NZhDZsTEEpRqTEJpwRmYpVgb5eQkf+i37hMQGk87nXEYrwZ/uZ1+sPLyLm+GBvQ2me3KoBAf3dXb0/clv3TDaP1HRdE8y13dmLDW5eWb03co9uJeDTkMzaM3nUK49MguzxOGr3Y/BtfnhoqHvWRyvV2gLqKNuZ6j66OjXuW73jV0U2Cgvjlc6jMrCaofu21Ne9sTp50WBlvJlWtvOLH3j04vDy1+63u0j244d34nI/OfrGF+7SGHz/8Fg7Wb7xpPXFxagpwyeX7pKlrM9FCyDVMLNtZJz69xCtVQaRqZA5EPwMZD3aVAWPxKeTnvexLAQSNYvgUz5K4yyhCoFFV8F7uyynqZ4V6eu7Ot8TwFNPBWI6QClkAK+aFCp6g9qnTk7Pu6HPAAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "647",
+    "id": 647,
+    "sortid": 647,
     "identifier": "keldeo-ordinary",
     "name": "Keldeo",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABZVBMVEX///8xMTFUUlFzxv81NTU2NjY5OTlKa61Ri+ZSi+RSjOczMTE0NDKlSlLTYkHWY0L7+6P//6VSUlQ3NzcyMTFUVFJxw/tyxf4yMzR1xv+jSlJQieFRieHTYkLVYkJRiuTevlX5+aExMjP8/KP8/v/9/aP9/qZSUlI4ODhUjuUzMzFSi+U4NzZTU1EyMzZUU1I0NDRUVFNUjedKaqtWVlNxwflxwvsyNDZxw/1xxP5ywvtyw/tyxPxyxP1yxP5Laqtzxf5MbaxMba51x/11x/53x/yiSVCiSVKiSlRQcK+jSlOlSlE1NjimTlLTYUJRUVE2NjPUYkJRiuPVZELWYkIxMTLWZUPYuFHYuVPbu1HdvVNRi+XvlYT4+aQ2Njj5+qX5+6T6+qL6+vv7+fn7+qJSUVL8+qL8+6Q2Nzn8/Kb8/Pz8/ab8/qY2ODhSU1RSVFb+/6X//qT//6RSiuT///83NzRRUlOegEzeAAAAAXRSTlMAQObYZgAAAT5JREFUeNrt0rV2w0AUBNAFMcvMMUOYmZmZmZnp+/Nit1q5TArPeYWKqynmLKrlD8PBYbiqzlCxYapw1ZxJ4iZEdSvlMEBwZYjrlDQTWpphLiRMUogTWZQUcYsBhVTbzJppkg7JIysQUUozKzuXNw3SUFYidLJhcilBZOVDlMR5fYRZCDKV3CDywctVIaLrus9tHmv7Yu5bnp32rUTAwRCwhBP0WnbT/fjQM48EQwUToDQUCDkV2q9f5+3dTwgBAkOzYaBOAx1e303Q5oqjNPsZptlWxykxHxumpR7E+QdDfCwImLmRd4A+TvEZW4Pf6oJst3g62Ze3czfvv7LIMZ8Gt947Wnqw9v1nb6vILULXWH8+5y94di6T9a6S223J7DXi6DE+0txh1HOiIYGHj1s3BwRXRJFDVQJttfyP/ABtZCU77F/tKQAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "648",
+    "id": 648,
+    "sortid": 648,
     "identifier": "meloetta-aria",
     "name": "Meloetta",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA4VBMVEX///9SUlI1NTUxMTGSu3qUvXv///82NjY4ODhRUVEyMjJxcXFycnJzc3MyMzIzMzKVvXy87oMslZ37+/u77IQpkpo5OTkzNDJ1dXU3NzaTvHpSU1RTU1KVvnqVvnyVvn2Wvn25ubm56YG56oK6urpj1e277oVj1u+9vb29vr29v79k1e7skoLW1tb7/f1k1uu77IOUv3oplJw2NTVTU1ORuXmSunm974TT1NXV1tZTVVNl1u+TvXxi0+yUvXy67YX8/f36+/y664L5+fn8/f78/v79/fz9/f3+/f3+/v67vb3IBgWYAAAAAXRSTlMAQObYZgAAAMVJREFUeNrt0scOwjAQRdGxHRsIKST03nvvvXf+/4OwxD7jHULiro9G1pPh35ejQNVcUA/qatA0dcaUJCEatxjqApJxZ84tFGo3IfIqstJ+Ne75as1G3PbqHi6tZmiftbxhtCfEur7cYSdpWMjcY8E52V6MSdl9uqNFLhIHTyhl5yG6IYcnAfCFeHWDrsNYwCCaw3EIdJYhBmEq34Joq/TAVoAmmfblI7FixYRBysPPPsjoE9+4lLLxk2c/gJ/6AJfw73d6A8GvDwOZGqPVAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "649",
+    "id": 649,
+    "sortid": 649,
     "identifier": "genesect",
     "name": "Genesect",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABDlBMVEX///+thM42NjaMY71SUlJyUqQxMTE1NTUzMjRzUqWLY7tTU1SMc3urg8ysg82shM1UU1TUs9QzMzM5OTmKYrpRUVGLcnqMY7wzMzRSUlOOZb5TUlNTUlQ0MzUzMjOvhs9VVFXWtdblUlL9/f03NzdzUqQyMjN0U6R1VKaJYrlRUFGKcXmLYrtRUFI0MjKMY7tSUVI0MzQyMTKNYruNY7uNZL00NDSpgcmpgsqqgcmqgsurgssyMTOsg8xTU1MyMjKtg81UUlOuhc6vhMyvhM2vhc42Nji9vbXRsdHRsdLTstPTs9NUVFbUs9XUtNRVUlU3NjfmUlPnUlLoU1P8eWL8/Pz9e2NxUaP+emL/m5OieElDAAAAAXRSTlMAQObYZgAAAS1JREFUeNrt0MdywjAUhWHdq+aKbTqEYiC990pCeu897/8ikT2THVK8SHb8Ky8+z50jMup/kkKITO660wmF6leXV3IjBzBpxnLO8yIlKaUJNskSK3se88EsH0UxB2MsyTfBxe1bUKXSV9f7QnP2+WgnCELmp9YwptA9eQhDOIOnNVozvg++tY/bp18vn+vKGWv1Lnrv3dcwvskrKbWbW3Zj1m2Ey9CJ59WSPc3ozSvO+bnDYRrgXoiPmj8cimgKEQki360ETH0UaW6oTFSaVXLdQfJnUUF9lkUXKGXVKkHHtle1Dil10KGNAJpE8ru89s2dykSLIOcMoErk5QrRJeIDWxBEtn8YCFJA/emozDGdtuVa5CfjeElpn2QJ6/VmFleYiaKl8UxSSklG/XXfg4cZmTKZ0SsAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "650",
+    "id": 650,
+    "sortid": 650,
     "identifier": "chespin",
     "name": "Chespin",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAKlBMVEUxMTH///8xMTFKajlSUlJalDlzUjmLYkGLxUq0tLS9e0renGLmYjH////DOT6XAAAAAnRSTlMAAHaTzTgAAAC0SURBVHgB7dSxbsQwCIBh+gOGC8n7v26Nog5dyA2Vutzv9ZOQbdny9WYf+PdQfgKkG2ALsHyCOEJauvEO1L0eoZGu7YABCtm5Q+YEyTvNdiNU1ZsiA8Q1Ijb1dhPUK6Kq7skjZLOrymeIU+dZVGj6CBFqF6EPN7OjqTrJDLFlhxrCDFnLqixsM2CCVg1jwXkyjq5bWjrT6NexZVgsg3kzgB1lz8fT+HpdyAx/vy35xw/gA78BaR0J6nrmOaEAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "651",
+    "id": 651,
+    "sortid": 651,
     "identifier": "quilladin",
     "name": "Quilladin",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAKlBMVEUxMTH///8xMTFSUlJalDl7WkGLxUqUakqkpKS0e0rNUjHurGL2czn////GyyvtAAAAAnRSTlMAAHaTzTgAAADBSURBVHgB7dSxboMhDEVh99jYbYD3f93en6pTA8lQKUuOLkzfiLCPJ3vD/4YG9qf78LYkPIJGCFG/ENhCLzRYbIwdNCkvDbEcN2wLw38omQm2hYaUXEam2Al2L/eeGdgJMhH7umRyhGLdmT3OEEZXzBJMtpBw71f1GOYlvcv5HhJRLuEhd4RVILKUjiBsnxlZC0Z4wLgPV1SWlHDEwLaQ5hKtrhvsAL3RWlU5YgdoICwodoYLz8/5FDSQW73/npfBb5FPCZT24d6pAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "652",
+    "id": 652,
+    "sortid": 652,
     "identifier": "chesnaught",
     "name": "Chesnaught",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAALVBMVEUAAAD///8xMTFSUlJag0pzUjlzxVqLYkGLi1q0vbTFxWreSlrupIP29qz///+ZxgsSAAAAAnRSTlMAAHaTzTgAAAEDSURBVHgB7dTNagMxDARgd2blHzny+z9ux04ItLFpDj1mMOzlY5BAbPp6Mx/4Fkz3AOl3DtDxLvwpARyhY+XOIo7QLHrvtxAVO8PJcs6LLpc2EJguUxG91TMMp5xHuGiPOt0WesiphpzyFrVuoWTvLKUYRnNVmvseQltwFBuCZLYwr9hCZrbRxxhNYYTkDiKTF3l3ZLdg71t4DZKNk+nlTo2ygcizCpCdxVkht3A5fZdzSb3N1rCmIC3ZmqTc9doIoz2cmJxXXip9hYBhueqUqzWAVfk64+MEZQhEOBKufB3PzOjALFZlIZH2MD2PW5UsKCf4DIoVICH9ASXFVv71T/GB31ulDbc4cVPUAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "653",
+    "id": 653,
+    "sortid": 653,
     "identifier": "fennekin",
     "name": "Fennekin",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAIVBMVEUxMTH///8xMTFSUlKUeznFORDVvVrV1dX23mL/Sin///9jdASOAAAAAnRSTlMAAHaTzTgAAACeSURBVHja7dSxDsMwCARQemcI+P8/uOC2UpfgbJWq3Px0NgzI42Ju+EMoIpDvnEM4LkHoBwLooS0JuHcQGqsymauigbEgikX0MAbTJdPNH2lu5aoQ7XoyCxIInDeavyQ5PDqYiHSfk+VPITidU8uNHs6MxjxonnI0Tyc9DtJSDXRTJ022+to9VmClsIXpmAiQbSPcSm1hUXnnPgB/BZ+KqQl6HlikTAAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "654",
+    "id": 654,
+    "sortid": 654,
     "identifier": "braixen",
     "name": "Braixen",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAC91BMVEUAgGs0Njc0NDIxMTEuMDEtLCxJSUlRUVFSUlK5OBG8ORD+SinSulnWvFr13GL13GP33mP9/f1KSkpMTExPT09QUFAwMDAuLi5UU1JUVFRVVVWmMw+qMw4yMjIyNDXiQibmQiUzNTbHsFQ0MjHWu1kvLy/cxljgyVrmzlzz22H022MtLS0vMTIwMC6bk4v4+Pj7+/tMSkr+/v61NxC6OBAxMjO7OhJMTEu9ORG/OhG8OhKBUzWLWjmGbzSUezkyMzROTk7kQybmRCbpRCbtRijyRyf7Sir8SSkyMC/8Sir+TS2/pk/BqVDAqlLFrlTEr1UwLi3IsFTNtVbQt1jTuFjRuFkxLy4wMTIyMjBUVFLfyFxVVVPhylvlzVx+UTPnz13o0V3p0V7r1GHv12Dx2WF+UzT022JramhwcHBycnJzc3P33mb432aOh4CQiYJ2dXOdlY2elo6/sKDMva7UxLPf39/h4eHj4+Pl5eXp6enq6urs7Ozx8fHy8vIzMzH5+fn6+vowLS2wNQ+0Ng////8rKyuGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Py5UbP4AAAAAXRSTlMAQObYZgAAAQJJREFUeAHt0L9qwzAQx3GBKDpOSIhAtw4Z0j8e7MEYMqRkK+rQoTWhYymkk2e/QMr93rpD5SGjD29Z8h2MBZ/h7sy1y4al7m2JBMxNj/Ov4tZ36MMHJvYIDSPnbhNg8HA8AFgrkDmEFb4Tbzjnk5nt07t92FfRee9z1sa0FEvOM3sPde8qplaIme2rtgyOsSXbCJMtry/MuZefGIilEfkrBjuYmU5jK+JFpKEtsHvH/Ii1TKwhStX2uVa3cUMjI6VShNGyIoMQTWd60iT6YUwkFCimA/RLpgIHsiGwJrEKlAYqjgN3v4q0ZIkcjLXMnTokir2dhK3LVw/u3iwKxV26a//b1UFK1dSyrAAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "655",
+    "id": 655,
+    "sortid": 655,
     "identifier": "delphox",
     "name": "Delphox",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUgICA0NjeiLBa0MRj+Sin13GM1NDIsLCx6GREuMDGyMRkxMTHpRCUwMjP8SirVvFo0MjH33mN8GRE0MTFRUVExMzQxLi4yNDXlQiWyMBjrRCb7SioyMDAxMjLex1ngyFrhylrmzlx6GBD8/PwuLS3w2WFSUlJOTk6lLBb+/v7y2mH122KfLBYzNTaSejm/v7/iQiS1Mhm2NBq3OBLoQyVUUlJVVFNmZmbWvVugKxVvFg58GhEuLi6tLxhNTU1KSkq1NBBxFg8xMC51GBArKyswLi0vLCurLhetLxeqLxhQTk6sMBiyNA/Tulr33mb432aRkZGbm5u6OBFycnJ1dXO8plC+qFDBq1PFrlTFr1XJsVTKs1XNtVfSuFhST0+1NxJtFhBwFg5xcXH9SSk1NTVtbWvXvltsbGztRSalLRfhylyoLhbxRyj2SCgvLy93Fw8yMS80MTAvLi3VvVzbxVjbxlmHcDTfyFnfyFyIcjV9GRCWfTrjzFvlzVzGORDr1GDFORHGOhEwLSzgQiUwMTKeKxZJSUkwLS2hLBWdm5q/vb1NTUvFxcTKysrS0tHl5eXq6ent7e3w7+9OTUz5SSj7SSmWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7///83KX0cAAAAAXRSTlMAQObYZgAAAUJJREFUeAHt07Fr20AUx/GDd9sbHrcYe3Mf9VFJoMlQCoUa8cP2rt3LLV1UeehYrpA1q8nkPyv6exxdTJY4RzwEsvgLQjzxQQ8Jznxwt8DXwt8weF8BMSzxF+chzRnYHUKI5QKJ/QOW3TInY7CxqmpgvujDIazW2eUhVk7q+7LSaAOFDsg4S06kck7UWhtC6KZvywmRuFRyY3GN3O6Zey7Gs2xyDs6Js4UrCm9THTJfndyeTsXgxau1X3Obfzan1NC2QqQMkw+qWtciokTUI1EAlww9ETPLcJbbbzCY//+C1+47aJYe8nEQ74lWPbBwFS5faCZIt4fj4NvWq9ZlWVbZfzndbB/Vt55IRZyTJuN+rMJIyHtLdpTN3mS62+1IlchaS6QwufDLMzO9tEFe/hkvZiX2TDy54px5z2yuiWE+t1tPcVRIxNm/T1sAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "656",
+    "id": 656,
+    "sortid": 656,
     "identifier": "froakie",
     "name": "Froakie",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAC+lBMVEUAAAAxMTE0NjdRUVEzNTYuMDFKS0tOT09QUFAwMjNSUlJSUlNStM329lK8vKwuLy9IoLb09FEyMjJRtMw1NTJKorlUVFRHhpZIiJhKi5tKjJxStc5Jori7u6xNqcBRsstRs8wsLCwwMDAtLS2CgnIyNDRNTk4yNDUuLi7j4+Py8vL29vb///8rKyv5+fg5Wqw6W61Be4lCfIlEf41GgY1GhZUrLC1IhZQrX21JiZlKipowaXhLjJsxa3pNjZ0ybHxJoLcybX1ISEhKo7pJSUlOrMNPr8cvMTJLTExMTExNTU1MTU5Vt81Vts5Vt88xMzTb3Eve3kri403m5kzo6E3r607p6VDz81ExMS/09FIuLi319lSpqZuqqpytrZ+1taa3t6i6uqq7u6svMDC7vK0wMTK9va2+vq6TwIaj1JTf39/i4uI0NDPk5OTl5eXp6enq6urp6uvs7Ozv7+9SVFT19fU0NDR2dmf5+fn7/P38/Pv8/Pz8/f3+/v59fW02U5yAgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f1lzNC5AAAAAXRSTlMAQObYZgAAAOJJREFUeAHt0rFKA1EQhWGHgMphhhBSyDSiy7KFzGFJIdhsY5C8gII2ohYX8gw+toIgCI6C5V63VfI3t/maO5y9XX8kNjLNndsF8yF/gadmJyvy+jh5Ndpm6d3N4u6KdXe5EHXYrS07VijXrtb3MDE9fH8Zl1xGeJ/YTBHPZ+NSIkqEbm2rKaMZhTxQTfiVI9rKSTnDNwNQKi4TSZMKpTyyBqkoGRxPdbeeOdJBITXG+xbwCIfrPsfd60PBMIi7D9BuNS7nEtIwPySOwBGrc/w5U5TNpF1+tPHGKVJknu4/tesTRLsisguACt0AAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "657",
+    "id": 657,
+    "sortid": 657,
     "identifier": "frogadier",
     "name": "Frogadier",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAC+lBMVEUAAAAxMTE0NjcuMDEsLS4yMjMxMzQzNTZRUVFRUlJBYqxCY63+/v7///9OTk4rKysuLi4sQn5KSkowMDBPT08vLy8yNDRSUlN/f28vRoQvRoUwSIkwSYoxSos6WJk7WZtAYakyNDUwMTJFgpFIoL1JoL5Prs5QsdFRs9JRtNSDg3Lw8PAxMjIoOHApOXExSowyTI7k5OS5ualQsM+EhHMyS40tPXY6V5g1ano3b387Wpo8Wpw/X6Y5coNEf41AYKVISEhBY6pJSUlISUpEZKxFZq40NDRHhZVIh5VIiJhKiplKi5tKjJw1NTUuLzBKo8BLo8FLpcNNqchOqslOT1BPr89QUFAmNGgnNm1SstM0NDPt7u8rLC3y8vLz8/P29vb39/f4+Pf4+PgvMTIqOnQxSYgsLS1LjZ1Njpu9va3e3t7f39/g4ODj4+MuMDAsLCxLTE1NTU1AYKgrQnssQn20tKW2tqf7+/vr7FDs7VD391Knp5irq5ysrJ2vr6CysqN0dGW6uqq7u6u8vKwtQ39Ss9QnNm5StNVStdaAgHBSU1RUVFTb3Ez8/Pz8/f63t6i4uKgwSoqSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3/Lj9aAAAAAXRSTlMAQObYZgAAARpJREFUeAHt0LFKA0EQxvEZYpEZ7vgSFkHMnQqKx50k+AARbGV9hiDmmn0CIWAhSrbOawqWFhYB90LK21y6NPk3y8KPGRg6aMewr6sbCXR5nC8R2LDuhONsiIvpcrSFQGxxpjoqMu1t/9+zdomRriZlWdbYzMJjsh60upPVRAN8Hl9i9gO8Jn20ut9solpbXqz0ap2+/a2TyOKvPFXNF7zIte/SkBhql6XXRuZenJM0ZaZIzL5JpHIVG9COWKRh7rPz4h9BVU6c6XDXm3niBdgNLT9IyEtxg13uVgK0NsCyQJzhvpgTwkjrxc7j7n2q3LxGgrNADA6qhO+wOZFKPn8aR6UBDUCEF9U+qAfqCGcJp4b2CKcEOnbw/gF+9i/9FC576AAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "658",
+    "id": 658,
+    "sortid": 658,
     "identifier": "greninja",
     "name": "Greninja",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAC4lBMVEUAAAAxMDExMjM0NjcwMDAuMDExMzQyNDUzNTYuLi9SUlI/XqVBYqtBYqxCY62bQlGsSlrlY3M+XaI1NTVAYKgsLC00TIw/X6Y7WZswMTIyS40yMjIwLy+oSFgxSov3760/XqSaQlCqSllJSkouRoRStc6kR1b+/v4sQn3///+gRVQ6WJlLTE09WpxDZa0sLCwxSowvRoUxSYoySoo0NDLz7KsvLzDlYnIxLzCTiVKSilH29vY+XKD8/f78/P0sQ34rKysyNDRPT09AYKdOT1BSUFBBYardYXDgYG/hYHDjYXFRUVFRUVJRUlEvMTIuLi5SU1RKorhKorlNqsHj4+Pk5OPr6+tAXqBBYaRNTk1CYak0MzLMWGbQWmjTWmnZXWzZXm2vp1+zq2LDuWnDumtMTEz39/f3+Pk7WppISEiUilKVjVNSUlNKS0w+XaNEZKxJoLZLSUpUtc2YQk88Wp01TY3Du200S4v07Kv07Kw0S4zf4OHg4OBPrcVQscnEu2uAjoiAkImCkorb1Jnf2Jzi2Z7i2p7m3qHp4qTs5abx6qpStM1UVFMuRYI9W54rQXsrQnyeRFMwRoShRlTy8vMwSIinSFenSFj5+fn7+/r6+/z8/PwuQnyqSVmpSlgtLS6rSlqhoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fUOIBo6AAAAAXRSTlMAQObYZgAAAUNJREFUeNrt07FLw0AUBvAcJIOvPrxAXNS+UKjIma1DyfjokEHFgoLg7CDNkMkhLga6mSyK6KAU/0IHB3dfsrjcBTcd+sEdOfLjOx4h3jp/Gm6X73V7r0vY46LTNffB7eiMBxGLvndA5m4vcP85wrvzhdONtriDDSE2zUldlr4V7unVIzN/YUPiEOLYNYqfDp8OLw1KIRpEKEfOWdI01SCQjCGi8qVvaD4WgoaUyWPdJ/lInFSGJtd61QM3QkKBeevCWcJuqkRSVQnTIeD1h0i75mFIWljrSCksmJPELv1QIhRQySkajOv6wSoVgFQCILZNpwHi1N7IuASAakn42gHf8ckv3gCWVbWrlDEiXeFPA4pkivb5YLJgK5IUKDcpWXLMKMAdtrjk5mqcTX7ezNkL7I3vmAW3m/yb/2rq8dxb57/kG2YEQoy8ZtClAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "659",
+    "id": 659,
+    "sortid": 659,
     "identifier": "bunnelby",
     "name": "Bunnelby",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAAAxMTEzMzM0Njd6Y1KsrKQyMjItLS0zNTYuMDFLS0tOTk5RUVFSUlJTU1NUVFRjUkIwMDB7e3t8fHyJalyTc2OcnJWenperq6MsLCytraVwcHBKSkovLy+EZ1lUU1OMbV6ObmCScWJMS0suLi5xW0yhoZmhoZp6YlFJSUlubm7W1tb+/v5tbW1SUlEyNDVycnJzc3N0dHR4eHh5eXl6enovMTJ9e3w1NTUyMzSHaVpgT0BhUEBiUUFMTEuScmJkU0OUc2OWdGXGa4zEbIvFbYyZmZKampObm5RtV0ienpZvWkqfn5hwW0tMTEyjo5ukpJ2pqaF2X06sqqJ5YVBbSz36iqL+i6T9jKTU1NRfTj/X19fj4+Pk5OTq6urr6+vv7+/8/Px7ZFMrKytkZGRlZWVmZmZnZ2doaGhpaWlqampra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7////wGsy+AAAAAXRSTlMAQObYZgAAANpJREFUeAHt0LFKA0EUheG5MKdKbrGDSEACEi02IGmiTWCJw75AFJeFtKcVfFDrfRircXyCsxbp8tcfl8MN1/4VG7NZ7r2LA+fA2LXnV5Ia1tqHw6DlR4yeu/OBCj6nVOFxI09a6nc553sGKfu0G4/aBe6Tj1hrt4X3MO1OAFbU7nuFKUlI8gdTmdKjcLenPVCsJHXRDOMfXGylhAMl4U1KvlQJ91bBwCd3z9kCFbWYY/Q7fn1SPNxrdeVCrlyiOsCUGzo3B5xB1DQM5svqdLyJG4ZZcm3h2kX6BRQpLVqFeEuMAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "660",
+    "id": 660,
+    "sortid": 660,
     "identifier": "diggersby",
     "name": "Diggersby",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAACglBMVEUAAAB6Y0JSUlKbm5OSclIxMTFuWTxwWj1MTEsxMjN8ZEN7e2szNTaUc1KLi4SOjoeampI0NjecnJQsLCxMTExSUlEuLi5UVFR6YkGGaUuIakySclFaSiptWDv9zUr+zkqKioMwMDCMjIWOjoZvWj2RkYotLS10Xj6cnJMyMjL8/PxLS0tZSSmEZklVVVUvLy8vMTL///+Jak2MbU5URidUVFK6mkrluUIxMzRJSUlKSkl7Y0NKSkpxcWKSkoqSkouVlY2VlY6FZ0qGaErAwMDW1tZURSb9/f1NTU10XT8yMjFycmPi4uJ8emtQQiQ1NTWxYH5yXD1XSCm6ZIOoi0KqjUOukEWxkkYuLi28m0q9nErhtkPjuEJaSinsv0Ttv0Xww0Z8ZERubmBwcGExMC9sWDpzc2V1dWaPj4iQkIeQkIh6emqSkokwMTJRQiZ+fm5OTk6ampFRUVFSRCWdm5RTRCeIaku+vr79jKRTU1NUU1KKbU7j4+Pp6en7+/uMbU0yNDX+/v5yXT4rKyuEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dX4fgpKAAAAAXRSTlMAQObYZgAAATNJREFUeAHt0LFKA0EQxvHlg8HiWDhGiQNXxAuc2m5ppcFSFEK6wDYhIMRCzspUFvOAguD7OIOFhXtyFunyr38w+234X4e0Hcf05EbHsK7nb6h/cd3Oa+ZqbUZnVzrsznpmxvL+OOi67691yM3Y2y2fNejjC9edlt1chIWxO73s9LwCc3mVdrVBZgNcPdVga6sluPhxKVVgTwvurYlRmCi+ciJih8Xjk2g1GgiIlFJ0KFKAJNmd3klC9OCwL0KhEPQdkhIQBeKy+S1V8kKDfnxCLFQwF2MBBpqoPRUGYcikOWluXZa2C6ZIyf8I0cqxLcOjqWUSlrMsVIaNuHQkAmPZXLGNu9UqiwXJrQ44fYAxdxaJsUGYQS4FoDDsTG4oaEuAUBgRiVzoGKgxN6OgXw976dAXBbNI1P9/6mMAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "127"
+    "gender_rate": 4,
+    "rarity": 127
   },
   {
-    "id": "661",
+    "id": 661,
+    "sortid": 661,
     "identifier": "fletchling",
     "name": "Fletchling",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAAAxMTEzNTZRUVFSUlI0NjfEUjlQUFDafVUyNDUuLi40MjJPT08uMDEwMDAsLCwwMjPlg1rmhFqhuMkrKysyMjJUVFQvLy/igVics8NTU1MxMzRXZXzVelMvLi1MTEyiucqku8ykvM2lvc7e3t7p6enr6+vx8fHz8/NVVVU1NTVjc4xldY1ldY6TqbeYrr6wSTNJSUmft8dLS0vGUzrLdVHNdVDmhVxhcIlicorhgVlISEhebYQtLS3khFszMjFjcouDk6SRprXaflfcflbff1jhvDPegFfggFe3TDXCUDjjg1jjglnDUzz6+vr7+/v9/f1MS0tSUlJTU1NUVFRVVVVWVlZXV1dYWFhZWVlaWlpbW1tcXFxdXV1eXl5fX19gYGBhYWFiYmJjY2NkZGRlZWVmZmZnZ2doaGhpaWlqampra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7////jZg1/AAAAAXRSTlMAQObYZgAAAKRJREFUeNrt0rEKwkAMxvELF64iUrgS6C2l8K236FSkg3UR7KST77/7CGLNCxjuAe4/ZPpBCMTVak7aQjeKSJHjw7i3gKbTyYOZyXDHYXcX5XOzbZYbUlzTIPPomchY+2xiePi0ZjD7Wf7L3vtwed0CwNSLdUqM0YdpWpicmSSVXbcAJ7ElRS0D+LxtKQEKr9i+6mx5BpAzUcEvECsrqRVXq5X0A+0zE0bzdAXsAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "662",
+    "id": 662,
+    "sortid": 662,
     "identifier": "fletchinder",
     "name": "Fletchinder",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAABra2vme1JqamozNTYxMTEyMjJoaGg0NjdSUlJkZGRmZmYtLS1oaWkuLi4vLy/NWjLKbEjedk/jeVEwMDCRpqakvLz9/f0xMzReXl7MbUjVc03ieFAyNDVubm7JWTFOTk6dtLRTU1PWckxUUlHZc00wMjMvLi1hYWHlelFhYmP7w1L+xFJNTU0uLSw0MzE0MzIrKyvAVS7EVjBUVFQuMDEzMjFPT0/ScEvVcUxRT05RUE5RUFDYdU/ddk5LSUjad1BJSUlKSkrjelFrbGxubWvkfFPmfVTofVLhr0jqtkzvuk3yvE71vk/2v1D6wlD7w1FUU1L9w1FheXmDmpJke3ucsbGds7N9lI2etbWiubmjurqju7ukuLiMdTbg4ODm5ubs7Ozy8vL19fX39/eSeTmrSjjceFBoaGhpaWlqampra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7///8TnSleAAAAAXRSTlMAQObYZgAAAMNJREFUeAHtzDFqA0EMhWExQixKwDvFoJAbeGGal7Qhp7CP4MDe/wAbyaRIYa2nNfgvXvXx6NnDhTboXkDAgHubgONhBPL6OskOiK7Oto0lZ8UDwaGXu2BLHE7qhxNyt3jfIKj/rUgP3cXlJz5KZdaGzEW1X1dVLx3I4E+R7nBRZe7efNMdVeumceiMQ+Kmez+IE/3nhLJQSzH7g5fc0cwW0kI20E5ysoCm+8zDl53OdjahO2EWNWUB3U9kBQ3VQA/Us19VKRstZ7L53AAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "663",
+    "id": 663,
+    "sortid": 663,
     "identifier": "talonflame",
     "name": "Talonflame",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAAA0Njdra2vme1IxMjIxMTEzNTYsLCxRUVFSUlJTU1NqamouMDHYc03edk/heFDieFHlelEwMDD83GTScEsxMzRhYWHgd0/MbUgtLS1tbGsvMTJoaGg0MzJLS0suLi4yNDXlfFOJiYmFhYWKioqLi4uMjIwrKysvLy/YdE3gd1CJiIjNWjE1NDLddk793GOCgoKEhISpSDhjY2OtSzrQb0p8fHxMTExgX15gYGAxMC+rSjlPT08zMjFlZWVmZmZJSUlpaWlrammNi4tLSkjOzt79+/swLy3HWDDJWjDMWTGhRTXw0V701WD62mLfwlcuLi2Dg4MwLy5OTkxmZWQzMjDXckyBf3+yfUDme1NmZWO+miy7g0K7g0O8g0LFoC7HoS/Npi/NbUnixVjjxlrqzFtjYmDqzFztzlxISEhkY2FkY2KodjuseT2ZQzRNTU2aQjPPqDDQqTDSqzHWrTH93GLOXDT/3mPKbUiBgYGkRzenSjdfX19OTk40MjHWc01RUE5UU1HYdE5VVFJeXl7BVS/GVzCHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7///8Il163AAAAAXRSTlMAQObYZgAAATJJREFUeNrt07FKxEAQgOHIMphxqlwTi8AVZpkUIYUiaAInF7TSOxDhKgn4BDYb9wHU59ZZb6tLciuI3f1FwoaP2WI30aE/xLPfMb5geYTd1Tpjvp4H3UPWYb9+hqnttq+I3/s2JmrrCXb5A/mEV20XW2s7HmWbyg/MniwhES15nCWJh4QdunnAPHBvaZqUtV+8yjyUiBa84zZKKj9ZcstYjARQ7LjKMVRpVVWnYnPtxs2G+94nqiwtKpVI6eNZTloPmcDVuYI7Q0pk0zRKaa0JRtxtbEv6IiWJUs6KG1YgQCnAOxfGo7dBvgFot+MWknTz4eVQ506ilwCTd5Ez7UKhABDtCVCY0JwDF/DFAAAJZt7rjmrYHp4xCw7+SMzGGCgEBjom6EWFY1h6F6bz6NC/9Q0WGi+X6FC4qgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "664",
+    "id": 664,
+    "sortid": 664,
     "identifier": "scatterbug",
     "name": "Scatterbug",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAC7lBMVEUAAABRUVFra2tSUlJoaGhqamo0NjczNTYsLCxKSkpLS0tPT08tLS0vLy9fX19hYWFlZWVmZmYuMDExMTExMjKilXf7+/v8/Pz9/f00MzNhYGAwMDBjY2NJSUkuLi5nZ2cvMTJpaWkyMzRQUFBsa2ttbW1ubm6fknUyNDW0pYTk5OTl5eUwLy9UVFNUVFT+/v7///8rKyuzpIM0NDSoqKiqqqq4uLi5ubm7u7vf39/h4eE1NTVMTEzq6urr6+vv7+9VVVWgknVSUlGsnX6xoYGxooJGRkZHR0dISEhJSUlKSkpLS0tMTExNTU1OTk5PT09QUFBRUVFSUlJTU1NUVFRVVVVWVlZXV1dYWFhZWVlaWlpbW1tcXFxdXV1eXl5fX19gYGBhYWFiYmJjY2NkZGRlZWVmZmZnZ2doaGhpaWlqampra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fmrHJz8AAAAAXRSTlMAQObYZgAAAKxJREFUeNrt0jEKAkEMhWGX7ANFCyWNMOIie4DNmxMIgtjYW4p4zb2RjZXYOWJv0omwf/0xJDMzGvp9TEH3nDAEx9bcIpIPGO4Mwd40NGOnMZcSI4znSq703XY1BTCn53YQlOqDI2f5DQ24OFBRYNaMxoXygbL2hqysSMC/SBUINgy8Xy8ibYGkI5dmvbXkaU/vRJO+Oy6k/r6PqpqUkOmuo8iSYx8jqY6G/qUXnQsbhWbUOY4AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "255"
+    "gender_rate": 4,
+    "rarity": 255
   },
   {
-    "id": "665",
+    "id": 665,
+    "sortid": 665,
     "identifier": "spewpa",
     "name": "Spewpa",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAC4lBMVEUAAABSUlIvLy9fX1////8uLi4yNDUxMTEzNTY0MzPj4+NUVFQuMDFjY2NmZmZqampra2uomXu0pISnp6eqqqq7u7s0NjczMzP4+Pj8/Pz9/f319PS0pIMtLS20tLRhYWFpaWnnAACgknailXdLS0vz8/P29vYsLCxlZWVTU1MrKyvUpEyDg4OsnX75+fmrnH2zs7OIiIiLi4uRkZGVlZWuoICxooKzpINVVVVNTU1sa2uoqKhubm7QBAThAAC3t7e4uLhOTk6+u7u8vLy9vb2/v7/f39/lAwPw8PDx8fHmBAS/k0IwMDD49/YwLy9VUVH7+/toaGgyMjLAlELSo0tVVVVWVlZXV1dYWFhZWVlaWlpbW1tcXFxdXV1eXl5fX19gYGBhYWFiYmJjY2NkZGRlZWVmZmZnZ2doaGhpaWlqampra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fU+J5v9AAAAAXRSTlMAQObYZgAAAKtJREFUeNrtzjsOwjAMgOG4cuXRE5sHijq54iGhMrKQMffgGBwBicMwcC927BzAYYb+SrZPttPSD6aF6BumW5G9atONs4icnjdtwSuLMMNLG26zZmALjhrD2R0afMSwZ4NCwnCPoOrIUGFjdbc7A6BJgAx9OHJAxmyYc75EsKDH9mOXFImqHYZVuPntcJoc5kgWAsQK0W48RDMJiZwRchcfqY6LJnvtNC39dR9G0RYvX/0e3wAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "666",
+    "id": 666,
+    "sortid": 666,
     "identifier": "vivillon-meadow",
     "name": "Vivillon (Meadow)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABiVBMVEX///82NzcxMTEyMjI3ODg7PDxRUVFSUlJTU1NUVFR5eXl7e3urQVKxsbn2epv3e5xTUVI4NzhTUlI4ODhUUVJUUlJVU1RVVVVWVlY5OTl6QVJ6enozMzN9QlJ9xfw7PD2sQlKtQlKuQlMyMTLBsJjKUWnNVG5SUVAzMjL5+fmrQlKtQ1M4OTnPU2zbYoKwsLhQUFB6ent7Q1JSUFEwMDB8Q1J8fHw4Njd8QlKsQVK0tLytRFRUU1SuQ1OuRFSrQlE6PDyzs7tUVFW7wsq+yNC/xs6/x89VUlTBsZk1NTXKUWpVVFTNVG/OUmvOU27PUms1NjfPVG3PVm/YYoLZYoLaYYJRUVLdYoPxeZnxeZryepnyepzzeZrzepz0epr0ep31eZn1e5tXU1RRUVD3fJ35ueExMTD6+/v7+vv8uOL8+fr8/P79uuX+uuT+//9/xf6pQlGqQVEzMzIyMTGvQ1QxMTJ+RFQ5NzisQ1KtQVI0NDSrQVFWVFQzMTLLUWrNUWrNU2s2Njf//f0QcaPIAAAAAXRSTlMAQObYZgAAAW9JREFUeAHt0sWP4zAUBnDbYU6ZmbnL3S50mXeYmZmZYf7yiSeam2X1Mrd+UZx3+OlFnxLQSdvpQW3CW2bp4fGSYiBiAPj0K4zHFymKjKF0GJ8YnpsIUCSE+LRu1y6GtHB4HYDVeOQRvjlkiBLaMBLft1m+ZQqIvBLDwf/qMe6ebxVVZ50lr8TX1fClNTpevU0EyQ5DBjHoD4aOKSNZdDsR2bFCSAyJ4kAAlMd146DRCObJTlMUWVEUBpRXotlK5TRB7gJrZ7IsSrwsouVvfdO6UUq4h4iQF0KCVPDzz4Sv61vR7HUk+DxHKsPx8usvhd8Fv3Yx8f3HPz1JfLMttc8+SdK8Yzdrd9uTH9ScwAKyhBZt/u3/6fGOzpZOciwkO5uKGU9VN+a8780UoAXWfFKme8ZY2PxI/4lc81pTGunqXX2nOmkQpgO8KLOLG0f4Q1NcnbXsHuB24iauTCljYR7hAVojPTGeBe2FA508We4BGrcuMz8zVT4AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "667",
+    "id": 667,
+    "sortid": 667,
     "identifier": "litleo",
     "name": "Litleo",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAAAxMTEvLy8wMDAsLCxBOTlQQUFmVlZpWVlrWlorKystLS1fUFBhUlJkVFQuLi5IOjpOPz+se1L2OTHEmmrFm2vGnGtSQkJlVVVoWFhPQEBoV1deT0+ZbUimdk+selFNPj7dMyzxODBANzevil++lmfBmGjDmmlAODhMPT1QQEBnV1dNTU07MzNSUlJLPDzoNS6SMzqdNj+lOUKxi2C3kGO6kmS9lWZgUFDAl2ibbkmdcEugckyic02ldU6xoqK6qqri4uLv7+/29vb9/f2mdk5GRkZHR0dISEhJSUlKSkpLS0tMTExNTU1OTk5PT09QUFBRUVFSUlJTU1NUVFRVVVVWVlZXV1dYWFhZWVlaWlpbW1tcXFxdXV1eXl5fX19gYGBhYWFiYmJjY2NkZGRlZWVmZmZnZ2doaGhpaWlqampra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7///804U2kAAAAAXRSTlMAQObYZgAAAPdJREFUeNrt0E9Lw0AQBfCdrAuZJzay6zJKqtFGspBDbdXWk9CL3//jeIxDirdk6bXQd9g/8OPNsuaS8whOQjDYYDwg69pPvK9eVO92QKa/atp2FcIW+5T2x+LXSUmN+wh9Xae6LdO1OvfVVTOzQ8/MpXPOQ69dTDQJLROzCLNrMI6I60mIX1Y3HITL0eGmwHThncIDDVFodGJn/ycEiUP04wPRkpkNSYzivV0Cy4XqjCR1wny/eOC8NOj5P8i6NxE+/pHc5uRVL+KYnZBkIb5FSGEJQ/KDeff47MmgZLYGT77KNBakS1KtmzX5IHEHc0psAXPJGeUP1isU4e58FO8AAAAASUVORK5CYII=",
-    "gender_rate": "7",
-    "rarity": "220"
+    "gender_rate": 7,
+    "rarity": 220
   },
   {
-    "id": "668",
+    "id": 668,
+    "sortid": 668,
     "identifier": "pyroar-male",
     "name": "Pyroar",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAM1BMVEUAAAD///8xMTFBOTlBpLRSQUFSUlJqWlqDOUGDWjmse1LFOTnFnGrNpDH2OTH/xTH///8E8uhAAAAAAnRSTlMAAHaTzTgAAAEZSURBVHja7dRRb4QgEARgOj2RxRXu///azixnapQm99C3diJg4pdZnkwfb+YPwzSCdAkYnReIjvj2zVZG+AYbtA4XyN3qGUKul35yy6pXSpxGo0GFdAOCD52CC2zoAxYhcjUGrCcIAio5SaiXEi93gSZoJtujcUCkMxTx2AZUrZxyhomSkMs90xGuK0un8Mn57jXnztBROm6Q0h5keAZsgtkmEK2UhWMfz+UozD6HrQGo1WoJ90lId4OSBnOrmd1bAaH9BBs7LPPctpKgyRU3KNl7zuEEEyozgdh5tUZc5Agk7Qbp9l1k11nWF5zeEaWGVIazGWQQMKoDAEgzGA0bEkrxQ0xhNFAsfrg5PAKv78EonsL//+PvwC/2YRJVgd8muQAAAABJRU5ErkJggg==",
-    "gender_rate": "0",
-    "rarity": "65"
+    "gender_rate": 0,
+    "rarity": 65
   },
   {
-    "id": "669",
+    "id": 669,
+    "sortid": 669,
     "identifier": "flabebe-red",
     "name": "Flabebe (Red)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAw1BMVEX///////82NzfEKjHHKjLnSlI1NTVSUlJVUlJrszmlexg0MjI0NDHU1NTlSlLmTFIxMTHoxwroxwz7+/v8/Pz9/f3/7Uv/70n//Pz//f4yMjLFLDLGxcQ2NTPHLTIydQnX1tPX19fccrvedL3kxAk0NDTlS1FTVFLmxQjmxQnmxg40cgnoTVJVVVU1NDJtszn87Up1dXV2dnb+7Ef+/v6kpaM0MzGnfRg2NTD///3FKjKofhtUUlI4OTnHx8enfhzoyBCfYEAKAAAAAXRSTlMAQObYZgAAAMBJREFUeNrtkMcWgkAMRUmYGUSKgDSx967Ye/n/rxIXbCeuOd5NNve8vET5UzAe4jcPfRCKKYRJmgICc3C5uGcy0drMdlEUTZpDITe1Z/D2PO/W3VdRajq1JQQAPoAglvcAljXYWlUfqZqNTj+wEOXeKju8PD1oR+rqNDHi8ms+TpEwkztnp5itE8IzSowv3BZnJUP+G845C8OQZdORVlRtlX+52qq8JCKqlcqoriEqFKjrbT3XiFQ970eryp8C8gHqAwvefsMNPgAAAABJRU5ErkJggg==",
-    "gender_rate": "8",
-    "rarity": "225"
+    "gender_rate": 8,
+    "rarity": 225
   },
   {
-    "id": "670",
+    "id": 670,
+    "sortid": 670,
     "identifier": "floette-red",
     "name": "Floette (Red)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA9lBMVEX////////nSlJSUlI2Njb7+/v/70oxMTE0NDSmfBemfRvGxsblxAjGKTH7/Pz8/PwbbURSU1EzMTFTUVFUVFQYakHmSVFRUVE0MzHFKjDkSVEyMjD+/v4wm1nEKTEYa0IzMzOmpqaleRileximehg1NTUxMjEyMjIwMTHmwwhTU1OmfBgzMDExMzHDKTHDw8PDxMPDxcRRU1IxmlkznFgabETbcboYakLkSlLkwwjlSlFUUVJUU1BUVFE0nVznTFHnxAnnxgjnxgv77Elpszlqsjj87Epqszn97Un9/Pv9/f3+60n+7kj+/P3+/vtxcXF1dXWjo6NNNMofAAAAAXRSTlMAQObYZgAAAPFJREFUeAHtk0WWAzEMREdy23JzhyEdGGaGyTAz3/8yY19AyjKLlDa1+K56T3qem2kKFBBNxj1cPbdpAm6nNqgNPtpybXfp3E2PhLgmputhEnaaWOW4LiLefhpjbpypCoELr8ZsdlI+crmlxoipozDd4qpbhwcOxIsx2xzQ2dEwqyulXiqKWXqg77+LDOB6mBWP20ytht88Lj0H86vsqnU9txp8aDwSrvL37qASosWedMDduLQ6Su4uSSJPvgCiJHyzAqeL/v6Gop8cLA82svh4b+QeSOBT5bS/4pMBrMCtkTfaahakhs/zzo30raZCM/0D+n4UVNtp9vsAAAAASUVORK5CYII=",
-    "gender_rate": "8",
-    "rarity": "120"
+    "gender_rate": 8,
+    "rarity": 120
   },
   {
-    "id": "671",
+    "id": 671,
+    "sortid": 671,
     "identifier": "florges-red",
     "name": "Florges (Red)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA/1BMVEX///8xMTFSUlLOzs73Y2M2NjYzMjMxjGtCvZRRUVEwi2pUUlK6guy9hO/MOUopWkL0YmL2YmIxMjH9rO/+/v7///++hO9BvJO8gu5TUlRTU1MxMzJUU1RUVFSUQ967g+xCu5LMzMzOOUo0jW1RU1P3ZGL7q+z7/fz8/Pz8/f01NTX+q+xTUVFTUVQrW0RBu5I0MTHzYmJRUlE0MjP1YmRRUlKVQtxBupL3ZGWUQduUQt4rWkQximqjo6OSQdsyMTP7+/ssW0T8q+z82zEzMzMzjWwpWUL9/f2jpaSmpqYpWUEqWUTOO0w0NDQxi2rNOkz+2zH+3DHLOEn/re/Ly8v7sgg6AAAAAXRSTlMAQObYZgAAAXBJREFUeAHt0sV241AMBuDo3mtmDjMzTwYmw8zTvv+zVM5xN43i0+6jjTeffsmWC9eS4JHOtORUQ37LGPqxZcmwEmIJ2AKX46z61nCFmByE0bCCWL4Eg6prNLsfepObqrsvYjg92CwxdMqOsZS7+xfFYENCzZ4cUAyjqMYQCoGhZKa0Ehg4iDjnn5J8aLDmKOJh1Dm59rRBzh7/n7bCzoCHHSX5Wrb/9kT66jK14xCXG2KcOuJhzRUIwSSgdJwxdFEN3n4rY4/9fAYFidzxuBXG6y8R/9n2DJTZ3DGcQfOPJwzGbO9fL4Xv41RKzyoPXT8u2Z7Iaqk18KBvSGjKoLHWfM3s9hRwkaIVbADOHMqCdMvnzrrZbX08NdZ/LFTFp/8L7bezUPGKv1L4El2CgaR8pWQSvvff6bTLoOI4+o591vGRqJTLJGCm7qRDVbUCNLoPdTBM8QHyWCZ1Px9lzqc+HgEBr6GSksB0JB37tLrWHTA+Juv6v8VRAAAAAElFTkSuQmCC",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "672",
+    "id": 672,
+    "sortid": 672,
     "identifier": "skiddo",
     "name": "Skiddo",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAACN1BMVEVPogAuLi4vLy8xMTEzNTY0NjdBpCmki3qljHsweBgxehhzc3MyMjOCalmSfG2dhXUwMDAtLS339/f8/PxSUlJUU1N0Xk9wcHBycnIyNDVAoChBoCksLCwsLiyDa1orbRWUfW4yMjKfh3egiHegiHgvMTKki3tKSkqnjn69vb329vZNTU36+vpSUVH9/f1tbW24NRBubm4vdxcucRgvdhg8liU/nydAnygxdhkxMzFBoigyeRouMDG8NxCBaVkzexoyfBkwMS+TfW5MTUyWf3CVf3HDOBCbg3ObhHQxMzSdhXZOTk5PUU9QT0+iinmiinqji3stbhctcRdUUlEucxemp6Wmp6aopaW1tbUudBfv7+94YVJ4YlP4+fh/Z1b7+/tlZWVra2v///8rKytkZGRlZWVmZmZnZ2doaGhpaWlqampra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLwtUnkMAAAAAXRSTlMAQObYZgAAAMtJREFUeNrt0bEKwjAQxvGYgyiRYocDF4kOclJEhA7OTnbrO5hP0NXXEx/Oq517Oot/kpDhR0KI+/dbofzS7c/QFfgoaX4BrrfLJwnwdLu/e3WA5VZrZp4y6fYIg5bCIjobYBkPB+NMknfrTR3b2ry7hynHdtI2GHbNWCRLzlWIIuPZoPSFOlIXOyjeD0FizllH7wrrMVlTF2KSlB6GxI67e2NKRKnyBqxDUKeMHE5kfTYHSlJCtyMYTo+Bo2dPzLDosHdfhZH794u9APdhJ9Y+H0nbAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "200"
+    "gender_rate": 4,
+    "rarity": 200
   },
   {
-    "id": "673",
+    "id": 673,
+    "sortid": 673,
     "identifier": "gogoat",
     "name": "Gogoat",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAC/VBMVEUAAAA0NjcxMTExMjI0MjEtLi4pWjExekpRUVFSUlJ7e3tBmllCnFrMtJPCOBHKspIwMDApWTEtLS0tb0MwekkwMTJ+UTNJSUlKSkpQUFAsLCxSVFMxMzR2dnZ4eHg8jFEzNTYvLy+0czG0czKSemthYWG8pYcmUi0pVy/OtZTJyMjMzMz9/Pz///8rKyt5eXl6eno9kFQlUCxZWVnOzs7k5ORBmVkpVjBCmlpgYGCLWjmxcDAwdkhkZGQpWDBjY2MyMjMzMjAqWjI+k1U/lVYwMjFOTk6uMw9PT0+MWjmiZiyhZy2mai2oay5OUE+wcDEvMTImVC62dTSGb2InVS8yNDVbW1srbUI8jlLu7u5cXFwucEUuckWrbi+mazAxeUpPTk0tLi2ycjGzczQpVS4sWzFmZmZtbW2MdWaPd2hubm5wcHBzc3MsXDOyNA++OBG7pYeAUzSFVja5o4W6pIZUU1K9poi/qIpUVFRVVVVYWFguMDFjYmGzcjBAlld+UjV8UjQnUS0xeUktcEO3oIO3oYSHVzm1trW4uLjAqYrGrY7Ir4/Hr5DKsZGHWTrMs5KKWTiKWTrAvr7AwcDGxsUrbUHKy8rMysrNy8slUiyMWzrj4+ONXDxdXV3y8vL19fX39/f5+flfX186ilA7i1GlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7sQuJfAAAAAXRSTlMAQObYZgAAATBJREFUeNrt0jFLQzEQwPF40Hte8t6jSEAqODTUSXII3eIupZubOEkHQXRyznPxA9hF0MGlX0fylcR7mV9oty79k/FH7gJRh/YZj2E3dx/nrJhZ5ZhL8CzGm1N+fjnKhD+xIHkeia7OJ1ovHlmcveVht9gQaa0JALTAb2stD8INiRKX1+N3a3GkhhrpqGX2Ncttxrwdky2tGGP03lG35DtjTG1Kbtl5r4lC1z1YU6PBguTrPw+eSE5dI67QrXjQ/USvW08poDjnXAjr5ZCcXiTvSZwLtUhxzcfr8JVfKYe9E9Z3UvgRCRNmh5mFpvBuqIRJPZvNmuCeCpArqUaB4gDSpbiCtFhVeS6A4rYdF+EEK+rnNpB3VsWgbQEat2a1rTGLTr8Zbk2Wm+7i8nKH9t4/56c4xYQ0HJwAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "674",
+    "id": 674,
+    "sortid": 674,
     "identifier": "pancham",
     "name": "Pancham",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEWeEW9SUlIxMTE0NjdKSkpMTExzc3PNxJP+9sX/98YyMjMyMjIuMDFUVFQuLi5xcXEzNTZOTk7l3rLp4rXt5rju57lRUVEtLS0sLCxwcHBPT080NDMRuirn4LRJSUkvMTL68sP89MQ1NTQvLy9qamqPelOSe1STfVUxMzRLS0stMC3n5+fJf2+chFqdhVzcjHu4sIS7s4a6s4e7tYe8tYe9tYi+toi/uIpmZmbPx5Xi27Dj3LDk3bFoaGjn4LNpaWkxNDHq47br5LcuLi0gXihTU1N0dHP99cV2dnUwMDCLd1H+/v6PeVNNTU1OTk5PT09QUFBRUVFSUlJTU1NUVFRVVVVWVlZXV1dYWFhZWVlaWlpbW1tcXFxdXV1eXl5fX19gYGBhYWFiYmJjY2NkZGRlZWVmZmZnZ2doaGhpaWlqampra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7///9kNZ2DAAAAAXRSTlMAQObYZgAAAKtJREFUeNrt0rEKwjAQxvF8pya3OUkP6ZAS6CCELoJOTj5AnsDVyaXvD5oorrmsSv/zjxzJxSz9UBIa3ehFGpj46MeLqO5+GhyzF83dhsglbboIf0qPc1V2/A1zqB5oC3KwDFDFHfeZgZ6Ac1R/aoD5DaNyb3K54nhXlSLXaYqFhrrr+wOhRNr+OiMJFljrO0wWloCVaHBrc4Skwg2IsqSmbysJYpoKYpb+rRdnvQ/etJL3gAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "220"
+    "gender_rate": 4,
+    "rarity": 220
   },
   {
-    "id": "675",
+    "id": 675,
+    "sortid": 675,
     "identifier": "pangoro",
     "name": "Pangoro",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAC8VBMVEUAAABSUlIxMTExMjI0NjdJSUlKSkpMTEwsLC1qanJra3PFvLT+/v7///9RUVEwMDBVVVVgYGdiYmliYmosLCwuLi5LS0v9/f0xMjNNTU3l5eVTU1MvLy81NTVqanFOTk5PT0+0rKXEu7MuMDHj4+NfX2bo6Ojp6ekzNTZhYWnm5uZpaXH7+/svMTLn5+c0NDTGvbX8/Pyzq6Tk5OQvLzAxMzSvr55hYWgyNDW2raa3r6e7s6u9tKxISEhUVFRlZWxlZW1paXAxMTJfX2UuMS7o5+cxNDEQqybq6urr6+vt7Ozt7e3v7+/z8/MRuiqbm4yhoZGkpJSsrJsrKytUVFRVVVVWVlZXV1dYWFhZWVlaWlpbW1tcXFxdXV1eXl5fX19gYGBhYWFiYmJjY2NkZGRlZWVmZmZnZ2doaGhpaWlqampra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vqAkmNDAAAAAXRSTlMAQObYZgAAAQ9JREFUeNrt07tqw0AQheGcAdsRy0hFbhgMUeNKT5BCoCSFi1TWNMn7v4NNXOXMrkKKrBY37vxLyGA+DlqDb65dKGvOdN9mZyizk7YfpGVt2+P6aVTdv1hvJffVqgeEdl2EQ3JVBcAsS9PXbzpJBDxv83C3Mz51TDIEdO7mJu006ghRDRxtCr/NQVUEdIRSOMxtHKOi63qb3bOlBEbFc1fd+8yxP5ePrdDQTQ3ZURuIINC0hziagw++JqKq0cbZ194yVDyoF4SStK4XGcqsBtw5JPXqVeZFbQUWeCG9R6Sb/4P3+Eu8SBeZxV8RjzLJJv+OdP7ZRch/j9+5rIluqMDrzrfKiUCwSa5cY35fu0Q/B2IpZJb7zC8AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "65"
+    "gender_rate": 4,
+    "rarity": 65
   },
   {
-    "id": "676",
+    "id": 676,
+    "sortid": 676,
     "identifier": "furfrou-natural",
     "name": "Furfrou",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAADd5s1SUlLc5cwzNTbe584wMDA0NDQvLy+jq4qkrIvEzLbN1r/a4soxMTEyMjIxMjNMTEwyNDXFzbfK0rsuLi4xMzRUVFNVVVR6gWOCimuUm36gqIhRUVEsLCylrYzCyrUtLzBOTk7Hz7nI0LpQUFDN1b7N1r46OjrQ2cHS2sPW38c9PT3a48vb5MxKSkorKyuhqYktLS0/Pz9/h2j8/PydpIXZ4snGzrgvMTJERENJSUnU3MTV3saepobX4MiRmHzL07yaoYNBQUHc5c3d5symro5DQ0NNTU3Y4cnZ4cpKSkmFjW0uMDGepYaEjGvU3caVnH6WnX/LMjKXn4DY4ciTmn2Tmn47OzvJ0btGaG9KcnrM1L1MdX2XnoGYn4GYn4LQ2MKYoIJ3fmF4gGI8PDx9hGaepodPT09QUE+hqYrZ4siiqomBiWmjq4vb5MuCimpAQD+lrY1LS0tMTEuGjm37+/tISEjGzrd5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7///+0sLfgAAAAAXRSTlMAQObYZgAAATBJREFUeAHtkDFrAkEQhffNwaEDbqp0sQximrxAEFLEMy7+gBBsYh8UEtzOn292Lqa78fwBfmyxxcebeRMKV1hf6DUM5AXevDrwrUe0IO6Rm77AksTpCsCO7BnbfGUUqvXDeTXin7vZopiOTT5mGCKqO3OcVoNmZFoWFFG/eTpVV2R1StTy7OwcvXLRYdaaAGw2AMZsPey3w7qrTDFvPo4JFf8mAEN21tlKOh5Tgpnk+wqqXYH8FJGUxMQDJ2srFUMXL8UyV1GWE0DH9C6eU9IEgSG2gAOfc9Lciipwqhj8yTEDUlyB4kxkzRCBVovlM2dw4UxxGhpVl/TFebtdtO+TKl1vqZqLSfuKKP08bbebMDDK2A+8l2HbZ2Q71ue6DGLgFMi3oR9uxcr048+84vMLHoEvMq2oX2MAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "160"
+    "gender_rate": 4,
+    "rarity": 160
   },
   {
-    "id": "677",
+    "id": 677,
+    "sortid": 677,
     "identifier": "espurr",
     "name": "Espurr",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAACkpLQxMjMxMzRjWmuSkqCWlqWhobEwMDGlpbUyNDUuLi90dIyenq2enq6fn680NjeiorIwMDBlXG37+/tiWmp8fJUuLi6cnKxeVmYzNTYtLS2jo7MyMjLEzMTe3t5tbYMrKyucnKt7e5R8fJR8fIpdVWW9VuxfVmd4eJA0NDRsbIKgoK+hobA1NTVzc4thWGl6epO+WOzx8fHEW/TGWvd4eJGiorFaUmGYmKajobSlo7akpLOZmahsSoWttK3FXPWHh5aIiJeKipqMjJyNjp1iWWq2vrYxMTIvLzAuMDH29vaamqmbm6pOTk5PT09QUFBRUVFSUlJTU1NUVFRVVVVWVlZXV1dYWFhZWVlaWlpbW1tcXFxdXV1eXl5fX19gYGBhYWFiYmJjY2NkZGRlZWVmZmZnZ2doaGhpaWlqampra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7///+R7x+LAAAAAXRSTlMAQObYZgAAAKhJREFUeNrt0jELwkAMBeC+QdwqHgQRSukji6tgFwehVCSDLv5ff5fjSYNr724ufRCyfIQQUq1ZWhi88m4YyB0L3HisT9c3K5JJON4FgD7ZvTZMuE8rOsnHdg/U8zKYwOOtPcyPtNjjT9sYrUrICbqWwIRjBwXsdgFg6fs0ANADIpljmvmG2rhLU1WRkHfsVNWyzNdUfFniAGEJPAMNyz4yaih+3jULzA/nUxdLmZNYhgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "678",
+    "id": 678,
+    "sortid": 678,
     "identifier": "meowstic-male",
     "name": "Meowstic",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAHlBMVEUAAABSUlI5WqVSe+8YrVJa78aMjIy9vb3///8xMTHTPSrqAAAAAXRSTlMAQObYZgAAAK5JREFUeAHt0jFyhFAMg2GsH7B0/wsnO/sm3XPotllVFB94LHN8Lt/kqXOews4zB8mR/AuBcuxfmWSCLrftJPYELb/SEox7RW7bKmB0F9JyMzxBFuXJrXoQ1No7mfrhvJQcyTQ/Bddp8q60aiPTVCH5zosBld0X27a7oGCcrXYLSrzjbCCSqHYtxw5GAFVJctv7Q6aDIKss9xbmCMl6yfOf0cvZ93zI/D3k+GC++QEdEAY8EIbTZQAAAABJRU5ErkJggg==",
-    "gender_rate": "0",
-    "rarity": "75"
+    "gender_rate": 0,
+    "rarity": 75
   },
   {
-    "id": "679",
+    "id": 679,
+    "sortid": 679,
     "identifier": "honedge",
     "name": "Honedge",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAAAuMDExMTExMzQ0NjdKg8UuLi8sLCwyNDUvMTJJgsQwMDBatf+CalFZsvtRUVFSUlJCd7JGfbsuLi4zNTZLhcdQoOJQoeNWrPNWrfRZsvoxMjNZtP1atP4uLi1mTi+EbFOYfF6cfmGUlHSoiGitjGustJa8xaS9xqX6+vorKytQn+BCdK40NDNDd7NDeLREeLJEeLNFerZFe7hFe7lGfLktLS1Hfr1Hf75If74zUX1hSy9KhMYuLzBrUjFsUzJKSklKSkpLS0tXr/ZYrvVMTExPT05as/xPT09PUFEtLS6AaFAyMjKCa1KEa1JSU1RUVFR0XkiGhmiRkXCTk3J4YUp6Y0ysi2p8ZU2qspSrs5V/Z0+utpivt5myu5ynp6a1tbW4uLe9vby/v7+3wKG7w6O7xKM1U4E3VoXo6Ojv7+46W4z7+/v8/Ps6XI1vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7////ZXIPTAAAAAXRSTlMAQObYZgAAAQBJREFUeAHt0U9LxDAQBfBsIILTDMb1sC6MF1lceXgsKEJ78LQgeFiFrJee/CPsZ+w3EytJz0lz2du+Swv9kTfTqIPlGFSF7n4OFEFq6rsCiRpqRufTMtaCvjHltl2UD5Nw/RpIM1EOdJ8jmNEjMuz9aRNOjN2EpLv5ODPWfW1HSXVKXqyds8bddhE0RMkb0v3QtuzWQWJujE52//YtD717g8JCSGeWbpn7QWuFy73skYYnQ89t6F2K/GScgvd/CE8Ryf/vFftKhQHlqsm56xfnQ7OQNUvkmplX4fupNUIL5Eb0mzijNbbJnbhzXo9vlc7u8uwYqiSad2VQVVDHHDT/AiEqNq7clgwAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "180"
+    "gender_rate": 4,
+    "rarity": 180
   },
   {
-    "id": "680",
+    "id": 680,
+    "sortid": 680,
     "identifier": "doublade",
     "name": "Doublade",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAAAsLCwtLC0xMDE0NjdrUjExMjIxMzQyMjEyMjMwMDBSUlIuMDF1X0mCa1KKOXIyNDWySZo0NDMvMTIwMC8yMTJrUjJsUzIuLi5+Z08vLi+JOHAzNTaMOXOxSJixSZk0MjO0Spu1Spz+e62GNm58M2b4eKj4eKloUDBMTEyLOXM0NDSSknKZfF+gQYqmh2eqimmvSJcwLzBUVFSySppjTC6ANGm1tbW8xaT1dqe7xKOIiGr6eKr9eqyDa1NMS0tpUTExLy9QT0+NOnRQUFBtVDSYe190XkifQopRUVGgQoqiQou8vLtgSizJVZunRJD29fWnp6eEa1KENmz7equTk3O2TJxkTS6iQ4ylQ46lhWamRI+mRY52YEp5Y017MmWoRJCor5KosJOqRZIuLS6qqqqqspSqs5WrimqsRpOsR5Wsi2qsjGusrKyuR5avSJZ+M2evSZiwuJl+M2grKyuxuZt/NGh/NGmzSpuzupuzu5y0SZt/aFA0MjKAaE+BalG3wKBgSi1jTC28vLy8w6O8xKM0NjhKSUnWW6XebJjhbZnh4eHmb5zm5ubpcZ/qcp/rcqDv7+7xdKTx8fHydaWFNm2FbFOFbFRnTy+Ga1SGblWHOG/9/f1nTzCenp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7///+pkAGTAAAAAXRSTlMAQObYZgAAAYVJREFUeNrtk79Lw0AUx6993NLgidBBWiqEBNFgRTpIbA1oFnHoInSogy1YBAmUom+QHpRSKHZwEgT/mfxt8V1+wJl2yCC49MtxL/f48P0+chzb6q+FFSjGfTnnWAQsOYCok4ibDckOFl3MCMT+KW4GWwy//S65Pr3Q1pmOWmPcwL2C2j3/uFtatufvJ/MeMOzjOmirXtUwwlsQrhDLnjqXKX19QlVCw4AwEtZqlpxlzhMHdk2Vrs85RCFfWbzCEvIZdW5Sh7gugHNaglYnsTyQOlhu2Jj+OYBICAp3pwkAcqiR4DSyS8HAiDiFu21Ms2VLz9510n6TBwKU3P2kMTZBB+t0zzEXEMcFMFwmwwylAvVwe4AM7++Un+A3yLJk8zeIjqxPsDlTfpzInZS7ML34S59SytFZoEKPlOdDkvzoWdUcuCclkBiBnMj4ZvDTs6ycY42GMd/iJlwhg1IMEneYv20wzUrao5JNaJmXuP5k8o0P3zMsKPKKri2DRiwiqCLb6n/0AzfhaBySIxKiAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "90"
+    "gender_rate": 4,
+    "rarity": 90
   },
   {
-    "id": "681",
+    "id": 681,
+    "sortid": 681,
     "identifier": "aegislash-shield",
     "name": "Aegislash (Shield)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAC/VBMVEUAAAAxMTFSUlJRUVEwMDDWxlouLi5JSUlOTk5QUFAvLy8tLS1yaqxza62kg2ssLCybg+UrKyulhGuigWnFtlOcfWWKdMySfNmllEJPT0////+XeWLSwljTw1nTxFnUxFnVxVpMTEybg+b9/f2SdF5KSkqkk0JvaKiYgeJmX5q+r1C/sFBxaaqVft2Ufdvz8/NuZqb6+vqkg2pyaqvJulSLa1pNTU1mUELi4uKMa1pxWUmikUHs7OxnYJv7+/uQetVoYZyjkkGbfGRsZKKjgmqJaViMd8+UhTuVhTyVftxISEhLS0uhgWiaguOWf96ff2echOfBs1GigmmSkpL29vb4+PiUlJSlpaV8X1CEZVVwaKmKaVmXhzy9r0+YiD2biz6djT+gj0CUd2DLvFXMvVbOv1fQwViVd2GWeGGKalmYemNra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7P9LpaAAAAAXRSTlMAQObYZgAAAUFJREFUeAHt1DFLw1AUxfG8m1BKfYMHHNKHktuIUNAWuViHulgrCgEXRxeRIvihnMTv6FY8kU6a18RV/IcGGn6c13Zo8tdDV7fXUeKxG8RqHx0HF60SBDgrikUrvEWCVGREiG0YT1W1UnYEHG+F54uDQkRUh88XcQggy1MpQ0laZEDcIXHiffBeNHeogIjjnZLlecY3PdLoIqprMxO3eRSXL/cmanZVA2A0SBrLen3TmcxUCVEX+4TOTCWIKiebGOstLwFUxr36Uuvv8GnTKoaj5anMuSd8zU2WNDfT6fQ7HHgmJlybiZjJeDIZl+Xdz/OdSC0150VXMu9Pmr7Og/fOmZHaBrKm3weZ4y01Js59DXqXxMreRSTlgTXdRdThNajqGwFpFnWEHzUMhyQtYR00BG615kJYtzMGFwb49T/Pf59bGyqJPj5nlwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "682",
+    "id": 682,
+    "sortid": 682,
     "identifier": "spritzee",
     "name": "Spritzee",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAAAuLS0wMDA0Njftg5vvhJwyMjIxMzQzNTYuMDFPT0/WYYHgfJLlfpXpgZjrgpoxMTHOzs7T09PTdIpSUVPV1NS9vb3dY4S8RFvhOkjtP03DR17BRl/GSGDISGDNSmPOS2TSXn0yNDXaYoLcYoPcZIXUdYrWdovZeI40MjPjfZQyMjNISEj5eoqlmJisn5+8rKy9u7xOTk7ngJfogJcvLS4vLy9TU1PthJtUVFTvhp2zKTnQ0NDR0dGzKjrmfpbV1dXW1tb9/f3GxsbHx8e7rKyKSZqKSpqcZqrV09SxoqK0paUsLCzcepDscoI1MjLeZYb+RFS5qanDwcHDw8MrKytWVlZXV1dYWFhZWVlaWlpbW1tcXFxdXV1eXl5fX19gYGBhYWFiYmJjY2NkZGRlZWVmZmZnZ2doaGhpaWlqampra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7///+ikTlnAAAAAXRSTlMAQObYZgAAAKFJREFUeNrt0jEOgkAQheGFPDpxp1iCFcSExMKQbKGxoGAqlZLi3ZjOQyleYHd7+OsvM1OM2dtyzA2T3FjywAR3A2yZAi0ApmxugOHOuDuj64ATo26aqgqwF0bgpP+KJuaWSvU7KIqWQfdR1f4xOwdLBmim6n2fz65GdxyzwEgR7/3stK4BSPjKVWrbrjMl+hJuZSJiYsnr/aRJSa40e1vuB0WCGcMYxZvzAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "200"
+    "gender_rate": 4,
+    "rarity": 200
   },
   {
-    "id": "683",
+    "id": 683,
+    "sortid": 683,
     "identifier": "aromatisse",
     "name": "Aromatisse",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAAAyMjSla7Xtg5s0NjdUU1SUYKOjarOkarQxMTHngJfogZjqgZkwMDDW1tYyMTO+VGrHWG/KWXGLSZuMSpuNS52SX6AyMjKZY6icZqudZqyeZq2haLGiabIuLi6ka7MzNTYwLi/TdIrZeI3fe5LhfJO/v79KSkpMS0xMTEzrgppNTE1SUlIrKyswLzHZeI7ifZTvhJxOTU5QTk8tLC2XYqGWYqSXYqWXYqaYY6SbZabEw8RTUlRUUlNLSkufZ65UVFR8QYqharGja7J+Qop9Qot/Q41/RI6lbLGmbLKnbbPOzs5TUlPlwAftxwr1zQr70gv+1QguMDHogJfOWnPMWnT7RFP8QVHthJvSdIn/QlLIyMjJycnKysqCRZHR0dHS0tLT09NPTlDf39/w8PBOTk6DRpKISJWOjo6vr6+2tba+vr6KSZq8UmmmbraJSpiKSpnUdYrsgpqLSptQUFDaeY/CwsKfaK2OS5xRUVEvLjDMzMwsLCwzNTXPlxLfuwkvMTKmbbagJTT+1QuCgoLU0tLJWHCvKDe0KzuTX6EwMjPgfJIvLy+bZaflfpXNlhGUYZ+kbLSlbbXU1NTV1dU0MzNRT1C0T2W1T2aZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7///+eDAYjAAAAAXRSTlMAQObYZgAAAQJJREFUeAHt07FqAkEQxvGDgfNbSIp4TeTUJkiKzFhYpck7ZOEqqzxAKqe6JrX2i+AD3XOZcU27k2tCGv/1b4dhYapbf5Dcj3TtTCqREXI9r+UgVyzOC5lFbBYvrxcs9WMtDuzRwPCmbd+xLk+cH5FTxDiBs2xAQkomI4DWgXJOOUCbheeel4OxM5vk4Lj6c29uG7bMgHjfeDylNGzDngfg4Eih/uPEQ3aN554acN/gkupOim71hqhEygAr7VYluST+YiLiaJDorjgxmCGLr54eilJ2lOPsOmfJKf3UkRWKsAomMlJ1BmZptKNOod1UfrsaDUGBEMbcl0yMjWop1T936xsBIzrJyovUhQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "140"
+    "gender_rate": 4,
+    "rarity": 140
   },
   {
-    "id": "684",
+    "id": 684,
+    "sortid": 684,
     "identifier": "swirlix",
     "name": "Swirlix",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABGlBMVEUAAAD9/P3+/v7n5uc0Njf///8xMTH7+/suMDHlxOXy8vL39/czNTb8+vouLi7ti7vYuNg0NDTp6ekxMzTpibjMr8zPsc/Pss/Wfqrevt7kw+Q0MzTj4+OtKTkwMDCuLDz4+PgtLS3NZ5aifpTbgK3eg7HCpLPMrr3khbTkhrTkh7VSUlJVU1Tti7zwjr+ZJDPOsM2jJzYvLi/PaJfTapsuLS7QscHQs9DStNLnxufi4uKgKTiqKzsyMjIzMjOvLT2fe5Hh398vMTKjfpU1NTUyNDVOTk7l5eXXbJ3Re6Xq6urs7Ozu7u7w8PDx8fHz8fJPT0/z8/OlgJangpn5+fn6+vqxiqKzi6P8/Pyzi6T//f60i6S2jaYsLCz46U4GAAAAAXRSTlMAQObYZgAAAJ9JREFUeNrt0LEKwkAQhOFTmIXFIq0WJxEUAsc15xEsrewFC3HZ938NFwx22aRP/mKqr5qwtuC00Byl+sJBp92lewCbu/kJ2HwSA9J2e/VhawpWzuq6J/75EHFgLDd13M5gP+C3A8tWTAwQp3FIgEhvw7BRdSUkxh5Wup7HpbKJGAHmmnMu3uGVfwkRuQcdyVSticJkRJQbDbMqGtYW3BdNuRf3w1lllAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "200"
+    "gender_rate": 4,
+    "rarity": 200
   },
   {
-    "id": "685",
+    "id": 685,
+    "sortid": 685,
     "identifier": "slurpuff",
     "name": "Slurpuff",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAAD+pNX/pdYxMTE0Njd4Hi2EIjK8QmPllMDpl8QyNDUxMzTl5OX8/Pz+/v7//v+EITEuLi6qO1msPFqeSH+3QmIuMDG+RWakSoOlSoSlTIW9cpjMeqTikr7Us8TWtMXrmMXxnMr7otP8otP9pNQ0MjI1MzTj4+MwLi/t7e3z8vP39/f6+fkwLzD9/P16Hy56ITAsLCzolsMzNTYwLi7jUWHkUWLmUmOjSoN8IjFRUVGlS4VTUlKnTIa2bZK4bpS7b5VUU1PFdp6DITHOfKXOfqbPfqe9oK+/obDBo7PCpbPFprXIqbnIqrnNrb3Nrb7Prr80NDTjk7/jlL/kk7/QscHSssIzMjPUtMSGJDTWtcZ3HizmlcHnlcLnlsOpPVqqPVvpmMR2Hi3tmcfvm8jvnMnwm8mwPVyxPlyRQnT9o9SUQneURHeZRXrg4ODi4eHi4uKbSH0wMDDp6enq6uo0MzPv7+/x7+/x8fG7RGR8IC76+Pi9Q2T6+fr7+/u8RGS+RGUvLy/OSVjQTFv+/f68cJaGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7///+u5DLoAAAAAXRSTlMAQObYZgAAAOxJREFUeAHt0zFLxUAMwHGPGzLJ6xOHGw4OvdFBMh3IQ8F8BXFz7SsRP0S/tGtMnl3T3iIu/dNuP7hkyNXen4Vz7HNnOGOPmwCmG+yAoE247fBR4YCb7qXSAAPdbUi8Z2YamOsHrjEcK4fA+of6ib57ezWXwyVG142czckivzx5DKoSiSyyPnsyhpAOBinZAFxHT+Kc0qEolKRUO7pjGlEp5RdGz10DFUUAUkiH9Pd+KkAk0lojOM2uU3kroJRaAynRZQrfRaV+NucDrsiYZOkk32sQsy1ty5QZt+4llkux57hyyh1Oi/ru3v/2Ay/GSsQemT2/AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "140"
+    "gender_rate": 4,
+    "rarity": 140
   },
   {
-    "id": "686",
+    "id": 686,
+    "sortid": 686,
     "identifier": "inkay",
     "name": "Inkay",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABgFBMVEUAAAAzNTY0NjftiossLCw0NDQuLi5jm92MhXeclITjhYUyMjPvjIz1tLTMxKzr5Mz17dT27tX379bVfH3Xfn4tLS2Ohnjjvwf90wv/1ggvLy+dlYXAuKHeo6PggoM0MzPsioo0NDMuMDExMTFTVFXe18Dl3sdgltbt5s7y6tJjm9wxMjLUfHz479Pq6urKSWLISmLOTWbSfH0xMzRLS0tPT0+LhHZSUlJSU1QwLy/jvgrlwAfpwwrtxwnyywjyygr80whUVFT91AhDYZT/1wyXkICZkYKakoKbk4NEYpdEY5ieloa1rpi3r5nagYHbgoLcgYFJaaHBuaNJaaJKa6PhhYFKa6TsiYpKa6VYisXvi4ztjIjvjYlej8vrrKxcj8xckM3Y0bvY0rza073b1L5ektDf2MHl3cZgltTo4Mbp4soyMjFhmdrv6M/v6NDy6c7w6NBhmtvz69Pz7NP27dEwMC8wMDC2RFq7RFvAR1/s7Ozu7u78/Pz8/P3///8rKytwL7MTAAAAAXRSTlMAQObYZgAAAM9JREFUeNrt0rEKwjAQBuDCgaFD0t4iFJy8RaeO2RyEameHLu6KgqgtdJLeq5u04Oalo0L/ZPxydySJpvxTuB3pihWPYXwomxOH3cKUMeKFw313KTp54xC8a62dbBKWXa3BRcdpwaJLttBH7wMFN1kG4DagKDk5etfjVIQIPgM+S5Igz/MB41os+SKlemuRxNcjC7ajzqKN+bubG1MpUBQ7aITGM2OIVKW6TinbCJCIInbQL8KGA1e+9NCdqB9XWUZUPb0gTEMfveXPJFN+P2/Cdy2xeqkbqgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "687",
+    "id": 687,
+    "sortid": 687,
     "identifier": "malamar",
     "name": "Malamar",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAC/VBMVEUAAAAxMTEuLi8uMDEwMDAtLi4wMjIxMjMyNDUzNTY0NjdSUlKIiMGKisQtLS3OKaXHKJ9+frJRUVGMY3N8fK80NDQyMzT7+/tLSkuRgpGIiMAsLCyLi8X6+vqMjMb9/f2Fhb2RgryHYG9lwOC3JJJUUlRJSUmkk9ROTk64JZSMjMWllNavoOL44XgvLzD95XvNKaSHh780NDWKisP64XliYpGJisLCsfnDsvuyo+Xg4OBSUlOMZHL///8rKytTU1SAgLaDg7mHhLxLS0yGhr2Hh75+frFMTE2IiL9ettO9vb1ivNpkv96Li8CkI42lI46lJI2mJI4uMDAyMTKZipmcjJ2BgbXeymzo0nD34HdZWYRaWoZ8WGZ9fbDIKKB+WmdiY5KXiJfEs/yIYm/19fWdH4VjY5SHiL+cIISgIIhPT0+gI4mkIouOZnR7e64yNDS0peiNZXOIYG9LSUsvMTJ8V2WAfbLCJ5uOZnb+5n24qO28q/GJYnB/Wmlnw+RnxuaNjcebi8mcjMlQTk9oxebEJ52jktOkk9PDKZ6kk9Vpyemtnt6voOFqzOxrze5szO5sze+RHny9rfS/r/bAr/fAsPfCsveUH3/CsvqCXGpQTlDEtP3Gtf/Hx8jKysrLy8vMzMz843pRT1H5+flgYJBQUFAzMTMwLzAtLS6pqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7UgpdIAAAAAXRSTlMAQObYZgAAAUJJREFUeAHtzb9KQzEUx/Gc0u0ki3cQMaBTR5NNl/tD6NRVuLtcbKfQqWOxOFhIwQ7iZib/cN+iayffxScQcy0FhyYgOPbb4QT6ueeIfX8L3e3Ih9MZfuYtRL6JHEAAsvX5jXrZw6WUyCqBsVTXSiq1vMq5MXpKjbTWaknZhXIRVQtHbxACaaiVamX8PcyAQUYqvU0tZjIJ0ecQTdhINUm6oeNgdQhGa+Z3pN3cO7bWkOE4bD8lcec9kXM6tCx2nIJzTwIvVrNlds7aeyQk+R6mrJm5CE1wdpiC8L5jCi6K4hmCane+GwKrDyYTmTHhAKjrZrdbrT2RwDS6uLIjUCcuU7f9o2lXcnkBcRYv56LCcPkFgcdwhCzFlEvqCjxV5eFNRmLNZUXto67KE+RuU1V+YvN4hchFDbbf5OWv0BH7/rVvL1lQ2qlPo3YAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "80"
+    "gender_rate": 4,
+    "rarity": 80
   },
   {
-    "id": "688",
+    "id": 688,
+    "sortid": 688,
     "identifier": "binacle",
     "name": "Binacle",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAAAxMTFQUFE0NjdLS0svLy9TUlGKajmMaznNWkIuMDFSUlMsLCxUVFRSUlIxMjKGZjdKSkpmUDNNTU1RUFAwMDBRUVJ8XzN9YDNtbYNzc4p6epJ7e5QyNDWJaTg0NDK2UDstLS3ZdULcdkLgeUXIsFD2hEq2tMPj45Lm5ZPm5pPn55QrKytsVTV3d5AzNTYuLiyAYjQyMjF4eJGKaTkxMjN2do40NDN4eJB+YDR5eZIxMzR6epMuLi6AYTRoUjNOTk6HZziIZzdPT09QT05RUE+LajqKajtrVDWObDqNbTy2UTowMC+9Uz3DVT/DVz/JWEDLWULLWkFvVzfNWkPPXUVxWThyWTlzWjnnfEXnfEfrfkfsfkftf0i5okq+pkzBqU3Bqk7FrVBTU1TKsVHMs1HMs1PNtFLNtFPOtVTtgEnxgkr1g0lUUlH1hEukpLOmpbSmprWrq7usrLuwsL+wsMB1XDy0tMW2tsi6uMi5ucq7u8y7u829vc7PzoTPz4VsbIJ2XT1vb4ZwcIfj4uHw7+7y8fD29fT29vb6+fhyconX1YnY2InZ2Yvd3Y7e3o5MTEyEZTf+/fz+/v7T04eVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7///9tTK+7AAAAAXRSTlMAQObYZgAAAQJJREFUeAHt06FuwzAQxnEfaE5HTgrIUBRpoFZrHZhUupJuZQNVQWS0TdOqPIKR9wSTNrD39S7lvYSU9Q+MfsAfOHeVbkkzS4mTd5kDv+XhR/EkhO6zCx/yNS3lhCHsVjPggQMOQaHYboeeMCzFyaspFyki+qO62t4EBaPSXt6ew7L+k8sQfSox9vtTFdb71fYy9L4AIlM1hGoYwBkS0SPrQ7QWa/YTIkY+b+KjKe9YGzdF6hcGfElEidHrfkTjj1L7UjzrpoSdOAsqYuZxEzcW3LCWiTVwRtu2zRpTzodaLAkqOTMT8a8JZdNqmbX2fuK4AJRq4CYb5aO4GQE06m5do3+WSjJxVf8eaQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "689",
+    "id": 689,
+    "sortid": 689,
     "identifier": "barbaracle",
     "name": "Barbaracle",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAAB6Yjk0NjcyMjJSUlIxMTEzNTYuLi5LS0tNTU1tWDNUVFS0tMXl5ZNyXDUsLCx8ZDpKSkowMDBMS0pMTEtMTEw0NDNOTk5SUlE0NDRTU1RUU1IuLS1ra4N2dot6epDNWkLcdkK+pkzMs1KCgpqDg5uzs8QyMjG1tcbi4pHk5JJwWjQrKysuMDEyNDVVVVV7Yzpra4RsbIVtbYZ9YzowLi67Uj3JWUHKWkF8ZTt9Zju7pEw0NDLGrk8xMS/PtlT1g0ouLi0vLy8wMTKjo7KkpLSlpbWmpranp7eoqLhtWDSEhJwvMTLMzIPa2ox0XjZ0Xjd4YDdUVFJ5eY+goK90XTZ8fJO6Ujw1NTW7Uz6/VD/DVz8yMjBOTk13YTjNWkPNXEXbdkNQUE/dd0PgeUXlekTpfUa1n0i2oEm5o0tQUFBRUVHDrE7GrU9SUlDFrVDGrlDLs1HMs1FtVzJ5YTjzgko1MzL2hEr2hEv3hkwwMjNvWjSFg5puWjUxMzShobCiorFgYHekpLNhYXhiYnljY3pkZHtmZnypqbmrq7usrLytrb2yssNwWjW0tMRJSUlsbITLy4LMzIJwWzbOzoTPz4XR0YbU04fV1YnX14nY14rY2InY2IrZ2YswLy/e3o7h4Y92dorj45Lk45JzXTd3d4zn55Pn55TS0tLu7Oz6+vn7+/v8/Pz9/f54eI2vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7///8kow1iAAAAAXRSTlMAQObYZgAAAZRJREFUeAHt07+KFEEQBvAuqcq6kVuTTRqGWztw7ws9LlppjEwnWAzEZEEE927B6QHfwQsmlkPvwKCfyOcZy1YD7T7YXD8YmD8/qKouxvzrwcLgGAbc4gZHwCc0rK8qCFSvJJMbP+OPb8B0+elvifcrIoJBmtIvire3r9fP6uKjwhNMm9g/Sj8kbtaHzJdV7QUT87vd4AYXzwp0xHlozCfCWfEqr9yHBIMz0vRoju5WNLNyJgBbmuWbNN015466WWam3fWeyM5NZx5aYra2i0zEHCMvYNoR6631vjiiEfev0dvgg2Vmy10n9ylMF4+9/R3mj2iqlF6NJEFl8L74BsTpyV3/dOxgRIIWL9e+dmZxcMuBqKx1CoE5BNGpaykr1nWU5h9Y1jlYDL6MCaiWl+nnmcFqj8zhBYzEmFIllRU37W2Jn1SO1J+ifUQvL5bsLbPOAoP+4A5XaMKtthd0FI6iT18Hdju03GZHJOLVxTcKJPO6Xfq89Coi1G31Bvl55erfYqOmYpW7W7qxraqDPYc5Pv/zHbwDUpDWUjvwAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "690",
+    "id": 690,
+    "sortid": 690,
     "identifier": "skrelp",
     "name": "Skrelp",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABHVBMVEUAAACsY0I0NjcyMjIzNTYxMTFSUlKZWDudWjwtLS0uMDEzNDRUU1KCSjkyNDUwMTKhXD0uLi4uLi8wMjN+WZR5stMvMTKESjmESzqESzx2QjN5RDWdWj5LS0uqYkJNTEusY0P2QjGLY6SleLuygsuzg8y0g82T3f5toL1toL5uob9vor9vo8FwpMNxpsV1rMswLy96s9R7tdZ4RDQwMDB7RjZ8RjZKSkqcWTwvMDAyNTehWz1MTEykXj6nYECqYUFNTE2rY0NPTk1QUFCsY0TeOyzgPS7gPi9TUlGAWpeCXJiEXps1MjGhdrajd7ijd7mjeLpSU1Q0MzRUU1QyMzS1hM6FxuOHyuiIzOqR2fmS2/yT3Px+WpWU3v8rKyuuQ0oJAAAAAXRSTlMAQObYZgAAANtJREFUeAHt0bFqwzAQxvG74eRQ0ODBGLwECUvZEqUEN0tyBS96BQ/+3v8xmmydzmsL/sNtv+Hgoz/SHm6ybfC6y3rBlrs3wLJaEAARDqrHqVuvhhuGAWgequpErBfhp+NDe2Z9MbPSV9Zea9UGMKW8nTKzHmyIJ6uEyrUU20FjCMElFtuNY4ouuDyCzDDnKDnnFEEwLVp5j+xiRAPaDjE+2w0CENB5r1+w4QCcu1tKtTvDpJim2XnP8nldFlvOjh0L4XT6Nv8szE70DpIPkJkUUPk1tR1a0P9o7wda0yq9GBhbGgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "225"
+    "gender_rate": 4,
+    "rarity": 225
   },
   {
-    "id": "691",
+    "id": 691,
+    "sortid": 691,
     "identifier": "dragalge",
     "name": "Dragalge",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABmFBMVEUAAAAwMDAxMTEyMjI0NjeJUEHVQlozNTYuLi4wMjMtLS0xMzQuMDFRUFFSUlJVUlN7kkOFTj+lXj+GTkAwLy+KUkKMUkKsY0LSQlksLCysOVK+OlCCTT5MTExOTk40MjKIUEAyNDVUU1J7SDqpYUF6kkF6kkJJSUmygsuASz2zg8wrKyuZVzqaWDwvLy9OS0yJT0BtgzyLUkONUUGmYECpYUKrYkGrY0LEPVPFPlR9SjvTQlrUQVmBTD1SU1GDTT98SDpPUE58STuYVzuHT0JQT09PTk98ST1UUVJNTU1OT02aWDtUU1ScWTyfWz2fWz6gXD2jXj+kXj5tgzqCTEAvMTJuhTtwhzyIT0GHUEBwhz1xiD2LUUJziz52iz+KUUR1jD9LSkpLS0uoYEBMSUp7lEKeNEujNk2rYkSsYkGkNk2tZEXNAwTQAwTnAwTBPFHDPVOrOVHEPlPHPVRST1DJPlTOQFfTQVmtOlNRUFC+PFFMSkuedLSgdbWoe7+pfMGsfcOsfsOtf8awgcmxgcqxgsouLi1KSUis26YsAAAAAXRSTlMAQObYZgAAAWpJREFUeNrtkr9Lw0AUx5MDb/NB5N4SEQoloPct9uDWa6hDQReRdHASRIlwHSpCVdwcpP7b3kUKbSXRRVz8BJJwfPLyfiX//AJIf6bhGs3jO+/yClHbB7pdFPUZcP80KS6naLcSTIsX9/w4XBRFrdq9O6Aondw9reu6LDsCzmbHBUmqayJybh+tYp6XtQwikZTSoaOSB3LRkxHRWbNzOTUeEVZnSL52SrlcMnPQ2PTx6Y2B8XhDBPAoc+Z0roNs8DkemGFmJusxMbiobr338/mh9iyCiX6IhAPm0vYyrEWcGO+FDgQvwTLLlsvwZ8t2x6YbiyKEQiIC3ENMON5gLdMJNkseMd+g+cIeAauznmUebZmGOUPkTZ+do5n9qyYR2G6j4l42OhopIv32DgxwsWikr6SpVQaJ8ER7VXUbuzBoWUzEC+Q9LUplfKA6H6BtkpX3rLWIuXhvVMdmKiG8RnxLQ5LdpEj++Ws+AFXhRlwvkccSAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "55"
+    "gender_rate": 4,
+    "rarity": 55
   },
   {
-    "id": "692",
+    "id": 692,
+    "sortid": 692,
     "identifier": "clauncher",
     "name": "Clauncher",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABSlBMVEUAAAAxMTEzNTY0NjdjvP4uLi8xMzQuMDEyMC9TVFVXp+Fdse9huflhufphuvtivP0wMDD+pAguLi5iYmJhYWFRgstXpd5jY2NjZWZJdbdOfMJOfcNPf8ZRgsoyNDUwMjNISEhcr+xPUFFes/FftPJgtvZSUlIvLStiuvpXWVpju/xeXl4tLS1jvf/0ngj8owgyMjJaq+ZRUVFQgchQgco1MzFRUlNSg8xShM1ShM5SU1QsLCxUU1BbrOhbruter+lVVFFdsO0vMTJcXFxes/JdXV1etPNftfRhtPBgtPNJSktMTExNTU1MTU5PT080MjBMebxMe79NfMFlvPplvv+RWQSXXAScXwSjYwGgYgSjZATekQjnlQfolgfqmAnynQpSUU/4oAj4oQn6ogj7pQxQUFBOfsT8pAn8pQyRxeKc0/Kd1PSf1fUrKytsz6dFAAAAAXRSTlMAQObYZgAAANNJREFUeAHt0qFPw3AQxfHfJcxA0tulxSFQtyzN28IEByHBQBAkTNeQgEH1/f+Wq17pqtm+5pmPfOUfdo7Lme6bhZzpPnlMJdquuOExdvfKzd63+9W0e1431Yd9WXfxTk64XrVx62CBfn05yHFOVYUbkj4AzRULdxyhfEsYDhiAQKM/vG3bl0O4UH28d/ToYoBaa7tzkXKQQKRzDAiGSFhfs4zFxJ4qTBJGXbvfjMu0VURS68JdJET+hAsIJIkDMnmOJQtzBH3FMiMCLLPgk5TT7dwvo98uDSQtLTAAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "225"
+    "gender_rate": 4,
+    "rarity": 225
   },
   {
-    "id": "693",
+    "id": 693,
+    "sortid": 693,
     "identifier": "clawitzer",
     "name": "Clawitzer",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAACEFBMVEUAAAAxMjQ0NjcyNDUzNTYuLi9RUVFSUlJRUlMqWr4rdOEufO8wgvsxg/0xg/4xhP9goOBRUlQwgfkyMjJUU1FYWFhaWlpeXl5hYWFiYmJjY2MuMDIwMDAteOgue+01NDEufPAvfvMvfvQuMDEwgvoxMTExgvxQUFAtLS1QUVJiouNipOZjpefwqxj6shn9tBmDzPyDzP2Ezv90tuH8sxn+tBgwgPcwgfgyhP0vgPdRUE4sLCwpWbpTUlArdN4xMzUrdeIteOVhouQwMjN3uuZ8wvB+w/F/xvS8ixDkohfnpBfqphdLSkkue+5TVFVJSkuAyPdVVFJNTU2Dzf4vf/VdXV1OTUswgPUwLy5gYGBOT1BQT00yMS9hY2RiY2VjZGUlUKkyhP4mU64nVrZSUU9XksxYkctYksxbmNYvf/YvMTP3rxlQUVMvfO1jpOUteOZISEgzgfRcXFwwLyxfYWIpWbspWbxenNopWrxiouIvLiwuLi4rdOA0MzEwMTJjpehkpugwMTN3ueQzMjB7v+18we4ueedJSUkteeqRVwGhYQGlZAGnfA6ofQ+ugRC0hhC7ixEue+u+jBHenhbeoBngnxZISUssLS9KSkrsqBfvqhjyrBcufO4tLzD3sBj5sRdKS00vffEvffIvfvLlyARZWVmDyvaByfmByvlYWVpLTE1NTEqEzf0vgPah2fkrLS+mTtfPAAAAAXRSTlMAQObYZgAAAUhJREFUeAHt07FLw1AQBvAs7YE8jm71wEEoDyxvC7yh3FKcXPUtrXSy7VBwKFQwFNylSt1UyNDFWf9F79IWbRJCNx36QRIe+fHdDUn0f3II1/Zj/MLV73n9XFY65sfTKateMlex7sSYpurXeVXduGOMwbtruRFvG4vNfI8GNcdtRLqaHHHG0rO8u8FNCOoAgM0pC0s577pD6UsSRAAvgfZte5Wm81lh8BDFYaIMYI1HI2FlTqOMAEFDBIXBbLJCacyWhOCCyH5xwQZqEtlRAiE450IIUMtDcT+B8BlLo0h6513XwZZN0Nq1oxAH7QxEX+Md+WbkWJPLQgYpSNSBa+xAe7KtvqhrIdmPS0cA4FwrKgsvFx50tzh+2JRz+Ze68N6KtAOOrPcI/VL3vPK+t1k24tQ/AZ1z6eBZb/D7ZB3ZPf8tcX+VQ74BsbJNm3s+TtIAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "55"
+    "gender_rate": 4,
+    "rarity": 55
   },
   {
-    "id": "694",
+    "id": 694,
+    "sortid": 694,
     "identifier": "helioptile",
     "name": "Helioptile",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAAAyMjIyNDU0Njdzc2v13GorKyszNTYxMTFDQ0NISEhJSUlqamNtbWZxcWovLy7u1mgxMzTx2Wj03GsvLy/r1GZoaF8tLS00NDIuMDG2oEJKSkpLS0t1dW12dm4YY84cZs/bxV9xcWlERETy2mlLSkl2dWssLCz33mtycmowMDBKSkguLi0zMzFCQkIvLiyNdyeWfyncxl/fyGDfyGHgyWFNTUu4okO7pES8pUS9pkWMdiaXgCmYgSibhCqchCqdhStPT09QUFBRUVFTUlFSUlLCrEfHr0jKs0nMs0rOtUrZw19lZV9mZl9FREIvMTJGRkXn0GXq02Zubmbr1Gft1Wfu1mdvb2hGRkbw2WlHR0fz22v022pycmhKSUcwMC+tra3y8vL7+/v6+/39/ft1dGpmZmZnZ2doaGhpaWlqampra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7///8uxrmfAAAAAXRSTlMAQObYZgAAALdJREFUeNrtzrEKwjAQxvGAl+PAFpc63dBBh4stfQMJKhYCDoWCThl9TJ8tpi9w7az9D7fkx0fM2g+GJ1rEsIQCcZ51o4NX8cAZ1xVHSB/mZoO6O3gf6gQMbx0OIlbqJFmi5i4cbJAkIhy1X1bXO+dFmCCM6uSNybnsiMC1GjyTwYpCvhF6bbKdHkn2uA32iUYPe2+tZWk6nIdehDmUqMMhchDrg98ZPcpZ4QrNgiiiWRS2Zu1v+wL6WxlAgF56nwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "695",
+    "id": 695,
+    "sortid": 695,
     "identifier": "heliolisk",
     "name": "Heliolisk",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAABra2MzNTY0NjdKSkpMTEotLS1gYFkvLy9CQkJEREQuMDFLS0sxMTEsLCwuLi5DQ0MzMjD27mpHR0cyNDVKSkgvLiwyMjIwMDBfX1hJSUlhYVppaWFqamIxMzTNYSHOrinTsirUsyrt5mby6mr07GtGRkZNTUtNTU00MjEvMTI1ODhiYlpjY1tlZVtlZVxlZV5mZl1mZl9oZl5JR0ZJR0dISEYZY8scZs6WRB+KdSWMdiSjSiKkSiLBXB/LXyFISEjSYiLWYyHUZCLVZSOdhCmehiu7nyW8nyXKqygzMjHRsCkyMi9LS0nVtCnUtCrxhSjzhyj0hyn5iCj6iSr9iyra017a01/c1V/b1WDo4GXp4mTs5WZFQ0Lt5mjv6Gjw5mfw6Gjw6WlFREL37WpMS0pFRUP372vj4+Pr6+v8/Pz8/f8rKyttbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7///94orD5AAAAAXRSTlMAQObYZgAAAPZJREFUeAHt0bFLAzEUx/EMP/BSSMUnlrP0QcFBoYVSKS0dFAw4iEeWo6Or0+//X8+E6nbnK+jYL4EQ+PAgPPf/neOpbsHT9Hi6IHlvS0LXy881bbhSheo1LXeRHUI3M6Fm2O26lQ2h2NkDHUdlJKRypqyTiMDTmYWUgGWGtgRUPX8o2c9IzjQ32h8BH/ohn/2mONxMju/bq37HzQFQIF5+D+zfJv17CjggY/FF0Le9sK6a4DgVqABzkvu2cYN5yQoi2/nbXfvEQceXV5F8YtymNKEbhikWGaM0Fd1vMX8oBBEJxrY/UAQt58Y1y1U90oDGiv/euS82/zL3EzuGXwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "696",
+    "id": 696,
+    "sortid": 696,
     "identifier": "tyrunt",
     "name": "Tyrunt",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAC2VBMVEUAAAB6Y2MyMjI0NjdYQUlZQkpaQ0t2YGB4YWF5YmIxMTFXQEgtLS0vLy8wMjNSUlJuWVkwLy9RO0JUPkWhoaGioqJYQEguLi5tV1dUVFRUPUVtWFguMDFwWlpxW1tyXFx0Xl52X19PT08zNTYyNDVRPEORkZFPOkEwMDCkpKSmpqbh4eHs7Oz4+Pj8/PwsLCxXQEc1NTVzXV1TPURTPkVZQ0kyMzRVPkRbREt8ZGR+Zma2Wwe8XgjDYgrFYwjFYwrggiX9kyn8kipcQ0mSkpKTk5OWlpacnJydnZ2fn5+goKBQUFBRUVGjo6MxLy5TU1PEw8RVPkbm5ubq6upISEjv7+9NTU35+flOTk79/f3+/v7///8rKytdXV1eXl5fX19gYGBhYWFiYmJjY2NkZGRlZWVmZmZnZ2doaGhpaWlqampra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vJIfW5qAAAAAXRSTlMAQObYZgAAANVJREFUeAHt0L1KBDEUxfG5kANzLkpAJBu28KOauZVgY+E2g7WWwpr7ur6QT2Bif9Va91+k+sFJMv3lTvlvTEf+6P4jq9X94bDfxWQo/3g9lpv7Ujx2fW2p1+W5WRIpL9/Aq4stCdGsgRq7QyE2QAStpbl6CAufNsgXBHnrkaszAbE85HuXZ4FbuiO1ZYMAlOiOOxYI24BZlFKWYFopQsnNOlQo0j6GGDKbqakC6S56zExChpv8DYIUfo8yW3eXPq3a9NhdKNXM1gH6cR7Dnq86/fNOfQJfviDG4IXrYgAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "697",
+    "id": 697,
+    "sortid": 697,
     "identifier": "tyrantrum",
     "name": "Tyrantrum",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAC91BMVEUAAAAzNTZRUVFSUlK0Qjk0NjdMTEwvLy8xMTGBMDCCMTGgOjOuQDcuLi79kin9kiqBgYHi4uL+/v5QUFAyMjMxMzQuMDEwMDCFMjGEMjJ6Li59Ly+yQTi0QTlISEi0QzrEYwrtiidKSUktLS3/lClOTk6CgoK+vr7Dw8PFxcXGxsZPT0/4+Pj5+fn6+vr7+/v9/f1QT0/mhiZ0dHTigyThgiVMS0sxMjLyjCfyjCj5kSiEMjBNTU11LCyfOjN4LS2Dg4OxsbGkPDStPzcwLi41MzGyQjno6Oj19PT39/c0MjI1NTVTU1PFYwjFYwlKSkr///8rKyusPzYsLCyvWAmyWQeyWQi9Xgi9Xwm8Xgp4LiywQDexQjdQT02wQTlQTk4wLiy1QzhRUE4vLSu2RTy+WEHAYQp9MC5+MDA0NDTGZAnJXUXPYEfUYknUY0pUU1FUUlLjgyZVVFLkhijtiSfuiiZUVFTviigyMC54eHj2jyj2jil8fHz6kSn7kip+fn5LSkhLS0mAgICCMjKDMzOEMTCFhYWGhoaurq6EMTGzs7O3t7e6uLi6urozMS+/v79MS0rExMR0KyuEMzPh4eGFNDTk5OSGNTXq6urv7+/w8PDz8/N2LSugOjIyNDWhPDKjPDShPTX8+/pPTkyoPTWpPjWoPjanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/PwyggCAAAAAAXRSTlMAQObYZgAAAVpJREFUeNrt0zFLAzEUB3DpA00f9BCXDuZ1kCAGFQo6lJsydHAJ5OHgUPoROnYWhC5+jd7Xc3F28J9rpdD0XLv0n+Xd8ctL7nJ3dsrRohh/5fA/t9SJbic87qYcgNW8Hinyqe9jFJubz1rC6OK8vmnO7y7H/vbhKwsd1Vq4EaBz1BMKKaRk2n7raq378K2CizGSUILb7MZZ2+zJV9c2hBNI/4RH0pkTme451RU7ZxIRszDWftFlba0ttzhxHBOgSIbJ02wmlZTvU/uyYPIkvnWBnKysrMqGtWPJ8d4zJyTLfukaK4u8KBGg9wklLj8KeGGlJ4LFATFIiLM0B87PgpEjokBZsnOQWsKpWRgwuETBEyPOasdHZjJMgMGjoXQ4yO/QOjYhEBpKXzvgT0rJ51PWYeTIDHg4BgfnaaCoiInjdRdUT+ZK28oQ6H0Jd3+KDrYVqClA16xTjplf4xRLfC1VOcMAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "698",
+    "id": 698,
+    "sortid": 698,
     "identifier": "amaura",
     "name": "Amaura",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAAAxMTE0NjcwMDAsLCwwMjMxMjQzNTYuLi5SUlJZeqO2dGyLyfCU1v8rKytzrfeT1f7kz2eDveFVdZxZeaMyNDVbfKdxq/JyrPQ1MzO0c2stLS2+r23Vjn/QwXguLy/64nEuLjCDvuKLyO8uMDGR0fmR0vqS0/uT1P1QbpTZkYH8q5L/rZRScJdSU1RMTExZeqRbfaZNTU1lmNhroeVso+htpOpup+xvqO9OTk5yq/NRUU9zrPVzrfZSUlChZ2Ctbmavb2ezcmoyMjI0MzJVVVO/sW7ApBnLrBvSshnQi3zUjn48WqvAsm7LvHbNvXY+XbLVxXvWxnvVxXzizWXjzmZQbZPw2Wvw2Wzw2m3z3G4zMzX44nP85HL+5nNRcJUvMTKHw+iKx+2KyO5KSkpWd56MyvCNzPOOzfSPzfWPz/eR0PhXd5+R0vlYeJ9BYLWS0/xBYrhCYrmU1f5YeKBZeKHbkoLdk4PdlIPkm4XmnIXvoov7qpJYeaL8rJJLS0vX19fg4OD4+Pn9/f39/f5ZeqKGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7///8q7452AAAAAXRSTlMAQObYZgAAAORJREFUeAHt0rFLw1AQx/HGdHnK/XyjOOgsKXKDQ5UDa7bo1MXxELSLkzxEA63/qv9KPHXPr0u3fpcsHy684yb7dhDqLd3iAb8fUNh/HmCC9S0o7I/ugc2GwrO2b++um2YKBpfLPvnstFmDOdXk7rPFKDwPJ8mjdvzXVbh/6B9gUN27rnMnI0V0qIZkNXt1wFKGdEL3uBJJ5dKs5kdhdqxqmNCqyN5eEBTUiny9PgJXROI5m+a8ms+n4+4ii8pQsj6RgVkiLfIOAlX+Un7mh9/BlO8SN0kkWcIWqxSpau6iUDtq3w8L4CoSXufv1QAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "699",
+    "id": 699,
+    "sortid": 699,
     "identifier": "aurorus",
     "name": "Aurorus",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAC6FBMVEUAAAAwMDEyMzRSUlJyg8xzhM4uMDE0NjdKSkpRUVEvMTJmdrdpebxxgssuLi9zg80xMjP+/nNaY5toeLstLi5qer9JSUktLS4yNDXp6Wn8/HJTU1Sru+wsLCwzNDR5q9ru7mv7+3GZ4vp3qNdxgspVVVVaY5xmdbctLS1zhs9oeLowMDBSw/3m5mgyMjJzhM0zNTZPT0/9/XP+/nKDi9WFjddtfsSsvO6uvu2U2/Kc5//j4+Pw8PD8/Pz9/f13fsBMs+VMtupNtuxQvvRvgMhwgchygslUVFRLS0tLS0xMTEw5WrRQWIpRWYt1hc52hs95gMJ7gsM2U6Po6Gs3V61ufsWcqdd4qdmsu+15gMR6gsZ9hclxn8xSW49TXJBWXpV6rNx7rN1YYZdTxPtTxf+niSezkym1lCm2lSu3livFryvEry7Gsi3IsyzMti3OuC7NuDDZwzHbxDDcxTLexjHg4Gbi4mZZYppNTU1NTU7t7Wrt7WtbZJxaZZ1PT001NTVmd7hnd7n8/HSmpqa4uLi6urq9vb2Cic6CitNneLqFjdRod7pOT1Ccq9WfrdidrNmfrdqhsN+mteUvLzAzMzFqeb00NDSJy+CP1OpsfcCV2/OX4PeY4vltfcOa5Pyb5f2b5v5ufsNTU1Xj5OXk5OTt7u9TVFXx8fH29vb5+fn5+vtUVFJ4f8L+/v7///9JruCwsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/eYUv19AAAAAXRSTlMAQObYZgAAAVZJREFUeAHt0UFLMlEUxvF7OL4v+ILvYSht47MoZNy4kaSBWQSFm0hoJUFSMSC5Vzd9gcmFm2YIgij6BPP12nbuFLToenVff3BWP84jXPPTQ/719brRGfSbZTCAF/buGkAWZQ3cP8AHZ9Ob0cl+xIvdZtN/cjrjIJgEWrQBLB0ZXzvzTze5hdEAuCGEAy7Howsl2Kq3nRJHNeai4PnHf0S7/6964JA4fh0rI2F1rLBP+nPA7bSi7rQQnk9yuywDmLz+XVKqrlAoPIVdCPUcKv8d24cFWacnF6VUY/cdsmpVLNxTUoa6w2mkJRYOUTIMdX1VZOECUDa46qx2eEx0nlvPGFxeh3897733R8Yi0uovww553Hkci031EsYDX+LEIj1a8zmDp1hYtHCNRDeOS5iEfmiIk0RlqHDohQiZLKQ07XqhfWHUhAxyMmvCW8Ewm0S53/3m6B26HUV+cJvOSQAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "700",
+    "id": 700,
+    "sortid": 700,
     "identifier": "sylveon",
     "name": "Sylveon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAAAxMTE0NjdSUlL9g6T+/v8xNDVMTEwuMDFUU1RVVFX/hKX+hab8/Pz9/v4xMzRRUVEsLCwuLi5KSkpLS0sxMTItLS0yMjJUU1MvMTIvLy+kWmvUQnPmeJbyfp4zNTY0MjM0NDTtzO3uze7vzu/h4eH7+/swMDBJSUlOTE3ld5SWUmHCPWnv7+81NTWnW2zYutjUQnL5gaJPT0+nXG4wLi7EPGk1e95PTU7edJHr6+swMjPneZfoeJbpeZc0d9Wfg4Opi4uxkZE1edmo1uWs2OZRT1D7gqLl5eXm5ubo6Og0vf7s7Ozt7e01vv62lJVQUFBNS0zpepnzfp3UQXK9PGbk5OS+PWlUVFRUUVLjd5UvLS7neJXi5OX+vM3/vc7+vs4tquYtrOcxsu3g4OAyu/zi4uLy8vK/O2bj4+MrLi/jwuHmxubtsL/VttPYutcvquPZu9ndvt3jd5M5g+39hKQ5g+45hfD8hKf/hqfu8PHx8fHsy+z39/f5+fn6+vo1etr7/f79+/s1et3SQnLqepgrKyuHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7///85p0OAAAAAAXRSTlMAQObYZgAAASZJREFUeAHt0b9Lw0AYxvH39T2ocCj1B4Kk6HBDgt2E1C4uQtshQ5Bm6WIRBx0cgy4pnXz+Zhd9vcTVOzs4OPRLCAl8eOA42vbnId3Q1fAv/O7mrRs9tTLK82YIDOuq5W/XsXG4plfV4wPCRT0D4T44i75UU7dCNq2Nh3UQpjYR0bvE6MJkuDwOQRwl1iZqzFJF+ntjhI9tfe2oE1WWXQrKD9slwsyEUXDyfLK0VtWaTuRVCO68v+pStVDbA/xgEKIpVPXFS2kyZFVOobDvYVFM1J953XDkKqVUEdX2kfIRwMPhz4srK/abOmFen12BQnDgoZbiHPvf9JQC4VNURBw79wyKxaWopiBO5lGIkTi9aQnP4vB2YQfcfZ1QNBjDtFE56H+07Qu+RmdEM6VCIwAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "45"
+    "gender_rate": 1,
+    "rarity": 45
   },
   {
-    "id": "701",
+    "id": 701,
+    "sortid": 701,
     "identifier": "hawlucha",
     "name": "Hawlucha",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAC6FBMVEUAAAAxMTE0NjfuSlr9kik1MzFZwopZxIsuMDHlhSXZRFMtLi5cxIotLCzi4uJRUVEzNTZSU1NTVFNDf2E0MTJKjGtPr3xRsn5StIBVvIVXv4ctLS00MjJaxoxSUlLXVClKims1NDHtTFzjhCThhCYxMzRQUFD9lSu9vdswMDD7+/swMTJLjGxNjW5PrXs1NTVTr30yMjJSs39StH9JSUlTtYFTtoFTt4JUuIJUuoNLSklMTExYwYlNTU0wMjMvMTJcxIkyNDVdxItdxou4JTy7Jj3GKUHJKUHLKkLLK0PMKkPMLETTUyswLizYQ1IwMC3eR1bgRVTkSVfoSlrsSVlUUVLsTFntTFtVUlPwTV1VVFJUVFTjhicvMC/jhijriCbuiSbtiibvjSbzjSfxjin7kSj7kir7lCv8kSpEf2L9kypFgmTczyff0Cbk0yfo1yfq2yfv4Snx4ir05Sr35yn15iuGhoeJiYmLi4i3t9RIh2jExN/IyOjMzOxJimnn5+fq6Ojz8/P29PT29vb4+Pj6+vovLy/9/f3+/v7///8vLitKi2rUUyiNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/c9nAFSAAAAAXRSTlMAQObYZgAAAPBJREFUeAHt0rFKxEAQBuAdZ2AQbkhhpeLa5fAR1GYL0YDgcZAHECTNCnpiKiEpT4ZNmXe1dfMAu5dWyT9s9/GzxW+W/JnIHmYxEf8ic2BjaTiaIWXwAzWHoRwT0SXkjcT33BAxX0vO7R5Fbogc8/r0JCc31cd9H533dp2rlF0RSsfRtZYubnOFRSgwQmit561IsvSKQ8CKVz46rOX9LimBAdBaVUSs6of6LSXlDIyUODHtXdGW26Q08jOionZjYNe7r6Q0ot10nQaOca9PSQktdGBV1XLgsNrsk5Xn0we+RwWOd3CY8gmTnzVf8++y5BeVIC95+bUegAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "100"
+    "gender_rate": 4,
+    "rarity": 100
   },
   {
-    "id": "702",
+    "id": 702,
+    "sortid": 702,
     "identifier": "dedenne",
     "name": "Dedenne",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAC/VBMVEUAAAAwMDAxMTEyNDU0NjfdpCEuLi4uMDExMC9SUlLIdw/KeBDJeBHMexHmSinEkh3ZoSHQmx8zNTYsLCxUU1FVVFItLS20bA/Fdg8vLy80MzEzMzDKeRLLehFLS0tMS0lRUVHGlB6NZTHTnR8wMjPaoyJUUVHqwiLvxiP29m/29nD//3NMTEpNTEvCdhPGdxFQT04uLiwxMjIvMTLMeRF8VyzPfBFKSUfDUVHHVFLEkR6BXC2HXy/IlR/Klh7NmB/Omh+HYC+IYS/LmCDXnyHUrx3btR/XoCDXoCHWoCLZoSCNYzExMzQxMS7fpyXkvCHnviDnwCHowSC2bRDuxSG7cA/wxyPh4Wbi4mbk4mbl5Wfy8m3z8273926eTErKQiX7+3H8/HL//nLeSSfh4eHs7Oz19PQuLitoaGhpaWlqampra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v5x1fARAAAAAXRSTlMAQObYZgAAALxJREFUeNrt0rEKwkAMxnE5/KC1pEsWnRpwLIJOLfgGHsINN0s93/8Viqm3GtpZ+7/t+JEs2az9WHxwy1yIDS+CKQWFrM3ANg2KuhC2k9dnyqdgx2FIMQ82XQONUsrQkLrpNGaoLv98dVrt8JEiV87OmPgCASOBiCZoSq782ONOEJK9LbUCjx6opRTpFNnLjx5QWJckO87OkOeY4FGSdtHFNrxRar0nbeY4isK5GMl73Tybcw4VL77Ktf/tDVmWGiudUnxmAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "180"
+    "gender_rate": 4,
+    "rarity": 180
   },
   {
-    "id": "703",
+    "id": 703,
+    "sortid": 703,
     "identifier": "carbink",
     "name": "Carbink",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAC/VBMVEUAAAAxMTEzNTY0Njd6epP8/P3///8xMzRtbYMuLi57e5SKipmXl6ibm6ycnK3t7e36+/syMjIuLi9vb4Zycol4eJF5epIwMDAzMzMsLCxOTk5PT09QUFBRUVF7fJR8fJRfkbVkmr9mm8JlnMFTU1SNjZyOjp2Pj56QkJ+SkqKTk6OVlaUMSqmZmaqamqsMTK41NTWcna+vr6+1tbWL1uSQwvqSxf6X5/aZ6fia6/qa6/tJSUny8vP19fX39/dxcYf7+/xxcoj9/f5KSkp2do7p6elro8wuMDEyNDVmncOa7Pub7PzBwcLDw8Ph4eHi4uJQUFBRUVFSUlJTU1NUVFRVVVVWVlZXV1dYWFhZWVlaWlpbW1tcXFxdXV1eXl5fX19gYGBhYWFiYmJjY2NkZGRlZWVmZmZnZ2doaGhpaWlqampra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7tBu6yAAAAAXRSTlMAQObYZgAAAI5JREFUeAHtyqEOwkAMxvHWNKxhFWMnSngBZiZIFhTyCKm7d97zIPCEsgfomcn7Jd+n/tA0MUT016EeyqSgj5fWy3TQu41eu7hcjiYy6uk6haG+514WkZQKht1nJZK5J4o76Aq5L7mbQgCZidZt5zgszPLHmTuIqGXeGEIMi1c5XxRqELPZUO+cPhH21DQ/61cRMyrWvLgAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "60"
+    "gender_rate": -1,
+    "rarity": 60
   },
   {
-    "id": "704",
+    "id": 704,
+    "sortid": 704,
     "identifier": "goomy",
     "name": "Goomy",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA+VBMVEUAAADUxPYvLjAwMDE0NDU0NjfUxPUtLS1VVFVDtFSE3ozCs+DEteLLvOosLCwzNTbWxvcuLi49qEw/rE5Ds1NDslRDtVIyMzSAW7STYKiWYqyfaLWjaruka7ula72mbL6NZcaUfsemdcSodsapd8ereMmwe8+yfdK1f9Wji9umjd+6gtq7g9y8g9y+r9u/sNyA2omD3owzNDPAs94yNDUuMDHEtuPGt+XHuObJu+nLu+o0MzTRwPHUw/UwLzEwMDDWxffUxvVUU1QrKytERERFRUVGRkZHR0dISEhJSUlKSkpLS0tMTExNTU1OTk5PT09QUFBRUVFSUlLhlgIXAAAAAXRSTlMAQObYZgAAAIBJREFUeNrtzkEKwjAUhOGMAV3VVQkiEtxJaR+2Kzc2FOYC2vsfptULzDtAPsjuZ15CVTnQ273oDN/0rbJj4JOOy5/Tf1UPomFzp/4hMM+d7sYvdstFlYfxiBVIy1mEMWGXpkQVZiDf0tRedZnNhnawhyjZW4xmuZQgsPxeDFUlbaXDD+00a7iLAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "705",
+    "id": 705,
+    "sortid": 705,
     "identifier": "sliggoo",
     "name": "Sliggoo",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABd1BMVEUAAADVxfYwMDHAst40NDXWxvczNTYvMTI0NjePgNOaiuSbi+adjei6gtu8g90uLi7DtOHHuObTw/MyMjMyMzSUUrWmdcSodsaves2zfdMvMDGRgtYsLCwyNDUwMTK7g9wyMjLEteLUxPUhkynWxfeFSqJMS0xPTlCPgdQtLS2TUrROTU7DtuCTUrOOT61SUlK1f9UvLy+G6UmL9kqM90qqd8jBst+bi+VVVFWbjOWVU7aLfc6Of9GmdMO+r9u/r9y+sNu/sNzAsd5vQIZzQ4zCs+AvLzAhlCkklS3EtuO3YG7JuujKu+nSwfLObX3UxPSFSqE0MzSOho7UxvQxMzErKytWVlZXV1dYWFhZWVlaWlpbW1tcXFxdXV1eXl5fX19gYGBhYWFiYmJjY2NkZGRlZWVmZmZnZ2doaGhpaWlqampra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHxPZo0qAAAAAXRSTlMAQObYZgAAALpJREFUeNrt0zEKAjEUBNDML/0YUQgo2hhhRcFiWdQLiCJstpvbeHg3F3DsbJziV48M+SHhnx+H9qWb9BwnNVwUBq4vlDCzjkJdPQt83k26pq3Ygm5+kRNq13tuSkPpdgWAo1XwsMt4AOjVkZYxQkeR0Guzd3qLvKYEdBZkOAwAGHTajI6B1IsEsOd8S+HOx5jgC3dxH25iijfHaMXzWEy3CHfk6fKT5CrWAIgn0d2mKpOZ6c9VE/75dd4UhRzUpY5IxAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "706",
+    "id": 706,
+    "sortid": 706,
     "identifier": "goodra",
     "name": "Goodra",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABMlBMVEUAAADVxfYxMTEwMDAtLS3SwvLUxPUvLy/WxvetpefJuuhSUlIrKyvAst4sLCy9r9pQUFCDe8WEe8aqd8ikndu5gdq7gttMTExNTU2/sNyqouOspOZOTk69hN7DtOEuLi7Ku+nMvevOv+7HwOXTw/PTxPSDesQ/rE6MZbOBecKspOXEteLLvOq+r9u8g92blM9RUVGim9l9dLulndymnt23gNd+dr0xlDk6oEg8o0pLS0tftyuM90pAr09BslFCtVKak87FtuTGt+XHuOZJSUmBeMF6cbZPT0/NvezOvu10ba92bbDNxevRwfF4cLSqd8d5cLWtecyues2we87Y0Pjb0/ve1v/i4uLq6ur9/f3///+L9kpqzDBqzDGooOFrzjF82kGDXqc+q03Gv+Njvi2ro+SY1UZ1AAAAAXRSTlMAQObYZgAAAR9JREFUeAHt07FLw0AUx/F7L+SUvl/FuAgeV0MoJaKLVHAzCAXrEHDQDCmpU///f8G+SLa7poNu/Q43fZb3gzOn/j4kfJy7dksYYBReOLddYTIbo/gUJ4v0i4p7HIZrkUZIe8JB+EZCwsxEViEQcXdElClhsq8wyKcIQ0vUtnOYXuZYLeogRN4QPbfUSySUpjY8auKJPLeVxbB9bHz2vvS+qsf3Zv72e7nGQON3d5vOV1Q/4FdgmsfkRrwvz21RTFSgvgxL3OydF9qXzlRwZpOQe3RXpbq+DwDvRByCS+7K3mX6bJfFPORUGkhD1GXUqHaOKkQnItkMsPIvMacyk06cOl+dxZ1e7pjFOSfMYx9Mn0WmbDTsdjBHdQvzP536Ac7WHDEUkfrvAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "707",
+    "id": 707,
+    "sortid": 707,
     "identifier": "klefki",
     "name": "Klefki",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAC7lBMVEUAAAAvLy8wMDAxMTEuLi4tLS1RUVHN5v4rKyuctda2zOHJ4vnL4/vM5f3O5/9SUlIsLCxmZmZpaWlra2tfdo5iepO0R26wY0y9kjrOn0DTokFNTU1OTk7+zYP/zoTB2e/D2/LF3fTG3vXH3/bI4PdPT09QUFBISEhLS0teXl5jY2NkZGTGmT1XbYNcconVpELit3XqvXnsv3qsrKyysrK8vLyOpcOQqMaSqsmWrs6Xr8+YsdFhYWFgd49heJFoaGjA2O5je5RMTExqamqzZk62Z0+6aVHI4fi7alG8alG8a1LhT3zoUn/4+Pj7+/v9/f3////9WYuDQTKgttOTSTm70uhheZKZsdKastObtNVaWlpbW1tcXFxdXV1eXl5fX19gYGBhYWFiYmJjY2NkZGRlZWVmZmZnZ2doaGhpaWlqampra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fku2baFAAAAAXRSTlMAQObYZgAAAShJREFUeAHt0LFKw1AUxvGTnNrzoamnCG2xEiypoFIhWFDQijZEWzJWRIyji48o+E6uQjdvSp2SG+6gW/9D7hf4TYc2/V/wHd3yCk6wnUdukDhwg5hK43cCtbKF9fj6hl0BzxNgNZYXsBACBlG7pcEhgLePT1QhnI+By+hWRUT1+uRgT7nszsb7YT/uT6SjskhyI1U0RQluNeMwjONmrCzJQsTIVFugcr4p9FWYEylKzDKwOnjChI4aXkBCgJr74UVT4TzJUQP9ACBWTVeOvLkNEt+dGsndrm8IEFgh3rUQuws23+MHtijCjQqKVQjcZz1UuleMONUpsPrDNmeP1bAxAjHzkaHAYO5lT7Cdcf3sDKNhgwmzDFQbPObimXnklteDGwRo01/3A+PvHzcZXffJAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "708",
+    "id": 708,
+    "sortid": 708,
     "identifier": "phantump",
     "name": "Phantump",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABEVBMVEUAAAAyMjJNTU1RUFBRUVFSUlKRcFE0NjeObk8zNTYxMTFISEgtLS1PT08uLi5wWEGCZUgxMzQwMDCSclK0k3O0lHN0W0OMbU6oimssLCwuMDFEdz9qUj1UU1IvMC9zWkIvLy9qrFFJSUmDZkmHaUuKa02LbE1LS0tMTEyQcFA0MzNOTk6Uc1Kgg2WggmakhmgyNDWsjG2xkXCwkHGyknG0k3JQT04+bDkrKytCcjlUUlOObk5VU1SQb1BUVFNDdT6TclFDdj9zWkN0WkIyMjGjhmhnp0+lh2lop0+qi2xpqlGsjW6vkG9rq1I/bTZrrVKzk3I8aTgvMTJTUlHrgpj0hp77i6P+i6Q+bTqKa0yFZ0qE5nJLAAAAAXRSTlMAQObYZgAAAPtJREFUeAHtzsFKw0AQxvGl7bQwIbYMDNhL1oqHCtODxchXvOQU0UNAPBR8/wdxNuJtk3hU6P+Qy/5284W/0CXIL90e4+c/x9sZRt0BbdX7WyqGZYXD01uX3GpWEiUIZHi3a2utgoc5EbHfbPGSe/h0knqDAJTu5nDRtfKaXcBNc4fP5wV5y3RH6mMOYmP2cVxHS8X4gOta9SoH75tIVGtMqT6u3e3a94wUMzqrKlH6RFPlLuM85gTJUzKvQRgKC4fnHkYfK8Nwad/QyIw5DMe+0zN/DWE0ZpeZeZkg/V8xRbEnDyiKCbmlVFnKzWpqJXniSDA50ide+jd9AY7QI1UAuuRJAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "709",
+    "id": 709,
+    "sortid": 709,
     "identifier": "trevenant",
     "name": "Trevenant",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABa1BMVEUAAAAyMjIzNTZSUlKTclKyknK0k3O0lHMyNDU0MzMxekJKSkpRUVEtLzBUVFNCnGuEZkqRcVEwMDCihWejhWiujm+wkHAsLCwxMzQtLS0xMTGCZUlMTEyFaEqJakyObk+QcFCSclFQUFCUc1Kgg2ZjvIMxMjGsjG6tjm5UU1JJSUmxkXFyWkK0k3I9kWMvLy8uLy48j2KhhGakhmg8jWGmiGpCm2tQUE8uMDCCZUgyfUSDZklSUlEwMjNOTk5LS0ssbzyfXHIyeUEvdD+VdFNRVFU/lGZPT08yeUIwMTIze0OGaUuIaksyfEOKa02MbU6Nbk4wLy+Pb1CQb1A0fENpUjxUU1NVU1RqUz1vV0ChXHKsY3vkfpSfgmWgg2VyWUJtVj87i187jGBISEilh2kwMC+oimuqi2yrjG2sjG0vMDEvMTJBm2pMTEsxdT+yknFaqnizknNarXlcsHtPTk3whZz9i6T/jKUrKyvlkeVoAAAAAXRSTlMAQObYZgAAAUhJREFUeAHtjU+L4kAQRxtqpSCbi8K6ULBgU3gyYf+AiDs59Gm8ePEwJ8FBJAehIeAM+vv40x3BS2xlDnPzVehOyOOV+SwP3H0FMDDu4O65mG6wwdv44P7fMVflopn58dh7F+tpMKqY89wH8G96w0RfiVkp94uGVybNb1IiVf0W9CHMDUT0FFXmXtoDEM/j+hRNHSS97d9tULE+rolFJOm5zHs3xyQn4hKXDR3vxdoss9Uk58gPoN3QFeu+LYpahIg4DC32+2efua4pWqiVUM6phVmyrGmW6Iq17toXpjgljKhyU3eSiBOePUeCh+/MymKugPkSu2HVJnP8ssRyVQy/7HtDZ8qZqorB1WBdvXLMxSJzQX9gEogyq/L5sDApMFehkArDJJo2MaoNStYYlvCVFmHQ0wGMiD7B/IRJcslIuG+Dy/3gS/gAIsVLy97mYLQAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "710",
+    "id": 710,
+    "sortid": 710,
     "identifier": "pumpkaboo",
     "name": "Pumpkaboo",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAACOlBMVEUAAACLYjmMYzmJYDiGXjd9WDMyMjI0NjfEalKEXjYxMTGIYDctLS0uLi4uMDEsLCx8VzJQQTcyNDUzNTZrUjlrUjovLy+HYDdSQjlgSjOJYjhKOzPTfFjWfVngkgjjlAn2nwj3oQr5oQr/pQrkhl/mh2DoiGBLPDRNTUxSQTk0MjCLYzswLy+MYzq9Z0+/aFDAaFBlTTZKSUgwMjN+WjUvMTJ9WDQyMzRnTzZqUThTUlJUU1LCaVGAWzOBXDWDXjZrUjhUQzpVRDpsUzlPQDcwMDBMPTRNPjVqUTnti2PvjGPjqFfys177umL9vGGop6a1tLNLS0pSUlJTU1NUVFRVVVVWVlZXV1dYWFhZWVlaWlpbW1tcXFxdXV1eXl5fX19gYGBhYWFiYmJjY2NkZGRlZWVmZmZnZ2doaGhpaWlqampra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb16/5egAAAAAXRSTlMAQObYZgAAALVJREFUeAHt0rEKgzAQxvF+1SE9W+4GcdClNFBIN7cKDTi0gotD3td361E6J1lb/OPmj8M73P1MW9xkOu85yx3cJDmSKzf4LNjDUY6TAHWchhiCMEtC6msCisknIAvzuQAw3uIDT73vFsC26Dg6kjBCU3sX4dhGVGOtAQzYVxLdiJ/Aik9FWcbgBZqrEYA2ttHROnXLEkxo4hd6GeeMtWZ+pE5+NWbWZ6b0b0v0delIv+//2noD8o8Rhk5YtxQAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "711",
+    "id": 711,
+    "sortid": 711,
     "identifier": "gourgeist",
     "name": "Gourgeist",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABCFBMVEX///82NzdrUjkxMTFSQjFqUTg0MzLGlFLti2PvjGMyMjJuUzrujGNRQjE7PDw5ODhqUjk6OTlTQzJuVDmlczmsWlLFk1I4NzfPdFtSQjDtjGM4ODdSUlL/pgr/vWOtW1JqUTk0MzEyMTBrUjpsUTlsUjltUzdtUzhtVDo7PD1QQTFvVTpwVDijcjijcjmkczlRQTGmdDqndDypWVGrW1IxMTA3NzauW1KvW1OvXFHCkVDCkVHEklHFk1E4NzYzMjHGlFPKcVfMclrOc1ozMjLoiWDpiWLqiWHrimHsimLsi2JUQy9VRDHui2PujGJVU1NpUDjymMj4uWL6uWH7ogn7umL8umP9pAlQUXmZAAAAAXRSTlMAQObYZgAAAO9JREFUeNrt0z9rxCAYBvDCKaGbQwMGgpQMGaThAuEZ7sAhBImQ3EtKB7//N2m83T9L6XIPossP31fUt1f+LMClzO18R4k7eocyaFFUeGnnFVkFSHK0WmSYvbVE5G4SSSctum4mqj/eJVLO4Zwnqv3Q0gxEIRHCMhhlOlg7xShqt4Qtv425I/Rr55hcEeZrFeCzCRmTYcMvU1VmeEpLqSPdjbkyjeBWh7ibeiM+R70FuSbc9sOZEH7bA0wV3nveiIfi25G5RO25F2fGHGwWpc7Sosk9XXCmlK8Z1zmojwsTjImCF3mOUZT9rqBf+e/8AjB1LmG58unBAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "60"
+    "gender_rate": 4,
+    "rarity": 60
   },
   {
-    "id": "712",
+    "id": 712,
+    "sortid": 712,
     "identifier": "bergmite",
     "name": "Bergmite",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAAAtLi4wMDAxMjMxMzQ0Nje95/8wMTEzNTYuLi9hirKIr8+KstOnzOGx2e+13fS44fi54vm64/u85f285v4uMDGcXKaEq8pOTk9SU1SLtNWMtdWMtdaNttemyuBXe56ozeKs0uiv1uxaf6Vdg6m13vW34Pc0NDVjjLW75Pxljba95f58oL2WVp/KysorKytJSUrgixJfh67ukRL0lQ/zlhD5mBD8mhO8vLyCqMaDqciDqslcgaaGrc2Hr85egqaIsNCKstJOTk6Ls9SLtNQsLCxgh61gh65hiK5hibFiirFSU1Opz+Sr0Oas0Odii7RjjLQvLSu03PNkjLVTVFW23/a34PZljrdUVFS64fp/pcOQVJSRVpu75f0yNDWXWKCZW6ObW6XJycmdXKLMzMz39/dZfaFnZ2doaGhpaWlqampra2tsbGxtbW1ubm5vb29wcHBxcXFycnJzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLCxsbGysrKzs7O0tLS1tbW2tra3t7e4uLi5ubm6urq7u7u8vLy9vb2+vr6/v7/AwMDBwcHCwsLDw8PExMTFxcXGxsbHx8fIyMjJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7///+c+t16AAAAAXRSTlMAQObYZgAAALtJREFUeNrt0rEKAjEMgOG7DskqZwfJpoIgCnHrIPcAkiFw4CI4FB9X+kya6tzrzcf9Swr9oEPTLM0xdhNdf+dJbuV7ritu+Ak0cM2dB957UKrCruu8/iGPYiQPYPLBvBuDfAH6QdocDjzitjcxmSGJtGU3xCBgDrJULsIWgiNRiDFLvRYlQjACEfMgUld+e233FEN4nfIBy/AoYEVzml05TKgKoKrkuPLV+FFNCfHN9W2UhDbaSYu7NMO+hXkiwkgWzEwAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "713",
+    "id": 713,
+    "sortid": 713,
     "identifier": "avalugg",
     "name": "Avalugg",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAAAxMzS85v40NjdjjLWCQoOcXKadXae75Py85P0uLi+95//9/v5PT09hibFji7MuMDFkjLV8oL4zNTY0NDUxMTGApMSJsNGLs9KLtNWMs9WMtNanzOGozeKozuOqz+Wq0Oaw1u254vm64vtISEgyMjNQUFBSUlLLy8vk5eXn6Ojo6On29vf6+vv8/P39/f5UVVX+/v+Eq8ozNDRZfaGKstNZfqNcg6lgiK9giLBKSkpiirKpz+RLS0tii7RMTU2x2e+03PO13fS23vS44PgsLCy54vouLzCCQYItLS295f6EQoSFQ4W/6P+LUpTh4eHh4uKPVJeQVZmSVJvu7u7z8/P09PSWWKBSUlP8/PxTVFT9nBRUVFSCqMeaWqKNtNGZW6ObWqSbXKQvMTJagKTtkRFbgKanp7eApMNJSUmBpsSBpsWCp8ZdhKqFqcmEqslehauFrMuGrMyHr86Irs2Ir8+JsM+JsNBehaxfhq1gh66LtNQwMDAyNDVLTE2MtNQvMDCNttawsMCyssKnyuA0MjCoy+EyMjKozuJRUVFQUVJkjbZ8n7ur0ees0OWt0umt1Op9oLqx1+6w2O58oLyy2fCy2vC02vC12/N8oL0uLi5+ob+23vW34Pe44Pd+osC64fp/pMF/pcN3O3e65PtTU1S75f284/y95fyDRIR2PHa+5v14PnmERISERIXBwcF8PnyNU5WNVJbj4+Pk5OR/QH/m5ubn5uePVZlYe5/s7O2SVJrv8PDy8vJYfKCSVpv19vaTV5yVVp6UWJ2WWZ99P32XWqGaWaMrKyvJycnKysrLy8vMzMzNzc3Ozs7Pz8/Q0NDR0dHS0tLT09PU1NTV1dXW1tbX19fY2NjZ2dna2trb29vc3Nzd3d3e3t7f39/g4ODh4eHi4uLj4+Pk5OTl5eXm5ubn5+fo6Ojp6enq6urr6+vs7Ozt7e3u7u7v7+/w8PDx8fHy8vLz8/P09PT19fX29vb39/f4+Pj5+fn6+vr7+/v8/Pz9/f3+/v7///8ig4hVAAAAAXRSTlMAQObYZgAAAUNJREFUeAHt0bFKA0EQxvHj4CD6od2iU6eYXkghwqhBRdJZB4tt0limNEUgVQRBsE1KH8CncArzPJbr7C5YnLekSpf/BdL8+Dabq/btOJ1tJ2ofna51G7l+04dhv15pmV296+fqpof+l2+ofixIfV33aiNmANhXKMF+XQOjUTQIIXhfOtvZVkjZmnVXWvwJPouAfP5QtQBtKxNkenmmXbCHVOMbZOr5eKL/mB6JINfkUetlMG+7yXRJkkqj+ccKk2u5p3MiZiISkr+LC7mWq+ZiDmBmMZtoY+PGWrm4F2LMcRSQhuSk486ONxlmKjZMF93/4rf3yMXNqF3VCQ+BSIlsW4yxaOFNw/LkxhzS9ZcFVykgcj8eL0NY2ODAXAHexp3nU14sPiCQ2mSJzhzZs2Fn0GdYtPbMtHIeB9lty5neRft+AeGbnE5G8uhZAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "55"
+    "gender_rate": 4,
+    "rarity": 55
   },
   {
-    "id": "714",
+    "id": 714,
+    "sortid": 714,
     "identifier": "noibat",
     "name": "Noibat",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABCFBMVEUAAACbirQwMDEyMjQyNDUzNTaai7MuLjAyMjNRUFFSUlFSUlJUU1RoUkR3SqN4S6WDUrSEUrWLfaGNf6SUhayairIuLi4uLi+bjLScjLUuMDB6aot8bI2CUrIuMDGEU7QwMDBTUlMtLS6PgKaThauUhKtZQn5JSUlsX3tbRIBLS0t4SqQtLS2DUrN5S6Z6TKV7TKd7TKh9TqxwYoB0ZoR4aYh5aYl5aYp5aopZQn17a4xPTk+CUbFlUEJnUUODUbRQUFBqVEVrVUaKfaByWkoyMTL/tTn8tDuPgKVtX32PgqeQgqiSg6lKSkljSotkS4yXiK+XibCZibBkTIx1SaB2SaEyMjKejbTdtF8AAAAAAXRSTlMAQObYZgAAANVJREFUeAHt0M1KBDEQBOCpBhEpkLC6zCFnwZ9iYFdRxIFcwoIoIYjg+7+JyXiVZq4LW+SWj051hlOOKhrXMe21ik37BUq+u9zVWU3pWz6ckNK5XqfpTq57AEKZK5DMH5gQQoAVFDmq3RkZUAyz524lXQFEf3503NP97hpdhWJOQ71coDcEMHoL6zFyWeQAfHlwzDGyOTuA7s+YZYvEkhsN6kf/j1TDJEC+bfRxpvdPOXMzmQnU7c+2Ok4b5kYBRMBtqmczkM2Z6/6aRstZw4qo81OOJL+JaxohBWZiDQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "715",
+    "id": 715,
+    "sortid": 715,
     "identifier": "noivern",
     "name": "Noivern",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAACE1BMVEUAAABSUlJCQkJKSkpMTEwtLS0xMTEyNDUzNTY8PDw9PD1DQ0NEQkJJSUkvLy9RUVEyMjJSVFODUrRKS0ssLCwtLjAuLi4wMjM/Pz9AQEAuMDFaxItEQUEuMDB3SqNKk2uTMTHFMTHEMjKEUrW0tLQrKyt4S6UzMjRFhmJKlGuDUbRFRUVERESNLy9hSYm2LS1Dh2GgoKDl5eWBULFSs39PT09NTU2tKyuTMjKyLCw+Pj5EQ0QtLC55S6aCUbKCUbNAQEHMzMw7Ozvm5uYwMDB8TamILS19Tat1SaBStYCAUK/i4uLj4+OBUbAxLy+jo6OlpaWmpqZ2SaG1tbVaxoxQUFB5TKZ7TKiGLCw8Pj1/T61/T69OTk40Njfa2tr/1jmFhYVFh2O4Li7CMjJCQUKnp6erq6uysrKzs7NLTEuCUrKDUrNMTk0wLzHGNDL91DqAT6/n5+c0NDRzc3N0dHR1dXV2dnZ3d3d4eHh5eXl6enp7e3t8fHx9fX1+fn5/f3+AgICBgYGCgoKDg4OEhISFhYWGhoaHh4eIiIiJiYmKioqLi4uMjIyNjY2Ojo6Pj4+QkJCRkZGSkpKTk5OUlJSVlZWWlpaXl5eYmJiZmZmampqbm5ucnJydnZ2enp6fn5+goKChoaGioqKjo6OkpKSlpaWmpqanp6eoqKipqamqqqqrq6usrKytra2urq6vr6+wsLBpo8B4AAAAAXRSTlMAQObYZgAAATBJREFUeNrt08FKw0AUBdA+rLOwJIEgQgiYBPIWCbSIpS5KixcTiD8QEIp0240g/oL/I36id2hAop2STXe9kMxADu9lhpnROSeL1gPdWIfB64dBUNXTbqJH3dVd0qpVS88BuzpJUASvOvHGUjvcMyWdxCKLpCgCV711s4d0UkQSty7YlCs7PNHFAnLf5XDBNbxEAiCmM4cL3pQlFhOdpkCWQSTS3+3qQRPar2kaZdYB+VcHdH35HyLNmK11+ee37vdi89aHIBS2jc2WE8pcyfR2TteDbGgMsQ3odkq23pTv+geaTPkWWFblAJb60czLRz18BvWerKogTBuVjO86EzvrQisRMsblAlak6CAbOyGXNJtBALpaj14XPsZulOm1df8C2QCXYjrsgtW+js45SX4A+ykxzpAJuP0AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "716",
+    "id": 716,
+    "sortid": 716,
     "identifier": "xerneas-active",
     "name": "Xerneas (Active)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA5FBMVEX///8xMTFZatNSUlI5QoxCQkJCQkRCUqVEVKRRUVE0NjRTU1FTU1IxMTJZatVaa9armjnLw2LMxGL8kkL89Jr89Jz/95xBQUH785o8RIxUU1FUVFNSUlRBUaNBq5pbbNRcbdWrmjgzMzGunTpCQkPLw2M0MTHOxmP7kkE7RIs0MjE0NDIxMTP99Zr+9pv/lEIxMjKrmjqtnDlDQ0FEQ0JUUVHLxGTLxWNERELMxGTNxWJEREPOxmX7MTH7gv1EU6M5Qo37+/v8MTFErZtba9M6Q4r9MjFRU1P+MzGKSaQyMTI8Q40gV1cpAAAAAXRSTlMAQObYZgAAAWtJREFUeNrd09dywyAQBVAtSJZQ75Z77zW99578//9kwcmLZWM/m2GkZebMckEj5QCHCWJi8Vf+1+uORWPIJnd9CNr1pWLWl1jgHI7XYVaJyv6s894PXpZ8Xf+gz2c0KgPkZDqwaZx2rHDkcHjxiW5Rjif5kCtaUr+++bJlhXYkXE4W/VlJVe9/UAKQanhshXN0eTg8DUa9EZdqr5FUMEeKbrtEZpOqiEth211C6009urZjI0nTSrQYS+49sCnR9SQ1ugCgSCCLDXf6dHupkamE8ds0XOzX9DzhZFs/uJ7nFQBWmSUSaq736IiypusOAEio7vBXUcPBKIXNindyp/idSIFpfGx0iHAzwjMSvcsoNtzoRK4uuWp4BYInQihJiCdIDHHytXh5eT4fNITbASG7iZsYssikDo8LzH8t4A+2E2qAk1csbMsltE72g4EdT3iR4VMKfUu0MgN8yuVKmCBluT1lEDvuKZVDH79OKyBkzGlDMwAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "45"
+    "gender_rate": -1,
+    "rarity": 45
   },
   {
-    "id": "717",
+    "id": 717,
+    "sortid": 717,
     "identifier": "yveltal",
     "name": "Yveltal",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABLFBMVEUAAABSUlIuLi8wMDAxMTEyMjJBQEFCQkJOTk5RUVEsLCw0Njc8PDxAQEAuLi4tLS1JSUlKSkpNTU0uMDFPT09QUFAyNDUzNTaCgoqDg4uEhIwrKytISEg+Pj4yMjNYWFizNz+FP0e8OkOJQUmLQkr+Qjn9QjqBgYlLS0s7OzsxMzRDQ0M6OjpEQkK5OUC8OUFMTEyHQEhUUlJRT0/iOzR4eH94eICAgIh6eoF9fYV+foZQrOpQsfF8fIQwLy9+foU/Pz9QTU1EQkNVs/SpNDysNDusNTxERESCPkVBPz9BP0C6OUJ8O0K+OkE0MjJZWVldXV1gYGCMQ0t1dXzkOzPsPjXyPzbwPzf1QDj4QDf7QTl2dn1MSkp7a5owMTI9PT17e4J7e4P9/v98fIOT0t7FAAAAAXRSTlMAQObYZgAAAbBJREFUeAHtzdWSnEAUxvFzWrrpZhAYBoFxl3Xfjbu7u+T93yHkYlLFTCDJ/f7qFBfUV/2Hc2sY54xBNQ52m5/cOTsyoVJ2hXQmXzuTw6y6CDyJJ2kSpwmtmLEvih4xZsfHJ8lpG8poK3ADoi1/Rn+8oJ/L31MoBV8oRNWu6lKmmaUtYyYMJz51/vyWJlS3RLb/VhNO9v3apOUyWMMf7+0hbm4Oef854vcb4+vxAhFXl5TXutu3eo2bXeoNGh8vXjjY6mk0aopAgWMo796jl6+33fvUbWwdvOvOrJ4TG47a0YUhttlwPBqPRg+GnJlSyoXsM0wR2Uq7/om5194/fBXW57sZhBl52nlme6ql1VRDAVHem6FLACCq5x9KntDggzI8upJmKE2JwoTfOKYJLgSXZmGo/QhslcESpV5wyVW+Ixwo4CFAiMufzMHjQxVMBb0tCKwzzWVVpXkXBe+LvFyGaiNonn1rGpf14O4GhTJETaWa5l26WxtYNQZlOAr8dZGUVn6l5WznatPIz4awtSHsOpSZR8IXwlcRQDQ3oQprmKzB4O/COoTNOfwbG879p59xdSb5SkDwHgAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "45"
+    "gender_rate": -1,
+    "rarity": 45
   },
   {
-    "id": "718",
+    "id": 718,
+    "sortid": 718,
     "identifier": "zygarde",
     "name": "Zygarde",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABm1BMVEUAAABSUlIyMjJQUFBRUVExMTEwMDA0Njc8PDxAQEBBQUFCQkJDQ0NJSUlKSkpOTk4zNTYtLS0uLi6T1EmT1EqU1kozNDJISEguMDEvMTJLS0tMTEw6OjpPT08sLCw+Pj4/Pz9TVFJUVVJxkkmEvkKIxESKyEWOzEePzkiS0kkvLy8vMC5SU1FtmkmFwENNTU0wMjNwkEkyMzFyk0pzkkt0lUp0pE52pk56q1KCu0KDvUE9PT1RUlCHwkOQ0EiJxUWIxEY9Pj2KyEaMykZTU1NTVFGPzkmQz0hOT02R0UlKSkmS00psjEVujkiT1UsxMzQrKytxn0x0ok1DREMxMjB6q1E/QD97rVF7rFJ8rVJUVFR+foaDvUJlgkGFwEJmgkJnhkKGwkRohkRphkVqiEOKx0VriUVri0SMyUZQUU6MykdtjUaNy0htjEdRUk9tmElJSkhwkUgtLi09PjyS00syNDU7OztzlEqU1UpDREKpqam8vLzg4d/h4uDj5OPw8PDz8/P09PT19fX5+fn+//3+/v50lkqCu0F8rlLWSwRMAAAAAXRSTlMAQObYZgAAAgZJREFUeNrdk0WPHDEQhV2GZpzuHmaGHVjmWWYMMzMzM+dnpzfKKXLP3PeTVQfrqfxelYwON6y/BB+UOgj9dPtmyK9p8rf2EtZBPY7wQ1gRkJAKMiD4bUIDpMRICboJzBI4qFtEEJJjiclsYpLMR94YEdV/3OYYECnklNNAVaAAigcDgBEG3vs2LUxTMq3IcSCZ5+YRyIYg2+FFTu3o2XpSCL1UMjqNP1IWdM1GHCwAipcZMKppCvgehinwk1vEXj5nyHdsakpKW1JuGtAJCG58bse/Lm7Stq5KSUVKigH7w++0/I/vv0cwA1B9AnRpmbwllY/d+wY101SWrA7iE5WJTu42V02dCjZN9Ni1CCDCBGCM1WMALMxYkPJFFIXSQiapnrysLDQ3SlGuSrDZQdUV+Rkdb9VuXAzyyChgxuAsgJPzTr36N+sw5oRJpXR5/UPq3vkTn4obpadD/l2jONpA4f9zWVbM2pldqV53vlwVb1+p1VF46Za31HB5HrDjvXZcUURY1TTsua43uiXylnh0qrI9JfiOpc0Z45LTKtZa3OxDq/O16iz2/4R5rWDG4UFpeI87IvfMt113UMNkhM7kKAFq8fe9Xym/Hy8/JlmdGM3BWFSMIT57ha2yU9vO0fV8dVFEPRAn1nbd7s/8E7dgoZ50omNzv9bmLlgx1A8mhPyDDjt/ABvgQBai6GGzAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "719",
+    "id": 719,
+    "sortid": 719,
     "identifier": "diancie",
     "name": "Diancie",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAALVBMVEUAAAAxMTFSUlJqaoODg5ycpL20Wlq9rDnFGDHVzcXmlJT2tL325mL/1f////8L0qioAAAAAXRSTlMAQObYZgAAALRJREFUeNrt0bEOwzAIBNBwARJDzf9/bi9Lt+AsHSr1Brw8HUje/vla5KGSKWt8Kc8UPrKAmc5wTulheFV6ePZQFMUkXaxgVMVVuboxEJEAVg6nUZVaL2VCzc44TTGlc9xqlKqIOaXpAwZABuS9ZB/G0DxeR1knJTKhHMfQqlaKVHl6sVeHZEZzJsqrKCHbJQlvJegAkmtD94c7yD5LG7mbqcfScbepqhMupagK3YOQ/fM7eQPR4gZms8hcQwAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "720",
+    "id": 720,
+    "sortid": 720,
     "identifier": "hoopa-confined",
     "name": "Hoopa (Confined)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAANlBMVEUAAADyjpAggzExMTExczlBtFJSUlJ7g6yDg4OcezGkrObFxf/NOWrNtDH23jn/Wov/////ALtUIevpAAAAAnRSTlMAAHaTzTgAAAC9SURBVHja7dTBboQwFEPR6RgMJH4v/f+vrZPtTCI2ldqqdxE2R84CxOPjZr8C/vdtAbjnWmu46Zrg3TnBOGUnQpg6YpxOlFaQAFrPFCt3xdVUZanBMIFXkjVrtVVfxIn3MGXXpW1jgudk0vA54NYdeXICQ9zttm3PATmBD1r62v3zaRjXzDmA1fl+ihGLV3ME2S37E/NBHQdDKlIySyOmgwIiZRcsrRSsvgrLzACKaLgKPT9e3GL+h/Snfs1faoMKcckmiYEAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "721",
+    "id": 721,
+    "sortid": 721,
     "identifier": "volcanion",
     "name": "Volcanion",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAALVBMVEUAAADyjpAxMTExe+4xtP9SUlJaYmqUMSmsQUG9UmK9cynVlDn/zTn/////ALu7wqRUAAAAAnRSTlMAAHaTzTgAAAEASURBVHgB3dTNTsNADMRxmOzEHta8/+syBm7NbiMkDuB+5PLTP1ZXzcvrzfkT8PcHwD2niFsWIUW1xd7lcSgaayeBoWNESaLlbr+R6pqz5AZGyjKms9LYQLo0AFJ2mRvpEnoDji5rKZES7DKZ2kCkO1TDXmIX9C2pdvQSCSyTYgft3M7BCKyOLwzNjiPdZmAVVJKUoYO5cgBDkj8nm5ELFyx5UufJHl9w6YLTrqbBdzET11CKmmkXX1/io8SMgCLxnpWMk7IKxSPkBJA5DAsdR8uLewOf3KzQv1P4xbk8mXorwFfKNWHtmvVAHjz/S6NCYfh0gELZ3ZH9/tn8q0fzB7u1C7vWmESgAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "722",
+    "id": 722,
+    "sortid": 201.01,
     "identifier": "unown-b",
     "name": "Unown (B)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAS1BMVEX///8xMTE2NjZRUVH///81NTVSUlJUVFRra2uDg4Ojo6MyMjKEhISCgoLLy8v7+/v8/Pz+/v5TU1Nqamo0NDSmpqb9/f3MzMzOzs4ewN1hAAAAAXRSTlMAQObYZgAAAIpJREFUeNrt0kkOwzAMA8AwXmVnb5P2/y+N5Q9Qt6JAeNBpIMiEhye/zwijKxk2OEeYnJMIWPZNMZapcvj67N+jUBia814lXbgluXwqByg86+qT0JeH9e22BvmRS7/R0s+yd8chZlPhwUmFFs731TZ5jU6UqLRDVjjQJhRyie64zDnbfi6A4cnf5AZ8JwTnO54hiwAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "723",
+    "id": 723,
+    "sortid": 201.02,
     "identifier": "unown-c",
     "name": "Unown (C)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAUVBMVEX///8xMTEyMjJSUlJqamqDg4OCgoJra2uEhISlpaX///9UVFSjo6P+/v5TU1OkpKTMzMzOzs78/Pz9/f1RUVE1NTXLy8s2NjY0NDSmpqb7+/tY0acLAAAAAXRSTlMAQObYZgAAAJ1JREFUeNrt0jkSwzAIBVABwtodr9nuf9CQpHAHaj3j30jFm49mkLtynjwAoIsNt5QQTDdEBBCMhtsYf6cXqRcSSeH3osLdB6opRZQbo17IRFRFSqXmAvmpzWM1IfHUcp5HRrDgWnjNhThGC77wLdCHACr0y3NbcmEEcar8v9Ha4D4Q3Nvh1EqQOBseC+mQ0tj7H9F10t7xMvvKafIB1RoGimYDwe4AAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "724",
+    "id": 724,
+    "sortid": 201.03,
     "identifier": "unown-d",
     "name": "Unown (D)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAUVBMVEX///8xMTE2NjaCgoJRUVFSUlJUVFRra2v///+EhISjo6OkpKSDg4MyMjJTU1M1NTWlpaXLy8vOzs77+/v8/Pxqamr9/f3MzMympqb+/v40NDRu/uQlAAAAAXRSTlMAQObYZgAAAJVJREFUeNrt0jkSwzAIBVB/IclabXlRtvsfNCR2LdEm419QvWGAYbjyM1EARC6U4jMEkMZxjCULoAFAsStnbcC1KxVFHnFQOuXehMaEj6xtqer9uU7haNlxzq1TYkltuNt0c1YCH3lztqINWW4vvTuL7trz8p0RfEiD9n0W3vpoKHoedTbsYolTAHmJI88M0g+/8od5A6esBc3nP1dyAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "725",
+    "id": 725,
+    "sortid": 201.04,
     "identifier": "unown-e",
     "name": "Unown (E)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAVFBMVEX///8xMTEyMjI2NjZqamr///+Dg4OEhISkpKT8/Pxra2uCgoL+/v5TU1NUVFSjo6OlpaXLy8vMzMz7+/tRUVFtbW1SUlKmpqY1NTX9/f3Ozs40NDRz/cENAAAAAXRSTlMAQObYZgAAAIhJREFUeNrtkrkOwzAMQ03ZcmzHua82+f//LNAhq7gGCOcHgqLoXj1IHgDFtU0aBQwoCDEJAzoPynGnIn7aNHagTiklNWI3E+Z6doOY8eJcVQkSIffxq/0gMMiQD1l0280i/XKtWTf7i376ZwTR41RvzvBcAW5lAY4FAQ4s3B6dx71HhnWvnqEfkQ8EcFS2u0MAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "726",
+    "id": 726,
+    "sortid": 201.05,
     "identifier": "unown-f",
     "name": "Unown (F)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAOVBMVEX///8xMTGEhIRra2tSUlL///+lpaXOzs6CgoKjo6OkpKQ1NTUyMjJTU1NUVFSDg4Nqamr+/v42NjZ4hZ9WAAAAAXRSTlMAQObYZgAAAH5JREFUeNrtz0kOwkAMBVGXh+7ORID7H5YIWMfeglLrJ/lbrn6kBai455ibrrljmPtUkFh/9G0ychcRffMchmvEbdeVDDYijPvczimBH9BhHPQMvjeaIstw5Fx2B0Wzh4BD5E4wPl5S6F+UQ2uUIJQcVjuspl6ToIqUArn6y14M2wJnAJGxigAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "727",
+    "id": 727,
+    "sortid": 201.06,
     "identifier": "unown-g",
     "name": "Unown (G)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAP1BMVEX///+EhIQxMTFSUlL////Ozs4yMjKlpaVra2uDg4Ojo6P+/v5qamo2NjakpKSCgoJUVFTPz8/9/f1RUVFTU1P7vw8HAAAAAXRSTlMAQObYZgAAAHlJREFUeAHtz0kKw0AMRFHpq7rdHjLn/mcNxgeQdibgv34UlJ3c1Y29gnvcp8m9k8LP3GGbvefy4DncArbUHWuj8gb3iMV7Dsdrbd+l5669VxUkQ+HSswInpMhvI0KKQQqbpLa7gmyBFWJQcoYHZzgDd+oUK1K7+pt+DYoDKWq9qcQAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "728",
+    "id": 728,
+    "sortid": 201.07,
     "identifier": "unown-h",
     "name": "Unown (H)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAATlBMVEX///8xMTEyMjKDg4M2NjZSUlJUVFSCgoI1NTWEhIT///9RUVFqamqjo6OlpaXLy8vMzMzOzs77+/v+/v79/f1TU1P8/Pw0NDSmpqZra2v9FS29AAAAAXRSTlMAQObYZgAAAK1JREFUeNrtkscOwzAMQ0spntmr4/9/tFIStKcIvrYIAQM6PFukwdulX1GFQiwkKuFqTm5/MsIEgwM+k8Ul0vUCVw2TBSrXdp3w0SBjEIMIzrlWyUCGQ07UDPO4trT5ON+Mmoc553FlJQ1QzuJ5yb4EfNKUfSNuDVAzTI/6nj0kGBtpBOw3jxC3yQBf8tX9LNx+61RRyQhAx0RmKWgfIFNBG48WWfrmR2nPL/2b3qoHBcGxO5vAAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "729",
+    "id": 729,
+    "sortid": 201.08,
     "identifier": "unown-i",
     "name": "Unown (I)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAS1BMVEX///82NjZSUlL///8xMTFRUVEyMjJUVFSDg4OEhISjo6P7+/v8/Pw1NTU0NDRqamqmpqbLy8vMzMzOzs5ra2uCgoL9/f3+/v5TU1MTuDMeAAAAAXRSTlMAQObYZgAAAGlJREFUeNrt00kOwCAIQNEKOGvn6f4nbW0PADtj4l+/oAlh6DWUIqELO8ngAZWg0g6IJPM8QPCGhXlar+0OLFSvQyyShcm6E60EziaidfzbcdRJBJfvj8SwXxYnKGvhCrN41/VgOYVeOz0IYAQNIXFMYAAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "730",
+    "id": 730,
+    "sortid": 201.09,
     "identifier": "unown-j",
     "name": "Unown (J)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAASFBMVEX///8xMTEyMjKEhISDg4NRUVE1NTVUVFRqampSUlI2Njajo6P7+/v8/Pz///+mpqbLy8vMzMzOzs40NDRTU1P9/f3+/v6CgoINiP+KAAAAAXRSTlMAQObYZgAAAH9JREFUeNrt0rkSwyAMBFB0gbEMTuwc//+nmVDQrtpkvPWbBY2UrvxWVooYSqsLQ2cq7FIJubfU6sIEC5f763g4R1zvAZmXVvTZizNsbDtvvSh+ezutheBt/JGQG3I6IK1OhwaiiPouh7HLziljONrINAJNRSrFZp4O3+2Vv8wHjLwEfG4ldCIAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "731",
+    "id": 731,
+    "sortid": 201.1,
     "identifier": "unown-k",
     "name": "Unown (K)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAATlBMVEX///8xMTE2NjZSUlKjo6P///9TU1NUVFRqamqCgoKDg4OEhIRRUVEyMjJra2vOzs77+/v8/Pz9/f01NTU0NDSkpKSmpqbLy8v+/v7MzMy8/B9AAAAAAXRSTlMAQObYZgAAAH9JREFUeNrt0scOw0AIBFBmgV1vc4lT//9H0+6GUyJLngOnJzES0JHdJMDpZIQPZv4zDLBcKwxQkLgt11yZpXapRoEwPO5TlLE4nOpbggy4pHLSJJ1MeO2zptLJkvO5LZoGhgVvn44s0SGnCOSLKdfGeM3M8J7w19/zXXpkT3kCxF8EIykyQL4AAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "732",
+    "id": 732,
+    "sortid": 201.11,
     "identifier": "unown-l",
     "name": "Unown (L)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAUVBMVEX///8xMTFSUlKDg4OEhIRqamoyMjJUVFRRUVE2Njb8/Pz///81NTWjo6P7+/tra2uCgoL9/f2mpqbLy8vMzMzOzs5TU1M0NDSkpKT+/v6lpaVnE++AAAAAAXRSTlMAQObYZgAAAH9JREFUeNrt0lcKw0AQA9DVlO0uiZ16/4Mm7AWsX4P1/WAEo3DlHCkg3WSRg1ktAiCki5gJI1cTYQoU3z+P5xQZ1xohu9ekt5YOYfF6j3NLenx7fuVKwW10RAiEHI6QWUC+kR2Gk7D/Yed2Aay2gICL2vvLSCC7jgExFuHKOfIDV3MEsNylv6UAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "733",
+    "id": 733,
+    "sortid": 201.12,
     "identifier": "unown-m",
     "name": "Unown (M)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAUVBMVEX///8xMTEyMjI1NTU2NjZqamqDg4OEhISjo6P+/v7///+CgoJSUlJTU1NUVFSkpKTLy8vMzMzOzs77+/v9/f1RUVFra2v8/PylpaWmpqY0NDSIdHK5AAAAAXRSTlMAQObYZgAAALZJREFUeAHtkslugDAQQzMzIQlhX6DL/39onXLghOHYSlhC5PDG41hxr/6HvDzkUiePZnwzqDOBMBOVklHTJ6QpttRSmrhDYYjKV8NHKnxbGPhm7DOAzlPSkNAZMpbfFpQYajFt2xTLYRdyZeerqZ67hAMsqeFU5zx3gKzh4NqHNfeV3INfutyCJePyvX3kXo6MzHL8zShHpxey0oiNNTje49GdiRQ/9ijOXJw7X+tFQDbx6s/rBxY8B9Iq/XqKAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "734",
+    "id": 734,
+    "sortid": 201.13,
     "identifier": "unown-n",
     "name": "Unown (N)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAUVBMVEX///8xMTEyMjI1NTWDg4M2NjZUVFRqamqCgoJSUlL///9ra2tRUVGjo6PMzMz7+/v9/f3+/v5TU1OEhIT8/PzOzs40NDSkpKSlpaWmpqbLy8uePeZmAAAAAXRSTlMAQObYZgAAAJNJREFUeNrtklkOwzAIRAPGe5w93e5/0BKkfFQqTg7g+UM8ZkB219RUl4WbXFnxoAEu5myIhBCerwXOOQ1E6CnHyISU+b+lORrGD/O+FJRaN+TmMKckpPVUBSdHU3IF9WR2EPCNY3LEoJosDmZ89NsVKBd8ZEeoJIeVQSGZCwj1ZJa8jPVRu7kz8FP5DLc/SFNTVV9XfgVTPY/nSgAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "735",
+    "id": 735,
+    "sortid": 201.14,
     "identifier": "unown-o",
     "name": "Unown (O)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAVFBMVEX///8xMTEyMjI2NjY1NTWCgoKEhIT///9SUlKDg4Ojo6OlpaVqampUVFRRUVHLy8vMzMzOzs77+/v9/f3+/v5TU1OkpKQ2NjX8/PympqZra2s0NDQtALYWAAAAAXRSTlMAQObYZgAAALNJREFUeNrtktkOwyAMBGNz5b7T8///s2tQH2M/t8pIRCAmGxtSXfwMngRTcxRuHWAyvLGJTCQ2G15N32DWxADP5RIdTMWLXLm26yLLQhNZQuu6jTJ5nTV0z4H9vC9HizR/GokdjHlPaTkalqX65W1otjT0aMoSn7yaotS4vsdHGqi8p0VOuUYqZ3pCPhE/oesSaNyMH/HIU+OuSQogzQNe/p7AFCI8FUdQAYtnqUJ18Xd8AIqCBj25JXCRAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "736",
+    "id": 736,
+    "sortid": 201.15,
     "identifier": "unown-p",
     "name": "Unown (P)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAARVBMVEX///8xMTFSUlL///+Dg4OEhIT8/PxRUVGCgoI1NTVUVFSjo6MyMjJqamo2NjbMzMzOzs40NDRTU1Ompqb9/f3+/v77+/vIy+p/AAAAAXRSTlMAQObYZgAAAHNJREFUeNrt0bcKwDAMBFCf5G6nl///1GAyZpAgSwy5+XGomD+dJEHpiqsqOAbrKgCFHIisI42MjqgNIFdOx7yWqnHMTYrQZ7tzlmHwWz05Wwmm4JfgOQ8QG+8ZYURIbWtoDg7dZyI19WmYXjc+JcyfrnIB9jQEXdN5SPQAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "737",
+    "id": 737,
+    "sortid": 201.16,
     "identifier": "unown-q",
     "name": "Unown (Q)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAARVBMVEX///8xMTGDg4NqamoyMjL///82NjZRUVFSUlKEhISjo6P8/PxUVFT9/f1TU1P7+/vOzs7MzMw1NTU0NDSCgoL+/v6mpqbAxcp9AAAAAXRSTlMAQObYZgAAAHFJREFUeNrt0jkWgCAMRdEkhBnFef9LVRrb/F5ffU8CB+jvuwVmhlyUrIDcjpxSyWpDt57LXJQB5/2QJqxNJt9MGFy9tPsmal6677FCsEzjjEwEyGWWxBQYeBn3yCgKjH3kmGq3udfh0t6u6Hejv492A/m+A4CiOaEdAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "738",
+    "id": 738,
+    "sortid": 201.17,
     "identifier": "unown-r",
     "name": "Unown (R)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAARVBMVEX///8xMTFSUlL///9RUVE2NjYyMjJUVFRqamqDg4OEhIT8/Pz+/v6mpqY1NTXMzMyCgoKjo6NTU1POzs79/f37+/s0NDT6zdEfAAAAAXRSTlMAQObYZgAAAHNJREFUeNrt0DcSgDAQQ1G0a3Akh/sfFS8XkCsKhl+/QqPu74P1AJqci0nQ4JYksqaBwzCXfVspnKpTNUlh9vFQz6HL43Cqjw3wcll9AD3HNo4b+IsyF3P8HQFcFPC/BVU/ksMqG2E3EVeFQet9aOv+vtkNn5MD/zmgCyYAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "739",
+    "id": 739,
+    "sortid": 201.18,
     "identifier": "unown-s",
     "name": "Unown (S)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAS1BMVEX///8xMTEyMjKEhISDg4NSUlJUVFSCgoI1NTVRUVGjo6P8/Pz///9TU1P7+/ulpaVqamrOzs7Ly8v9/f02NjampqY0NDT+/v7MzMyKGW0EAAAAAXRSTlMAQObYZgAAAJBJREFUeNrt0skOwzAIBFADtvGWpWm6/P+XlkrpmblEvWTk49NgJMKV07ITyNpEEFsWYd+1IFyjC4sKUyjkF/7KIEkWRFKNwohUSakhe6/v121qjLgxfGmw53gf2YVl7Q+eR47+7PlZOwS37x+hs9hs65gQSRY9pK8RuZM9Ff/WKhkDCouKMXM+PJgvKVz5ez5DBwV6gxGnsAAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "740",
+    "id": 740,
+    "sortid": 201.19,
     "identifier": "unown-t",
     "name": "Unown (T)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAUVBMVEX///8xMTEyMjJSUlJqamqDg4M1NTVRUVFUVFSEhISjo6P///9TU1Nra2umpqb7+/v8/PyCgoLMzMw2Njb9/f3Ozs40NDSlpaU2NjX+/v7Ly8sy2BxzAAAAAXRSTlMAQObYZgAAAHtJREFUeNrtzkkOAjEMRFGPSZz0yAz3PyjmBPYOgfqvn1QFRz/SGTHlSr8bYQKXyjIrgON4ujKLmlF8U9gTzED0IIY7f9QX4EN0zjwsuzF3oxjK6XmdOmXcGLF0uDW9jJaBC62jaby93uqWgi//uEwIkJAp5xIR4ej/egPlJASH34yHCAAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "741",
+    "id": 741,
+    "sortid": 201.2,
     "identifier": "unown-u",
     "name": "Unown (U)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAUVBMVEX///8xMTEyMjJSUlKCgoJqampTU1OEhIT///9UVFSjo6NRUVE2NjY1NTWDg4OlpaXLy8vMzMzOzs77+/v8/Pz9/f3+/v5ra2umpqY0NDQ2NjWu9pFcAAAAAXRSTlMAQObYZgAAAJNJREFUeNrtz8kKwzAMRdE8SY6deR7a///QSnQdOfvkgg2Cg7GKtyfXAjdhXeKeG4ZIGWNHmLn2ZSekMEz7XNZZ2Mq0pzSXPWXgV7aq31J1QGcPdmE9aTFo4yU8ILR8mjVVjAIKLyUD4/+PjMhw1+5G3RoQRHW+bBh6Ow+a6QkI5sScKyMFAL4zCaUamctRq3h7bj+gjwWDMB8I/wAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "742",
+    "id": 742,
+    "sortid": 201.21,
     "identifier": "unown-v",
     "name": "Unown (V)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAATlBMVEX///8xMTEyMjI1NTVRUVFSUlJUVFRqamqCgoKDg4OEhISjo6P///9ra2s2Njampqb7+/v8/PxTU1POzs79/f00NDQ2NjXLy8v+/v7MzMwKAJDHAAAAAXRSTlMAQObYZgAAAIVJREFUeNrt0jkOxDAIBVA+8W5nss16/4sOVnpDHeUX0Dy8SNCdq2WCxOKSlMLoE2M3A3BZaC08gI/EvSL6WjxU2LuHOFWebQxd5vNAMkh0p+bt4mxxUypevsw6jL/vsVe2uNa6VOEW8rMFC1x4bSHrd68vt5ngR9647CAySHHW1aU7F8wfXe0EusNji/cAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "743",
+    "id": 743,
+    "sortid": 201.22,
     "identifier": "unown-w",
     "name": "Unown (W)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAS1BMVEX///8xMTE1NTX///9RUVFUVFSCgoKDg4OEhISjo6MyMjJqampTU1M2NjZSUlL7+/v8/Pz9/f02NjU0NDSmpqbMzMzOzs7+/v5ra2vJI/CbAAAAAXRSTlMAQObYZgAAAH9JREFUeAHtzzcSwzAMRFGBmVCWg3X/k3pRucNsbenXb7Dk8IfdBeHc3JtysJxCjRqkRhkI8oOzcND9Uyg6HKk2hTzgHXhKactix4IDIUcZX5/31CdJFdCRcDGa9B3gluseM07C+fCpa8xVXWZyfaSNgn23N2KXkJSDFIG7u3Bf0CAFiAUVJNwAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "744",
+    "id": 744,
+    "sortid": 201.23,
     "identifier": "unown-x",
     "name": "Unown (X)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAATlBMVEX///8xMTEyMjJRUVE1NTVSUlJTU1NUVFRqampra2uCgoKEhISjo6P7+/v///+Dg4M2Njb+/v7Ly8vOzs6mpqb8/Pw0NDT9/f3MzMykpKRJIJfzAAAAAXRSTlMAQObYZgAAAHxJREFUeNrt0scRBCEMRFFaGrwbszb/RFezASAC4FcBl0ehA2a1Utow5/aSyeyAkW0MWWTKmSDn+GkGW1uoZAttyPO4nOoEnkdrlxOnwer7u/kwAR9Um++kwxc/J+DGn/+MAYoLnertvg5jmCwQYkRSJe4FuREx/TtWK6UfpPYEPlcqVBcAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "745",
+    "id": 745,
+    "sortid": 201.24,
     "identifier": "unown-y",
     "name": "Unown (Y)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAS1BMVEX///8xMTE1NTVRUVGEhIRSUlJqamoyMjKjo6P///+CgoJTU1ODg4NUVFSmpqb7+/v8/Pz9/f3Ozs7MzMxra2s0NDQ2Njb+/v7Ly8ukAGKCAAAAAXRSTlMAQObYZgAAAHpJREFUeNrtzkcOwzAMRFEWddmRW8r9TxpCB7BmZyTw33DzQJLufqMXY06SiyRsWvgcqsniKLLN89PBW6km53nwpO7vDXQ5b3Xk7PQyT2ueAwAfsXU4ku2pCwLl0380B8juAKmeCYLlKigcICjl8JOL0EbWLjFLd//XF50jBFwG9PlBAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "746",
+    "id": 746,
+    "sortid": 201.25,
     "identifier": "unown-z",
     "name": "Unown (Z)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAclBMVEX///8xMTE2NjY1NTUyMjJRUVFTU1NUVFRpaWmBgYGCgoKkpKT7+/v8/Pz9/f3///9qamqEhIQzMzPPz883Nzdra2s5OTn+/v5VVVWioqKjo6M5ODjJycnKysrMzMzNzc00NDQ4ODhWVlaDg4NSUlKFhYXrDBWvAAAAAXRSTlMAQObYZgAAAIlJREFUeAHt0McNwzAMhWGR6l0ulp3e918xI5DXBP7PHx4Iir2fSQKwXA+HKHmL6JhSSKaUanRHRTt8+8EaoPfC52n8QC/iclunzd/JwXZNpU7mpUiYN5+rDUBBl+OYqm0U7DrNNhfrkDzyvNYSDf3xk76k+EBB10GDYNV1U3ypuHKZeRJR/Ft7X9/HBdE/c6xXAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "747",
+    "id": 747,
+    "sortid": 201.26,
     "identifier": "unown-exclamation",
     "name": "Unown (!)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAZlBMVEX///81NTWjo6MxMTE2NjY5OTkyMjJUVFSioqJTU1OkpKSlpaXMzMz8/Pxra2uBgYFubm43NzdSUlKCgoKDg4OEhIT9/f2hoaFsbGw0NDRRUVFpaWlqamr6+vr7+/s2NjWFhYX+/v4SbBqSAAAAAXRSTlMAQObYZgAAAHBJREFUeNrtzUcOgDAMRFEnTiWE3jv3vyRcANlbpPz10wykfpRAppO94cGWDQtM8NOZskBkuKWzNutpqbosBOtmcnCTL5ReIgmn1oWrIaFeozdV1Tgkv/daxMGWNQX1GO8h9wqAlkfuT2CkhVCQ+k0PFisFBDQmxiYAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "748",
+    "id": 748,
+    "sortid": 201.27,
     "identifier": "unown-question",
     "name": "Unown (?)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAAAAACpleexAAAAAnRSTlMA/1uRIrUAAACoSURBVDjL7dTREcIgDAbgrhRq2mMMoUsInjvY4iBtYJtOpNTad/GSB33wrjx/l/CHI9UqPNUOfwQRQASRUlIggX0IMShZa1eQxTDoogxuF30r+QH2Hr4KC66YuiYvghS9AcHAlTMgeBk8DqajwFdshpiSpQMH0dEGyZJi4Xmd4s2wUJ+yVf5ippoNc28xL9215aAe83OZbcPPUY+P2aLkz+gGcV8pfwRfrcnsC9Z94E4AAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "225"
+    "gender_rate": -1,
+    "rarity": 225
   },
   {
-    "id": "749",
+    "id": 749,
+    "sortid": 351.01,
     "identifier": "castform-sunny",
     "name": "Castform (Sunny)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAM1BMVEX///+tSjn////3lCn35zkxMTFSUlKGhnY1NjX8/Py7u7v+/v7WY0L+/v01NTW9vb2Dg3Lk2CNiAAAAAXRSTlMAQObYZgAAAJhJREFUeNrt0MkOxDAIA9DBQNbO8v9fO0a9Q6+VaiU5PRmU15Mbxf2aclW/4FQUlFWrg5CRotWdhuhszfvkOCRsBlmndJFovQTZmleKhdKoRCqlkZmZVluK2WFofCVcOtusuZmoFB95jpZzcEq5JY/QFRAtaKvdBnrv6J8Cvr9AYMyRwvFbG5t3VrPHWHPxDhZWlIbnyU3yBxYlBPmBHhW+AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "750",
+    "id": 750,
+    "sortid": 351.02,
     "identifier": "castform-rainy",
     "name": "Castform (Rainy)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAOVBMVEX///8xMTFKa7VSUlJjjN57pf+9vb291v+Dg3KFhXVrrZw1NjW9vby7u7uUvf+EhHOczr28vLz////HRowGAAAAAXRSTlMAQObYZgAAAJZJREFUeNrtzjsOAzEIBNAABvxb7yb3P2zGSpHOuEykHXmonjCPOz8RItpjtVbaYNe15equY+YNSMyqCkqR0zEUiSTpB0JSsHAmXkmuX7mEgq/dfYTQXf0lmJoA19IFI3CAKalPF0BISUkSCreGJsIsclLkulkpxUog6XmaTWy5LWGT3K2jR3Rja/nIaMPCiMLg3fmXvAEIvwTtzGJxWQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "751",
+    "id": 751,
+    "sortid": 351.03,
     "identifier": "castform-snowy",
     "name": "Castform (Snowy)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAALVBMVEX///8xMTE1NjVCe0pKm3JKnHNSUlJSVFNaSq1rva17Y86Me/+U59alrf////8IsCFDAAAAAXRSTlMAQObYZgAAAKZJREFUeAHt0DFuxTAMg2FTsfRMx+r9j1siaMYqXoou+YdMXwjB7e1vArDH1iI23GIoABvOqRx4guShZFFBkppU8l5LFYpcROWG865YhHOOH+qjHswpejUlCxhznpl5Tv3AQo7MmV+hr2B5pGQGBOUcv7sYmsqNwbiujMttvLfYcK8knHc1lHQecciFXJVZfPzTe5i1h6x7t2em4GhbWbe2l9zb//cNP+sHET2K/ToAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "752",
+    "id": 752,
+    "sortid": 386.01,
     "identifier": "deoxys-attack",
     "name": "Deoxys (Attack)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAArlBMVEX///8xMTE0MjE2NjZSUlJUUlFjrZTWWkr2g1nTWUn3hFpjq5Rzc3OaSTicSjkzMTHTWUrTWkpKhGvzgllUUlJiq5I1NTVJgmqDzLMxMjIyMTFMhGpRUVExMjHVWUlTUVF0cnL1g1l6SsSCy7L7+/uFzLNycnIyMzOdSjlUVFR1c3J5ScPUWkrUW0tSU1N6S8V7Ssb0g1n0g1r0hFp7TMX1g1v1hVt9TMYyMjJKg2rOOeZBAAAAAXRSTlMAQObYZgAAASlJREFUeNrtktdywyAURLMIgXp33LvTe0/+/8dyQfLwECM8efaOhgfNYVn2cnbSP+QBx2DnqGXu9KKvjmQ2cXFhDuJk7uSk/zItJTm6QH/0Hlel09JLlwSKqszWDEAfufuKBYFBpMR6wMFTLMa7m4EQbwy29qDWu/iR84JCwjaLYVXNAcw2sXjwAeuRojWiehrOL7+tHLmli2yCdH2bJMlrxEA6BI71UChjuNo8f0TXiyBqOHCY01FnxSpJ7qXPi0D69N8GhtmSk37UzWpDGhCK8wAatr4Sh3pGTQeaCimbArc0FGow9IuAqbxBRxppULdZ5ipAQOPTlqOrv43vH6QCLj6toNmggGmZa453oJUezrUhw7YHNAGYLq6fbEN4raFbbtAUfNIx+gXcMhP0qS8SiAAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "753",
+    "id": 753,
+    "sortid": 386.02,
     "identifier": "deoxys-defense",
     "name": "Deoxys (Defence)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAk1BMVEX////WWkoxMTFjrZQ0MjH3hFpUUlE2NjacSjlSUlJUUlJiq5Jjq5QxMjJlrJN7TMWEzrWFzLOaSjlSU1PTWUnTWUrUW0s1NTX0g1n0hFr1g1n2g1kzMTGDy7XzglmDzLNjq5KaSThRUVFTUVH1hVvUWkx6SsTVWUmUY+eVYuR6S8UyMzNJgmpUVFQyMTHTWkr7+/sBv2C3AAAAAXRSTlMAQObYZgAAAQZJREFUeNrt0kdywzAMBdAAFKnee3NL77n/6QLQ2dGws8lk47+QqJk3n5LAm2v+Kj7i79hGaw8vu42mACwX68p8vQMgiWfrom2Rr0UHEExZKrtmjrb5qpTqgkmXxavogGGi0q/3aioLNXonXd8AzDp6SOowrCadqVF7UmFwO0TxS2J3tvEEt6vbOYp/HPWTFGCKDZgwHIgZjDsrXUjO+uene+A/7rP0ThfyYv9ILPjgZTxSpQD9QxtQyJ2FdDMtUAweJ+XC3kL6AGBpBgt6B/KW1a5GfPvk44AEUGjk44r8AgR56GXBT5qgOO/FVmWqpqsMufjowbjQDcPFgWKxv3edzK/5p3wD+e8SAcJ6Lr0AAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "754",
+    "id": 754,
+    "sortid": 386.03,
     "identifier": "deoxys-speed",
     "name": "Deoxys (Speed)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAt1BMVEX///8xMTFSUlLWWkozMTFUUlHTWUljrZRKhGtRUVEyMjIxMjJirJNjq5RycnJzc3N1c3I0MjHTWkrVWUk1NTXzgln0g1n1g1n2g1n3hFpSU1M2NjbUWkpJgmpxcXGcSjmdSjlMg2r1g1z1hVvTWUpKg2qVYuSaSTiaSjmbSjmbSzpjrJMyMTGdTDxlrJNUUlJiq5IxMjFMhGp5ScN6S8V7TMX0hFqCy7KDzLOFzLOSYuSUY+f7+/sKuTj2AAAAAXRSTlMAQObYZgAAAQ1JREFUeNrtktduhDAQRZkZUw2m9+0lvff2/98Vm1XeYluK8rhXMPKI44PF4Bzzp4wApseVvEDdMI+5SeMxqPscPFqbudPSbXqiZbmOg3uj0G0eClq2q5KY6YCe+/acBIUCmWMF/eCsXV1ZPsndU+L7F+3NS24H+de1HXSqx2RAbHqbEMAjFWbh5rE/4I5cFBGA6YA+h1Agfmyy87LLQe/jsi5mJ5+bTBprYjohn0YjZl0WqV7O3ASSK9IUAUCuu1zLhftCgrjremIaslJgFeK+YOC9byUn2zrXGlG983V7i6DAX5XjVEJQewaRRlOrH9EIqiwu+aEjsP0cP6CRVMrosACr0tGA2oBzzP/mG5smFbrLkK15AAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "755",
+    "id": 755,
+    "sortid": 412.01,
     "identifier": "burmy-sandy",
     "name": "Burmy (Sandy Cloak)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAWlBMVEX///9SUlKEhHPOvVKDg3L07IMzMzHMu1IyMjJUVFI0MzI1NTWCgnE2NjZRUVHLulExMTFTU1Lz7IL27oP374RUU1FTU1GFhXKNhEqNhUq6o0EyMjH8zDn9zDkCfQYdAAAAAXRSTlMAQObYZgAAALJJREFUeNrtkzkOwzAMBENSl2XHlq/c+f83swJSU2yCNF5A3WCEBcnTkd/lXIzckExcP3CyCUcqNhBGG0fkkqXx6JhKm1s2mSmuucVN61YjIBu+juCrrEr2S+eYiTycQRV2rx3ke/e6EqBLKJ0eFw+lWiUPDOMVn2d9eD7DyLXP/alPxX97N9qMABHA8aYaJxFZwTmKQd/FqQ4Qr8FBOTsGKaG9tUawrlmUUGw3WE5H/p4Ph/IJL/hv8E8AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "756",
+    "id": 756,
+    "sortid": 412.02,
     "identifier": "burmy-trash",
     "name": "Burmy (Trash Cloak)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAbFBMVEX///9SUlIyMjI2NjZRUVExMTGDg3KEhHO2U1rWc3v8mpL9mpP/nJRUU1OCgnE1NTUzMTGzUlkzMjK7u7vTcnrVcno0MjL7mpJTU1NUUlL+m5NUU1G6o0G6urpTU1H8zDnTcXn9zDm1UlqFhXKs8lAPAAAAAXRSTlMAQObYZgAAALlJREFUeAHt0rkSgzAMBFCEbxtz3+TO//9jBJPaUpNJwxZUb1azjLMf5oxQTFfmLFeVhgeFBMWD2MhzAJohhZLaMG6LqXAL9OtIu29GykXAPlJWU9TGAHgCiineN5TPjZAIdY6j88vNE9DWpcHGN3jitA0jNhp0ha3Tq22IOMaGwrUpKPdfg9gG96pTrps9wr0vVViha4YV0dIMycPXWcneoetmlX44KhMPx5CYQ7ZKdiQ8eo/PP3PmA9GVCqnJ9oOZAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "120"
+    "gender_rate": 4,
+    "rarity": 120
   },
   {
-    "id": "757",
+    "id": 757,
+    "sortid": 413.01,
     "identifier": "wormadam-sandy",
     "name": "Wormadam (Sandy Cloak)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///8xMTFSUlJxcXFycnLOvXP/75RUVFOtjEIyMjJTU1JTUlE2NjZzc3OLajGMazGri0JRUVHLunFSUlH+7pMyMTG9U0pUUlLMu3IyMjHNu3KrikHnXFP+7JIzMzKKajG6UUm6uro1NTXmWVHmW1LnWlK9Ukr87JL8/Px0dHSsi0F1dXUE5rQGAAAAAXRSTlMAQObYZgAAAOtJREFUeAHt0klvgzAQBWBmvGDA7JCELE2b7u3//399EB+dKZeql7yDkdCn59HIyd/lHk8rmcrWuEury1XQK+ZfBFGQcqM/1/V4dUyy65kI31FlaBdgzxXoeSQ1n9KIV6rLkqu6p0TqrHowhLlxk7BBaj++FwhXEOEHRRu7XGcqFBbVl5sO4DH3stVLIw6eOxvn3BSDm+ftMmL29DnLWxBysKkOje82JTrARaEZUtyomeGsebi5dk9d3hQw9vh6sgZSWHoLt0CT7wSYXDpjhuPJpjuxEPGPb/vNHirsWoRgQYmyi14qPPR7/jc/IdsQCehtQL8AAAAASUVORK5CYII=",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "758",
+    "id": 758,
+    "sortid": 413.02,
     "identifier": "wormadam-trash",
     "name": "Wormadam (Trash Cloak)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAaVBMVEX///9SUlIxMTE2NjYyMjJTUVJUU1ODg3LOc3v/nJQzMTKCgnFRUVGEhHOzSnq1SnvLcXkzMjLTaprWa5w1NTVTUlLMcnqEhHSFhXWySXlUVFTVaptUUlP+m5P8mpL8/Pz9/fz7mpK6urrA7DjoAAAAAXRSTlMAQObYZgAAAMxJREFUeNrt0ckOgzAMBNDaARK2shW60u3/P7LjiN7A5FKpB0ZRTi/jKNlt+VkMB7I8CnGHwpZB0OREIU7kSqPhryNW3bnKmFlkJKdYkwgwoGm7THcx2RKjxakwBkOIWH3Affy4eEloVO74SmyUe2chQXnBpYl9nuBkEyl2DtYjpBRG72NJXlbXTJNopHuatHDVPHSub7ubJYJL04TaWQfJdb+P0eUXTi3/jimka2JDo71l7UZhEs1NF6XBNRi7ClHm1bqUoQESQ7f8QT5PSAycOBCQtQAAAABJRU5ErkJggg==",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "759",
+    "id": 759,
+    "sortid": 421.01,
     "identifier": "cherrim-sunshine",
     "name": "Cherrim (Sunny)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///9SUlLOc4zvlKUxMTE1NzVVVFRVVVLMcosyMjLUxWvnUmPtk6Q0MzP35zH3vc7WxmtUU1M1NjX35zJVVVX1vM33vM3nVGStUlLlUmMzMjLwlaY0NDLPdI00MjKsUlJVUlP35TKuU1O0pFr35zT//f3////Rt217AAAAAXRSTlMAQObYZgAAANxJREFUeNrt0sluxCAURFEX7zFjwHaPmTrz/39iwHsguyhS3/VR2QKme38d8+8MJx7amXaIanuxIDvZx5TSaQApHF6QSkZ2oSR8+QqP++A8c3NyuV5BdIR9KozINqGBLhCHV2efiUg1N1lFrYFvDx2o1oSnWNLeI4IohPZPnov7jEDcEIKUTTe7txjr6ubQZpMUAt5v5y3mjLl/NcvN59rHIvih7YwRgHMuKwgh3tujUhpFSgFUoTHc+Xg9PhApIwSvawcy7YW1wGn0hC4Xqm93AIvIcUfjCrv3j/oBpgEJdiL4ImwAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "760",
+    "id": 760,
+    "sortid": 422.01,
     "identifier": "shellos-east",
     "name": "Shellos (East)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAqFBMVEX///8xMTFjxv9SnNa9pkHz8yn39yljlFp7tXO9pUJiklk2NzdlxvtRUVG7pEIzMjHOzsYzMzNixf5kxfxSU1TMzcY0NDT09iwxMjF6tHKb3f+7pURSU1JTnNN6s3L9/v+6o0FSmtP///80NDBixPxTU1MxMjNlxv8xMzS7o0JSUlJ5snFklFn7+/v8/v9UndNiw/tTU1HLy8NRmtP19SpUVFH29Sn09Cm+rtUKAAAAAXRSTlMAQObYZgAAANNJREFUeAHt0sduhEAMBuDY0wd2Kct2SgKk9/7+bxZPohzjzBWJX+L2yYx/+WTOdJJAnIKXIsa9rvO8iHFCrM8B4OcBPKxuxkO3gfsN5yDAEfHQ9XnBzSsRvyE+9OzAJ/zNFXBOpWHWJQ0FfuUF/XQ7EBcXbO+Jer92LlOpIJiA0sPfUmstn8+oIVBydcyYek7dh2xo8eozDc/gmlz45QrxSN9WZtxG3iybMqKiW2vt26MosQK+odYGqaW727HQ163ZB2t2/94t+L2pAaKOnNhkMucL/1ENyvSIyJ0AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "761",
+    "id": 761,
+    "sortid": 423.01,
     "identifier": "gastrodon-east",
     "name": "Gastrodon (East)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA/FBMVEX///8xMTEyMzI5lMZCxv9RkllSlFpBcUFCc0JCxPwxMjFDc0JRUVFRUlFRU1M4ksNSUlJSU1JSklk5ksRTU1G9pUL39ym7pEJRk1lRlFw2NzRFdUFSk1o3NjVUlVlUlVy6pES7o0IxMjO8pEO9pEIyMjG9pkHx8ir09Cn09Sn09iz29SkzMjE4ODVVVVBQkVhSk1kyMjI3NzU3ODVTVFJTVVBTlFlEc0JEdEJEdUFVVVRWVlS5okG5o0O6o0E4NjAzMzAzMzG7pUQ5OTS8pUFRUlI5OTU0NTFRklrz8io1NTEwMDBBw/v19ClBxf739io3NjH7+/v8/Pz8/fziBSNzAAAAAXRSTlMAQObYZgAAARhJREFUeAHt0VWOwzAQBuAYPGGGtFtmaJeZmXn3/nfZ8QHs7Vtf+ktRHOnT6B/HWGWZWSMLKUpNZwG3Y5qH/vaAyvMupa8q1zAtv3PqJeKRDKiAzXU19DvZz8lTbbRRBwDHUENHxFHijvcFgGYgdvxuoShnNf1AhERIYVa2tAMRXrgVgN9WnNS1DuUb51VHQBwR+fnwooSezfm0OLYsB9nV8+eluiXOvHElbIzuev33L81CIWtjVVnAP+/155qiYXvWBIhtXt27P7vVbjRtlgcAMBkeXWucZyOESVHIpcq59oqkBFR5nhH1wPSDs2BcFMM8i6I0IMpVgpQxFkSYlOG5q74fgjeE6ZIQH6L/ldLIl/Fv0Cw7q/wB4+EcmE5ebZUAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "762",
+    "id": 762,
+    "sortid": 479.01,
     "identifier": "rotom-heat",
     "name": "Rotom (Heat)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAclBMVEX/////WkpSUlL3jEL7WUk0MTHTYkIxMTH/c1rWY0LWZUTzikHTYkH3jUQ0MjH+/PwzMTH/cllUUlH/i3L/jHNqalnVZENra1q2S0L1ikL2jEO6urr2i0L8/Pz0i0L+/fy9vLv////7+/tRUVG9u7tsallxWkrZAAAAAXRSTlMAQObYZgAAAOVJREFUeNrt0ckSgjAQBFA7C4uAsgm47///i86QSFGYWNy82BeqklfpSVj886sA81xVR5jn6noORFENDvgKo8oCaDWSmEKWZlEnKzWayCFhvgyBAU4lAMPCRMpVaCgcV+w3mHVbKbstUVooosjRzS6RQ7gfJNlNu/VteXi7OM6VnfxT6n1D8HzNiFnoflOdrjN5adYZuzJU/UBOeD/RgcvHjpgIcgUv3AghjtRMjKvBcZ+4aVvBCWy1B0IT5IigFP1DervTp4Ei4Ev7Ax2mMdnewcvsvyYb56b4O2WrMHEeS+yfX+cF2MULCzy8c9oAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "30"
+    "gender_rate": -1,
+    "rarity": 30
   },
   {
-    "id": "763",
+    "id": 763,
+    "sortid": 479.02,
     "identifier": "rotom-wash",
     "name": "Rotom (Wash)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAflBMVEX///9ClN73jELWY0IxMTExMjNSUlL0i0JUUlFBktszMTFRUVFzc3OySUE0MjHzikH3jUT+/fxDlN30jET2i0L7+/tEld7TYkJTUVG1SkLTYkH2jENycnJCktujxPy6urq9vLtRU1RitPZxcXHVYkK7vL38/Pz8/f5DlN7////JvDluAAAAAXRSTlMAQObYZgAAANlJREFUeNrt0EcSwjAMBVAkyyW9QULv9f4XRAEPbKKQHSz4M/bqjWT/0T/fDsBAp4NhUmdpMGwgw4/bATRliCl9oC1zFtHZlvZuVWP0SSUJvHaSM1R8+FJhIJaiN2WFnolQz8NAT+oKsbjl2AcThlmR47a8PKBrfy5NPMQWi/q0QOVMEzKELqjCyFhnzryZmVICBD2fHZ3hLOPYPt/IrFMSRWZ93RmL+IbQXWS0Ag9bx9mDUGYyNc341Q4rURJRxnDmXyhLjqZkSuxk+B77cE/pnTh25OE/v587WH0KFSCaKOEAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "30"
+    "gender_rate": -1,
+    "rarity": 30
   },
   {
-    "id": "764",
+    "id": 764,
+    "sortid": 479.03,
     "identifier": "rotom-frost",
     "name": "Rotom (Frost)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///+Me//3jEKKefsxMTHWY0L0i0IyMjRUUlF1c3L3jUSljP+1SkK8m/+9nP8zMTHzikE0MjGki/9xcXGMfP3VYkJRUVGNff9SUlJzc3PTYkL8/Pz+/fz///+2S0L2i0LUY0L2jEO6urq9vLv7+/t0cnL9/P+8u771i0Q34Cz1AAAAAXRSTlMAQObYZgAAAOpJREFUeNrtz7duA0EMBFCTmy4n5Sxb8f+/0CRtAgZuF1JhQI2muOYeZrgf77w+AP8MIRh4pg1C15v0f2XB2rnvTWp9qOGHkco8Ym8TtG5KYNYhojsgZp5pDJYEw3xNiKR8MX7owIXnQhFl35rUa8LX9E59YvfVLAGlcUFwuyucq2bOKYQxnGwKPE2vdEC2Vgg1jKe7fOW3i9unQmZNo1DDEDHf7AoUWLUGhjIKgWR+vKy8QHLAkty4cuJzT63LpSwDS4hBORLxz4nKYtu/y5k1KSbSMqXplhzDpGRKbcQIqUtSYY8jk++8PN9UZAvQNPoqkAAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "30"
+    "gender_rate": -1,
+    "rarity": 30
   },
   {
-    "id": "765",
+    "id": 765,
+    "sortid": 479.04,
     "identifier": "rotom-fan",
     "name": "Rotom (Fan)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAh1BMVEX////33mM0MzHWY0L3jEJSUlLz22L3nRkxMTH2i0I0MjH3nBhza1L33GHzikH7+/syMTHWY0FyalL23GLTYkL///9UUlH3nRszMTHWZURUVFJxalH0i0L022L2nBrTYkG6urq9u7t1a1HUY0L3jUL3jUS9vLpRUVF0alH+/Pz+/fv+/fzVZEM0eoJmAAAAAXRSTlMAQObYZgAAANBJREFUeNrt08cOgzAMBuA4i71XGS3d+/2fr0ZNuWF6qyrxHwKHT8a2CFvyowB8XjCUw7yf3LY1QcEKwGIMWShdpJT08EQnytT3Y01/HHir1o1KEZJ9ovOVykWpOlczKliwk1KI7OiSJdlYMV9pckvAL2sYe6QoD0XWpP5nmGkJKJ19bPboeQEh7X7ozyzMCqZdKKUZGSysOOV6R0ojqWl4VCXOoziJlWZk+HaT7Db3ehYCj+pbdX7S0AwTFUNBYLOyPVxj4+gMf/jXt2fJH+UFQ1kJpMpuZU0AAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "30"
+    "gender_rate": -1,
+    "rarity": 30
   },
   {
-    "id": "766",
+    "id": 766,
+    "sortid": 479.05,
     "identifier": "rotom-mow",
     "name": "Rotom (Mow)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAjVBMVEX////3jEIyMzFRUVFSUlJUUlFiYmKE3jHTYkLWY0L2i0IxMTH0i0I0MjHTYkGC2zH3jUT+/fxtxjS2S0KU71q9vLu+vr5jY2P9/f1sxTOD2zFTUVFkYmLVYkKzSkLWZUTzikG1SkL0jEH1ikIzMzP2jEO6urq7vbr7+/v8/Pz8/vtUVFT+/PwzMTH///8u3TVvAAAAAXRSTlMAQObYZgAAAPBJREFUeNrt0skOgjAQBmCnC1LKqoD7vq/v/3j+ox48lMrFm38IIeHLTGbazj8/SveZFk5YJOt+d2lERtusRT2WtwzdvW5ptAq1UtzdY+GAYtiIErZN44pUKyC81HxDlKBmw7gMY+pPINkmmautDAZWssPUL4eZXAUDBWUiQjS7mXFCgWKnnN7RXhhXo/WHDM3K3VrGRQ+wuOdwwQASa3cOE0ZFTtXonFN/Csew4fRSjFL0DjujA95688LFcWE41wtvHc5zJfbDelhvrQy5oO/S8vHIsbDS795hj8Ye9vntcI6//pRlO1q+aCvHzz8/zQMSqQ8BaHD4TQAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "30"
+    "gender_rate": -1,
+    "rarity": 30
   },
   {
-    "id": "767",
+    "id": 767,
+    "sortid": 487.01,
     "identifier": "giratina-origin",
     "name": "Giratina (Origin Forme)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAeFBMVEX///9SUlIxMTH/3jG9pUL82zGEhIRUVFFRUVEzMjGchDm7o0JTU1G9vb3eWkozMTFTUlGDg4PbWUq9UkL72zE0MzG7u7u+pUEyMjIyMjG6UUE0NTbbWUm6o0FUVVaCgoJUUlGEhIJTU1O8pEOagjj93DH93TGagzlP/sHSAAAAAXRSTlMAQObYZgAAASdJREFUeNrtk8lygzAQROkZSZgdvGI7ibPn//8wDVJ8sCBFDrn5HWag6tGDCia58xfOMrBQk1OzyCM/d7+K18vVupnXrmErADLjbVNx/aieqRGZ8Q7lvnKwOy/6J2L3SbYG+1dY3dErShrUHppYtAqbqmoqsmVJxlyJBz+WVvXwSdGwZ96Dnx6JBGDJj+HcwlY3tyJo7uqhmiwcJ6Ett6NNaVOsN63V3GQ+TgRDi00Qqwd2Qg9T3ntb5B9KUhQgnev9x4nE4yqEFQZfbYcQG4kyvv9m0xaaI8eMR0QuDsTSM4CfPpVozIvDun6moKgqNufcm8mmEgEfmVZElWYfJ/pfoGYi8Ylk0gt/4Z6On2vM/CaceOrhEI5ldhfDBnSOLNjYsIR3/o1vxyoO5mgOZpQAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "768",
+    "id": 768,
+    "sortid": 492.01,
     "identifier": "shaymin-sky",
     "name": "Shaymin (Sky Forme)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTFSUlKczkq9vb3///9ae0K1SlJ7nEo0NTZRUVFcfUS6uroxMjHnWlL7+/uVlZXmWVL8/PyzSlK7u7t5mklSUlFTU1N1dXWay0lycnK8vLxSU1G+vr59nUxZeUEzMTEyMjGySVEyMjJTUVL9/f1TU1FtvBvjAAAAAXRSTlMAQObYZgAAAMdJREFUeNrtk7cSwyAQRL0XAAfJsoJzTv//iT4xbgXq3PhVFG+W2eOY/PkdwFhRRplTkPQmkBMXYgDsviaAAXPWChEFxiQGi2Lw8gUxO2YwoKKE4evdmjmYTOZpInLHESI1BInEzlmck2gl21tmoL5TtJLiG8uKQtZbzut5XYmJMBIzf6lqdRBX4L4qr6lENU5Czaos02UQPe/9E7kVmu371o2PYn45NvkBXdat6vbRuSInFtDz0R7plhERxx4PWcAY/83+/JgPCmsHa48RhkkAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "769",
+    "id": 769,
+    "sortid": 550.01,
     "identifier": "basculin-blue",
     "name": "Basculin (Blue-striped)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABJlBMVEX///83NzVra2trvWP7+/tSm0JTU1M4ODQ9PDg0NDRUVFRak/xalP9qampqa2wxMTH5+flRmUL8/Pz9/f01NTU9PDlVVVX///9akvlKdEJLc0NpumFRUVFqa2pqvGVSUlJrbG5ru2NrvGJSVVI5OTf5+/xSm0T7+/xSnEX8/f86OTcxMTJVVlRpams3NzcxMjFqbG9qumFXV1VYkvhZkflpaWlZk/tZlPlKc0I3NjVak/1alPoxMzFLdENLdUNpuWJMdURpu2Fpu2JqaWpNdkVQmUExMzJRUlFRU1FqumJqu2FqvGQ4NzVqvWNRm0E4NzZru2JSUlNSU1FrvGMyMjJsbGy5ubn4+vlSmUI4ODb6+vk5ODczMzNSnUMxMjMxMjT+/v41NjU0YxxKAAAAAXRSTlMAQObYZgAAAORJREFUeAHt0FVuxDAUheFrsMMODHcYysydMjMzw/430Vjqa24XkPxR3j75yIasNPcWfwC9fx3hU5EFvfi/Ql3/Pcjl8ve8ZPmT4yjkRSllM/i2Fp0vFNY8SmlTPtpq7RNxL5pR1WrdUKexjtxEO0XLrjtTXzg7TFK+r3eVszTSuV4eMkIjARYCW7vV0e3qRV1Mg5k4bNY876HsDu5fVieKeUCaO957/ZlvsIodlfgY8jRH7e7z7sbOXeVpOEIc9E8Y6w6cbs6uhAbBls2tdoexj4Pbc81QSUIhBH7aXwVCCGSlu1/Szxfysg3xNwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "25"
+    "gender_rate": 4,
+    "rarity": 25
   },
   {
-    "id": "770",
+    "id": 770,
+    "sortid": 555.01,
     "identifier": "darmanitan-zen",
     "name": "Darmanitan (Zen Mode)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAaVBMVEX///9jpcZSUlJTVFRjpMUxMTGczv9MfZZKe5RmpcRLe5M1NjWbzf6bzf1KepMyMzP3lClLfJVUVFUyMzQzNDX///9jpMQ1NzVSU1Q1MzFkpsfvc1LwdlX1lCtNfpb3lCr4li39/v+bzPzLUdQwAAAAAXRSTlMAQObYZgAAALZJREFUeAHtzsdyg1AMRmGOirgUDNhxen//hwzgZUZ4n/ho+80/qm79vU5bV9nTia1rdPyApqFZ6a57f4Vpat7mXXk3lvM54uVzqlnzxHnfxtcCY9Fglk56Lb3BMKzaHo+GJzCkVUPUIkLqOGbw4b4oqqCA9BH5k8IlAakJxiqT8Lwcl8WBOZ2sLYiNaotCCkN6VmqGChwy2H1LYaWiM4vrqqzO3cuhSADFvdrNlwJ+swRXt/5tPwc0Byb/DTABAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "30"
+    "gender_rate": 4,
+    "rarity": 30
   },
   {
-    "id": "771",
+    "id": 771,
+    "sortid": 585.01,
     "identifier": "deerling-summer",
     "name": "Deerling (Summer)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAsVBMVEX///8xMTEyMzJjrVqMznPOxqX398b93Sr/3imKy3E0MzD29sWLzHMxMjHMpVpxcXHz88N1dHE1NTX72yk2NjYyMjI0NDMzMzL83Sn29cRzdHOLzXJiq1n19cQ2NjWNznGNznSupoXLw6NkrVv+3SnOxqNUVFN0dHPNxaTOplwzMjFjrFqLzHJRUVH19sRSU1JlrVlUVFFyc3L82yn83Cqro4KspIP9/vxzc3P+3SrLo1mguBuOAAAAAXRSTlMAQObYZgAAAONJREFUOMvt0jcSwyAQBVAQUVlCknPOOef7H8ygyo0Wd278K5h57J8BEPrnh8m/da7z3YHcpQ5SHwcAuMeZh40Ho1zSOJ7loR2tLN2qE01kGkQTz2yg7kymlzQQ0jPjq/vzzukRtALSKAdC0KV0xwe0VSDU02sHgPdlU0unhNUu4byWMH9AQpRvN0Dzq2kgG4dmttaV6eGEszEhob5y0YckUjhekzYtIzzL64g+FXL6lNM6DDNjmD9c+DMYXruM+XxY4ITVbZJzY9TIAkfzW7dmFnEBw1i3lhBbvhq2zvq0//w6b6BZD7FqcxKIAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "772",
+    "id": 772,
+    "sortid": 585.02,
     "identifier": "deerling-autumn",
     "name": "Deerling (Autumn)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAq1BMVEX///8xMTHOxqX398b/3inOczH/nErz88N1dHEzMjHOpFnOxqM0MjE0MzD29sUyMjL72yn8m0o1NTX/3Ck2Njb7mkn29cTLcTFxcXHOdDJzc3P+m0n+nUv+3Cn+3Sl1c3L/nUk0NDOupoX19cSspINUVFEzMzL39cTLo1mro4LLw6P8mkrMczL82yn83CrNxaRRUVHOdDB0c3H+3Sp0dHPOplxSUlJUU1H//fzUjd6MAAAAAXRSTlMAQObYZgAAAOBJREFUeAHt0bduBCEUhWFugMl52ZzXOWf7/Z/MMHbjYi7uttm/OkifhBDq1DEb/dfZ/HcEock9am0ehJ9QF+C9WGv16vyenxdpogJykq45btJ14Q/S3TXHD3HTcdG/bNhNXubNptEr52RojbmkpdlUPzsX4Nf72Mnc72HXRkS7CMulTtTo6da5IXg19hBnzlnj9LCEiHCmdQLW8NZJiU7v9ML0cRH4nW5rOs6YEWRYZ6+cYbl/pA8ZXh8QS9pXQAghSYQXSkEI3rydHXbKwXkATiuIeghKhuCtAP7aU8fuG2UfDuB4QUOaAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "773",
+    "id": 773,
+    "sortid": 585.03,
     "identifier": "deerling-winter",
     "name": "Deerling (Winter)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAq1BMVEX////GnIQzMjI1NTWce2MxMTHOxqX398b+3Cr/3il1dHEyMjGcfGTEm4M0MzDNpFoyMjLz88P19cT29sU2Njb72ylxcXF0c3PGnYXLw6PDmoLFm4M0NDPOxqPGnYL29cSupoX93CmaeWL+3SkzMzJUVFFUVFMzMjGbemP83Cpzc3LNxaT+3SrOplzEmoNRUVHLo1n82ymdfGJ0dHNzc3NTU1Kro4L+/f2spIMW/9dDAAAAAXRSTlMAQObYZgAAAOFJREFUeAHt0bd2g0AQhWFm84IIiCBplS055+z3fzIzuHHDjDo1/NUW37kLZ6Oxc1af6oL4O0gWgsBVGQQLP3WTafRkMqj95at/W+bXESMv8oOP0/yQMR8qGx/fxqnzWf9nxODdRzpL1b5zNAwAWzuHWYEOQBDw+xGlQDjs6tLaVWmquUqi+vlp+Ob6ZYvQTBLc6/RgUpfWTJRKdAC3ISTS9kYtoc9lzOu4DTi/fvDrIw0bNKba3VdXNPyaGlPZXaFLc+SktWjkgoGL95/pCg9tQcO2u7WHOqKhZrf+23M39gs+yw8EbQCnYwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "190"
+    "gender_rate": 4,
+    "rarity": 190
   },
   {
-    "id": "774",
+    "id": 774,
+    "sortid": 586.01,
     "identifier": "sawsbuck-summer",
     "name": "Sawsbuck (Summer)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAh1BMVEX///8xMTEzMjFSUlKMUlK6eVm8elm9e1pTUlL/55Q2NjZUVFOKUVGLUlJJmkmNU1JKmkq7ellKnErdu1oyMTExMjE1NTVRUVHevVr75JL+5pP/pjxUU1K+e1lku0K+fFrbulnbu1ncu1lUU1G7e1m7fFn7+/v85JL9pDlKnEmNVFNRU1H//fvdNL2GAAAAAXRSTlMAQObYZgAAAPFJREFUeNrt0ceug0AMBVA8BdM7qbyS8mry/9+XOyOxiyGLZMfVIBnpyB5DsOS5WRHheQAmRdMXfZA8JBtvfdA8IZLlpWrQFZdAfxzJ+fRU4PhKmk1r/ZNWaIrIDllZcyy91bryTpZRHralrpmjOckMa4wmIneZCYgY00GAWSWtA/d73Z9q5V+UjUh0pvvev3lHWcis7sMsbHfxpgxZEVl3WXH0Nk51jkb8/nfGWiRvvT7sPhhx9guDZbmN41HyHPx3s9uhHqEo0xpug52m4eeA74I9sPf07Kxz/0e5kuwsNN1Yy5DwWDXWcoROYtclr8oNSjcP+Eu2TPMAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "775",
+    "id": 775,
+    "sortid": 586.02,
     "identifier": "sawsbuck-autumn",
     "name": "Sawsbuck (Autumn)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///8xMTEzMTG9e1r/55Q1NTXGMTlTUVFTUlJUUlJUVFOKUVGMUlKlEBi6eVm7elm8elkyMTHnWlLdu1revVrkWVHkWVIzMjH+5pNSUlIzMzE2NjaLUlKjEBjmWVEyMDBUU1KNU1K9eVnbulnlWFHDMTj75JLEMTlRUVG+e1nbu1ncu1nmWlKNVFPFMjn7+/v85JL9pDn+5JK+fFr/pjxTUFH//fsOrwA8AAAAAXRSTlMAQObYZgAAAStJREFUeNrt08eSgzAMBmA3TO/FdJKQtr3v+z/aypDcIpLL3vKPhxEzH8KikHtujkFh3cJ2PeuGqxcYeZIk0v+hpKHdkCeMIm7XJ1r2kuXS30KRMKShBGkXemkFB4Y3tN+dgwnwFHYJdv5WmhXAT6eAhjrSpJdnsUOr9bQ1q+owWYZskQVWW4ENOVe5dsgwjDQB51YbeV5MGpjdHy7AJmdEQwg4fY7sER7z5D5+vx+UduiDnPt58dsMj1UhUehGaSmydcQVDbhV2KGiiNwLB6aOOH+WG25N0yMv/PhYvoDTed3A/IogcCyF+OLnqIVvbS/E1DJdzfdFO2alcEJwGcyU1gSX7tOKuhFPa0qDNFuUMTECrnRJx2twXMenevFHBFifazxIJ7TrPf+VPz0uGJ4ssjl3AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "776",
+    "id": 776,
+    "sortid": 586.03,
     "identifier": "sawsbuck-winter",
     "name": "Sawsbuck (Winter)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEX///8xMTE0NDQ1NTVSUlJTU1OKUVGMUlK9e1q+vr77+/v9/f3///82Nja6urq7elm7u7u8elkyMTG9vb1UVFJUVFT8/Pz9/PwzMjFTUlK+fVyLUlKNVFT/pjwzMzO8u7u6eVlUU1G+e1nm1XRVVVVRUVH9pDm9fFu9u7vk03L//fvl03KddcjsAAAAAXRSTlMAQObYZgAAAPVJREFUeNrtksduAzEMRJda9bLe5i3u6e3//y+UYiAnUT4kNw8gQYeHwXCo6q6/VQ14bgItA8viK1QBgCYTGCxrHKM9/Q/ofYEzYmKR20Ihpfwa9z1Y8zQWwMvsD/xjbE8ARfLAJ7/daL2USK3VvFOqr2iFi0bdxr1+Hh9XDkVO9fb4gDkZEOsJsnt33ogWL+eZ7PSSQWPXHLEonH3NT//MJ5O46Pu27rslu+yrjEtlQrbHxiVHTIAc1XoNL22aZxAg5x1FNoKjm+oh/TqCGwaxmc0pBsYU+ZDyLLDuaFWD5BMQIQGdrmTht9XoxGjk17W667/0DV2xDgA9MsZuAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "75"
+    "gender_rate": 4,
+    "rarity": 75
   },
   {
-    "id": "777",
+    "id": 777,
+    "sortid": 648.01,
     "identifier": "meloetta-pirouette",
     "name": "Meloetta (Pirouette Forme)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAQlBMVEX///8xMTFSUlJzc3PWc1L3lEr///81NjXvc5y9vb3GWmvW1ta7u7szMzOlWkpycnJVVVU0NDS8vLxUVFT8/Px1dXVgg+EcAAAAAXRSTlMAQObYZgAAAKZJREFUeAHtz0sSAiEMhGHTCQHmwfjQ+1/VRveEjeVmfrZfdYrL2U8SvimnfCxiAlWFmQVUzECXUqdDmL6LpJH8QDLaoZQGoLFEOZ5UmLtbp8F/Wk21ullLASxu7rVSBnBx91JWtaEj9N7iCsJQLmUNHWV1X2XCQaAhY9wSxYykNcHMbVGeRgQzjuOhuu+Bo5Tb/fpSRQ7ldviG2FHmZ87dxVH9u7M3SukEHN/6ptIAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "778",
+    "id": 778,
+    "sortid": 641.01,
     "identifier": "tornadus-therian",
     "name": "Tornadus (Therian)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAACNFBMVEX///8xMTE1NTWcY97///83NzeESr1TVFL7+/v8/Pz+/v45OTmZYtljnEpimklim0pjm0o3NzhknUpztVKCzFmDzVk4ODiEzlqFhYW7u7uaYtubYt2bY9ybZNs2NjedZNu5ubm6urpimUm8vLy9vb35+flRUVFTUlT9/f02Njb/1lpTVVIyMTMxMjFkmUtTVFNnn082NTZUU1aDzFpUVVVVVVW+vr6+v7+EzFz6+/n701qaYtr80luFTLv9/P0zMzP9/v2YYdiZYdlSU1P8/Ps0NDR1tlX701llnkpmnEpSUVNxslByslFytFFzs1RztFJztFNSUlJSUlSBSbmBSriBSrmBS7mCSbmCSbqCTLmCyVuCylmCy1pSU1GDSriDSruDS7qDTLmDTbmDylyDy1tSU1I2NTWDzVpSVFGES7uETLuETLyEyl6EzFtTUlOEzVqEzVuEzlkyMzFTU1NTU1SFzVyFzV2FzlmGzVyHZz+HhYSHz182NjUyMTJTVFQzMzRUUlaaY9iaY9tUU1U3Njc3NzWcY9hVVFY3NzadZNydZd6dZt2eZdqeZdy5ubhXV1dhmElhmUkzNDIzNTK+vL6+vb9imkpim0m/vrzDmlnFnFrGnFzGnVvInlr5+fgyMTT5+vr60ln60lz601n6+vhjm0n70lgyMjJjm0xjnEn7/Po6OjpjnEs2NTP8/P38/fz91Vr91VxkmU39/P5kmk79/vxknEr+/f9knEz+//9RUlFlnExpx7OPAAAAAXRSTlMAQObYZgAAAg1JREFUeAHtk1Vz20oAhbWwgpWZmdk3zJzc1E2ZmZmZmZmZmZm5f64rFxJL0XT6nu/BMz76dHRGs+IGKAECAPSuFH9///MhhP7r1/MpMRQLvV6/Jvw/DYAieh7/EtOz/YjXmlVt7RgTIGJcrJQNCKUPndRWwinMU/h8sQP8NAPVzbkwv1MtTnhfn6Cv8DHExlmV5HnWcL01rKnccbmpIcM0nh/2563AnjBSi9C02PbswlGeb2/o6JP25MK3VeICp2PzvOVj3LY79bA3vdraVlUqEmnNkDdDX2x0Oiu8tFBMmH/w7gn1k0VceT93Y8vH7YOD3bdcLMmKmIBHN2cd4AjoI8pJire+vULxoM7j5WXKnVFJkg5fa37JkSThSk0Ri6+/Vj40LVx3jhV6E546w71tHigVuBJCydoHtZamzu/5ihr3+bJT8YRET9fFKRZdqhPRXb7LbDSa8jVuhk1YFY1nKMYZWlAfiQ/70LunxpnTNrkV7ME9Y70SpV4vKRXl8XP8aOmoS+MCaEXRnOrbH4knoiTLqZBjc5c12oW9AX+wkXmOL+sjJMLqtMAzM9i2vGCYv9btWPlkUkuIk1mdllDq24jRw0fa88L01Z8mtoSg3qfUVR3bkMrGLBbzEkEAOhpDBl1Wg5WTF6UsRuPZI5w+bJBcnBAzm3brWqoJk9XHWm8CyXJ/xwXZhAH+lR9KYlzYaYcv9AAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "779",
+    "id": 779,
+    "sortid": 642.01,
     "identifier": "thundurus-therian",
     "name": "Thundurus (Therian)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABhlBMVEX///8xMTE1NTVSUlL///80NDRSUlRUVFRzped5WfP7+/v8/Pz8/f79/f05OTl5WfF1pudRUVGzs7NzpOV7WvczMzNUVFWkzf6lzv+2trbW1tYyMTQyMjNSU1RTU1T+/v5xoeFjQr03Nzc4ODijzPz5+flSUVRSUlM2NjV6WfS3t7d0peVzo+c2Njb6+vz8/P42Njj7/P16WvJVVVV8XfeysrJ6WvR0pORxouH+/fxxouJxo+Smzvymzv+xsbFypOdSUVNMjNNNjtZjQr4xMjF0pud1dXVVVFc0MzPV1dV3p+dTUlZ5WfSkyvx6WvZ6XPZSU1ZRUVNiQrl9XPe2tbhVVVeDYjmGZz/Gnl3T09NVVlaizP75+vt5XPdWV1ZyouI1NTdRVFZ7W/Z7W/d4WPJ5WPFLjNa0tLa1tbV2p+jGnFpJidF7W/RKi9VKjNZLitVRUlT5+/7601oxMjP6+/yjy/ujy/38+/0yMzRypOWkzPv91FmkzP5ypOalzv7/1lr//vx6WfNmuhUqAAAAAXRSTlMAQObYZgAAAahJREFUeAHt0kWT4zAQBWBBG2yZ4wnDMMPMDmSZmZmZmZn3n29byR6SyCnvPe+gyuGr11HL5D8zCKMZnQ1aRgdahla27gIYtE8rk4cshIMiwWkTNTysSlJYcgGh0PrBkd1clMsNiQ2qdPIGVjzysc45F6XHLv4BTQXL0eEPn4/f/V40C8U6TW6zfmRI6fIXv/5cO1E0nR1mVW6doewdfCU/Z5rXtl9uOhBUU58IodF0gsKBt7+eboGjL99RKnfVE28CtwGB+eTSt9+AlY58nFBx69u2cR13sgIAyNzSEEXHOe2ezqylm5vfw8reN+AE22qTMxXSgjTkHdLz46VDodjz46Ezl6uPr8Xz1Yqlcz4T64g7P4XF58u2cSuXOzY1NV64N5/3dS5A624k3s5Ny8SjZ2r6xr4Xr7fWeLTKo/brk46MseTwd506ab26uipgdtZ10SmkjDf85YY+ueg2ABONSojDVXJh+M79c+cTaI+RfxClgj47LRttrb3hB3K0Svobjxr2pwv7W4V+ipPjJ8To2T/6QnswI+mUEW96Wv4KOfos8VgmNshfVggwv/1de2UAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "780",
+    "id": 780,
+    "sortid": 643.01,
     "identifier": "landorus-therian",
     "name": "Landorus (Therian)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABjFBMVEX///8xMTFUVFTOexj/pSmUc1K2trbMehhSUlL8oyn8/Pz/a3NTUlH//Pz///9UU1H+pCj+anL+/PtUUVHT09PUMjnV1dXWMTk1NTX7+/v8anI2NjY5OTn9/f15WTj7anH+pCkzMzP+/v7/a3Gzs7P/pCq0tLT/piy1tbX//v42NjU0MTI0NDT/bHLGnFo3Nzc4ODhTU1PLeRhycnLOehlRUVHOfRvTMTl7WjmScVGSclKTclHW1tb4aXAzMTEyMjHNexnOeRhWVFJWVlRXU1HS0tJXVVPTMjk4NzZ1cnPUMjrV1NP9a3L/py3/py91c3F2dHLWMjh5WDkyMTH5+fn6a3N5WTn7oyn701n7+fg1MjJ9Wzj8bHR9XDz8pCr81Fn8+vk6Ojo1NTT9oin9pCozMjE0MjCVcVGxsbH+pSn+1Fj+1Vr++/mysrL+/PxTUlI0MjI3NTP/bHC2s7P/bXH/bnT/bnb/oytUUlLEmln/pSvGnFk3NjbGnVz/1lo0MzD//fv//vxVVFLMexnuNtA5AAAAAXRSTlMAQObYZgAAAcNJREFUeAHt0+WS5CAUBeC+QCSBpN3dZdx9Zt3d3d3dfV98L9mt6q2Bmp4H6POTfDkQbiU0TD8ZANiWK3OeXt+GK+U45zbAQLiUjKbvG8aRkUHOkEHIYavz92EyChqX9X2zCphAPgcorRjJ+CWdCyJ1qCD5zbllwyiPbIaJGnGR1aQd/beGcv/6Zvh0ygm7ZEZilBCsLa4Yi6A0Eqf+IXfQ/p/C3PKG+jHTkZPxhThS20Zrdqpy0UiCAi8wGqGIHRZ2fTP1Fy6lQSl8xDCIGRWNTie1WpVuQ3HZ9uWPFfa5gnbfg9Sq2dqL8NapnuYa2z++Pv42XmE0RhqJRGfKugul05r5yQu/en18x+GaT2ZO7Pp1KLrnnOxTK+djZtGXIVaEOQ9f8ea9kBYSi8Z8nA5x8JzHrzXf3P4emgCNPB+2XWIJ26nzJhUL0Tu/X2bOTOogY2ELb4fV0zuFJdz53W5xVOPKTUoFwHSE1WeFHA6mlVfdxfbbd54/iS+8/0RFluS84jOzqilc87oePkA4NjYba3yB8uuzuj+mAGs3rhyQzd1jR3/KsxXyuK9O9nr5oPlJ18u2JrRGaX6RGeiCHft7DvMHR1A+fKtR1mEAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "781",
+    "id": 781,
+    "sortid": 646.01,
     "identifier": "kyurem-black",
     "name": "Kyurem (Black)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA3lBMVEX///8xMTE0NTdSUlJqampra2uU1v/W9/90ptY0NTZzpdZTVFSEjIyT1f5RUVGrs7OttbXT8/tUVFEyMzQzNDSDi4uS0/wyMjPT9PzU9PzU9f7U9v7z8yn39yn///80NDRxo9OrsrJTU1MyMjKV1v9yo9M2NzmS0/uCiorR8/tUVFR0ptd1p9dra2xSU1T0rCv09Cr19iz2riwyMzOutrJqammstLQ0NTXV9v/V9//W9ftUU1GU1f3S8/vS8/xTU1A2ODn3rimV1//U9v/V9f01Nzj39SlpaWn8/PxzpdVlrfc+AAAAAXRSTlMAQObYZgAAAZhJREFUeNrt1NdywjAQBVDWau7Y2PTeQkISUkjvvfz/D2XX5QGsgTxnohk8aHx0tZYll/54MwB+5YCLLdBIndjqJNC0Pmcskxbo4QxKhhBM5JEQKtBCTomC8dwpNQGd+6ygNHzn/J26O5cP13cH7bgI4fG4gtBpxonbu3qR++37J01ip4uRfkMBdULTk/JVxQUFCWSskdZlDdBJGRXjwrjTfb5tKGXW0xVApk0MJydnb4oapFDv6E4K54mz0EUA2sUJT2+UaS8YB8CKB15enoV+dWqcqFOpSYcLeiK7TgR/2GWwCs2jj0rN9hx0ps2++n45WPpcCPQrkeahIOI5dJFYRNll2DisF4mDm+TY1LNbpnR6c0bTCoQF2YyBdlmNQhes6pIsBAJtwyRXVBnB8gglq47XHMfR6HZdCqJHKgf4t+j8xBF0k/dN7mKEg8aFPKqGZOIkwQDzQFdglo2OFidwAUB3CrjI9mELYYQjXdCfVCNPnHq4Da2hHQTLTUc2VCa+ZmP4LaHX3/w5mUXZ0cUSN8vs6P83aj+zGR1gCQPdEwAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "782",
+    "id": 782,
+    "sortid": 646.02,
     "identifier": "kyurem-white",
     "name": "Kyurem (White)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA9lBMVEX///8xMTFSUlJUVFRzpdb7+/v9/f3////8/Px6eoN7e4QyMjM0NTdRUVF9fYWU1v+ao6OcpaXW9/80NDRTVFRSU1RTU1PT8/txo9M0NTabpKQ1Njedpqa9vb2+vr4yMzRyo9OS0/xypNX8/P2V1v8yMjK7u7s2ODmT1f55eYLT9PxSjMb09Sv3rin39Sn39yk1NTV8fIQzMzP8/f6S0/v+/v66urq9vbpzpNQzNDS/vryT1P10ptbU9f+U1f3z8yn09Ck0NDD1rCr1rSr18yr19Sr2riuV1ftXVVN6e4VSi8R8fIIxMjN8fYVRisP+/fu7u7y8vLyVc6tSAAAAAXRSTlMAQObYZgAAAcNJREFUeAHd1OeOm0AQB3D+28GYDva59+u9pPfek/d/mQybw4oszsfnG6GVYH7MwuyC80DDb+oSNHLoLCoIii0uEbdZ/0bp4QXunDjhpzYJqW2g3nUS/vr0DTHrhsBd7sWPDyfvPp+d/bmWu/1+v1ZZuPDef3x6TcXkbj2p4POj41+6jHR7D6/E0SOl9ajAfe5ypPQgjl+ON1I7+I+hPRWXenTx6vhTKGCvVAoyXVu/uydyMxrGb0++PROiRflO8gSlk8Fcc0g4a5m5v8/nweO9MGMmRYeab9J/jo6UTCVFzqZhSCxSmh0kCyFyENSVW8P86yxnjK2KSPGDhLNJmJlUVu3aASr5c0Y1Jq12FCs+zVY0hGPrePkokvRtxcPZ4Xd0W3KgNEHDI8a0dYZ6pqyzkEy35fiSG8rwCTWBCDEWMUN8sHTW0vFpbEdFVBjOKFaKmNsrXGYG8XJzeTK35/U8j0WxN7cTu4xuVemmE1+IkDM66JHkrDxdAs4mHO97zCUXlAjwCEXL2q/VJwlABswlAJQdrIPo5lb4bdfzsG2rtW7OyVGdfeZugUC1vfz2JEeTX4ak1dFoAIGrMRpA+7IPO/4CL28lBLMMQeEAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "783",
+    "id": 783,
+    "sortid": 647.01,
     "identifier": "keldeo-resolute",
     "name": "Keldeo (Resolute Forme)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABSlBMVEX///8xMTE2NjZzxv/WY0L//6VKa6xKa61SUlJSi+VSjOdyxPw1NTM1NTX//qQyMzRSi+cyMjNTjehZsmpxw/tLbK5yxf5zxf5RieF1xv+lSlHTYkLUZEU5OTncu1LcvFLcvVX0lCr8/v9SU1QzMTH///82NTVSi+Y2NjNSjOUxMzFTUVJTUlJTiuI4ODhUUlFUUlJUU1FUi+VUjORUjuVVU1IyMTFas2txwvk6OTkzNDU0MjA0NDJLba91xftMa6ykSlNMbKylTFWmS1KnTVSnT1S8fEVNbazTYkPTY0PTY0TUYULUY0LUY0TUZERNbq3VZUVNbq/YuVPZulZQieFRUVFRUVPevVLfvlTslITwkClRUlX8+qL8/KM0NDT9/aT9/f39/qf+/KL+/KP+/6VRiuQyMjIxMjPRYkL8/KTTYkHzkilVjeVVVVRC3FH3AAAAAXRSTlMAQObYZgAAAUtJREFUeNrt0kVvw0AQBWDPgmFNYeY0ZWZmZmZm/P/XTlK1kerY1/aQZ1krS9/OW0sr1fN3MfGprADeLtj6Nga4vjLW4LUBgvke3QZA1wVlVtnwaxjYCIfyfZFikmFQVJhj4ojw2X4JTifRVYPSWRsTYdt/MDzwAxODUPOIaVnzKWeHzyz17Vz/2YyFm5T2VGBCUVa+at1CNDHFAtEoFass0Ya17lKeX9N3lI7qPBMAX6eEiwV/KbzM1gkgQhOi1A7ZTsfv7peuezcYMkRoaCGO1Fn9cnKe655LbhqG8UgxhVKcFi5rHZIQbXZ7eotz/qETeIggFk9SzRiU9nNucT6O7SjdnHlDA3vcynLejF+d4HrhRgWWWVn1yjoGzysZnWmh4kgtqplbT5iWF1X9PaPKBHY9oQQagRwQIpn7jZ4QCdrybOKOqraef5BPyLAh+P3+d+QAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "784",
+    "id": 784,
+    "sortid": 666.01,
     "identifier": "vivillon-icy-snow",
     "name": "Vivillon (Icy Snow)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAV1BMVEX///8xMTE2NzdSUlKcnK3///97e3u9vcZUVFRTU1O8vMUyMjL9/f00NDP+/v5CQkLEs5v8/Py7u8TFxcV9fX1+fn56enrExMTFtJs0NDSenq8zMzObm6yHgbN5AAAAAXRSTlMAQObYZgAAAOZJREFUeAHtz8duxDAMhGENSRW5bNn08v7PGY7jADmEgi+57QAGdPjwS06Hdx9wFK6bnDGMrSnJhQRtJAVEskHTUVJEiPz7sD6Cu4IHrfxAAJEkLIadZdU/pfyCZDmCZAm7yzWXyKUZACGdL3RvvahXHLJndj4HF9/KNjpnYRJ1Lt7zJr5ZjaB2d5mSzHwR9GBG1qpEg78RvdXWdNJloYocJWnt1lpd+ELQhZRPNG3K3GioTUuxB948lKtOU/98fDqdyhDOF2h7lpf8bqoSO6gkvCLJ9Tp0SYQYPPA4njB1aHT/tPu+AAAWBiwMsX1QAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "785",
+    "id": 785,
+    "sortid": 666.02,
     "identifier": "vivillon-polar",
     "name": "Vivillon (Polar)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA5FBMVEX///9SUlI2NzcyMjI6Q3UxMTFSa7RSa7VUVFRRUVE3ODhSUlM6Q3MyMjRTU1NCUoRVVVV5eXl7e3v5+fn9/f16enq0tLw9RXYyMjNQUFBVbrdWVlYzMzM0NDM6Q3SwsLixsblSU1Q1NTX8/f07PDz///+zs7tSUlQ7PD1SarFSarJSarQ7RnU5QnQ9RnZTVFVCUoNUVFU0NDRDQ0NDQ0Rqkvtrk/xulv9DUoQ4ODhQarN8fHx8fH1+fn5RUVA5OTlRU1VRabLBsJjEs5vFtJtRa7T8/PxSUVI6RHb9/f7+/v45QnOrqFpNAAAAAXRSTlMAQObYZgAAATZJREFUeNrt0tVuxTAMBuDawTIeZhwzM/P7v8+SdrtLo3Ozu/1Vq0r95NiVnf+sHMZWhYNSEmYtNnAcfNKE+TaJTCMsYQy2koionvpux74N/iimCsbDXxgSYm60gl9xBduhAHMXWMHhPpaMcg6A5pL6qgpOqegCgFfTZZ/0SaBh+CHEDOrGP4RGlEWROjkUnHN6fGSexVtmZYgTKkVbomYWHJE0hQSyiHCl+IzzGuhCA2Tec6+BKkVV3oxw7qZXB/k07zUnD9s7dEuIzbWO5xjleJlIOfZ5UAjRNf/FSqKiTXnuTyYbvAgAtaulUQoxf7nfSxJi34xRIoP3y5OzxUIyG7y4HTej091WURSJDeLjnSsbmH/eZNDxLE59xGfmzPPXciEswygMTL/oke1ZBxMx7+9//izf75IVdfJSe+kAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "786",
+    "id": 786,
+    "sortid": 666.03,
     "identifier": "vivillon-tundra",
     "name": "Vivillon (Tundra)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABUFBMVEX///9SUlI2NzcxMTFUVFR7xv8yMjJLdY5TU1M3ODhVVVV7xf17xf5Lc4y0tLz9/f1RUVFSU1R5eXmxsblSU1NSVFUzMzM7PD1Cg6x6enp7e3tChK1Kc4wyMzOzs7tKlP/BsJj5+fl9x/9Kc418xv9QUFBTVFVDhK02OTn9/f5OdZBOdo84OTlLc41VVFVJcop4w/l4w/pJc4x5wfl5wvl5wvp5w/tJkfl6xf0xMjIzNDVBg6tCgqlCg6tBgqsxMjExMTI2NzhRUlT6+vv6+/z6/P78/PxMdZBNdo79/v9KlP40NDRDhKwyMzRKk/w2OTo3NzgwMDDBsZnFtJs4ODj5+/xRVFd8fH1KdI99xf5KkvqYw/qex/+wsLhKc457xf9KdI58fHwxMTA7PDxQUVJQU1M5OTlRUlJRUlN8xv5ChKw6PDw2ODg1NTV5xPwzMzIFoL+jAAAAAXRSTlMAQObYZgAAAWFJREFUeNrt0sVywzAUBVA9SZadmOIwM7ZNGVNmZmZm+v9drWRra7LpLnfGshZnnubaQp20HUzaheyh+doXDmMIRQ7C9pY8zQnkI8mG+crhzBtBAomxvfInNf3MocjycYgkJguzqJV5xhwlacHBxESLNeoAxGUkRqRSiO5yti2rahn2nLvzickon9JTl4oAJez2IQkj+ocNG0t56TgYdGnlgZgSV5QpjKqSpmmyrKecXSDeDEPVYVutSZJzF3K96fcD9cUVptnqp6ZpQWcIEANvzgunkBxYPl+V5T79FTs1Af89Nb9NapRHuu7kcUmygDh39gUMSmnAUvXFvFS8HbXA4/a/IZ026Ja1EOpXTRUwdr9t2Ef9UNnJnIRCvUR8eQ0v1W8uNjJX61QojyBgKGNn8mXN9Iogy774aMwz9N6tQ8kjOBgwwoe/KJJbARA4FMEcE77hlcX5hC/UXjDq5N/yB+5AI0WaGDM7AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "787",
+    "id": 787,
+    "sortid": 666.04,
     "identifier": "vivillon-continental",
     "name": "Vivillon (Continental)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAsVBMVEX///8xMTE2NzdSUlIyMjJUVFR7e3u9azn+5lJVVVKFUzm0tLy3nkv95VJTU1P/51LOvVI1NDK7azk0NDNUVFI0MjK2nEtTUlK0m0u8azpVVVXEs5vnnFrmm1p8fH2EUjr9/f3+5VJUU1Kzs7s0NDS8MjpVVFO9MzqFVDq+bDq/NDqGVDrFtJvMu1LNvFKGVTrlm1ozMjJUUlL85VL8/Px6enq1nEo0NDK2nUv/5lMzMzPOzhe/AAAAAXRSTlMAQObYZgAAASVJREFUeAHt0sdu6zAQBdApLKSK5N6730vvPfn/DwvHSnYi4U12voQNLg4uMQPBKUcH8VjYP0iFybI+AM2F4C4lCQXRAVpOVRJR+Jffux2n4I9CwI7NfuFQqVaJDbyw2LChZcZIpcCPnnQ/Du10ykyRynDeOtLSvbeXHHOgvsKZCOzWW7scx6b6V5lwqlsKrvxvr7O1and7c4iCrnP+6WoRmQVzZQzP2FTKFUV9vrUxyFVwLzNeceGcK7Js3T4MsVnpjdro3LsiVMYKRe5zrXU+KCdlXTsb3SKQ0Ly6G3hflmHbJC5KteGOq70/2ylIBcPrkzDM5yL9tUGfw+PPo9HSTpNQzYn1Kz0smt1Eg0yANwjU6yUdEAlGucg1HYpUtUj4s5zyDQVtDyzO5TKDAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "788",
+    "id": 788,
+    "sortid": 666.05,
     "identifier": "vivillon-garden",
     "name": "Vivillon (Garden)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABYlBMVEX///8xMTE2NzcyMjI3ODg5hEo6hUpRUVFRUlFSUlJSU1JStXNTU1NUVFR5eXl7e3uxsbk7PDxRs3E6jVI6jVM1ODc7PD1Bm1IxakI2ODdRU1FRU1JRsnEybEM4gklSVFNStHJStHM5g0pTVFQybUNVVVVWVlY5ilF51GJ6eno6hEuwsLgzMzO0tLz5+fk2OTg4jFJQUFBAmVFBmlFBmlIxa0JCmFJCmVFCmlBCmlHBsJhQUVEyMTExMTAyMzI4ODhRVVMya0M4g0lRs3JRtHFSUlE4hEk4ilFSVFIwMDBSsXE5OTkxMjEzMzI5hEs5hUtTs3IxMjJUVFVUVVQ5i1I5jFI5jFN50WJ502I5jVMzakF6ent61GI0NDR8fHx802J90WA1NTU1Njezs7swMTG5NDq5NTq6NTo2NjfBsZk7jlM2ODZRUlI5gUlCm1I6i1I5g0lRsXFQUlFRUVA6PDxStXJg5ap3AAAAAXRSTlMAQObYZgAAAWZJREFUeNrt0lVvwzAUBeDYYU5TZsYVx+uYqWNmZqb/P7vdo2X1ZW89URwn+nSiK5nppO1cgjbhPTvafCxSDAQsw3w/FPH2c4MiPaBexCuGPUHAUCSEeEW3ewhBahy4DhV6q42/L27AEiVswR1vo8XGEpIMyJUYdlcHK+jl6ToRKSg1jlyJr/lmoT88xUsycmTIAhZkXxvITatzfEAZITtOzmt5TRuoIGevp/rCPpbsLNM0TNNkGX9Ifbs7E3jyLLDrxDA0XTQ0EDpw3ZwfC3xglghFOS/r5Yx4JG/bqnp7GPZNDpOGcYjG6Wb5opyxtlCjK8aT/9yU1lVa161kaDemqvZaRJI5hiwhoqVkvxJcisdXCxIHya5FtazSOzMRjS5QjwaePa1nnbb6kxMkqhz/skr6h/NxX3hXaBDWl0XN4PZyKd9zjaO4GofsCuN4STRHpgyDsAjwBp94ejwiqYp8fjv5t/wC69ko7c2jvG0AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "789",
+    "id": 789,
+    "sortid": 666.06,
     "identifier": "vivillon-elegant",
     "name": "Vivillon (Elegant)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABgFBMVEX///8xMTE2NzcyMjI3ODg7PDxRUVFSUlJTU1NTU1RUU1RUVFR5eXl7Y5x7e3uxsbm9jL38u+U7PD1QUFBVU1ViSoJjSoRkS4V5Ypl5Ypp6Ypt6enpSUVI2ODhTUlO0tLz5+fn8u+QzMzP+vOZUU1NWVlYxMTKSYqPBsJiwsLhVVVUzMjNiSYK6ibu6irs3ODlVVFQ4ODg4ODk4ODpiSYQ4OTljSoM5OTk6PDxlTIVpUIJpUYJpUYNqUYFqUYJqUYRqUoS5iblSUlOzs7tSUlQ2NjdTUlS6irowMDC7i7y8ir28i729jLsxMTC+i7lTVFTBsZlVU1Q3Nzj9vOX9vOYzMzL/ved8fHz7uuR8YZp8Y5x5YZn+u+T0mlX1mlP5ueFUUlT6uuP7uuN6Y5s1NDR6ent7Ypt7Y5s1NTU1NjfrQkTsQ0OVZKaWY6OWZaeXZKKXZaaUZKSUZKWVZKV6YppRUVCUY6IyMTM0MjFUVFWSYqSTY6Q0NDTtQkP0mVL0mlSdSAdNAAAAAXRSTlMAQObYZgAAAW9JREFUeAHt0FWP4zAUBWDbYU7KzAxdZtjt8g4zMzMzzPz1uZm+JlZf5q2nsnsjfbrSMeqk7WziNuFvpvfx7x/FEMwg9H4gY48xTJEeXMrYtw3/JjCiSELsG85QY4EGIRwcgsjX+vE5auUVZhwlacFiV7XFVtKygF1WAvz4uvkGPp5dLFnp517WZSX8at8KMMbP7mcOEy4OEQYz2P8dYPzkrq/bJ7u0YoWoGBXFTy/BTW7f7u4Uq87O0HVV13UGxae1rbn9/2bCsQsp36iqqPCqiMOBoFaf7TF9zpAXooKSyvOrQi2iaYGjvavrmFMZjlfHL1Mbqbwhw8agZo25vCJI42dFUYz+0NvlNW1qZCInsMhZEqBJ6cuvmBReXxzOsQS5Bajo//E5EvkjSXIB0ULKFcUfgDJmVsY0+OLUSCqh4IeGlR2kQVJ6x4sq2zQP7LehOC8LdhRx85ZsV6aUAcxjeyAw0uPhWdReONTJk+UBYUkrzupa5lEAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "790",
+    "id": 790,
+    "sortid": 666.07,
     "identifier": "vivillon-modern",
     "name": "Vivillon (Modern)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///8xMTE2NzdSUlIyMjJTU1NUVFS0tLy0vLS1vbXnUkN7e3t1fXVSa8Y0MjI0NDRVUlK8Q0u+Q0rlUkPnUkJze3Ozu7NUUlI0NDNUbca8Q0x8fH3Es5vOSkLOSkOzs7szMzNVVVX3/WP9/f29QkpVa8RVbsXFtJvMSkLNS0NTbMVze3XlUkJ1e3PlU0W0vLZSU1TnVEToVUN6enr3/2P8/PxSa8Q8mh5dAAAAAXRSTlMAQObYZgAAASZJREFUeNrt0sdyhDAMBmBLcqe37X3Te3//Rwtik5vx7CW3SAPjwze/ECD+6+wCOBfOBikhGjYTAldMQMckAiMcoKNYJCL2d75yp2LwR4GAtU1/YSFlUMIJPjo4scJR+ClwgJt6wtm7wllLhOFI7os1p+T3znVjTshd3xXD/C17tmpsq0IlfasbFHl7uMrStJNht02GkiL3fvGRuZFdwMgkoT0lSvq6vjxk1qowJNW7zz0tqfbe1/O064LLICVLfZRHbco+sW7HJrPcGq21mTZV07avbniLYcnUTG+nZdk01hKyG6W6oo1vy/JFy/jP20+v+mWe5o4gBmdkjHpYLO6sjUK5QtLv+DVP+UNHBhMKuAaBk0nUCUTGwAc+xgtDUWEp/uvP6htWvw6ePZqeTAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "791",
+    "id": 791,
+    "sortid": 666.08,
     "identifier": "vivillon-marine",
     "name": "Vivillon (Marine)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABFFBMVEX///82NzdSUlIxMTFKc+cyMjJStf8yMzRLWoxRUVFKWoxSVFVKW45TU1NUVFT+//95eXlKjNZLhM1Lhc87PDxRUlIzMzNSUlNSU1NSU1U0NDNSa8ZStP1StP9Kc+Y1NTUyNDVVVVU3ODh6enp7e3uwsLixsbmzs7u0tLy/x8/5+flLc+VWVlZKWosyMjNRUlRRacFRa8RRsvtRtf9KWo00NDRKcuU4ODg5OTlSVVdKdOdSsflSsvxSs/xKgslStP5Kg85KhM5Ki9RTVFZKjNVUVFVUtv8xMjE7PD1LXI5JWYlLdeh8fHx8fH1JWYpLhM5JhtBLjNS8xs+8x9BMhc/BsJjEs5vFtJtQUFD9/f39/v9RUVAAsQEFAAAAAXRSTlMAQObYZgAAAUtJREFUeNrt0sVuxDAQBmCPKZwsMzOVGbfMzPD+79HY294cay+97USJIuXTnxlr0KymLkKmhQUpGdGGFRCCN0FIXieBCAQSUqyLBIDwKW6D5nTwVxFE4hX3DxqMqRudQJuSCTMoVncBEp646yJ73qDDIcagjhSXHRcptUsa5uFGRJcZlmGmgDXOK5Vc1FRruOm1PO8IUJVz7rquqZ6l0W3JYqganCWT1zRiFmizWAzXrZbHgn6fy3+roYWb2B+MrFv8FAT84cA1TeUwKSt2czqoDkY9Z/m5/zLepgsiUCk73brvd/KlxOcXL1N5imoJIe0dP+YdZ6cUnjYIF0m9fRznK1tONn2u34x23U8kd3m5uJrWLtHGd6fn7R3eF+27rA7C66blN2FxyTazHw2NCz/CO0Gpqzm5EJphQoyJeBEj6+tCeXrq/Z3Vv9UPZ/QcC5BRJuMAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "792",
+    "id": 792,
+    "sortid": 666.09,
     "identifier": "vivillon-archipelago",
     "name": "Vivillon (Archipelago)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAPFBMVEX///8xMTFSUlKMUjG1azHeUkK1tb2UUjHOtYylWjFarWt7e3v///80NTfGtZzDsprbUUHdUkEzMzJUUlFvFUAkAAAAAXRSTlMAQObYZgAAANVJREFUeAHt0DtywzAMhGHvAiCph51H7n/XrKCkC2E16fxzyOobQKPb5V4BF+EdeOrT4HEQEKjg26dMwnfi6dq8IVh2SizRfyGAiUzYAz8syD/l/YSWUCxmUEzHlnQjos/cDeqE8HVd546bDgXhEaP3PlnctuxwbjYbKYdN8zQTYu4jYgIPw/14zUVNqydQA3fsbJRyL34OWyPlXBVQUlR2IWU/4gvpZpTGxZ1KrAhN1Nx9RC3zQ91sRA3xALlhjN5ZQRCyuhGsByKxHnWrS3gtuVf/1TdXVAT14qCriAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "793",
+    "id": 793,
+    "sortid": 666.1,
     "identifier": "vivillon-high-plains",
     "name": "Vivillon (High Plains)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA7VBMVEX///82NzdSUlL3nFIxMTEyMjI1MzJTU1NUUlJUVFRVVFKTUjLHdEPWhFL1m1JRUVH2m1K0tLx6enqxsbl5eXl7e3s7PDyUUjGWVDKwsLg3ODizs7tVVVXFc0PGc0JUU1IzMzNVU1JWVlb2xTk0NDP5+fnUg1J8fH2RUTGTUjE5OTlUU1GWVDE1NTWsQ0OuQ0KvREM7PD1UVFVQUFBRUVDBsJjCcULEdULEs5vFckLFc0JVVFM0NDTFtJvGc0E0MzJarGvHdULFdEPUhFJdrmvxmlLxwTn1mVFerGr1xDlTUlE4ODj3nFFTVFN8fHxBaDu3AAAAAXRSTlMAQObYZgAAATdJREFUeAHt0EWPwzAQBeDMjB2GMjN0mZmZ4f//nB03uzfb6mVvfVWjSPn04hdnmYUjxKJwMpdSWMsmjgOnioihTYJQCOYwQVslAPBV/W+Svg3+KsGFSfwHXSm1UuSwl4icuYT6U0AO4xnkjFJEMFTyLy90C0RdxJbhlAM5kF0FXdol8n3DqksseVXPmwE7orjXiPRbWu3qPJIdM2oYtkBTVirYwaonKY5ph6jg62GGJQymo2wFe9zIiSLtmFpW+d6fbk1HxfD87JpHU19bqGS53QmC8jBNt/m9xq/IEpgWLx6GYfiURimCckbqHWNCnxtfoS8dW6DZCbr3L6+P4813YYMfh+Wid3tyN65HVghH61lQgue3eoQHLYvjh3AlnNrqGqLF8RjGKNSNmmzPHjJZKOyW+a/8ADPnFcS3HXiRAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "794",
+    "id": 794,
+    "sortid": 666.11,
     "identifier": "vivillon-sandstorm",
     "name": "Vivillon (Sandstorm)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAgVBMVEX///8xMTE1NjdSUlLnzoQ0NDNUVFR7e3uEc1LOtWsyMjK2nVtUVFO0m1q0tLy1nFpTU1NTU1LlzYRVVFO2nFqDclK9jFrEs5uGdVOzs7u1tb39/f28tHO7i1p8fH29tXO+tnQ0NDTFtJtUU1PlzINVVVXmzYTnzYR6enr8/PwzMzPLgATpAAAAAXRSTlMAQObYZgAAAQlJREFUeAHt0LeS6zAMBVAiMEuygrPf25z//wMXkMYdxXGznS8aFmcuSJp7bg7ArdDOMkG1zBqDByXQ1CSCIpxhpGolovoZNjV4VeJivkILqdy6wE1cIFim8i1wgTmitlnmNShMZilU1hKhKSb9yLQKgZ+Yh7XnP/dephcIzJw3x5DK7uTnzC5nPq5cEbrkPb2T75OyR+aPoQypF/ctkjbSKAmh+Bgk/+Au6eLOkyCufA7SqXPOdTTyP9nL4+rvoNKuiQ1N4xhGQnWr1LUUmafpdUimFpDtbWb+3AeCGrTUnfu37XYf6jAdkNwX/ldHWFlMaOAFDO52VWcQFYMecHE1XK4qSXPPn+UXzDQK8LR2Lm0AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "795",
+    "id": 795,
+    "sortid": 666.12,
     "identifier": "vivillon-river",
     "name": "Vivillon (River)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA4VBMVEX///82NzdSUlLOpVoxMTHNpFoyMjKthEJTU1N7a0OshEOuhUNRUVF5eXlUVFR7e3u0tLwzMzNUU1JUVFM3ODhVVVVWVlY5c4x6eno6c4yxsbl8bEJ9bEOsg0I7PDxCnNU0MzKulVqwsLhSVFVTU1I0NDPNpVpSU1P5+fmzs7s7PD1Bm9Rjy+pjzO1lzexCmdE4ODh7a0JCnNZDnNVQUFB8fHx8fH1RUVA5OTlRUlKshkVRVFSthENRVFY5cYk5cos1NTU5dI05dY/BsJjEs5vFtJvKoVkzMzI6dI40NDRUVFVzAObyAAAAAXRSTlMAQObYZgAAATRJREFUeAHt0MeOtDAQBGC62zaZyTnnmf/fnHPO7/9A24bdG7a47G0KgZD4VHLhbFM4QhSFi1QqYS1bOA68aCKqNglCI0ihi7ZKAOCnvt/duQ3+KMGFbu8XjpXKlSKDh67I2Jgw/xSQwd4AMkYSEQyVfGWFzChArBtOWVEV5TNkNyGam1Z9Ytsred4A0r7Q7fv5W+qbUhrFjhn1DVtgquIYG1jyFIUh9YiW83wYYRuTdTM6Q5eIbej7uWOGUXz6tX5YN8u1IAxuJFF+oZbdTSNJulUp5YSWxr/IEpiWk6Bau36TvkTQzki9GEPau53NVsqxBaaNRF7tHB+NHi+FDR6cd8ve7tPHqNVZ2SA8X0RJG/b/tzp4Urc4/givwhne3SOys4xhjEK/6Mn2/EMmhcJum7/KN/FbFVTL+qmcAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "796",
+    "id": 796,
+    "sortid": 666.13,
     "identifier": "vivillon-monsoon",
     "name": "Vivillon (Monsoon)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABGlBMVEX///9UVFQ2NzdRUVFSUlJTU1MxMTEyMjI3ODg4OTl5eXl7e3uFhXysrKStraWxsbn///87PDypqaIzMzNVVVVWVlZQUFB6enpQUVOCgnmDg3qGhnypqaGzs7urq6OrraY1NTVSUlOwsLg7PD20tLu0tLzBsJj5+fn8/Pz+/v5DQ0OqqqI6PDxSarlaq+NarORbq+NbreYzMzI4ODh6entRUVB8fHwwMDBRa7yDg3uDhHyEg3yEhHuEhHyFhXs5OTmFhX00NDRSUlRSU1RSU1ZSVFQyMjFSarutraQxMTCurqavr6dTU1SxsbhTVFOysrpTa7pTbLxUVFNCQkLDsppUVFX6+vn7+/v8/Ps2ODj9/fz9/f1EQ0NZqePRNg1GAAAAAXRSTlMAQObYZgAAAVRJREFUeNrtkkWOAzEQRc3t5g5z0mGaDDMzM+P9rzF2T6RsHCub2eVblsvy069SucBUEwuxSUHjIjrWtGYGAPXnhAwJ05Ax1loc5kZ3lAENGUExsXnpWgcOKSQMSwVjVJC60D9wp5GIrmbYgYSNB28KDVNewk7wnkwztaVcucjQfAuCfSo5dSOZwXJNASLBdWVipTjJ0AwlfgKY+DW4vOo9GWrOt23Ltm0DoDjNb352v9SWqHZgWRRii7CyA8lPpXNOsRLEJENgO4WXSb7swfWNre8e5qp+Y2v1pR22Uz7cdhxn7uisKjMrSb+UhNCHcdd1vdnjQZbwcf8t0CbMPVLYd+kgy5FmNDC1qCzx5LZ6qh/eWhL2d8veQuWhynTg0orfhPGCM1+5P9SBqLUnkvOi5+Rpmms48YjErNeLLiUaDtSRbDyTARKhXjP4Qw+MSDDVv+kXDUEc/W6TnucAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "797",
+    "id": 797,
+    "sortid": 666.14,
     "identifier": "vivillon-savanna",
     "name": "Vivillon (Savanna)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABd1BMVEX///9SUlIxMTEyMjJUVFQ2NzdDa7xCa71TU1M3ODh5eXl7e3u0tLxRUVE7PDxRUlM7PD1SUlRSU1RSVFNBarpzzpx3zplDQ0M0NDK01nLBsJhTpnRVVVJxyplCa7tKU41RonFxyZlDa70zMzJCarvq20ru3kz5+fkxMTNQUVJRUVA3OTdRUVN8fH1EbLpVVVVzzZuzs7tVpnOz1HOwsLhQUFBSpXVUpnNUp3NCa7xKUo5TpXLr3Evs20zs3Evs3Uvt3Uvt3ktSpXPv3ktWp3H9/f3p3Ezq2klLVIvq3UtRo3FCbLx6enoyMjQ2ODg2OTiw0nGxsbk5OTdUVVRSUlNEbLu01HJFbbu01nO01nRCabmz1XNUVFVUU1I0NDRCQ0Q1ODhWVla11nM3NzhRUlRyypg4ODh0zZo4Ojjq3Uzq3kxSpHNzzZmx0XGy03Gy1HOy1nM1NTVzzZ1UpXFUpXJBabpTpHM5OTkzMzMwMDBSo3LBsZnFtJseTFz/AAAAAXRSTlMAQObYZgAAAWZJREFUeNrtk0VzwzAUhC0w22FmTilpkiZlZmZmZmb68bXS5iZ7cuktK5h3+GafdiQxNVUtFlYLojIJoaEZYhjLV5yU9fBDHzRB3zvZCegwG1maWJbs2mp8WTYC/yjIwMNYZwXcR4h+UDLZ2/FE3S82kzADSLck4HxbiJzC4+F5DpSO6JZkTG6R7IvJ/hXOWhIZqhCCCEZaNNCT3HDGANBJJQrT2hBuzjVu1dke3nMjOrcgl4WYuTHvcKE7y9OzwOKuLAGsSgIM+p+Her3ZjmM6qAIZNKcPQAYMOgfW/a1htxuwtMiqlNkeeUhjZem166lwNkXtTGRS83mMsWIP5u76Uj1rjiYg6t23hirCld2+c5LjOFC+fl1UkMHn9WUgYLMh48dbxDgy4bpP8bwZGoGnDYqCoxeuR56zGoHI9wawJEZHyYMQDRprOeF3nLFshoBW6sui5YQAkqIS2ch1ttpfy9T0b/oBsaIn2wuOpHkAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "798",
+    "id": 798,
+    "sortid": 666.15,
     "identifier": "vivillon-sun",
     "name": "Vivillon (Sun)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAllBMVEX///8xMTFSUlK1SlLv3krvSlo0NTZ7e3u1tb2zs7tRUVFUU1Hs20nvnEKUa0qthEp6enq0SlFTU1MzMTHDsprsmkGtg0ruSllUVFTvTFnvnUKzSlL8/PyysroyMjF5eXlCQkK1TFFDQkJ7e3zGtZzWvUIyMTGVbEns20qrgkmsg0ozMzLvmkKthElTUlEzMzP7+/s0NDTL5RmwAAAAAXRSTlMAQObYZgAAAP9JREFUeAHt0MdyhDAQBFC6FQQCwebsnLP9/z9nDWWXL0jmsrftKqg5PKaRitE5xWI0xK/PG7t4kdEDOSjIirBP77mVQI9kysNeyWPv3tr7v69TUuDD8/nP7yxr4j8oLIQELBAh2ulcXLNLOtkS06q5uK3JOO/oyAhtY4xS15cYdmc3ToICjVZqbV5JDLqPC0fSEUattDZJ6DkhD5so92utr6TaD8OJ4+Hrc1PO9mo1TTaLrMoZWfFxa2JxCEzfTqQlO5Ja610NcUlKx2A0Y9KspyXZdZ2OzTWykFUZi5UKgci5hZQje5TeeRT2FgWWOScQUi4vQFw2AsdF3ClHyjd51wypBVOgvQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "799",
+    "id": 799,
+    "sortid": 666.16,
     "identifier": "vivillon-ocean",
     "name": "Vivillon (Ocean)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA2FBMVEX///82NzdSUlIxMTEyMjJ7e3tUVFRTU1NDQ0Njze00MjKcc0qedUq0tLzuS1ru3UrvnkM0NDNSU1VTVFVjzu9mzu1Cg+V8fH2FZEo0MzKcdU2ec0tDhOWzs7tDhujEs5vtm0LtnEXtnUVVVVLunENVVVXvTFpjzO3v3Evv3Ur9/f1ChOdUU1IzMzKedEpVVFJDRUU0NDQzMzPFtJvtS1pFQ0Ptm0Njze9FhuXt3Ert3Evt3U3t3k1CQkJ6enpCREVTU1LvnEKEY0qEY0s0NDLv3kr8/Pybcko8i287AAAAAXRSTlMAQObYZgAAATNJREFUeAHt0sdy6zAMBVACINWL3Hvvfi+99578/x8FlJKdyPEmO1+OPVqcwRU0FDtnH6JdYSWXkqzDKkLASBP6b5NAGkEOQ7SNBAD+17+D8NkGfxTxwLD9CwMpy1+0gK8hFSxYYvlbQAHbX3p2p7NcXiKCYSSfYmDnJcuMTshTPm8avmdZmqJp/RNX8XG5OVinaRRdeLLcDVQeKYIkiaLNxrALxVIpXKByZdLrfaTz+dgA0WX3ucAWhknCzZHnlS4DqFrOVm6deNbtdg8392vTMoCD2HGcuHrr+/XptH5u/Dqgaez2q7Waz0HQzkgdhcOrRm1WPZL2y8vt/nCyuvs3QbLBCnL56vq42exboRxx+SPcNJ48RLAUIwg6IwHjJj6A9Z5rTPpBP9oDhsoSKf4s+3wDPyATfEuiP7AAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "800",
+    "id": 800,
+    "sortid": 666.17,
     "identifier": "vivillon-jungle",
     "name": "Vivillon (Jungle)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABKVBMVEX///8xMTE2NzdJcllSUlI3ODhRUVFJcVkyMjJKc1pLc1pLdVs5WkpRUlE6W0tTU1NUVFR5eXl7e3uJ0pmxsblKclk7PDw7PD05WUpRUlJSUlFSU1NKcVlQUFBVVVVWVlZ6enpKdFo6XEuK0po5WUm0tLzBsJj5+fkzMzNsUzkxMjEyMjFKclpKc1k4ODhKdFk4WUlLc1k4WUo5OTlMdFswMDBQUVFRUVAyMzJRUVIyNDI5WktRU1JSUVE6PDw6WklSUlNSU1IzMzJTUlIxMTBTU1Q0NDRUVFVUVVQ1NTU7WkppUTlqUjg7W0pBQkNCQUJ6entCQ0N8fHyJ0phDQ0M1NjepgUKqgkGqgkKsg0GwsLhJcVqzs7s2NjdJclrBsZkxMjJIcVhrUjncaMT3AAAAAXRSTlMAQObYZgAAAVNJREFUeAHtz7VyMzEQwHHxMYOZ+WNmCDNzHM77P0RWdpPiTuMmnf+ekVX8ZnWL5s3cKZ4R3ugrk7+vCkOwjtC/u6G8frtXyALuD+UpoVbCSCEJkaeEiaOCUCoVDKT2q2cflBWZQptOIfmRlBjOGQnwwaZcsl9VShdrPGck/D5MBpL3HesTy3GI6FjHxQQgSaKWkf0wxFnTa3qexsFRw3YP9/VsF4dhEIahjohkhpEzkozXgsDzReBhzW6/oYZB/4hMKFiT+YOGOGBFGll2u7h3IrKWSUVwtD7YHDTijd+u67Y6Vs4yIOPruu/Hq8dfzLdGZGkO4yhbEqA9v/vTqVyZpulwgqA86gVe97a1UFn++xqpIuO6X/0fWR8vRmWsgu++xz1f29o9H+0wFST9z/A4P7sEV+MKV+Ngl1C6/VhmCgfLABZYXghc1RUER7OVonkv1hPREh7sBLxsvQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "801",
+    "id": 801,
+    "sortid": 669.01,
     "identifier": "flabebe-yellow",
     "name": "Flabebe (Yellow)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABAlBMVEX///82Nzc1NTX9/f3/70n////oxwo7PDz8/PzHpxHU1NThwQk0NDFSUlL+7Uhrszn///3HphHoxwz+70mnfhw4OTnHx8fkxQrlxAflxQflxQpUU1HmxgkxMTH46Uo4OjfmxQl1dXX//f43ODg5Ojo5Ozg0dQg7PD2jehikpaOmfhs1NTLFpRLGxcQydQnHpxAzMzA0MzH76kf760j7+/j5+fn6+PlWVlDkxAlttTnnxgjnxgnnxwn//vx2dnZVVVVTUlBTVFL56Un7+/v860j87knR0dH97Ej97Uj970oyMzH+7UfX1tP+7knX19f+/P3ZcbnedL00NDT//v5XVlZpsTlu8MKSAAAAAXRSTlMAQObYZgAAAMhJREFUeAHtj1V2hjAQRjNxIDgtlVKou7u7u/z738qfFWR45nBPHu/JfJd0jB5K23lKC0oMpQY1RwQzMkkkZqoDfybjluYXGaHCUZZZik+hwWnC4b9mQtiHZKnvL3Y1+3f5eKfnsZkb7z/MB3Bfrm34crMS7mDVt2Z7f7VYvJleQEy4Ph5LL05PXhGvnlwfTz+8M+9ozf3fbh5tPXPu8TyqnBOD+/LtXEo+sVeCOwYgeHp5mArngGAsDeLNGEgLFMQVaQcA6SA9Q1eUEPn4Lj6LAAAAAElFTkSuQmCC",
-    "gender_rate": "8",
-    "rarity": "225"
+    "gender_rate": 8,
+    "rarity": 225
   },
   {
-    "id": "802",
+    "id": 802,
+    "sortid": 669.02,
     "identifier": "flabebe-orange",
     "name": "Flabebe (Orange)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAmVBMVEX///////81NTU2NzdrsznUawHXbAH9/f3/jBA0NDFVVVU1MzF1dXWlexinfhw1NDLU1NQyMjLoxwroxwz8ixH87Ur8/Pz9jRExMTFSUlL/7kr//fz//f7///1VU1HX19fccrvedL3mxQmkpaM0cwinfRj8jBAydQnGxcTHx8c0NDTUawL/jhFttDn/70nVbQFTVFLXbgLX1tM8xUNoAAAAAXRSTlMAQObYZgAAALVJREFUeNrtkMcOgzAQRLHXGJteTQskIb2X//+4mANXb86IJ0u+PI1m1lqYGZT+54Ei1JKUSjyRODLtulSiibGfPTXDFSkB9cXJNOGaKDCa1colDhkfMgs2hLgr4sdKAVbz/N06MYDZi/TwYNjVEba6SLw2CPfvAhAz6QU/tPyRIJ7Xc3FPP4L3nvk2QgjeNA3Xf2WsaOe2GLnltrkkANhleXzVABYGMHZik4aksqkfrloLM+QHTlQJ2DEaBNUAAAAASUVORK5CYII=",
-    "gender_rate": "8",
-    "rarity": "225"
+    "gender_rate": 8,
+    "rarity": 225
   },
   {
-    "id": "803",
+    "id": 803,
+    "sortid": 669.03,
     "identifier": "flabebe-blue",
     "name": "Flabebe (Blue)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA/FBMVEX///82Nzc1NTVKhO/9/f3////8/Pw0NDFJgu1JhO8yW89SUlJrszk7PDwxWcnoxwrU1NTmxQkxMTExWs2nfhwxW8/oxwwyWs1TVFIxMjNKg+vX1tPX19f///346Ur4+fr56Uk7PD397k1Jger+/P3/70lJgesyMzU5Ojo5OzjHx8fR0dEydQk0MzFQUVNRUlPedL3lxQ1RU1Y1XcwyXMxVVVU0NDRrtDx1dXVJgutXVlZpsTkxcwwyMzF2dnZLhe3GxcRMhexKhOz8/f9Kg+zZcbn560/5+fn6+Pn7+/s2ODo3ODg4OTk4Ojejehikexr//f7//v6kpaOmfRtHGmcFAAAAAXRSTlMAQObYZgAAAMZJREFUeAHtj0VyxTAQBTVig8wQiAMOMzMz8/3v8nUCjdcud2nZpXlNesYApd08IwUlilKFmh+Cq7hpYsw0z8lJtWhJj5ARJljjlaWYEhKcJrycSS6EfUiWeVzghz+/V+uvcgWbeTO5wxMA9+VPG/6V/gWbWPWsGp/5Ly7GplcRE7Yeyu97//gS8d62a327u8/8vWX3f/OeLp/a1meezpwTo9Nce4yxeikHdwxANHF9dxC8A8GYOw83QiAdMBBmpBsApIcMjACEHxE3opM6KQAAAABJRU5ErkJggg==",
-    "gender_rate": "8",
-    "rarity": "225"
+    "gender_rate": 8,
+    "rarity": 225
   },
   {
-    "id": "804",
+    "id": 804,
+    "sortid": 669.04,
     "identifier": "flabebe-white",
     "name": "Flabebe (White)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA9lBMVEX///82Nzc1NTU0NDH8/Pz9/f3////Hx8fFxcU7PDzU1NTmxQnoxwr7+/tSUlJrszn/70z///3+/v6nfhxTVFJUVFRVVVU0MzFttjx1dXV2dnahoaExMTGnpqSnp6Q0NDTFxsTGxcQyMzHIyMjR0dEydQnW1tbX1tPX19fZcbn6+vo5Ojr87E05Ozjoxwz/70k7PD3//f7//v4zdAtTU1PBwcHExMT8/PqlpaX8/fymfBv+/P3edL03ODjmxgs4OTk4Ojf46Ur56UmkpaOlfBmjehikpKQzMzP9/vympqZWVlZXVlZpsTnT09Onp6f5+fn6+PmoqKjqbHQsAAAAAXRSTlMAQObYZgAAAMZJREFUeAHtkEVyxTAQBTWCkWWGcBxmJ3GYmeHz/S/zdQKN1y53adlVej2so2Vw3swzEjkTnAvSfEElwiwLKdOM/MX6xBKsESNMrFVtKfZRgtOEcU8qRPuILHPwoObOzpe2I3lIzdzYe1Q+gPvnVxv+FXzE81T1u/ip7ouLmbdjwoTLwe1n/rewSd171vNXnld39b+7GapcTY7SdIioSufE5ehabmmNXvQN7hiAq5vfu/X4CRjFaT/ZSYA1wEBSsmYAsI4WMgUwDhEPmgy/6gAAAABJRU5ErkJggg==",
-    "gender_rate": "8",
-    "rarity": "225"
+    "gender_rate": 8,
+    "rarity": 225
   },
   {
-    "id": "805",
+    "id": 805,
+    "sortid": 670.01,
     "identifier": "floette-yellow",
     "name": "Floette (Yellow)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA5FBMVEX/////////70o2NjZSUlLlxAj7+/s0NDQxMTFUU1CmfBemfBimfRvFpBDGxsbkwwg0MzHnxgkbbUT7/Pz87Er8/Pz+7Un+/v4wm1kYa0LEoxHGpQ/GpRBRUVFSU1FTU1AzMzNUVFSlexelexj97UkYakH+7kgxMjHDoxAxMzHbcbrnxgs0nVwxmlnDxMPDxcQwMTEznFhTU1MabETGphBUVFEYakJpszlqsjjmxQjnxghqszlxcXH77El1dXWjo6MyMjA1NTUyMjL9/Pv9/f0zMjBRU1L+/P3+/vumpqYzMzDDw8PRxWUBAAAAAXRSTlMAQObYZgAAAPFJREFUeNrtk8WSwzAMhiPXoDCnzLDMjF3G93+fTTJ7lnrsob9nND58/kVja6M1UANxNe7hIotwBW572BnKLOLTho5ylI3I2BVxtzdRjn+ziMjyhBDu7D9EBBguRNydzITr9woKtJ77slMId+oX4vydSt0/+MiEiO0q/BAdhyftdCylvBtIouuG3vtKUoD9dppc7VgEB4950Kw4+H4hR63HudFQmQYjZivLN4DS1Js+cQv8DZpGe+rWRo7c/QTwlPNqGE4nraNTifc5IA3O0+DscFQ+4MDrwWVrqx4VGIY7xroEQ4M4L/3qW3m4b7XRWugPc/gS1xPKo60AAAAASUVORK5CYII=",
-    "gender_rate": "8",
-    "rarity": "120"
+    "gender_rate": 8,
+    "rarity": 120
   },
   {
-    "id": "806",
+    "id": 806,
+    "sortid": 670.02,
     "identifier": "floette-orange",
     "name": "Floette (Orange)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA81BMVEX/////jBD///9SUlL7+/sxMTH/70o2NjY0NDT7/PymfRvGxsbWawDlxAimfBf8/PxUUlAbbUTTagH+iw8yMjBSU1FUVFQzMzMwm1nVawA0MzEYakH7ihA1NTVRUVEYa0I0MjD+/v78ixH87EoxMjH77EnDxMMabERpszmmpqbDw8P9ixD97Un9/PtqsjjDxcQxmlnTagAwMTFTU1MyMjLbcbrkwwhUU1DmxAfnxQjnxgjnxgtUVFE0nVwzMTAxMzH+7EgYakJqszlxcXF1dXWjo6P9/f2lehelexj+7kj+/P3+/vumexcznFj/jRCmfBhRU1IgjKP+AAAAAXRSTlMAQObYZgAAAPBJREFUeAHtk0WSxDAMRUey5TicNDP0MDMzM9z/NGNfQOplL/p7o8XL+1VSZWGeGUhANB23fLXYoSm4/aJSVO46cm3va9O9Ggm6KiRnWZq1qzDiuB4AnL8bY37cMBKEr1vG/LYTXtkfqAlA4ihIbrjqwd6fA6GYsM0BnXwPw4ZS6qGumKUH+vKzDBGvh2G5dsvUanzK47HncP2IXbVu5Fajl8ZN4SrPL4hOGr3VpANuxGOro/TilASyf/yBGKXZthWMumztHip6zNHyYDeMV1ea7gMJ3Knft5a8GdEK3AH5QVvNgtT1Pj+5J/1WM5F5/gFSqRReXEYy5wAAAABJRU5ErkJggg==",
-    "gender_rate": "8",
-    "rarity": "120"
+    "gender_rate": 8,
+    "rarity": 120
   },
   {
-    "id": "807",
+    "id": 807,
+    "sortid": 670.03,
     "identifier": "floette-blue",
     "name": "Floette (Blue)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA81BMVEX///8xMTH///9KhO/7+/v/70pSUlI0NDQ2NjYbbUSmfBemfRvlxAgxWs77/Pz8/PzGxsY1NTX+/v5Jg+7kxAswm1lSU1FUVFQ0MzEYa0IxWcwYakFJguwyMjAyWstRUVFRUlMzMzMxWcsabEQ0nVxUU1BUVFEYakJpszlqsjhTU1MxMjEznFhqszlxcXF1dXWjehqjexujo6OlexgxmlmmfBgxMTOmpqbDw8PDxMPDxcQyMjLbcbrkwwhKg+wwMTHnxgjnxgv77En77ExLg+tMhez87EoxMjP97Un9/Pv9/f3+7kj+/P3+/vsxMzFRUlRRU1KejI3kAAAAAXRSTlMAQObYZgAAAPJJREFUeAHt0UWSAzEMBdCWZGhup8OcDDMzZJhh5v6niX0BOcss8r3R4tVXlRUsMgcJAWZzj2uvLZjBLY06o85Ty7+2d/hsXx88dVXKanEaD6r0xrhKj4hqX1LKFzsAA13hwbuUp4PMUzlUE6LMKsrOGBcOT/4tpL8JuzmE25123lRK7TYUME48/EQ54ko7jzZ+A8bhfmFK5/D8mv1q0Sy0QFdqxp6rHH1aVGJy3Pcd8MKUWiTp/Sp4ZOXmGzFJ4w/tcSKqX20p2CtQ87Cbm+XLsfsBD9xsrNe3AwdZGVp3B24QWrAQuq7PTfaxqwGCucgiU4JPFFeL9/OWAAAAAElFTkSuQmCC",
-    "gender_rate": "8",
-    "rarity": "120"
+    "gender_rate": 8,
+    "rarity": 120
   },
   {
-    "id": "808",
+    "id": 808,
+    "sortid": 670.04,
     "identifier": "floette-white",
     "name": "Floette (White)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAolBMVEX///////8xMTFSUlLGxsYYa0L/70qlexgxnFrnxgilpaVzc3NycnI0MzGmpqbFxcXlxAj+7kj+/v6mfBdUVFQ2NjYbbUQ0NDRSU1ExMzF0dHRUVFHDw8PExMRpszmmfBhqszlrtTlxcXHFxMMzMzMyMjDec70yMjLlxAmjo6Pnxgv77En7+/v87Er87Ur8/Pz9/f01NTWlexqlfBr//vylpKIBbQX5AAAAAXRSTlMAQObYZgAAAM1JREFUeAHt0EXSwzAQRGG9HsngcPIzMzPc/2pRfIBRlln4ucqrr9quCUM70L60nXs9fZ9oC3djYxt/TArsWzr7vc3Pvfy556948rSar/5ny0PH6Q14WVRV9Qc4Uh1Mf+aL6jIvxjtv0ux8ybSb5dej6xojt/fpfllqm4Tlro7MObpoSUDGBxfHwXGMiL2jc/9PGKIfjQpeUrdBUNcKfooRUbetFeUDZFhTgCI10UwjClKJmKKCivDaUpOJABWcNkDIh+r3cgqlSyrsRENrUGkJnG64KEsAAAAASUVORK5CYII=",
-    "gender_rate": "8",
-    "rarity": "120"
+    "gender_rate": 8,
+    "rarity": 120
   },
   {
-    "id": "809",
+    "id": 809,
+    "sortid": 671.01,
     "identifier": "florges-yellow",
     "name": "Florges (Yellow)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA81BMVEX///8xMTExjGs2NjZSUlLOzs7/1gApWkJBvJNCvZRRUVExMjFUU1BUVFAwi2rnnAj3rlP80wH+1QD+9bv/973///81NTU0NDP787oximpUVFOV/kDMzMzkmgnnnAfnnQrzq1ErW0T+/v5Cu5L89Lv8/Pw0MjExMzJRUlE0jW00MzD8/f1TU1P+9br+1QFRUlJRU1NBu5L70wBUVFT0q1L1rlF0c3EsW0JUU1L7/fwsXEPlnQjkmggpWUEpWUL2rFD3rVD3rVIzMjAzMzMzjWzLy8s0NDQxi2qjo6OjpaSmpqb81AFBupL91gH9/f3mnAv7+/tybcXKAAAAAXRSTlMAQObYZgAAAW9JREFUeNrt09VywzAQBVCvLcsxcxwGh5kKSZmZ/v9rukoz05naatr37PPZa61WFnYlwR9dLogEIQvwawuCml+1r2BOaR+wBfhxQdUzXVrcH1OzGTh+xIPO0jUbU5deXC7dyigIIo4rEHTihJA1r9gjp50KtfL5GEUrDBeE5VIMjVLlnGLgKpRl+SbzOzRJYxDKcdhjrnhsNJ12uivFvZUc98TM47DsUYqjp0VmtRYeroVx6kCOFy6DkEuB0olBCJsEPp6G2ONWDBCkpGPy4Nl8eAvld9szUW6+K0HyIqseNQlhx2Nwz2dSeun8dDW/gIZV8ZX2tWYQcGAuAo2U6l1Stg1Yb95pAyQcSkG6letKtzEtXX+9kaOZKupC+hrvlZmKW7xjkLlMh/Mk8+JGwmnt0OI5jMmLoqJYE3JmKYqYUdHxJGCmhamo1A6kke9QBTNFHYCxLdLSGdrq9MTlpUPAbSSm4OFEJP8XF3b1v/oEy4Qm7q4HFEMAAAAASUVORK5CYII=",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "810",
+    "id": 810,
+    "sortid": 671.02,
     "identifier": "florges-orange",
     "name": "Florges (Orange)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA5FBMVEX///8xMTE2NjZSUlJUUlDOzs7/jBD/nIwwi2pCvZRRUVEpWkIxMjHTagHWawD+iw8xjGs0MjL///9BvJP/zaz8ixH+/v5RUlFRUlI0MjBTU1MsW0PMzMw0MzLTagA0jW01NTXWawL7ihD7mor7y6v7/fz8mov8/Pz+m4lBu5L/jRIzMTBCu5IrW0RUU1NUVFS+Y+tUU1JRU1MximoxMzL8/f0pWULLy8umpqYxi2r9ixP9zK4pWUE0NDT+zKrVbAMrWkAzMzMzjWxBupL/zKqjo6P/zq2jpaT9/f37zKv8zKv7+/uut4X5AAAAAXRSTlMAQObYZgAAAWZJREFUeNrt0cdigzAMBmCEjQ0hYSZk7713997j/d+ncuipFUl7jw5w+fglIe1YOvzRtaWvNKjHvriObDpjaAlRBPwEkuNk0+U5sbgcCd6TWeknwewsxyernHh6meWcgURIuyVD5xUY23HHGWSrJExlbkYo+kEwZypXYKhPypbAwG5gGMZDuB9yNtkGRhTUY8d7ZG+9xitRvWtEdS98LWXcxQWuTkU2Un0cro9x1taI5hgpOLR9MpExtQl8npXwm4zDQdM1srcr+PNbYNw6LkeJfenz6+0mSsYyrhAKfsjd4R83P11HLtGowj2KqR4edEzCtg8pVpnmWTxdbSCzVYBfDqWmnxpTOz9ZVe7jSe6GlpfW6DOe20MLr3itYBldiIFUNdbet4Sr97KZ5DBm7Xm2bRbYiYmv0EKXJAEzTVs1tawNJLE41MYwLw2g2AFpphU66NLEzyOnxGsQW9CYiKSrAdqx/ldfokIk/yqdMPgAAAAASUVORK5CYII=",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "811",
+    "id": 811,
+    "sortid": 671.03,
     "identifier": "florges-blue",
     "name": "Florges (Blue)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABAlBMVEX///8xMTE5e/9SUlKM1u/Ozs42NjYxjGs5evwwi2pCvZRRUVFRUlNRUlQpWkJUVFQxWcz///8xMzL+/v6K0+xBvJPl/v4YY707e/w7ff8xWs5Cu5IximpDvZUyMzMzNDQ0jW1SVFRTU1M4ev6L0+yN1u/MzMw4efvk+/v8/PwxMjEZZL1RU1NRUlJBu5JRUlExMjQ1NTXk/Pzn///k/P84ev37+/v7/fxBupIYY778/f0rW0QYYrrso3Lso3TspHUzW86K1O4xWcswMTMpWUGjo6MyW84rXEQpW0Pk/P4qW0QzMzMxi2qjpaSmpqYYYr1UVVQzjWw0NDT9/f2K1e0pWUJ/a1V5AAAAAXRSTlMAQObYZgAAAXpJREFUeNrt0ddWAkEMBuDNlG1sBRYRFJHOAoKNYu+9l/d/FTOcPV5oEL03N3Pz5Z9JRvsvHX7psqKkNPzcokOr3lk4hSZjA8AWmB0nOtuuydjWInNrIidgFsz5plvs7ue3Nn1zciwQ0m71CZ3R41xxc7IgciskTAXXiyjaYehzhIxhaImUTYaBo1BK+RwlEGjo8uJOKDNheeoKTm1zhXInTiNTHslM2YjuK8FBnuHo1N3rqTY+ro1x9o7M+CZDCFkC6nsO52oSGD5UsCd4dECj37i3zdzz11AeFaouyuReHb4v8qLKXM6D6mFewY26kvo4/dW16qtBlSU1SNWEWE6TMFuCFG/s9nlQcADBm8j5AGP4/kZNH8pdr1/sNm6njctXa7YRa/Q33nlrNv7ii4I36KK0Rtb6kpFIONu4tBJHRS4ZhudZPf5u4RHZiaMiATMtT11q22kgzWeoh2FGDKDYHGnFCs11Maglz4dq2cQUNCYj6eG1//pbfQDvNSZPh9jBzAAAAABJRU5ErkJggg==",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "812",
+    "id": 812,
+    "sortid": 671.04,
     "identifier": "florges-white",
     "name": "Florges (White)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAn1BMVEX///////9SUlLOzs4xMTExjGspWkJCvZT8/PxTU1NUVFSlpaWmpqZBvJP7+/s0NDQ2Njb//P7+/v5RU1PMzMw0MjM0jW39/f1trv//e+//fe9zc3NRUlIxMzJydHMzMzOjo6NCu5IzjWxRUVHNzc0rW0T7eewxi2r7/fz8euz8e+8xMjH8/f38/f8yMjL+fO5UUlRBupJrrf9Bu5JycnKMGDTZAAAAAXRSTlMAQObYZgAAATZJREFUeNrt0deKw0AMheEcSeMZ99jpZXvv9f2fbaXA3gR5y32EZ8Dw8SOY0WHG8kfXoDUtdv2Uu+6q8lkaoJVGz3AO1WX+mZb3HYqEddf6UHtFKs4mSlavqVoAPhQQqQtboh2vysV65kJicH6zTUBB1oVGW1cyUwy3YObz+mdIFADuMa8n017z05eZvyMjgDEP9TElLJ9QJC8pBJR6QoyP3KvRpDQeBJE6kKDKE4rTMpfR2N2x3IBKgDcbNpnQ+s8vUEVkFqTwrjM5fjvadyuYsXkH5MKWPHEhRIg4I7I9R8I91jMRc/tSLWcZRWKxX/DVRwwP/ntTyGIkQAxm6moNujJ8S8lWWTA3BFVm+tkJMWp5SFrTqqqimBumu14Q2WOuDA5ynIju9vtoTKIjfexDP3uY/80XJgAQAJ56z8EAAAAASUVORK5CYII=",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "813",
+    "id": 813,
+    "sortid": 676.01,
     "identifier": "furfrou-heart",
     "name": "Furfrou (Heart)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAolBMVEX///9SUlIxMTE0NDQ2NjalrYze583e587ve4RCQkI0MzOkrIxDQ0O7Y2u9Y2syMjKGjm3te4SkrIu+ZGwzMzOmro5FRUW8Y2tKcnozMzLc5czd5c3e5c00MjJUU1PteoM3NzeVS1P9/f2WS1NEREQyMzNUVFNVU1O8ZGyDi2uEjGvXNTWFjWxLc3vd5s2TS1KUSlJNcnpTU1NNdn41NTWkrYy8lJ0vAAAAAXRSTlMAQObYZgAAAUBJREFUeNrt0deOhDAMBVDsdDpM73V7b///a2sHzWqlEGnmfa4iRDm5WJBcc3aEELMz2EwYY+qZEN1lmvLqCdaGQ0fhnbW8+gq1OQVpm7UDS8HADevRHxQe2l6Io8XC/KuUhXeFDODysFu+HzqsMSFZlmURFHLDgIba8aCvrUy8pL4wfqjm/sfo+eOwu/Pm+8JKctOPrzZzz8qLCrgwDE6al++nvYNcKRYInoe5AYD9HhzAA7lqKCKFcgqcT4JVUqEb8dfsl5gD3NYEcwRw/DUjEsFRz5hqGc+NjkMYU49jyLKNQQnOnCBKyHOCEYnaGK2OR4W87W6VRGWrtcpU5n9hagcYlatMKcgA2TWNxagr19QGDHEDsJERh5NJCTJJ18jzAp1GQl2F5NksSxl13UOk2YJ3RmrJnZPtdptcc2l+AVgiEJvK0Eh8AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "80"
+    "gender_rate": 4,
+    "rarity": 80
   },
   {
-    "id": "814",
+    "id": 814,
+    "sortid": 676.02,
     "identifier": "furfrou-star",
     "name": "Furfrou (Star)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAApVBMVEX///8xMTFSUlJaxv/e5843NzdCQkKlrYxaxPze581Dk8VDlccyNDUyMjKGjm2krIukrIxCk8Tc5s5DfZ5ClMYyMzRTVFU0NDRaxf2EjGtERERFRUWmro5Kcnrd5s0zMzP9/f1Ce5wyMzOFjWxSVFQzMzJNcnpNdn5CREU1NTVTU1OkrY1DQ0NUVFPXNTXc5czc5c3c5s1VVVRDe5xCfJ1Lc3uDi2seOFthAAAAAXRSTlMAQObYZgAAAVxJREFUeNrt0UduwzAQBVBOI9W73HtJ7+3+RwtpI8iCppHsPQsKhB7+H0HqMkoNh8O/MeZ4/3vPQo6ZF6Z4+wnd0OYUW+6ti4vCnkfZt9T2vgPjyIzjhX2AvWcpEaUZ+JC5aZhNseB4qZRE5CYSz903Tbu2kMdsjItMKaLUC5Tyo21p3dhyHptSLKQojwj8HWu3UmvLuTB75bpBQyQeFHDLj95fmRfb7dImiYXW+ZHOza+un1++zKFb5dp3h6qEPm+fVhofyrETgKBOzgYTXK1QI7rGPAeUk07m6ObOwlxZhXkgUIlY81jY4wbQDajQ9FrPeIqDVONZCV03ZWZNRPoslFqzgzV1GgB3g2C3QMwcm8lkAkowpV4FZRnHpjLV8V9TeuZzKmOwQgey0Ygg6LpdVcLALQcRYiQBB0nSoQC5JAFECa6IWIvK6Cgl6I4vwe7mdQZiPReOvcw/5xuimxEyUscvBAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "80"
+    "gender_rate": 4,
+    "rarity": 80
   },
   {
-    "id": "815",
+    "id": 815,
+    "sortid": 676.03,
     "identifier": "furfrou-diamond",
     "name": "Furfrou (Diamond)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAq1BMVEX///9SUlI3Nzfe584xMTGlrYz/lEpCQkKEjGuGjm2WWzqkrIukrIzOc0Le5800NDQ1MzI0MzLMckIyMjJDQ0NERERKcnozMzPNc0NUVFPPdEP9lEszMzL///+Di2uTWjn8k0r9k0vd5czd5s3c5c1FRUWUWjmVWzqmro6FjGuFjWxNcnpNdn7XNTWTWjqTWzszMjJTU1MyMzNVVVQ1NTWkrYz+lEqlrItLc3sdRXmkAAAAAXRSTlMAQObYZgAAAU9JREFUeNrt0ldywyAQBmC2gKxqWXLvJbbTe7v/ybIYZ/wgSHwA/2+w3ywMi7pEqXb7TEc0PYcyEcV0kmXATdt0CB/XHdPxsXrQcm4zPfYfmzE3HYOO19ZdxbE7vDTGlB6oW+tkLe5Neg7shrFhD7xJzI4IiKilpY6VuAobENO9MfmugA3RrYWK8zxvNHR3Nyb5GrXEpbYRLvIF+uBE4OTpA0ZaD9zOkJUn2F+ZSf/uPs3m7mhVA/rnAqvv94dZBF2t8bAW7ssrAMxmEAHMxZVlGWiIfbB5EVirZ3av7ZfcBRjFArv8eHpt7yWj6Jq2AHJ8lISlQNgSUXSASzcXbxAi+oWMS/d3/JILokL3eloIf8p3DMq0KHSmsxQF7t2o/eFMa8jAgs5w+AesIU0RLOQKoMKwA0Y3O2SAoEOwRcutxKA7Ftnx/4MNF+6rLnH5Aau/EGC4d0I5AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "80"
+    "gender_rate": 4,
+    "rarity": 80
   },
   {
-    "id": "816",
+    "id": 816,
+    "sortid": 676.04,
     "identifier": "furfrou-debutante",
     "name": "Furfrou (Debutante)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAq1BMVEX///81NTZSUlLe587/53tUVFOkrIvOvWve581CQkIxMTGlrYzNvGukrIwyMjLMu2szMzPPvmw0NDRVVVT95XucjFKmro41NDPd5s1FREM3Nzfc5cydjVNDQ0P85Xo0NDL9/f2bjFLf582EjGtEREOnr46Di2uGjm1FRUPXNTVKcnqejlMyMzOkrYxVVVP+5nszMzLc5c1Lc3s1NTVUU1KmrIv/532bi1L+53xR/Y+1AAAAAXRSTlMAQObYZgAAAU5JREFUeNrtksdWAzEMRceS3DS9p0w6hBJ6//8vwxMOq4kDLNjlLbzRPU9PkoOT/qSsKH6HNYhFFrQ/cBwijkYmXBAfBxfdaLTrwp2mJMuyI4Za1zXlNdUVhKESQesbI9K6u6eaViD33KEERT9GWUbRimglpVIcMNHQUkynBtEYKSVIGSshAmdIByxZqOlU3arXcxU20NfZcXPHD03tbPb0fLW0F7jfeULk2dINACyXYBExCbgoK0rFIU5cw17WoLGJo+U3N+x9BiBhHGNjYYPYeM8jttbqsQZEtP3jv83DZqx1Do8OLM0RS35nxxHdYXiJykX1gcJylL8R0HpNLFKTL7whBVTmQ0bUL6bNKWf/R3uJw7iMHMdUVcReTndyCygdwHOAufBNE0U6TVrTtxQMILwZAVIBlBP1pPByX0WuBkf2wINsPk0mk+Ckf9InQn8Smj93zfkAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "80"
+    "gender_rate": 4,
+    "rarity": 80
   },
   {
-    "id": "817",
+    "id": 817,
+    "sortid": 676.05,
     "identifier": "furfrou-matron",
     "name": "Furfrou (Matron)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAulBMVEUAFAIxMTFSUlLOhOc3Nze1a8ZCQkLe5840MjQ0MzRUU1RVVVSDSpOkrIylrYyza8S0a8U0NDS2bMfNhOUzMjPe580yMjKEjGukrIszMzNSU1Omro5TUlREQ0W0bMVUU1VFREXMg+VKcnrNhOaDi2vOhefc5c3e5s7e5s+ESpSES5P9/f3OrM6FjWyGS5aGjm1NcnrOheZUVFNNdn7Orc3Prs7XNTXc5cxEREM1NTUyMzNTU1NLc3uFS5XYc/+tAAAAAXRSTlMAQObYZgAAAU5JREFUeAHtkbVyNDEQhHdAsMx7zAw/g/n9X8vSOZXOduDsOlCVSl91z7SCmz6jsiwHH8C0VkqNym7wDqyFOCuj32l2hey0FkYWHGGWgY+DsSgsuDPg9ulbn30gJ4fxhTwrjHvXouFwGF9QVOqHjW7CsPFYHo/D6RRbpdr+GuA70Qu4SRwuf/7BtG0z5gCISIB7b3x++H+ScZqCva1IuMFHRDydUKo47gIo42OeJ+xKXqKVAZWSna0d2N0Ry3vECCdbA2LP1O7tnNdSikmF1tIe/i6b3ryq6ALGrbHsvJVLItpYcK76Su1Qh55flDVt/s22+z0B3+2qqCJwRzdY/21/IVHOQVhRVefsjk50lGZpXBQQANX1agaeaC1EtMY9YhjAAjFZsGebohB5N6NIEDAgMvuKRMwZ6W02NphX9hHqmtyzOWzdszlsDfc1uukV9DEVvZn78RQAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "80"
+    "gender_rate": 4,
+    "rarity": 80
   },
   {
-    "id": "818",
+    "id": 818,
+    "sortid": 676.06,
     "identifier": "furfrou-dandy",
     "name": "Furfrou (Dandy)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAqFBMVEX///9SUlKU3lre584xMTFjvUKT3Fo1NTalrYxCQkJVVVRahEJju0JjvEM0NDRkvkODi2syMjKkrIwzNDKmro7d5s3d58ze581TVFKEjGszMzNUVVOkrItDREJlvkVEREM3NzeEjWvd582FjWwyMzL9/f2Gi2uGjm5bhUJbhkOW31xdhkVLc3s1NTUyNDLXNTXc5czc5sxUVFMyMzNERERag0JKcnpahEO/X5dOAAAAAXRSTlMAQObYZgAAAUlJREFUeNrt0sWOw0AMBuAYhsIMZVxmfP8320mqPTVTtff+h0jRfHLscbxrLkgWx/E5jn0iOodm1KeZnFaTOJsOTms+5eKSWqw3vZupE44rIiEEvmud/xfcFbtjqNKqocVCBEEAk0OTfI8Bj0ldVc1jECx8rQdZIMqxJnjdrXVFtnBpvz44HJ1KhXdRenObWpwCe4zjBW2y6On5dW+2247ZvtnJeNR9AsB+D6Ysy8yLY/83DEcLqh8YYhoi01/WB1s3Ks0SoIV5TvQFHZF7P6pbGjEXQFQa+yD3yjmdC9FDMn5jObtcYIRI0MKNeZvVVLug+jZRgg9+vkFkFdZJ4WySW4lNA4j2YorEcpd8Ea3UuR9ZxyilE7IdpU2BoPAsBJBOGEUizKZ1vzvFAEq5egQIFeChOeVk3uGQpTz6a9xlvXOyWq28ay7MH3L9Egeps+/lAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "80"
+    "gender_rate": 4,
+    "rarity": 80
   },
   {
-    "id": "819",
+    "id": 819,
+    "sortid": 676.07,
     "identifier": "furfrou-la-reine",
     "name": "Furfrou (La Reine)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAArlBMVEX///81NTZSUlLe584xMTFarJNz1salrYxCQkJVVVQ0NDRarZRbrpVDQ0NKi3rc5czc5c3e580yMzOkrItz1MWkrY03Nzfd584zMzODi2uEjGuGjm1y1MSkrIykrYwzNDRUVFOmro5TVVRz1cVLjHv9/f1KjHtNjn01NTVDRERLjXxMjXxNcnpdrpVNdn7XNTVz1MREREPc5s3d5s1FRUVSU1NTU1MyMjJKcnpTVFT+zvUnAAAAAXRSTlMAQObYZgAAATRJREFUeAHt0sdeAjEQgPGdkrK90DtSwN6Lvv+LmQTwYoJ68MZ35f8Lm8xEf+lUkiT9XzEiOvuZWkaW8hE0M9GhJOxYmr5gvTuymX2HILJMqoNT7Fwm2SPHy+XNHk4c5ExKn+SrrTGPFmIL3Nf4IbRqovL6tjQQ3D8vpRTgu8+kKs/v1np/lSa9HHtd1CDm63Wuq8mIzdNvRcpeB+9oZI46jp/emIjmK68zUueIc8yrarggk8Lgo+OFVg+4WAzbaGU/CFOh1UjfS/mBVB8ZOeBLMyDSiALLlhtkSBZFv6ZnIeYIUNYqvG7ASlUUx3Yy3Ol0OCgbpV4rIgsaIVIOus10OkC3j5wiCgg4Xq02BTBRjyNgxJCLALGAaNbr2aUBCLrdj9xu+5fGc+zY4zx1u93o1H/1CWJMEM8wRWZVAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "80"
+    "gender_rate": 4,
+    "rarity": 80
   },
   {
-    "id": "820",
+    "id": 820,
+    "sortid": 676.08,
     "identifier": "furfrou-kabuki",
     "name": "Furfrou (Kabuki)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAsVBMVEX///83NzdSUlL3Y0qMQjmOQzqlrYzd5cze5872Y0oxMTGMQzqNQzpCQkKkrItDQ0O0UkO1UkLc5c00NDTe581TUlL1Y0szMzOzUkIyMjKkrIylrItUVFOLQjlVU1JVVVS3U0ODi2uEjGszMjL0Y0pFRUX1ZEtKcno1MjL9/f00MjJERENTU1PXNTXc5cwyMzONRDszMzJKc3tNcno1NTWGjm2mro5SU1P3Zk34Zk2LQjq1e8SJAAAAAXRSTlMAQObYZgAAAVFJREFUeNrt0EdywzAMBVARJEUQ6l123Lud3sv9DxZ4nJ3MKJvs/Ffk8M0fgN4lf09xTD/b7YxBxF5aWBlqlkx/d6jszCpjeiSh0ZmchVoxLJufWc7AxmgrpZzZTJnS94nZUlrqFsahDRXLTErl+0PySGqpdEcKyoI02GyY2gc/BoZ80rJbKVqA9+3zp5Vq6AvheUvLbiXObAPw9HK7/5K6ouM1zLIVu27uAZL9PonqmgejokizVpxzYgssE4gmEzsoEHEUnFhXRgnACBJuhJzhGzi//CaK/GuAyQcCchonXCwi/3UtawTAkivJAQXA4xwxmgI3xoiGoUPO502J6zwfgRB3Jjx4TklXVzlOp7E4/SM55SAIqtyYIzikaeiEy6qqxqA1A2oBWuFwFARqLMhaRTwFADvn2mPh7bS2xBfhdKdHqmvJvD9cu+o4Z+0l/5ZvXh8UtU/Aa7EAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "80"
+    "gender_rate": 4,
+    "rarity": 80
   },
   {
-    "id": "821",
+    "id": 821,
+    "sortid": 676.09,
     "identifier": "furfrou-pharaoh",
     "name": "Furfrou (Pharaoh)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAzFBMVEX///9SUlJje//e585KY8YxMTE1NTbd5s9CQkJDQ0U0NDRLY8UyMjNVVVRje/1je/4yMzVlff+krI2lrYzc5c1CSpve581CSpzc5c6krItDS50yMjRlfP5LZMdNZsdSUlQ3NzdDS5vc5s1jevxKY8RDQ0P9/f1UVFNDS55ERESkrIxETJwzMzMyMjKkrY6Gjm2Di2tSU1RTU1Omro7XNTWEjGtKcnrd5s1Kc3uEjG5NcnpNdX1FTZ0zMzJTU1Xc5cwyMzNFRUVNdn41NTWAV5cZAAAAAXRSTlMAQObYZgAAAWdJREFUeNrtkcd2wjAQRT0z0ki2wcadDsaUBNJ7r///T5FPyCpWyp671dWb5uz4F57n/cE69Dwi+tXsdNxnMnS9XzxEoSlX3THJnzyJGAqtjnBsIr9KtJqmCMO+0FE0JDKR2xJ78ntg/lCIwlUmUlB+sC2BDWLS7Y/cIIoQKU8SI3CFRYPIvWKEIz2b0YzWSY/rv+FexQ3DFIio795u7glMoKHV6DmchRi+Xyw15Y9JLQz6xmvipQzK5XKh0/WxdKTn+aJ5nXwFAIvFRLfb14f1JVc+O82m3ofJpK/T9BJSI56D9TaxzszO4ekWgQwHVlEIdy5cDBCAcqIjaRPnQmgx1qcggHpKDW0iyyzbH9Or76+AuRomA8dmso67KbXbPa47js1+bLQ2m7OUqBYGvm8XW0Ucn4BSsm4YYM62acqyyFhGkYlkCcDWHgEydjpKoawbtnqfjzII8FtNS2zFzl+YTqfOjn/yATS9F6n4LKUuAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "80"
+    "gender_rate": 4,
+    "rarity": 80
   },
   {
-    "id": "822",
+    "id": 822,
+    "sortid": 678.01,
     "identifier": "meowstic-female",
     "name": "Meowstic",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABL1BMVEXQXbP///9ae++Ojo7Nzc38/Pz+/v42NzdCY61FZq9ae+4yMzQ0NDQ1NTXOzs76+voxMTH9/f04OTk7PDy/v7/Ly8tae+1DZK+Li4uMjIxEZK24uLi8vLxZeu1Zeu7MzMxCY6xHZ69SU1T7+/tUVFRVVVX+/fpYeu1Zeek7PD1ZeexCYqlCYq1aeewyMjMxMTNCY6+JiYmKi4yLi4eLi4pDY6w2NzqNjY2Ojoo2ODqPj4+QjodEZa64ubu5ubm6urq8u7tEZa+8vb69vb03NzfJyck3ODhRUVNSUlIzMzPvtQvwtw/4+fr5yQn5+fn5+v1TU1P6+/76/Pr7ywg5Ojr8ygo6PDz9PQf9/PpWVlb9/f7++/tXV1czNDX/OwD/ywf/zgv//v4yMjLJystTVFSllBGOAAAAAXRSTlMAQObYZgAAAS5JREFUeNrtkUVyxDAQRd1C09jyMJOHwswwYWZmvv8ZoqSyjFTeJYv5q1bVq1df3UYvf5fYbjROABbRhADDTgSOh8FdxhZRwKSJTMdxvu0xDXjEzFIGIeRIDECtTiyHVruMkG1LDCjXKCeg1rZtK89AJ5TgOUDNshhe1wuNxGFLqlozQZJpOak8eG3d7y2csWxcvuKuqwKnq8f7T88vs1npc11CPAXJ+9Ho6fXlzQqXugrB2PPE7x075XLJzi8+Sl8llSOeV+GK3wykV601mnTeCLltNDZTF6qSW10GMO+n6/WPFCHNmPo2OSrJh+aU+Y4xZrCh3E+h6DMKdKc6HgDgAIRKKQonS5M+53zMB4AgVO69T2wPjfCvgVNKi3HNGTuDcz81ZAxNrrjRy7/IJ/x5G9fF3yS6AAAAAElFTkSuQmCC",
-    "gender_rate": "8",
-    "rarity": "75"
+    "gender_rate": 8,
+    "rarity": 75
   },
   {
-    "id": "823",
+    "id": 823,
+    "sortid": 681.01,
     "identifier": "aegislash-blade",
     "name": "Aegislash (Blade)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAbFBMVEX///8xMTEyMjIzMzI0NDI1NTU3NTRSUlJTU1RUU1NUU1VUVFJVVFNVVVVza6xza610W0uMa1qNbFqchOekg2ukhGukk0OlhGullEKllEOmhmumlUPUxVrVxVrWxVvWxlrXx138/Pz9/f3///9Dl7rHAAAAAXRSTlMAQObYZgAAARpJREFUeNrt1OFOgzAUBeAdhj1OmQyLu3VWr9r3f0dvzeogDOG38ZCGNPl6Ck1g8+eDtU6xEgasLNSV8CUsSmxzYdTjIgzVpmbDxmCN3+DxvtYYo7KqFbPKwqCRpCo1YFbBAYG3PvlMAcxA5/Jt/9Cmts2Fjlcoynr3sVdVpjw1OpEV4c5LEsmUcD4ujCloawu0xuwykyeREa2uQchJqKeTXCQ4hu/fcCvasVMdQT+EpVAiE6NeKuF556/Abt/RxusAWsrk5gce+EnaOAxg61tM3qXfNY/aNTvpy8m1nnZhcjry9qzhTaxwFp4fsjcqfe8KhIcnUNylEiK2rxt+nplNYKYwNk6BZeuFwGR2izB3lr7lTmDtn+c/JV/WGBi9LMFrswAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "824",
+    "id": 824,
+    "sortid": 716.01,
     "identifier": "xerneas-neutral",
     "name": "Xerneas (Neutral)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEX///8xMTFSUlJaa9Zzrdac1v9CQkJCUqU5QowzNDVajLU2Nzd0rteb1PwzMzRTVFVUVVVaa9UyMzRai7RajLQ6Q45cjrdyrNRzrNQ1NjdCUqQ1Nzeb1P2b1f4yMjJSUlNzrNZERUU2Njdaa9RDRESb1P5TU1Rai7P////FwRcdAAAAAXRSTlMAQObYZgAAATZJREFUeAHd0VcO20AMBFANC3dVJPcSFzs9uf8Js5T8FVk8gOeDXhgPQwKqPjOofQ4+Xo8Bb9HjXqOCbF//yANyncEvfY3V/tbV23ODCZ5/+6v+v/Taa7de3W7Hp2S4E2oEW+h11on+3tHz1yEzimv2JERHnV3p9I/mQ964BJik0H7uPN9PzjY556+sa1rrgvPDMhcmxCmpqiw5Py3nRkidKZadd9JUl8xZAEsb46+YMUKnxZU+ZnehlMQlBncAAokLcx4BUkoIcFsACoN5iOithJPEqGBsNNJ3zhGA8UZORmTetwCTsRTJzA7hbkkmTTw5Cr/NRbR7uRg+1O5+pLmLoIF2PwxVSzREsDXDT/MukCCuHPbfJnhqYyikI/QZ7t6tTiP0wlh2GH9jN9sZVc52LgXVp+cfXoULbAlLo/QAAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "825",
+    "id": 825,
+    "sortid": 3.01,
     "identifier": "venusaur-mega",
     "name": "Mega Venusaur",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAArlBMVEWlQko5hHspe4RSlHv////2g4tSU1MyMzM5c2OUc0qnRExTVFQ3NTT//v5zvJNSk3tUUlKlRUw5g3r1hIw6hHtSm6S9vb06hXxVU1M1MzNSVFT/xgAyMjJqxcWkREz4ho6Tc0tTnaY1NTVUm6T9xQL9//9UnaZSk3pUk3ukQ0tVVVVSVFN0vJMzMjIrfYanRU0qfIU5cmNrxMRrxsZSnKVzvZT3hIwxMTFSUlL///99k/UfAAAAOnRSTlP///////////////////////////////////////////////////////////////////////////8AN8D/CgAAAZVJREFUeAHt1Ol22jAUBGDJtmywDWaBAEnapOm+L7Lunb7/i3UUyg/ZacMDMBw4OsefRxf9kPl9Zi7wGFWNX30GPjwUIipSFIfD/+BhNpM1ABFxov+CVXUrzpn9zZsbGPPdfX0SalXl+ed1Xcsd9nBmVphan4D6Pu+6TbeXu4JDihHhEHx53HjbNQ3A5yfIIM911Fg2IQTKtUQHRIcJZQo17ELOT4NIENMgvohRYwgd4Rwx0ymAeXjMqNHOG3z4gsWCjC7YktRGmUJdwXtTL4zB/RSB2YUSm7BKIVOBTmohnt6DUwS7C01o28HWamHECePMNQjTCU9QrWWhMXT87cHMY2dAlcI2TuiXzhnnllz1PcouHoG1w3/te//CL5f+paF7bT6WtsQ13YRyCDNS/6rfempQlNse+LlKoILum//hs1/4xI37MnaBC23bBGbwGet8puYtH2MzsZbw3ZZsAOkYFIWPEJPHxqvB8VBecXNaKgZHqkqXQkqmP+bvAlGN4QkzrM/6LNMzLgAtsgLnwDMugDQX+AcV7Taq/I3faQAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "15"
+    "gender_rate": 1,
+    "rarity": 15
   },
   {
-    "id": "826",
+    "id": 826,
+    "sortid": 6.01,
     "identifier": "charizard-mega-x",
     "name": "Mega Charizard X",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAAArKys8PDRNTU9eXld2dnAzVZYzqv9EgLlus9xmzP/ERDO7u7mY3P+i5/////8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACz9fyVAAABAHRSTlP///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////8AU/cHJQAAAT5JREFUeNrt1M1uw0AIBOBOh2XzU6/f/2ldBrDaQ6L00ls4RLL2EwzK2h/HH+sNo4C/QYC/JaIeQpiRQIBCIwqPIUEyQCH3Zx3RblDKL81O6C7UVrPTXVRnRxf0GRATYpAkOCiWNN3NE4YURP64hyzYW7tPQUmHGYTzgTA5d692c91q9JoTRi1KyAm6SrLOO+MCOahdUQ0TAiWVsLdeGFlEBpZLc2ZcDY9yNgw+BTlbZvlt9WhHut3MIo8rAskfuGoZ1ypxdt/NI66TmcLY8MwYHtHOcDebKxpyDgra6TBwCM7eRG66+0ZuLSGGYQkPJSSHkWv5juu2BZUzWl01nJcCFgwxVv8Qr3IxPaV9yhWUxA4P5gd0vMspC63nNxTty1aSe8Gnr0LKqGu7l68r1PcVbLrzS+4lVIL3Z+8/4Dcq3gvHCuJkFAAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "15"
+    "gender_rate": 1,
+    "rarity": 15
   },
   {
-    "id": "827",
+    "id": 827,
+    "sortid": 6.02,
     "identifier": "charizard-mega-y",
     "name": "Mega Charizard Y",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABxVBMVEXYcmpDRETZcmo9Pj7YbWS6VExhYmJgYmIxMTH/Sjn34Z5GRkY/QED3m3zZcWlLeZBJSEe7VExDRUX3nX9jY2PYbWX0mntcXV1akMNjZGNBQkL0nYC5VU01MjJeX19fYGBFRUXZc2pBQEC9Vk3Yb2b9//9DQkH/5yy6UUlFRERHR0c/Pz4+Pz9kZWRCQ0P2noFERUZAQUH/6C47PDz/nzddXl4zMzNjYmL/njU3ODjac2rYcGjCw8P/Tj78UD+6Ukm5VEz+///YbmbZvHL13528Vk1APz81NDG6UEhGRkVKSUr3nH43Nzf/Szu5T0b/5ytISEnYvHI7OTjZu3K4VEz/TDv2noJbXFz/6DD1nYBNeZD8Sjn/njZGR0jXcmr+oT3+VEJEQ0I8PT3/5y3XunL3oIMyMjJkZWW5TkX0noHAwcFCQUD+6DL/nDLWb2bYc2rWcmr75jX0nX//nTP+6DP8/f3XcGj7oDz+6DG6UkpgY2NgYWE6Ozv/SzrYb2dCQUH3nH3WbWRISEf2nH+5UUk8OjpfX143NDTYu29ZkMNKeZBDQkJERkb+UkJIR0fznX9iYmL/5yr2nYBCRET3noD2noD///8o1VYLAAAAl3RSTlP///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////8A8Z+YEwAAAixJREFUeNrt1GVzpEAQBuBhWGB3kXV3z8XdPefu7u7u7u4w/Xuvh7DJbuoud1/uW95ioCie6q6GGgj8Y1agk6D5N7gRlxoEkzVJd2YpPLK3G4KSCea3Jun2ZJbA7V2fVQkhlsw3wHeHPO4m2N114bsk7f7KYcFUm0o2wFZoZUqaF+SQEbYoMx4sWYdBgk+VhAMJQmYKYOespxGqacZSCaYgrJe0LMGmg9zVoUkUxvB4KOXrdxZPEmDz8JYGmF8zX/Aj9rYhIsqXBiO9e54sQBMdS7CU4ktL+MIp8cmoRq2fdBU87j+1bQGq6Aj2VsK+tGKSo3I8LsvWTVqitAdGDteuOMOYjOcMI4SEw9QaHfIdjMf9fr9lBYwktE0O19YtQsIq6K4VCPYslaiPDywYxoOxIryZqP1wz0PCJGZWiKLM7aBWAKlMKZedYy0tV/u+9PfesqGK9QrqB0KGpv2nvV5vRweXOAdseFrWTuw7fn//xCBCbHwAe9PrckAAwYtZjTOHw3eTANpsO1Tv3b48uRPhS4aNU0SQAxzOcSdbRiiUewbwaatLhJPHbrQBQvvTymjGp8cFKu/ynpOt0NSrXLmsAYiudihG+sCZ2qzYQwqCn1Iq3wmFpja9zs5GYmtBfPG2qEcvORANOBGoYTzKzazPDugRV8wlijFdj4q/21xCZ7LnfXbgue5Ch9Gj0eoft6umRZBgOftcXW5fizPnL4p4wQAsBzlZ+e39F/gL9BPg1hjE7qcAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "15"
+    "gender_rate": 1,
+    "rarity": 15
   },
   {
-    "id": "828",
+    "id": 828,
+    "sortid": 9.01,
     "identifier": "blastoise-mega",
     "name": "Mega Blastoise",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAsVBMVEV7re+MYzlSe621hErOtVJrSim8vLQ5Y4z355Q3NTR7re5VVVXNtFK7u7P9/f0zMjI3NDQ0NDRUU1L8/PxSeqxUVFR7e3s1NTVTfK/+/v6/v7d9fXxUVFJuTS2MYzozMzT355N9ru1TVFWNZTt6rO59ru60hEt6rO0yMjJUfa57rO20hEpSe6xTU1JtSypSU1Q7ZY4yMzNtTCw6ZI3PtlRVfa29vbUxMTFSUlL///////8ee6TrAAAAO3RSTlP/////////////////////////////////////////////////////////////////////////////AKHEOx4AAAF6SURBVHgB3dTHcttQDIVh3MIukerFibvTewlwoPd/sOBmk6HNO/La/3D5zcGGJJ2e2YuFst8/C8qxP4qch6IlSuXl8jzcYqs75qWcJJWHF91F/4qZd+9xH0KQDFxgvT6as2APQjFMQpOLxXxemiu3Xcl4+9UN0zBZgTmwAmnSSQZaApizzkCh9u4OmgpYOSdZ2B6oJaQ0BFxNw2GQa08PB09WgsWXSTg4h/bwUCXmwVyEYuK0iFzdAxv6RbRvq+8GLz8l+QgKmMHqr8mTqL8lMOtl8QSKqkLVg6gSpz56QHvVn66QEWx0De/120dqiW7/xIhUr2yTP2R0uhHe8Ae8+0xv4s0Mr+Os61ZlWThsmsdvj+zmaFDf1DPEWexUw2pVumI58Sk0chKkuQj0zoUQwDwfL/7XwO8IT7bogkNpbhJKhbquoVCDzgFyysEKMYLACsfwyWVO/9uEB5hR5WGiVrRVgMyN4CRW733Fo8WcVZXxYp6+8B/p+f4C51Q6yr+w+JsAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "15"
+    "gender_rate": 1,
+    "rarity": 15
   },
   {
-    "id": "829",
+    "id": 829,
+    "sortid": 65.01,
     "identifier": "alakazam-mega",
     "name": "Mega Alakazam",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAmVBMVEXGrTGla4x7Smt7e3s3NDS7u7Pl3Do3NTSUezH+/v40NDI0MzGWfTIzMjMyMjI0NDTHrjI1NTVVVVXm3TnFrDK8vLVVVVIzMzF+fn56SmszMzPl3Dno3DlTUlO/v7dUVFL8/Pz+MTH//vzm3Dp9fXyeJCL/MTHo3z3HrzWVfDG8vLR8S2y9KSm9vbVSUlLn3jkxMTH///////87ST3lAAAAM3RSTlP//////////////////////////////////////////////////////////////////wBxnr2OAAABdklEQVR4AdXU6Y7bMAwEYFp2bK9zJLvd++h9tyJHfP+Hq0QFLqrI6P7NABkhwCdC4Y+QvjJnCYHc/4O4aRHbt1iEeLRuL5A6LEL4e6Tj88qgj71/rEAbZX5u3NyjClddAePVGjShnfHOd3Z1CZq0nsdWoI2yANBlqMNxzWuQCGYIVBYOgk4HkQw16xYFnBKkSVIIf5cRCog3dxNfj/KcBwI4Ql/CzQ8Bb56/2kDIE+ZllBOvoTv58FtyoHUINzLjXf9FpO83Igwct3YCY5hYJF6IrmmardnhZOEP7hJ7Fl5/PEiWzVBd+CXe4+et3NL3b9JL/+IeokMJ90AIu8BCPV0EjnHuTndrwb8Qq9YDHK6ErsLbENgBNG5fDk8FVPgYjiJ+QjoHhTS/Pm1P3ojWpCVKqCL+GteghAqwjfMJ+mBfXVOBaYTLkmMl75mhNeiI7Jmps4XWoALgtCESzhRah2ZlJJBIel5YhkaRuDgo6rDk5/+Pu5w/1OUcJeIAeqwAAAAASUVORK5CYII=",
-    "gender_rate": "2",
-    "rarity": "15"
+    "gender_rate": 2,
+    "rarity": 15
   },
   {
-    "id": "830",
+    "id": 830,
+    "sortid": 94.01,
     "identifier": "gengar-mega",
     "name": "Mega Gengar",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAjVBMVEVrUpSlY4wzMjR7Y7Q3NTTvta3ve3O1a5RTU1S9rbV8Y7X///9sU5X//v7FY2NVVVUyMjL/1jlUVFTEY2OmY4x9ZLSce9Y3NDSefdTue3V6Y7NUU1NrUpOmZI2kY4s1NDJ8ZLYyMjN+ZbS+rLT81Dn91Tv+1Ty1a5W2a5Q0MjLGY2NSUlIxMTF7Y7X///9o1jtXAAAAL3RSTlP/////////////////////////////////////////////////////////////AFqlOPcAAAFkSURBVHja3dTXbsMwDAVQyvK20+w0SfduRd78/+eVppt0KEj92hIgbAMHV5QgmHYD649CkWHwDsOgtANhAjr/FZrTQJFfoUBhgsn+M5EDjAJ9Cc+WmSTYdmOYpiiwBJipWx+AeRyFDG0iY+h9DAW4vwWIiDtv+wKDj8D14xqAMXMd1NgYTmWKfXme7Cak+fI1UUS7wPONwmUPmUrhbgz6AsWWyberpxWWeR9YMlBS27Y/oXCeKJA8fwEBDOsa9eeMIgRt20Ku0ISSC+fclbs+QKm5rnEpMvMe2Gw8xg3DL9wZF8VrYa6HC14497ZLq9kFPPyMG4UcOlfMOf2EwUqnfHA85nHVjLISfFbyPHBqzuCHFH3OXTOqRlWTsZ26pKmYOkAKwc4gDVlWZRUbBNLoPopW/xKUMnonp264KGXHzgFO5DuMKOvEzjkOJ6CVyWBuCAwD4MHFMN6RmItgTAf/zf41fAcIbQTf2JPUmgAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "831",
+    "id": 831,
+    "sortid": 115.01,
     "identifier": "kangaskhan-mega",
     "name": "Mega Kangaskhan",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAllBMVEX///8xMTEyMjIzMjIzMzQ0MzI0MzM0NDI3NDQ3NTRSUlJTU1JTU1NUUlJUU1NUVFJUVFNUVFVVVVRVVVV7a1p8bF19bFuDY1KEY1KEhLWFZFOFhbakpNylpd6np96tnFKvnlS0e2u1e2u2fGy3fm7Es2vFtGvGQ0PGREXGtWvOnHvPnnz17az27qz37639/f3+/v/////2O+L/AAAAAXRSTlMAQObYZgAAARpJREFUeAHt0sFS8jAUxfHv8InIQbBi1RswQi9aTdWref+XM6njitBh7fDfZPODkDP8O3VqIEwmx8GL53CkRBsApBMYhv8v69QIZoZBV/fRQjjsxsCo/mk26DRqujd3I9SDEKrCu6QqzqNoMwBF2FVkd/4SpVnEcT9rAUqGfarKJ82XIxRmAoTsNDsqo0qSaFnX+3QKsqo+SZVFoytFvyrNpvszsg3LZdiJzrShIC8QCstD9MpSb7oSoQh4O49rlF7OrX2YvetOlXJP71+//ANK0DbbjTG9SIRwST6ur89KG9Esu05UATqaee9RkEAI1ASZZ8wfC97lryxazWXogpkjXdqnbKNE5NMxOO8H/sMAfk8UfmI5JPcX+wZbKR97DXcGcAAAAABJRU5ErkJggg==",
-    "gender_rate": "8",
-    "rarity": "15"
+    "gender_rate": 8,
+    "rarity": 15
   },
   {
-    "id": "832",
+    "id": 832,
+    "sortid": 127.01,
     "identifier": "pinsir-mega",
     "name": "Mega Pinsir",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAsVBMVEW9vbXGrYz/jDn/3jG9lDE3NTQzMzI0NDS1czmMhHO8vLRVU1JUVFQyMjK7kzH9/f1UU1P+jTm7u7NUVFODY0IzMjJ7e3ukg2OFZEO/ljGzcjk3NDT/3TI0MzOkhGM0MzE1NTX/jTz9jDrErIt6enr+3TLFrIuGZUTFrIy2dDmmhWNTU1NTU1L83DGmhWSGZUK/lDK4djy9vbT93DKLg3KEY0KlhGNSUlIxMTH///////8/3gnHAAAAO3RSTlP/////////////////////////////////////////////////////////////////////////////AKHEOx4AAAGdSURBVHja7dTZcuIwFIRhSZZN2Alk35fZ902nW3r/B5tWMlPEUKHmZu5yjO0q9PFjU2Vc+cd5gYX8eygY74AD9wDzjTAC1rgHOZi6H4MHmDl/hNq34fly4n4tO31gnvOrc9zdAWG8Cd/vqeQcaQu6IyULAMGAPtyL8exsKggYyCxJ7z2wCb/HyAGcGxJXKBUe5SkgugGVvF4KugFAVljjY9Gg6cN4TcHR5aUyLjvHMfbDfohN04Q1lJzNOHSjla7sQ1J7QaHwLZ7K9X+ew2nk6JPc11mTAOtm8TSG0DQXPUgm6PX2nbef3evkzYxRseaiuS1PIFOCluihMfPesDpsPqt3G/p3faPlthAZ8yH8G0PyJ+wYxHqQWb1SWmgmH3FS+3ZwnPRe14OtS7VY6OBGQ6lFsoOW3tgp0L+ZzHrCRJvgFcBC7/3xBpSpX0M4qJjSygQ6f9/yyyasVqsJkIP3ZjTP0t63W5DOciKTnHYzZEuSZRsmDQs12SwZafXCt6Gk4592StXwGajYOu5Yz7uf65rk2uyCar/87f0n+BtGdzxQ+fvV6wAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "833",
+    "id": 833,
+    "sortid": 130.01,
     "identifier": "gyarados-mega",
     "name": "Mega Gyarados",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAmVBMVEVKa8bGrWtjY2O9vb3///9Lk+XWSjk3NTRTU1OMe0r13HsyMjQyMzStSjk0NDRVVVNSU1RSVFW7u7s0MzIyMjJKbMdzxv9VUlL13X1Kk+XFrGusTDwzMzNNk+VNlubUTDz9/v9LbMX03HpMbcVzxf8zMjJNbcVTVFU1NDOuSjmNfEtMlOVLa8V7e3v33ntSUlJKlOcxMTH////ITNieAAAAM3RSTlP//////////////////////////////////////////////////////////////////wBxnr2OAAABfklEQVR42t3U53KDMBAEYAlTjHuJU+z03tDd8v4Plz05mYwxLn8TzSAJ5psFnRi5+sj2F2H/SAiH9XgI9h8QnWI/hPPz6MJh6EkGGgIG2AP7EYIunF/sgZefhMvB5JpO57tfjUqcX4o6Bqp67IMqUxeh8xECu6BmqpQuBgIKbELAXCVZ1hVKXr6o4S0dmzA5qU8Iu91KRIe5KGpC+gY0KXS0zMtzySgLwuC3INHaLZzhNwKovy+ai0FlbaJcziSmUsAF9k0ojBOn6tiJyCv3SR1a6oiX6VNKmI1lzEL2Bli4YQuc66OublmPac/Y2Vm20LZE+NPn0w9lyySE0hZ+5VZ0W7AMPf9ubEwYRHO5cRfFFkQHIqUXFemRSdd2584CR6NfaC6BpGKwkiRJKitoUoFuNsMGRA0ZUqJTCZnZhM8wK4q6CbnDATYFIrN5B9vfiDz9hrxliw9byoNS6GyWIg6ga/3D4UOJOkpSdnSt0DJ+Jmm0RxxSVEefZv8afgH+bRabyU5kOAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "834",
+    "id": 834,
+    "sortid": 142.01,
     "identifier": "aerodactyl-mega",
     "name": "Mega Aerodactyl",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAeFBMVEWcjIy9vb1jUpw3NTRCQkKEa2szMzObi4ubjIw0NDQyMjJ7Y61jUpu8vLxTUlQzMjJDQ0PWY0JERESlUjn///+8vL1UU1ODa2tkU52djY2lUzuFbGycjI1SpXP+/fxVVVVTU1NUUlKmUzq7u7t6Y6xSUlIxMTH///9ZdYZgAAAAKHRSTlP///////////////////////////////////////////////////8AvqouGAAAAUJJREFUeAHt1MkOozAMBmA7QMJOgS6z7//v93/DCYhWhSK1h5lbkfAln7El44i9+LwG35Avw3KK5f0Z9yG4hDmB2yy5fo3wN8i7LK4gSvOD8HoG8FZjBROkzCWP8GPhZ8eFEytoXqTNW2GhTaDOLhoFN5BfnHOtQ6nN4aAqnDqjqhZKW0FH1s4RzQFIBSBoRYSRrntkfGsS0eGcpw1QFI1Td3KnU7EdIY0DwKMAqUK1jdBVH9xvruHcFPB1hqJoXWRV9adKtjC6RiTPoxsErq4nyIWtYFCI/ASGVORH3XVd7bj7myVyFvwavwsk+8wsy7rOrPSP0Bgw9uM3iUjI7JJlnmfx/gFawr7vP9E4j5OXSwi5hJA8QONxPMpkEKORJEJC24GUSRgFXIok+zvDNJ0F+WS5CCzkKaT9W2h832b/F/4FYbbYw4GzWwoAAAAASUVORK5CYII=",
-    "gender_rate": "1",
-    "rarity": "15"
+    "gender_rate": 1,
+    "rarity": 15
   },
   {
-    "id": "835",
+    "id": 835,
+    "sortid": 150.01,
     "identifier": "mewtwo-mega-x",
     "name": "Mega Mewtwo X",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAY1BMVEXGtc61c6WcjKVSUlKMWoxrQms3NTR7a4Q0NDTFtM3Hts/m3e4yMjJ9bYZtQ2zl3O0zMjMzMzOLWotVVVXGtM1UVFSejqd6a4Obi6RtRG0xMzUshf/Es8xTU1Pn3u8xMTH///+LBBq8AAAAIXRSTlP//////////////////////////////////////////wCfwdAhAAAA/klEQVR42u3UR25DMQwEUBZ9/epe0md0/1OatgNkE0XO3lxw9TSEIEJSHqwnLIXcPghlxfuBBgy5vXWwAQdbDRyAViKn1Tz3wOcVLlyqcMB8PuMeyLWuWYEEDFFyg6pag/mqNm7fMFVhWTBt3mHSkSG7KuRpwulDpFNNjEhWLrPzERjFw2mgbQ3urPfj0U3WmjoWppR/hbTe8j51MTgahxTTK9BYdmHelATg+wosZGAXk4giZGb9CSmuOh6ABYKX/Ad8/VJ1THLoN+HqsOTe9z4CYGZjH410iDTXrDeW7OFa0CwMxRqJIfwG26MZog1/cg18BBLGNrzT5//4T3gBVUu19thHNo4AAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "836",
+    "id": 836,
+    "sortid": 150.02,
     "identifier": "mewtwo-mega-y",
     "name": "Mega Mewtwo Y",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAYFBMVEVSUlKMWozGtc5rQmucjKW1c6V7a4RVVVXFtM03NTQ0NDTl3O1UU1TOnMYyMjJ9bYZUVFQ3NDTEs8wzMjPHts9TU1M0MzSdjaabjKTeQjHm3e7m3O6NW43n3u8xMTH////W6Gb0AAAAIHRSTlP/////////////////////////////////////////AFxcG+0AAAEPSURBVHgB3dTPjvMgDARwYyCBpE37tf32/wzv/5Zror3i9Lo7YiQk/04+WNqT+a2QlicgCWDiIVw+lNylD+94M2LyAPJSZlkoB3BpW5kByAPJg9RFZqyyTsB/LGP476YCCGZAL8DLCJrs0BgwWc8cwsaOkrW7HOhBBSRBzjkHB1bBYyWSkqGH4z0C13dVA/RhvUG19Pnmw8akp1NaGmMMIXpQJL0W0GA058BJkgqgXdYx3CZRLToDuEdv4XG6ajEm+PxiG8MapajA4BpydWBjOu0Qktl8mKSaTJUuZJTERtWuHMhocJeJHjRHhh3qATQTejVkjiGDodafZPFhlz3MZHOgBOHP1z9SJP/MxfXzDfIirUAmyS3aAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "837",
+    "id": 837,
+    "sortid": 181.01,
     "identifier": "ampharos-mega",
     "name": "Mega Ampharos",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAnFBMVEX///8xMTEyMjIzMjIzMzM0MzI0NDQ1MjE1NDI1NTU3NTRSUlJTU1JUVFJVVVJVVVWLejmLi3qMezmMjHuNjX2Ojn6bOTmcOTmdPDyeOjmePT27u7u8vLy9u7u9vby9vb2/v7/FpEvGpUr0SjH2SjL3SjH3TDT85UL8/Pz95UP9/f3+/Pz+/fz+/v3+/v7/5kP/50L/6EX//fz///+vuqKaAAAAAXRSTlMAQObYZgAAAVhJREFUeAHt00Fv00AQxfG8AoX1w4baBJsm7ZAlhjbgZNr3/b8bI5MDiuOWGxLif9jL/pTRrOLFX+5/wB+QFIf0nEQjpaTd0aU0B9OwV0SM05PucJ691vKzooqQ8HLQeXf52H8PNeyqA5Ok5fI8xPrrtpPU0DM1NgN52902klUkf3c4Xam4WjeVrXkgw0fDEU5WQkV/x3KTaaO8OgLoRL5x97uLXNLMmqgYFSbvD49elTlzbVERtwkv+m6yU/HN/ZBjMGkrYJyp6/bm+tOphPtm8zZcWcbN6KJWfTvZBmQdMGcHYoQNjdT1X05dhPd1JVV+cI9bfJC0QrGYVhR8kB648fv7i6Sbtp39x0GRKlbkbt8+9u3ljMs/wtGjTOu229YwA2vtxRwPFdC6j6tVsZiTZsYcDjADwp2HZIg4M578ysC6xvj4OeRTAb+ce8DnAxvOuskP/9v9BHpgLBRgVKcsAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "838",
+    "id": 838,
+    "sortid": 212.01,
     "identifier": "scizor-mega",
     "name": "Mega Scizor",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAaVBMVEX///8xMTEyMjIzMjIzMzIzNDU0MjI3NTRCrf9SUlJTU1NUUlJVU1JVVVVycmtzc2t0dW51c2uDrNSErdakSkKkS0OlSkKmS0OmTESnTUWtzf2tzv+7u7u9vb3UWlLUXFXWWlL8/Pz///+BTJLOAAAAAXRSTlMAQObYZgAAASVJREFUeNrt01FTgzAQBOAspYSl1VOqqZUSr/n/P9JLnHFGKC2+Om6emPlmuWOI+8+vg7VOsc6FVXDjGjUI4F5dEw02d1txjNScaBDbZVjFjtGSC7fDOxYLSeloMYhhEMyKmuYLSgk1ZCjDFGKvikLxaAwpF6oMc6g5pbXmrm1TyPBp/mYfzUX9wKaS+jWkQJRC72ZSaaflC0XIPSHEocf1dR9iq/CPVBuYwqav0FxzTNTgnUf52qSWDTFxydg4jigPIa8CpVoCJtByRpm9rrod6sPBaM5P6HlJxnIglCMFfe/j22na6ODxPa12yo6A8+d0Slj8zajPSpEM/OWCG5BRldwU6b1bhIEAg+bVbwajAehKWCTWXOo5XJ41wa2Ta6GD+7v5BDN2FuT/35H3AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "839",
+    "id": 839,
+    "sortid": 214.01,
     "identifier": "heracross-mega",
     "name": "Mega Heracross",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAY1BMVEXva0pSU1RLe83GYzkyMzQ6W5UyMjNNe8wyMjI3NTQ5WpOtjBD///9VU1LGxsbtbE06WpPta0zFYzoyMzX/3jE1NDE8W5PFZDz8/Pz93DI3NTVrpfdSUlI5WpQxMTFKe87///8TzYxoAAAAIXRSTlP//////////////////////////////////////////wCfwdAhAAABPElEQVR4AdXU6W6DMBAE4LU5IHfS+9id4f2fsl4TgdrUlB/9k5FsQPo0tiVkGVbmLiGwFhL/Dom1sF4LiT9gvRIig5bXtR/L0OBTM1biEyW42bbjyiNkAbq0Fk0zQlA35VPDQiTNJYFhAW4tnL1S3ZWhb/OsZFTqIgQGBJNTYCAXIeu+E+m6A0lgCVIlR0lh/xts21TQI1LD6eH5SZNjwC2EmbVQhMgE3nfBYazxE8I82mOrGhlVyYpUJon6G5SXLG0DOehBSXk108i+Nrb1BLG3yiEwgCInESErl4FsjJigWZbJVcoU9aG2yx/WYF76mKD3WaU5pJA6wqYzzKdOGatzpZo4UfjcXS4TnAJVpKGo7PqzkdLYDcQxbxQ+zDQ/xfj2cdsIzOXjO/bA0iUFO+4xX0Zl6OW4+xu3lC9xaLjppUfbMQAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "840",
+    "id": 840,
+    "sortid": 229.01,
     "identifier": "houndoom-mega",
     "name": "Mega Houndoom",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAZlBMVEVra3PvjFI3NDT9/f00NDRVVVW1OTlubHNra3K7u7s3NTRTU1M1NTW8vLwyMjL/QjHtjFL+/v69YzlUVFQ1MjGbm5v8/Py/v780MzLxMiUyMjO9ZTz9QzO9vb1SUlIxMTH///////+6uNtoAAAAInRSTlP///////////////////////////////////////////8ADdDDcQAAARZJREFUeAHt1Mtu7CAMBmADyUySuZ/Te2v/5v1fsmZcVV1giXVVL9jw6TfOBaqD9XshBiHYJIZgrlCXQI6gB2Y93hncB3Bqq0cCyAhgXps8qsmcYcpodEaGuXuk944gkRR3XwX0IPZpmUXxM6gP0+HhdoDPE0O8pLT/OO0JDsPWW0omKZFAVc6Y3HVaI12NEoka/F8YZyB44PJ+/Ucym2OWEwt3IfAKFitztjwbQ+1CnqZHnmctelPRcpC32ocr88Ta8k7CT0JEwbveeGUULaKzMLAQnaOvZwOLSpt6RcWyCMJfQQSbSW4CiCGY0YCLGEIarPAxsNsF0HakOfbeQDC1b33DgQsAJKgDEJfdZQT6CQIY1R/8BAggwblEML2PAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "841",
+    "id": 841,
+    "sortid": 248.01,
     "identifier": "tyranitar-mega",
     "name": "Mega Tyranitar",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAADAFBMVEUAAAA0NDQ1NTU1NjU2ODU6ODhYWFhZWVhbWFhbW1twjz1wkD1wkD5xkj7wTyvvUSzLRkbKSEao11qp2Fqp2FuAgX/19fUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACKfkQxAAABAHRSTlP///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////8AU/cHJQAAAStJREFUeAHd1MGO3CAAA9B6CKaDk+kUt/n/P2VBZE9BWq67kaJcnmQbRfyqi8+3hMAahBfhtgjhNRg2/0PFhi9gOOz/2GzHOby2xmyXYh8Zoy/uMCqMhnxKHgCewAqhwsLrlG1cbgZzaG9PHg7wHFa08JBSsrvE4DMYsyAX7ybZccYc1iBpp5saLLaUbQIfog8OtpOPzlxwg6BEj4qiRAQZmB2PrlBLbnLfFedjgL+2f9O0RaU0HTNa2vxDJx9+5qxtazSEG0SSzGSbxSeQSzmAnOMNZu1UcZdnH51SKYzxHg3xRdoymQBJTI9JR4h8v980u6Y6FMMEUuJLjes6SwDKs+hGiCZtyQDGDz2BzaACsGx9ignsZnxtY+lKgSQswRPnEqyoWL/NfjL8AHBxoyVACMkgAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "842",
+    "id": 842,
+    "sortid": 257.01,
     "identifier": "blaziken-mega",
     "name": "Mega Blaziken",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAsVBMVEXnY0L33jHvlELGtYzATUQ3NTS1pZy+TEJVU1LFtIw0NDO8S0Oce2OzpJuEe2tUVFP97c3Es4uFfGz+7s2UQjmDemvvk0L33DKGfW1VVVTATETHto78/Pw0MzPlY0PwlkK+TUI1NDT03DH+7cwyMjIzMzL/7803NDS3p567SkJVVVLmZEM0MjJClP++S0KGe2vnZUSFe2uGfm6dfGT///81NTVSUlL/7869SkIxMTH///9Y2RyXAAAAO3RSTlP/////////////////////////////////////////////////////////////////////////////AKHEOx4AAAFzSURBVHja7dRnc4MwDAZgGUNCRjO69957Snr5/z+sksP1Epqm+dyrffiMeJB9xpiqJcufhd0lISK+usAC2I11yhOILICI/UlKY5f9CVRtQm0bfEvwRET25Mqj7Wy3CXc3q/tx7JxbPndrKaFm2hw6BdEpGQlK/2fYNlgSx+Si1NClTkF3WQ5SjtsO3dUp/ZqCepRVlcFyIDJSjTU8/gaPgxo8pLttGd0q11BDls9CDQ4LpoGscdDSYR1NE23ACvp09vIQ9JA7LvMUbTdgGpuo1wv6yOLLBAurz37zC3p+iwFMzGqNiIKeL3Cq9iDk08uTb4UDHmzwUHvDHeEeEa2stg7caePL4Jo3UIx5GEciO3RTFCYRwlY+Cyu8M6yNkUsR4a71W62PoOZmoMcLbztpjjJGhZXXfczd4X4xK5GypJf2UcyDE+eSGZNbVAvgOrzFL78rFOtwT/gFmkr7iAiYCxueiHQ5aHWpIwVWZ8v/QbqwfAKJx0OUYwKhiAAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "15"
+    "gender_rate": 1,
+    "rarity": 15
   },
   {
-    "id": "843",
+    "id": 843,
+    "sortid": 282.01,
     "identifier": "gardevoir-mega",
     "name": "Mega Gardevoir",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEV7znOEhIRapVJ7zXM3NTQzNDPWWmtbplNUVFSlSlo0NDS8vLz9/f27u7tVVVWFhYVapFJVU1MyMzL+/v6Dg4O/v7/UWms1NTUyMjKkS1pTVFM0MjJTVFJ6zHJUUlOnTV1ajM6kSlpSUlK9vb0xMTH///////9TtDWXAAAAJ3RSTlP//////////////////////////////////////////////////wCDVpfZAAABH0lEQVR42u3UyW7DMAwEUC22493Zmu7bDOn//8RSRYAeHCvtobcQonV5GPAg2s2/rBv8A5SyLK/Cdi73G+eclHkoXenMxWg0B4VIzmGMLj6IrMPhKTgXHA5wADNQLNAoOoVqJnHeb933jMaIEGQ1MSAFvr6NSlXk4EsMLj436ols4tYiN6gM9haYmbEwGet3+h5wZyitLOEs8Oh61d2uCvIhcytCwugCeg+AqKoGFL3vSO85LKD4Y1F8No9VdUINrwo/kZTljFKYburmVJOoex07WhUrzwzEyFTQHlMKvAhb8k7Vq11Q1JyOl6GQXvVgTSXIYSjmDLSTmqTIvAbPSJOnrO+M/EDrdWjyjNJHsusqRpMWkWt7bcLU7W/2X/ALJEjW4ymeXVoAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "844",
+    "id": 844,
+    "sortid": 303.01,
     "identifier": "mawile-mega",
     "name": "Mega Mawile",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAbFBMVEX/74TWY4S1QmtTU1PGtVI3NTT///8yMjPOzs5ja3L97oXUY4N2howzMzNVVVM0NDI3NDTEs1JkbHTUY4T//f5UVFL/7YQ0MjN1hYzHtlNVU1M1NDMyMjJyg4vFtFJja3NSUlIxMTFzhIz///8RO6d0AAAAJHRSTlP//////////////////////////////////////////////wBYLA0NAAABHElEQVR4Ae3UyY6zQAwE4F4CJH+W5J99d5V5/3ccdyOsEYIJc0+dOtKXsn0h9Ctzgx5yJbwoV46m8ipk13EVvOxEjln14+poZqgFJH+DpAgARdHkIuxEctYhyCpcgBTB4TBCwd0CNCenEKoqUJXHJYhgGaAAL0ZnIMUhkpb3Kxbhydy/AiHyGAJMTiF/Fm4jBP83UGymkFKStfQpHgyyqbCZg9AaxHvIrunPBic7shv6RohW2J+/sg7OIWXnfZ94sw0hpE3Wdz479EtYIblvI+pdUISnPSc7kj2Ls2c0iGTOYGTj0OOwuAQ1iME5dIcte6KtEIo4OcYd2ZL1lJRSRIomZxpZ5tpkEZYfMaa5RufGOP7R3Rwkb9/HP8NvIFHKqWqqXy8AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "845",
+    "id": 845,
+    "sortid": 306.01,
     "identifier": "aggron-mega",
     "name": "Mega Aggron",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAWlBMVEX///9SUlK9vbX///8xMTF7e3u8vLRUVFT9/f1VVVWcnJw1NTUzMzM0NDS7u7O8vLVTU1P8/Pz+/v43NTQ3NDR+fn56enpSVFV9fXy/v7dKrfdLrPVMrvYyMzXFyeAyAAAAAXRSTlMAQObYZgAAAUNJREFUeNrt02lywjAMBWDek+QlIezQ/f7X7HNKOwOEkgOgWI5+fCN5PMniGbPC57pY/pa9u/8Hw8/MrNAfwb43M1b7B+Y8DAuxXSmyh8ViOekOTGSCSIJ2byN8umNNawmgWgeDe9yDVkOgtMF6EyE5Da2asmZ1BNlk9klYCk3bG2CSQGDN4Vq5oEDZvkBtodBkBFdXPfd0LxWWv96BVM6OGfvb63aoEz8/QNTj6DakTxyRIyQ4FnJaSbL3S/cqsEUbj92OCYJApfv2Ei6pczuqWQHJDTJRVcOuG0JTHMUkEhE/J9iAGC7hKlxtu2xIzHJIDR4rYj0sL6Qru64DAbasENRsBk/XdzRCcIymlAGeVrd3iU5PkBEyTYbWXu5Wqqe76Bna9M/jhJjeLhxm9z7IUfyVmk/Bh+EwN7kZ0tt6xuz4BiAjCcZCFDPqAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "846",
+    "id": 846,
+    "sortid": 308.01,
     "identifier": "medicham-mega",
     "name": "Mega Medicham",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAe1BMVEVSUlK9SmuHhXXnWnvOhDHNzc2FhXSGhnX/rTFUVFQzMzOurq6HhHU3NTQ1NTXMzMysrKxVVFL9/f38zNw1NDQ0NDQ5pf8yMjL8/PyDg3L/zt6urK09p/9TU1M0MjL9rDLPzc2urazlWnutra3Ozs6EhHMxMTH///////8U/B/AAAAAKXRSTlP/////////////////////////////////////////////////////AFL0IIcAAAE8SURBVHja7dTZbsMgEAXQwUBiJ3H2pfvGcPH/f2EHiFpZWCHPVccSLxxfMSNsGu6svw0B3ILez2bZKa1wCzrnkoTWugZFnoajJB5/duezuR/DVZLgywFfOGCd357zkkcw0VWEtA6vdh0CYhxLLQsoNMIQvA8J+uhckZgPCr+/ugy9980Ipulggc7ufMwU+Rhd0XWaDrbE1FKOxImtuBLGWtCG3ilIybJBM0zAqwRR2AdZHkKfBySnHDfTNBEvmLoOLwF9nxjHQY5hxg788RwCY7i2LbKAae8JWjOlcSdnnZ2CMh+mjraQdMs2TlGeEvZbw46YdnwR2RRd/xaMpY5N6ztUbjiIPqk1vKlAnMkYR0RvQy1RnQ3ptlWoQaOUEqgrMElSWlcTRSpFDNzzXVNmdeiyq8NpN/z/SG/WN5/r4oo369GhAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "847",
+    "id": 847,
+    "sortid": 310.01,
     "identifier": "manectric-mega",
     "name": "Mega Manectric",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAXVBMVEVSrcbGrUJKhKU1NDKUezn15VrHrkPeUjlSVFQ3NTQ0MzJLhab05VpSrMXFrENVVVP9/v7ErEJUVFJVVVUyMjL25lpUU1JSrMQyMzP151xNhqRSUlIxMTH351r///8ztPYbAAAAH3RSTlP///////////////////////////////////////8AzRl2EAAAAQZJREFUeAHt1OlqwzAQBGCtfLs5eh/dmbz/Y3bWLiWkEjWF/MvgBYM/RrJBTqeN+T+8wQbbIFiF81nV3HBXgzAInRBVMDJcFYILARkQQA3OdHIZtsFLEHZ4bIzmNOOq5Yrw2NMCtOE6zUMFkgGPXDJqngsvMzeMBHaVvXjyzh24hDD+wN7JVlCXTRcQPI/L3aVwv/eICd73HZ5eFyeV095R/OANu3G4b+3gnRZOqpQrQOxsTPkzdjimMSlyRTjlt5Q+SKpur8nvZRhUNSt0ZAUVKMrVaVWgDoHsJDynEMhegTATBMBsgDqHMsTw/ZykmcVdrRFYvDsd+PMUAqLYdlyB29/sWvALMNWsJTZngE0AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "848",
+    "id": 848,
+    "sortid": 354.01,
     "identifier": "banette-mega",
     "name": "Mega Banette",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAXVBMVEX/1jH3WmvGQlp+fYMyMjK9pUJTU1P91TJ6eoMzMzNVU1M3NTT81DFkZGS/pkI0MzI3NDT///81NDF9fIP2W2xUVFL4XW41MjK8pEP91TNSUlJjY2N7e4QxMTH///+RNYa5AAAAH3RSTlP///////////////////////////////////////8AzRl2EAAAAQFJREFUeAHV1Dluw0AMRmFSixfHcfYlJN/c/5ghgwApZGtcpPEPjPGKD5agYqRduZuGwJVQ/hdCpOtDolwfIl+0LnzYt8eI2Pcgp5ja8xhBD0oYIuHrkMYcFhHzOsR52xY068HNySNd7/OwGbf3ER5dWO53rEDi6GUOXTh8FLT3g63DhiY0nrT3jne7qL3GKEu4lC/jfKRdhMBUvzv5lMi6BDFzJ2OyTdWeS1DE3Cdw94wIB85AVDVlDjBxs8jBuUenlHSZXvEjjSUc1HWmXMgwSEEzOQMVlIpImNLCJIMFJE8FJoNq/aWoqf3BxUAhJXMHFm2J6yi9K4USaW/xxu3vG3h4rsYtQP6rAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "849",
+    "id": 849,
+    "sortid": 359.01,
     "identifier": "absol-mega",
     "name": "Mega Absol",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAYFBMVEW9vb1jhK2EhIT9/f1aY3tVVVU1NTU3NTRUVFT+/v4yMjJjhKy8vLwyMzP8/PwzMzM0NDRmhq+7u7tTU1RaY3r9/v5TU1O/v7+8vb0yMjPnUjmFhYVSUlIxMTH///////+OnK4IAAAAIHRSTlP/////////////////////////////////////////AFxcG+0AAAEaSURBVHgB7dTpagQhEATgbh2dY+8jd1f5/m8Zp2EDQZds/m+BP4SPplBUyoN5wt2DEIrH4K6FQAdCG5jZQHebJed8vHXNBeTShZZm8i0v+rHueSRtyvgNfWB6EdaYDlihkEHYwEGNJ1WHiupYHatr4PAaeRK6dOi0gatMnOnQBLwFDbxO0baRLkVIzqQZOuco9nm5rDI6DFvuOZYWjmdTVbsNjDHZiP5dC66bqZLEQDOjsw4sKDAhjb5q0IduGSeZQwpOlwLcgQdOIlLROO5nmaB3IIJtJYjXw1kkuuvCYPJl5Aogku7BQwgQ+YHv+7EPUV3BCquEesMexGAVFrgrqLYHXQLFoRB/v2soh9b1IKBDH3bo83/8J/wGFMWwrbkM7GkAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "850",
+    "id": 850,
+    "sortid": 445.01,
     "identifier": "garchomp-mega",
     "name": "Mega Garchomp",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEUyMjQ3NTT/5zlCY7MyMzQyMjJDY7RSU1RahNRVU1L///9VVVLGUlJag9T95jz85TlTU1W9raVdhtf9a0s1NDJdhtS9vb3/a0u7rKTFU1XHU1L8a0pVVVW8tZ1DZLb/bUr+5zs0MzNFZLT9/f395Tv8/PxSUlL/a0pahNZCY7UxMTH////WCCuUAAAALHRSTlP/////////////////////////////////////////////////////////AMfWCYwAAAFJSURBVHja7dTXTsQwEAVQO8Gp2xu9wzT+//+4s5GI2CRaXniCUewXH11lPFHCxw/rr8MQ0k+gBS3oAnUGmhZF2woKNBh4CMHGYN62T5kcy1TFsOkQonbZ4r5zhKXUuZHELNu7ms9BgFVLG4Nwi4VINd8ZIc9hrnEULvdwq7RMDuEo2HjXcSmykjsjXhEcEkchKppsqlfirVABFuP0CO29rpnrjVDXsRmeATTDYmbiRoSsG4Jp8JMeuqGQtORtzTdSifhsoqIsafwOWSnPjRDalFQ9iHmk5rmn99Ddy+zZ1saPjJxaJOGMNKKpU3hrV2tLWcaN0qUopVCUnnYK2XtUkrdMia+FhIoyjxOQZz4UQAT6wG1kMnDYZ6rmDQmsX9IkPBzIjvEOR76eXn7du+rUrPtpGVxDzQAOi9g8+jzsXuM8hPz/7f0a/AQKIfjBa3lqpAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "851",
+    "id": 851,
+    "sortid": 448.01,
     "identifier": "lucario-mega",
     "name": "Mega Lucario",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABGlBMVEUAAAD///8xMTEyNzo0NDU0Oj41NDU1NjM1QjM2QjM2QjQ3Nzg3QjU3QjY3Qjc3QzY3RDU3RTU4QzY4Qzc4RTU4RjU4ZYE5a4o6MzI8aIQ8bo4+NDQ+NzRAPDVCOTZDQDhJSkdPT1BPT1FPVFlPg6ZPia9SUlRSWF5ShqhShqlSjLNTjLJUVFdUia1XVVdYUFFcUlNeWVReXl5eXl9hXldlZW5oaHJobntra3Jra3V5anJ6eoOCQTiDQDiLQjmMQjmQRDuST0amT0mrUk2rWFatVFCxUEqzUky1Uky3Xle3ta+3t626lFS6urC8Y17EurDGnFTGoF7JoFfMzMLUt27VvXfYunLkwnLmYVTnxnXp6Ofq6urr6+nt7e4AN9tNAAAAAnRSTlMAAHaTzTgAAAE8SURBVHgB7dJbM8NAFAdwe7RS0rgodamKSG0kEm1pEou6KBrERZBYl+//NZw+mukmmeGx/4ed8/CbPWfP7Nh/ZxSCmSa/IoSV6jgeuaBegEYxD1zSTSsP1FZ005exgGxIzSKpuExOhw3DNLA3pEN0PnMsy7c9dBUAMXTR+YzZlBagex3UBHBe8/Au23MMjzF2FZwtD4eKy1DJn0fMLgyGFLZWNM+xjPdDx4hVokDKY8pQ3bKs1TeuZi68rNEwidqeDFiDGE659vfLc/t+j8YqvEZ1EZzsnjbDp6RDTd+OeZRwdTgs3Z03406Y8I552Yo5x1EFEADw94Rt2guCVlhPmZGUqvqgb+/xppa2HszM7T7d3jG+NjLWs3h8siZtHuxOkAxIFiRClI+HWibEzF30++t5IJmVJCKGo/wtP0SYLHhs/6hZAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "15"
+    "gender_rate": 1,
+    "rarity": 15
   },
   {
-    "id": "852",
+    "id": 852,
+    "sortid": 460.01,
     "identifier": "abomasnow-mega",
     "name": "Mega Abomasnow",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAhFBMVEVSpXNCe2P9/f0xY0q8vLxVVVU3NTTWlPdTU1M1NTUzMzNUVFR6e3u7u7s0NDQyMjJ9fX01Zk3+/v78/Px+fn7GWkq81P3VlPY3NDTGXEw0MzX//v99e3s0NDX+//9SU1NDe2N6enq/v7+91v99fH291v69vb17e3tSUlIxMTH///////9H+WZhAAAALHRSTlP/////////////////////////////////////////////////////////AMfWCYwAAAFOSURBVHgB5dNHr9swEARgkVRxfz29l92Z8f//f1nGDwlgLxCf84YQdNCHneVBw/HK/L+QvBb65uzzmincuK9WOP7Nx08pDLfz3R/IA7+/yiC/urddu2MvxHQ8jPZze5PAN3S01kTKj1CxUszApDoE2p3c5ZIAhLUEHgg9Qs/KJZTSkh05Gu+1UoQUpN80gTPsZv/+9jTNPWRFCZncGlsuJlckkHzClzJn0Pbr10Eegpo/SFWfg2W33uhR+vFukQRKjlKYQJ5al2URXN+q7oPP2URo1IdRz5nMPOYlcM3q/oQqizPVujWzZEdSmmBvnyCvXoVptFtcQsokwUZbwdy2kDDus2q6vIaJ0+MBMc+XkAMwwOHuHXeomJfBCFqDdZnDk0MZBjIkLQL1MIFEsP5mfwK6PINnvyoxRLLq8zA2KSH/CWNp8joYiDnM88LhL++V92nb3CC+AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "853",
+    "id": 853,
+    "sortid": 666.18,
     "identifier": "vivillon-fancy",
     "name": "Vivillon (Fancy)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABR1BMVEUAAAD///8xMTExMjEzMzM0NDQ0NDU0NTU0QDM1NTU1QjM2QTY3Qjc3RTQ3RjQ4ODk4PTY4QzY4Qzc4RjQ4RzQ5OTs6RzU6RzY7RzY7Rzg7SDg8Qzg8SDlAPjxAQENCQD5CQkRHTEdISEZLnElMnElOTk5PT1BQUFJSUlRUVVVVVVdVWlZVW1ZWVlhZYFdaYldcVV1cXF5dXV9dXWBfWV5jY2VkZGVlX19lZWNrzV5smWBuo2JycnJzpWV2dnh3d3l3q2d6oGx7e319ommBgYGPymuQymuRzG6R1W+U0HKY2HOc3nWf03qkz26lpa6l3H+pqbKyfqW1tbu3qI+8e6+8faHAjKTBjaLJnKXOlKvSma/jt8XkuMjmusnn5+jr6+nsUT3wV0LwWDTwzFbywM/zwdL1/PH2yEn3xtb42l797er++fv+++0Xb+oRAAAAAnRSTlMAAHaTzTgAAAFiSURBVHja7dTJV4JAHMDxcappsw3bzbQF+llhpWW7mC2m5F4aWmmlRcv/f26GqZMDdejolwePw4dZHjyQ6491oGsQo/ZE0I0t6cb2kBt3ycecQrA9lDBDEhNSMkTsITUW+h3+KOr0+Cg37GkRZJLBeNr7zZIhIM6QM10XQC7ZccBdsnAVXwOChHCuC2NsQal2/XyzSZ0QzsqaqqmQ8lJn5gonC4FuIZzJniVYI/tjNbNqNDJsiW2QufmjhAqgqUSpGK3H16eMGE7LEFOhvkevlZZpVhvvq4EVEZySYwm1vviwk49UDMNofbx9RkWbYTJfDAPkI+WmScu9RO12PYkpLYbL2wB3Zk4PEYxEkDWOFb7EXQgG+20+Ct5ANgyp2yYdkI7oCOnsW/fV0/TS5UavA/SU/DJoE+fLh8fr4DCiR+6h1oc8F9ZbsYfDmJ4KYTcYI1vIG2KQ5wxRH+LxOr+9f4Vf+5lAdtFEiU4AAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "854",
+    "id": 854,
+    "sortid": 666.19,
     "identifier": "vivillon-poke-ball",
     "name": "Vivillon (Pokéball)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA6lBMVEUAAAD///8xMTEzMzM0NDQ0NDU4RjQ5MzI5OTs7Oz08MzNAQENCQD9CQkNCQkREREZISEZLQ0ROTk5PT1BSUlRWT05WT09WVlhYWFlYWFpZUE9dXV9dXWBeXmBfUE9fX2BiVldlZWNyPzdyQDdycnJ2dnh7Qjl7e319Qzp+QzqBgYGDQzmFhYeIRz+Jg4OLS0aMjIqQSECRSECUSkSZSkCZmZegXlWlpa6pqbK0Rze0pZG0tba1tbu4Szy4uLe/v77ASjrGSjnGxsbITz/KcmvMzMvMzMzbdW7n5+jn5+nr6+nx8fD///7////YC+f2AAAAAnRSTlMAAHaTzTgAAAEzSURBVHgB7dLbM8NAFMfxFcmqiyIOq4pISeMSF1IUbSV1T/X//3f89pQnm413vpnJ02fmnN1ZMfXL/jYUOumIn5khJPtyyEbeLWjnu44NaiS1kCebbjmEYVQNvxVcejjDhJc2QSiGB5dzX6y1Rl4lBGu3180QDN/eBbvbPD+GE2booNbp7MTlO3BGKP1IRYoGi+w66Up92gjlzVGsqwn59NhJs/x11zQabn4/VkSR8nw6y7AizmKEPgwVIf749Xn0qmuEUayK5bewu5WMxtdpxpMNELLbaxLBNQbb1OfbKXtmoL1mpJLzDUKeI8yQKcE9BEv1ur6bMshnb1LSKMLi4yXwbJAXTRrJ6HlohXjkGF57H19hTQuUvqutkPfDAM4CnQnm5yEsEDHkrJClsEBb/7C6T2lKJvbui/rNAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "45"
+    "gender_rate": 4,
+    "rarity": 45
   },
   {
-    "id": "855",
+    "id": 855,
+    "sortid": 470.05,
     "identifier": "floette-eternal",
     "name": "Floette (Eternal Flower)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAJFBMVEUAAAAYUqwpc+4xMTFSUlJzc3OkpKTFICDFxcXec732SjH////fdWMxAAAAAXRSTlMAQObYZgAAAKdJREFUeAHt0zFuAzEQQ9HVkjYV8v73zcymlgSktT8w3QMLAbq+fXgA6s4MtsAjhEw3XQv0AeaLG1eIgG2yoGxgI/+cKdI9usKQO+rhNriC4x5SIbUXFw7QPcLxWEnAwkUZSRqvVbuC83F5714bCIM8o7Pdjr4bJdIeFp0ziGwe5U9SUMHBZdyTxCsHiZE5Ji4coTnuIkjJg0MDBHuI3utw4fhXvv2nX7pGBhVqd3H9AAAAAElFTkSuQmCC",
-    "gender_rate": "8",
-    "rarity": "5"
+    "gender_rate": 8,
+    "rarity": 5
   },
   {
-    "id": "856",
+    "id": 856,
+    "sortid": 380.01,
     "identifier": "latias-mega",
     "name": "Mega Latias",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAHMJ3jJAAAASFBMVEUAAAD///8xMTExMTIyMjM1NDNRUVFSUlJSUlNTUlRiWZJjWpRjWpV6crN7c7WLi4uMjIyaitOai9OcjNa1tbXe3t73xjn///+E4QINAAAAAnRSTlMAAHaTzTgAAAFvSURBVDjLzVTRktNADJPVHoYu+MLJov//pzxkE5r2bsoLzOXJo9VKlr0TREQEAgAQBIAYi4iJR0QABAAbAGAJt6ebQK/HQID96kwAAeByejkBB+675f4Fdq0A1HvJ9KIEAqi2vivXvjmYQDy1eAoCJJu47SVApW8xBIKqazboElmcTICj7SWlkjhBjkFlVWVS0nmbNvBCABhT8+/7/BcgMNe8pwwE0Dhkj0CAzUcwZd9fp3V9YErVJmkVR+1GZHYuljK5g2DOcZa8uY9MOy1Jyv36SK1D5k9J+5MGxyC+XP4kwj5zbkb/acifj4i59eM+cdzjRmQTdH9E3YnMzLQ/lNyItCX1U2tK+sXrMhVJkpzFkUh2d7q7s77aZUsaVcWHMGugbtu2lZmSJE3Jm9SskWnbi1OSqiR9y7fzXeoxRnen7JSlqsy3VVNn8mBNkmBVZeaPKl7GOM1cvOtx/ihy9kUO4t0wW6ab8pj607/H3xc6FUAytYE5AAAAAElFTkSuQmCC",
-    "gender_rate": "8",
-    "rarity": "3"
+    "gender_rate": 8,
+    "rarity": 3
   },
   {
-    "id": "857",
+    "id": 857,
+    "sortid": 381.01,
     "identifier": "latios-mega",
     "name": "Mega Latios",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoBAMAAAEJ15XIAAAAJFBMVEUAAAD///8xMTFSUlJjWpR7c7WMjIycjNa1tbXe3t73UkL///+15B55AAAAAnRSTlMAAHaTzTgAAAFVSURBVCjPrVFNS8NAEJ0MiO0tLYLXdRpogxdxLSE3qTl4lNbQH+Ch5No2DHoq9pLcRNC6v8OT/66z6aaUFg9KB2Z483jztQutlg8+ALTFzyYKbG4dJTfiTQbHiYFfCgV+L9MSYUDg+N1ozYPGm42nCxsxnlx5cFLOZx4ADgQfVB1AH+nVtfK7sXKwnX8vwjENLQtB+RnlrARi0u2nussX1Smy1S14v/T9C9y8gpjARlPVsBduYWRqQXv1U7PneUlhHjxYAXaWGWtlIXTME6fPFgbaxMyzSnDH/fSa2QoAE3VT9QV7Atqy/61+RFK2AnfwxryK7KmwVHskam3e95Xhisv9cuSXy0yURARIypFULL+KfvxheJ4Ot4NkVGGMmWlmppqkR21MFnE+Zj2tpyf3RWSiVT6KRDolV06E6Uinw2SAMq7uKdaRbhionUEA7sPJkcd/zzWtVlgXMQuVNgAAAABJRU5ErkJggg==",
-    "gender_rate": "0",
-    "rarity": "3"
+    "gender_rate": 0,
+    "rarity": 3
   },
   {
-    "id": "858",
+    "id": 858,
+    "sortid": 15.01,
     "identifier": "beedrill-mega",
     "name": "Mega Beedrill",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA21BMVEUAAADyjpAxMTEyMjIyMjMzMzIzMzMzNDM0MjI0NDI0NDQ0NDU1MjI1NDE1NDM2NTQ3NTRSUlJTU1NTU1RUU1JUVFRVVFJVVVRVVVVra4Nra4RsbYVtboZyclpzc1p0dVx1dFp1dVt2dVqDi5uEjJuEjJyks6yktKylta2mtq6ntq+7iyK7s2u8jCK8jCO9jCG/tmzFUkPGUkLGU0LHU0PHVUXU3MzW3s7l7fzl7f3m7v7m7/7n7//1Y1L1zTL3Y1L3zTH3zTL3zjH4ZlX87YP+74T/74T//f3/ALu8+2/jAAAAAnRSTlMAAHaTzTgAAAGNSURBVHja1dRdT8IwFAbgeZxOQWwPjiFVEZ3MMaxDVBApBSvq//9Hno4YTeyCVxrfZF2WPXn7cVFv44f5a+itye9AH4phHfT9FqdBbK+BIKwT4qC7qqwGVTf0W0CYXAH9qkoVuCC0OFAhXnRjTl9H00w9cBfk3INNITC6AOoTWaoUlGxmz6CI0KBdwbFSU8XdEOYmigwas0NQTbMMynb9bFYZgokm2WRSCt+sejLDIaLBSbPZrLhhMLPufnhXwOaYUnHBIMUFTfs2nyGGmpwNfIPk0oZcLG5vZmEY5jh2Q+soB1LKOkqZSwt7vd6If4UfLoljDMMWIF4jH417ReFXWLgkiTmHUObg1YTwPbgcOyBLEsYYHZDsyNqW1pHYrKELelbZ4oZE3T5v6xCNG64CaYIRsQ7mqCOaO2FuGCQMtLFM1tsabaETAhXsn+kc+4inhydsVAZpobuvg3YfGYPsETxwQxsYvCyx2L6KmcdGrAzuL68sI/hgX/S4ISwL9nlcZZB+u/LHl9R/uMPfAcZ1ON/6Trq3AAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "859",
+    "id": 859,
+    "sortid": 18.01,
     "identifier": "pidgeot-mega",
     "name": "Mega Pidgeot",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAAEXRFWHRTb2Z0d2FyZQBKVEwtRGV2J4CxQ84AAAAGYktHRAAAWVn//5IN/JcAAAAJcEhZcwAAD2EAAA9hAag/p2kAAAUtSURBVHic7ZhdTBxVFMfP7ELZPhWaGCFRmWFN2j5ZDX5QTVmWVikPVtkA0oqV1NpdiInxobblwTShIKZ+PMhiEZsILEuLpakPbCq6LJjUGhTSJ7YPZFb8aHzaxSbaNrDjOefuzH5gKWyh8rA3OZk7s/fjd//nnDt3Vvrro09gPRcTrPOSAcwA/t9lzbLY3ter6XVN02C0/jVpXQCW9fYw2Lm8MjEBWiASgg5NTQsybReX9n6plffHVdLhXCADmT+sskVBA1uuDE2Swn3uawyOj1SArU8opsPRDVl31ixbdXiU2xKkJAkBSz19Gtl9SRJZlhnOKclJYCN1r0pkZklMQb8VFhWxilOuLiBLhUyM2xUDJrqUVLvsr8TgxwFMEhDcN1YJ3KAaYHqfc7k27u+PqHCh4jgoimKMedV52nC73jY1DEzpuNRqFZP0D6lQWWlhuJ6urUv29cnJE5pwdXsvtWHFvHIXk9SpcmeZTawYwRGMrl7dy7IBtyFr8WRREMOYMZ+rhlugQhXPX/KdZEVJRVp0EyigLQdQl/osmr5lkGtJPVJMh+k/rzIcx1cUYId9GHTX0uJonLH6AxIlSRSftkdkhtSw3t3RYqhIoFZZAXuewlmfushFgBTUWixmKCtpdQSnK6YDmTpv8ZVsYHcQSAEdbCC3NGnMo5tUhmybw1iVJRhWhKIOXyuciijQFilkOD257rhR0+Dn8+zwHTb24SCV6A4azPPFNvCgYvsdIva85UHeNmhQE24dVE8sdTfGjIlogbTQS7Em78/Fk4RWHQiH4HMEuz2/AKT4ki4m9ShmaCW//zrLSlKDaDTexmOfZiD+DeFKc+N7XyIcZ72nRytSBFxFCDj+SE2yI2j7b4xDRyzz/wsuSUFdPUfYb6yEnpHrSEXK1n1VCvSXTxvxYtuswCipGBvsU3ydUV9S7fuGAlyABj8Eb8H09X9EEqn5xsTd5sXuvGsWk3qJQUp1XRkTqusdCrFqFE/0/NjmWd4+CkvmQC6JoAckjEPchopkeH0sB6KYEU9vscCW/I1s1Ha4yMS2HLgkBXd7xa6e2pFUfNRqhS5XAwSvBOABfxSO5oVAnVHhp8mfweFwcLvGgjnKUa6XbLXw9cAYXqX4gucx5i6+cIzrj7nfgDu5dUWnGXt/nzbSfsK4P+Q+A866x+GXtilomBiE2tpaWFhYAEpwV36E25BLKeMbbLlgaezFWTC2MZCzz4TE5owlNDNz74Cknv9UC6dANObr4JVR+HBShbfqi/l+54uHobr6EDQVCLhrf95kMB489pbIcfVATc2bmLRR+KqiGSS8PtXlXJablwTchW73tb4HwR8D8PFUSMQpuonUGRzs5nuH46ChHil30J5n9NfVowMrv4+H3PB8eM+y3XvXd/G3uMI9x0+wYm9vL2QjOBe6mCbVYrC6a1PLTXe9OE1fcLN9NjDFb47sLPPqnqh3eePHopPv7uVMTiqBgHD/H39ztj67LYfvL1+7jTu1Lb5LIGxz+0Ve+Jod+QmWICUQcySxImjn9U3gfFAoKtnLDDAqK4VL+5vE7unV6KBK5XDddoZNBO30TvHV+QqGAgjV9JBZ848myuwPmqtg43SY79/5ehweevgRaNz3BCeLnhBE3OGZhN/wlZkOWNpHfgpwUoTAyGhyVVXh9NmrYEHooNfHRm69V7hV++wkVScmJqCzZicUFz+HG/e8Ab8u/lkgVXeUPAOjkA9PHmldNbhV/3DXt6PVglvTvz4y/25lADOAGUBR/gXanaBb+qsYbwAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "860",
+    "id": 860,
+    "sortid": 80.01,
     "identifier": "slowbro-mega",
     "name": "Mega Slowbro",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA5FBMVEUAAAD///8xMTEyMTAyMjIzMTAzMjEzMjIzMzM0MzI0MzM0NDM0NDQ1MzI1MzM1NTU2NTQ3NTRSUlJSU1JSY1JTVFNTZFNUVFJUVFRUZVRVU1NVVVVVZFNVZVRVZlWEhHOFhXOLk4OMk4SMlISNlYWOlISOlYWkk1KllFKnllSnllWsa2uta2uubGyvbWy7s6y8tKy8zby9ta29zr3NvHPOvXPPvnTUg4PUhITWhITXhYXXhob05Zv15Zv25pv25pz355z8rKT8/Pz9/f3+raT+/v7/raX/rqX/r6f//v3//v7///9y6rbzAAAAAnRSTlMAAHaTzTgAAAF4SURBVHja7dRbT8IwGMbx+m5AAdncy6bzgEo3FTwgpeisR0RWgX3/72OXKDG6Ndzr/6oXv6RPk2VkY83+NiSrao0G+VYphCspa7l3amboJfeDgePYAzUAIySO0s331J0yQ1CzmZpPH9Re4pkgNPv9/ixzMyXBsJHaeDuZTPqLbCkl2KWQsv2xdkeTm4XUMIQSCDGm+PzypO1tDkdIi6DjOhyH7tnxDmrakxfN6zCC39BVS3UQBZl71jvHm3Hv0h1tijiCn9Cbviol/ThNwc0AMWu+DbkQvyHxvERKX8QxTdOUpqNhp3PIo26r4DGVi7ttITTNizpKLQ+KNuYSmfjKV3rJg98qhASQ8U9ov0qZTIEUwwoGmnIueOTbSUKhUgIJsCAM2+0wj1IGpAxa2OVid1cIvYAxrJdCUgXkXDufM9TO9JlRDOI4DAKkQEzQ6ua3i4hh1zJCUq9beHJ6gtUqMUOdlbwn+T4zzGs9AlkLkq2t1fH//7hWH/I4OP1Hiq2XAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "861",
+    "id": 861,
+    "sortid": 208.01,
     "identifier": "steelix-mega",
     "name": "Mega Steelix",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAHMJ3jJAAAAsVBMVEUAAAD///8AjM4CjM0xMTExMzQyMjIyMjMyMzMzMzMzMzQ0NDQ1NDQ3NDQ3NTQ3NTVRU1RSUlJTU1NTU1RUVFRUVVVVVFVVVVVaa3NbbHRcbXVreptre5tre5xsfJ1ufZ1ufZ56g4t7hIx8hY19ho6krLSlrbWmrrbE5e3F5u7G5+/H6O/M1NTN1NTN1dXN1dbO1tb8xNz9xd399bz99r39/f3+9r3/xt7/x9//973///8IaaypAAAAAnRSTlMAAHaTzTgAAAIrSURBVDjLtZThU9NAEMVf0idCtKWPFIxtt0g0DwxVI6ih/f//MD8kzbQIjjMO92nn3W/2bvftHZIkSRKAIIByqRQAGABaAv1usAbmx24AAHEDoC773R6Bo7DcATZOYaJb0uSAfToEqsw4fgAA2yEZQKnqp0NKAdBF04Lu095B+aSPQ31QA8Qzpx0cBnQkAOBhF9Fzz13lnnmz08pw+F3uwkqbRgTAUvFtO7NXC10EQ0MmrHexl+0F9hdrKyUPpE1E1F385D1fQgQAZEPFWwCd6FWABrI3D9yJrryaO+zqcoNeZLiyi7DTrvIEoGxbUdhTNRoBCVjalUa5HdLXLxKRoLxyE1srrNvFYpFryGm7aFgDmNn9lcD1pPOYH3+1J8l+70pwucyvbvZF1CFNJ7uKBlcjFfZFbhjqnBpEtjUJtp34Ap3/P/Dv6+3Ozz0wy2xz32yw3X4fPwIzu7Bdvc5sH5G0V5/r25vxo4yZV3M7bFfV+1ipcjWtfsR9hgPw5Mhhe25birBlpUrlxuKrAeTJ2cy2515Mt4qisO3QSE3TNEqVdoNF6ayKRue5tJzNQnZExLnyeN/koY5DApBkOCJCdmUX19dUu2lPSTCWmpkHbo855vV1sV5rTKB/lyzty/hw9GiAMBnebdfoY9l5dX/38InPOMOrTU0eLTXVYrGYTCZ41kKGLaUa8Q8L9yCCEYqQ+ITXg79tW9cMkfWmJJ4HySHN3p/0EoP7r+BvKJI8Ehx7kUcAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "862",
+    "id": 862,
+    "sortid": 254.01,
     "identifier": "sceptile-mega",
     "name": "Mega Sceptile",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAHMJ3jJAAAAilBMVEUAAAD///8xMTEyMjIyMzIzNDM0MjI3NDQ3NTRKckpKc0pKdEtKm1JKnFJLc0tLdUtLm1JLnVNMm1JMnlRNm1NNnVJSUlJSU1JSVFJTVFNUVVRyzHJzzXNzznN0zHN0z3R1zXOk7Zul75ysSlKsS1KtSlKuS1PlUlrlU1rnUlr0Nh715yv35yn9rlOsxAAPAAAAAnRSTlMAAHaTzTgAAAHuSURBVDjLxZRbd9owEIRHgwlmk3VNLwMOrFuUOIl6+f9/rw8YBxJy2pe0+6Qz+rQXjY6QUkoJKQJA6gEimfkSCQBw2B3jgbzCTdAAgMfdMQG9H7Hk2lWxVAMkwBmv2ItLEPlwHoiIaVlmBhAJpHlFbYYEQB3trqkTAIF+YKe+Lpc4FUeSmOIgxm0bL8RFhEqcsAnpCtiUDzJTXc3a1stdQlo0hLfXzEH/7Ot1NeaEq2wUIlz1sRBIAHROOS/2+Q4iLs0OIFdgLM7FOXdtFzgXc+R+4Atx719+Rn12SwCj7+9BH1UygQD11HljxSBJpU6A0329sW2I5jIRCchbVK3b109RFZcZkACSkpz7ZjDXWkfj6aUoYiCtnl4DjWQ4x7ZGkQAgO519DBLvaMe/AsdZMgFgPs+nVj179gzGakbMIi5yR5B57nGbu66P7R/AiFXshmF4I+FUmrFa/eKP6AmAfI1PPXJ7fz88PDWqaG4ijQCdTicfClNC4mNFoGpNTexkyy7mhd9plMu1XtvwyDEjlZ00N7mZ0cIs9pVtJG8l3fFYmhsCbE2dt1btPbN6+uheJJlMy3oCa4Ckb0p8U2PG6GywZX1zLS1Zn184ALqL7hYRocNHYPUrZ8CwGH8Iyp1vWXgazJ5fkP/5Pf5l/Aa71iH/WSxSXwAAAABJRU5ErkJggg==",
-    "gender_rate": "1",
-    "rarity": "15"
+    "gender_rate": 1,
+    "rarity": 15
   },
   {
-    "id": "863",
+    "id": 863,
+    "sortid": 260.01,
     "identifier": "swampert-mega",
     "name": "Mega Swampert",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAHMJ3jJAAAAn1BMVEUAAAD///8xMTEyMjIyMjMyMzQzMjIzMzMzNDQ3NDQ3NTRCe5RDe5NDfJVDfZZEfZZKlLVLk7RLlbZMk7RSUlJSU1RSVFRTU1NTVFRTVFVUUlJVU1Jaa3NbbXVdbnVze4R7xdx7xd17xt58xdyMlJSkUlKkU1SkVFSlUlKlVFWmU1KnU1K91tbcWkveWkreWkve7+/1e1L2e1L2fVX3e1KaaKphAAAAAnRSTlMAAHaTzTgAAAHeSURBVDjL1ZPbctRADER7OjeIQ1BCJ5uLwEE7AUEWQ2D+/9t4sL21TlEVXqBAT672GV16NCillIKCfQCFSkfRpgGTXkopAIAC1DgpoCLK7t85QdbqCRYUJJXNVFBAQEZbsr/+BAgCKCiAy4nVmNfjVioolL61yw4FxdStsl2OLBRpeL7E8yIA0J3VMQ49irlX5dWzfSDlk0j1VR76fvmqc47ix1TE+xi0XpvNx80dlCsywohtIQAgyG2h3+/zT4gAgH2AWMwOVD866vd3RZIur+4EUKfZmXter9zb0KGfDeG95NUjTfJZRErex1qP6uRTzkER0dvQHq3T5BKHs9V5RF6v16fGqXqauzYbRRs+nc0tUSI6KTJDW+dBAHSFpfvxwnlyGvQvmvwvgvMi4mi8Ttae2IldkJy4q6rau/vh9vDeEsxDsLqqj1wOQxIAq5yL0swb1ZmLbC1Puo693Jcg8+Zevaqr+nl0Ebd6bBfdha+eZKRS0a77t+rf2TpbS52ZdZ3GBZhB5uc0U0REvPjxJr8M0vW5mclf7k7NtDS56y66191dKuIh82F9asalPTSTu3QsbdS7Ir+2ISNkB098JMeHA5LqfWwiZGYHTwzfCap3srWBIMld8H9Ys9+Jn4mXNAvR894yAAAAAElFTkSuQmCC",
-    "gender_rate": "1",
-    "rarity": "15"
+    "gender_rate": 1,
+    "rarity": 15
   },
   {
-    "id": "864",
+    "id": 864,
+    "sortid": 302.01,
     "identifier": "sableye-mega",
     "name": "Mega Sableye",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAHMJ3jJAAAAtFBMVEUAAAD///8xMTEyMjIzMjMzMzQ0MTI0MzQ1MzM1NTU2NTQ3NTRSUlJTUlRUUlJUU1RVUlN6UqR7UqR7UqV8UqR8U6Z9VKOTcsyTc82Uc86VcsyVdM6bMUKbMkOcMUKcMkSdMUOdMkOdM0KeMUO0jM21jM69lCHEKkrGKUrGKkrHKkvHK0zUUnrUUnvWUnvXVHzmKlrnKVrnKlvoLFrtxSL3k6z3k633lK34lq///P3//v7///8A5uksAAAAAnRSTlMAAHaTzTgAAAHMSURBVDjLxZNxW9sgEMYpKdoSNMYs0nMdnTOZmGVUqk3t9v2/1w7SKG2iPo+P2+4Pnrdvf+SO4yAjF2REKCFktNYlrtYUuBIX3b/u90gD4Go/O8298xQoyTSKKJFOWmsWixagqoY+OygxiS/Cy02U76TVoky8pLZRtpOmKHfA6lbwbtuu6OEU+ybZi9CktK3k2XzU+iuIvKRMdia1dlMt1Sd7CTIOTGvMl4eHKA62W7vSZnYuMhp+c65qwlMeZh+s82+YPul46OzZCyY7MLdHGQNAweLOnGy1FgBlTiBoyEbragZlAfRpOzapWjZCXUMuQ/PRGHF3B4yE5m80v6dxvGf+Mmcl3kZQEnWNPysSkYV1WqMqnknCQ5PPrziR8vCYvDcMH935fwo+n4b6uTsY9veDU9qCbAwdzmgPnExxGvTpucBnA9mxIxlrH0oITtbbH9rFKbj3hRHhWMW91Ed46WvEqsooAZc4ZQlAzno1ugeI5HLZNAgq1Apm0k/PEOimyyB48e1+kaZSxuQ18GciEiGOk+H28BsPNh7My6KYnYyH++jIlbnF09TiJAHK05QPN5zfGKXUVc0JzTP26s1wPq95K/iL4H+cx7fjD+neMwJghz9WAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "865",
+    "id": 865,
+    "sortid": 319.01,
     "identifier": "sharpedo-mega",
     "name": "Mega Sharpedo",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAHMJ3jJAAAApVBMVEUAAAD///8xMTEyMjIyMjMyMzQ1NDI2NTQ3NTRCWpNCWpRDWpNDW5VEWpNFXJNFXZZKesxKe85Le81MfM5NfcxNfc9SUlJSU1RUUlJUVFRVVVJVVVWkOkOlOUKmPEWss6SstKWstaattaWutqevtqSzs7u0tLy1tb23trzEm1LEm1TUWkLc5eXc5ebe5uXe5+ff5+X05UL15UP15UT15kX250T350KFxLobAAAAAnRSTlMAAHaTzTgAAAGMSURBVDjLxZJvX4IwEIDPizkZphwgiJpFaqaRZAHf/6O1CSh/0zfVXux3v2fPbtvtoKcG9ABAzS6TM803Z5KvChVrpObEOirCi9VckT5qAFlIROM8hKWf05LbHsoMUGSAUREKJigP08AlzEIiTehm5r4e+HkbQPdpNZjJLN9ShrHWhP2RqEGcOTZZnleGGKexi6kb2ewC9ccwnC6Xbj0n7vi2mrP1nr8As6efyn05PWNOC8QRNCGJVljbjuKOSBBVTT91SJZOq5h2IpFqnBKU5QxM/Tka0qWeSAHZlmV4/GjyAnIzlEVevPDalXA5DzeNex75pu3tAL/6HX8rll/ECKvP6xD7X/rgFpHR/iYR070QPx6Nmlpmn1IcErJucaAbxozyYVkWdh7dD+I0iQMpebKdyh1ZFfvp2lk7tuo52U/j6J2xVpERJal0XPbGAvLCrfnkOHk/lkWUaSaryWQVuvfTqW/oHLgazYwn7PrTh0U0D328Ukd+/DiEO397/QvVYcA3vFv8x368Or4B1UcdB78yT5wAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "866",
+    "id": 866,
+    "sortid": 323.01,
     "identifier": "camerupt-mega",
     "name": "Mega Camerupt",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAHMJ3jJAAAA1VBMVEUAAAD///8xMTEyMjIzMjIzMzIzMzM0MjI0NDM1MzI1NDE1NTU2NTQ3NTRSUlJTU1NUU1NVUlJVU1NVVFFVVVVza0t1bUx2bk17e2uTQlKTQ1KUQlKVQ1OWQ1Obi3KbjHOcjHOdjXSei3KejnbMWlrMxKTNWlrNxaTOWlrOW1vOXFzOxqXPW1rPxKTPx6flQzLmRDPnQjHnRTPoQzL0elr1e1r1tBL2e1r2fFv2tRL3e1r3fFn3fVz3tBH3tBL3tRD3tRL4fl38/Pz9/f3+/v3///7///8MHXZ5AAAAAnRSTlMAAHaTzTgAAAI7SURBVDjLxZRrd5pAEIbXDYnRrsOKtV1vFSzFbZbW0gI2o62msfn/P6kDCBFiTr/0MnsOrg8vMzsXYK3MWIux74y1NABdDTg+EcFon99lbEf/+cQo2ntK0lUIIq3KMgd86UUso0wiAKTtnMoQQ2hoz28pzGzHCg8dZsxVvp1qdCL7MttyJ/ebb40rbaWLaBLXmIegYxWnPh+iBtnROt3i9xSaT1/dE8jbiDMwxkQfeAX9JMEQk5VS4Dgl7Blz9xCoFG5TW2peQPFu6X6kMjiIeiqqQEKv1/E4EaIKdPacfwOWuXe7xywfId/vN7wJrz8bvKpBZBce1cOcQG2hhca4bjSvYFvPKGmABaxsVcIeMSpGHxSti/LxIQxRygjgy2Bgl/DHjftCUs8HKYCcHiE14vBWO7ZSUk/5EYKRr5c6r7H2q3O2pdQULJsPUUHh+4SSkRD1NAkIdlKQP175fyhkNbO6m91u330Ezwj5Fr9t9/v3/HlhJ7t3TS1wjRctXH5W2GYcscMsh14aL9NGC4+fEVpaT6gVNA8wN0tyGa2iFVzyhrDn68kMs4VjajD2I1A20IunFG945AnQytqbBEDDRJI+wIYWbwhf3sitRP8ukIGNg2zGNjRlKSht1ZPJkvUODwcXaBLtNL1VNgWXWk99UfO4JCEl8eonaBpEpRx0HJ0ZF3WPQrwZzof391KHWNpsHAT8ScFpVOn5MCxmeLaOR3Esyi9GozPCF6P1KBYx5SLYb3rN2VP734P7C+CoSRBicHgtAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "867",
+    "id": 867,
+    "sortid": 334.01,
     "identifier": "altaria-mega",
     "name": "Mega Altaria",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAHMJ3jJAAAApVBMVEUAAAD///8xMTEyMjIyMzQzMzMzMzQ0NDQ1NTU2NTQ3NTRSUlJTU1RTVFVUVFVVVVVai7tajLxajL1bjb5cjr9djr96rOV7rOV7red8ruh9r+iLk5uMk5uMlJyMlZ6NlZ6OlZ6Olp6TrNSVrtekzf2lzv+nz/+8zeW9zua9zue+zui/z+jc7f3e7//lzO3lze3nzu/8/Pz9/f39/v7+/v7+//////9ShHkTAAAAAnRSTlMAAHaTzTgAAAHQSURBVDjL1ZJRlxIxDIWTrgvT6ZJBZFlEEVcpJR3srAO9//+n+QDIwIGz+qBH85Tz5ebkJi0xMzMxFUTE9SoYYuuF6MAPVSImdhlM/NBY7laPKW0BEDExJ32U7IiJmci6tKcd7dWU9sFMTLpUh30Kv9MWzMT0QaTWxExMQ5mK0qFtkhLx6yN+ARJRAaAoir2VAwyjwRqqUqM4QpOxmfVWHx3qVs2pPejYaY5N7LTTcLJ8CKrRdGEnftvnn4BERMX9ydERYqs1GdOFZjEWIAOmA+90GvC8di30J+yj8n4BVQd8PcKI6ttsNQ0VJOsRlimKe5yr5tiUp+l3GoKuEcScBk2mzvtBI5q6Pq3zIhr15cw8WTdNNtlzSGTP1/wrR/43hYcHLwywKPqX3/JC2L/HdvQWNYCiBbS4ITSqI+80Q3dQhxb5uTBXhP2qCjp+LwsA88Vc1QEAehdCowDaaub9d7/4tNYQqkpaIKs5F5YpYpdls9lMt+3IiWQgq4vxS3k5uizLpKqyzcEpUKvGRlx5ZZnem4ELQbwMQvwcmkYkJntta2uHI+e9Xz49iaiqav/GHYmstRO3fOddjCnGl2RvCQ/qibWWrLXXDv4/fLPX4wfHmDfnPUCrgAAAAABJRU5ErkJggg==",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "868",
+    "id": 868,
+    "sortid": 362.01,
     "identifier": "glalie-mega",
     "name": "Mega Glalie",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAHMJ3jJAAAAh1BMVEUAAAD///8xMTEyMjIyMjMzMzIzNDQ0NDQ0NDU3NDQ3NTQ5Y3M6Y3M6ZHM6ZXU7ZXVSUlJSU1NSU1RShJRTU1NTVFRUVFRVVVVVhpZrtMVrtcZstsdzc2tzc2xzdW11dW11dW6b1O2b1e6c1u+zs7u0tLy1tb22tr69TVXt5fXu5vXv5/f///9jGpsxAAAAAnRSTlMAAHaTzTgAAAGQSURBVDjLzZRRc9MwEIRXFwImKmSLXYeYgzYYbzHn///7eHBKlODM5AWmftDsfF57dbobIaWUEhKAhAR6QoKUcOTzugISUh9ISBTP3r5I7DzCZylSR4mcaZfeZWkAgJSQ0ptgHD+7a+T7mSo6b2aJaaAfpeUpcEPELRBgU8Fs3skR2pccEcHe7QRBMsZQqxKaD9xTmesCAmJm7cQZhJFmZdDt+/wXECu8PAW0T9V6XV3AIdRGBN1P8LAdx/mUCudmf/DnoHdWQAvuYhRblZAR1kmkFUE/HtlTJMv0zeCSMrkpG2c517VYBgGYcs4MnUMjaWcV/Y9Dfq1G4D25OjW/nIELI97x81P88tVThFcV0DTk30Z7+/HrGOF8jogIsuu8t6U/2ve+3959GGOeJvdvvlmOZu7ozohQ0A99K1s0Ghm7XSgeHihJGrhshGkYxMPPfk85SSdtuWqb5GrZUtJ9ZkO/YoSRlN9TrLcieaUYAKacc13XdT2RvFLM7GRo0iSS9ue+WDICMJst11r4iufxNx8OJ/DHkTChAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "869",
+    "id": 869,
+    "sortid": 373.01,
     "identifier": "salamence-mega",
     "name": "Mega Salamence",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAHMJ3jJAAAAz1BMVEUAAAD///8xMTExMjMxa4Mxa4QyMjIyMzQya4QybIUybYYzMjIzbIQ0MjI0NDQ0a4Q1MjI2NTQ3NTRCi7NCjLVDjLRDjbZEi7REjbZSUlJSU1NSU1RTU1NTVFVUUlJVU1NVVVNXVVRarNxarN1ard5brNxbrd1crNxdr9+Dg4OEhISFhYWTOUKTOkOUOUKUO0SUO0WVOkOWOkO7SlK7u7u8S1K8TFW8vLy9SlK9vb2+S1O+TVTV1n3X1330a2v1a2v1/bz2a2v3a2v3bWz8/Pz/DKuGAAAAAnRSTlMAAHaTzTgAAAI1SURBVDjLxZR9c5pAEMbXq4UkNi13guYCh+2xSQMKMSXo2Tcjzff/TN1DRNM6k/aPps84uvPw29vlbk/oWUEPoAbo4RkzFM9HAbR+893qW2EEQLZCOHzahjO/CIEZQ8+gjKXMY7AhAE/RJh+yR0Nwifru2SQhcwfBmHPrlloWxhgKRRmG62q7qhNOVYKzpgDnyDj0ni3xrAlw4theXUbF6/rclrIVFnqyRlkMyCUxa4oEtcJEx3ltTFmKlqTGInmFpI1y3Z35Jo2ilUTkpc+gIxvxIW9+/6rPf2ECazsStedtD8yap42H8IE2xNuas9nrMM8ZUkJJ21FvSRgsJrXCgtkhsOfVmPj+i9EqL4p4b+rTRJ2h1vlkQ1sn2nRRShn6+TqvlLOrblUFd3iNWCwCtzOjbHQ7XaJGDIe8Nd9eptFyhSj5xUWXzjl90j6ijfZrNnp8hN1rvtAmvxgIR+RtT3WnDmT+qwObJl9UNPp1h7fgYBBLP3QGJIvhUNjc5lBNbbw9KEj98VjJfDKRI9TM8jvS3p59aWBz1HH9o7YXSRYkBo7Zkx3oYoJf3YeHRClEpSw5+bzDyoMVRX84fhdrUnASypha2GzuTFWV1NSTt7YsqYwDX45HCpVUpKtPsePCr2BzqaMsjM3t9XSa2cs9n9Og+f6YPQXZZZZFgdbT1WpJnaLsDz8i+nI7fHuQ36d9mss0lWkWJQS61hve8yOluz8KzvUN3rAjRwjH4N/O+j/O45/pJ8OSSbS7T71aAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "870",
+    "id": 870,
+    "sortid": 376.01,
     "identifier": "metagross-mega",
     "name": "Mega Metagross",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoBAMAAAEJ15XIAAAAKlBMVEUAAAD///8xMTFSUlJae3tqpL2Dg4ODxeacc1qsQUG0tLTVpGre3t7uWjlND9IAAAAAAnRSTlMAAHaTzTgAAAGbSURBVCjPrZGxb9QwFMa/mLKgG9yCGJiMk54qdAPgpCDcoUocpWqXtvHphmNAQmxZCJW8HyMj/wHHxBqQKqUsbXrTbf2Haudy0qkVA1WfZOvzT37vfc/G+joFBfBY7uLpz0O4s1uEUTzQFGu/acdsYKPJTl6BBtX7I5fVf97x1Z0yAg9PdOZ7eHaQR59B87+vPWy83LOEEjTe7azbkmhTKmvDysHHRJsv+sRKID+tt5tjK3uNGP9R3F0AJ+ekF7XSxaMY/6z7PxIE4LaelQ9HWRDbg5U6VW8MT1y34jIZGZGVVvZjOZRnadmmSVntfNp1U+Tj6irfdHf74Vep9gO01nnyNlj4Zb0PbJCjtW7bzUIsp/DZnae4TwjCTcwZUe9Ya6uFZKi0UUoIwRCoeAGD2TxSKjQ2EmEMa+GL4kKJaqhVIkO7l4uanDP/WyRkXc3madZBEH+4V9eT78m8aEaLdAwiJU5lLSI9ZYR13YtZGAeprFM9DdUxOp9FzMivH1sT5qf5EroYuD/sWx9sBbZhYYybEJwtx7z397wGCLl0Is9IjK4AAAAASUVORK5CYII=",
-    "gender_rate": "-1",
-    "rarity": "15"
+    "gender_rate": -1,
+    "rarity": 15
   },
   {
-    "id": "871",
+    "id": 871,
+    "sortid": 384.01,
     "identifier": "rayquaza-mega",
     "name": "Mega Rayquaza",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAHMJ3jJAAABAlBMVEUAAAD///8xMTEyMTAyMjIyMzIzMTAzMjEzMzEzNDM0MjM0MzE0MzI0NDQ1MzE1NDI2MjI2NTQ3NTRKclpKc1pLc1pLdFtLdVtNc1tNdVpSUlJSU1NSVFNSm2tSnGtTU1NTVVRTnGtTnWxUUlFUVFNVU1NVVFJVnGxVnWtjY2NjZGRkZWSD1JOE1ZSE1pSG1pOG1pSG15TEm2vFm2vFnGvF/tXGnGvHnWvU1NTla3Lla3PlbHPma3LmbXTna3PnbnXobXLobXPobnTobnXobnb8xDn8zDn87YP8/Pz9zTr9zjr97YT97oT9/f3+zzv/xTr/xjn/zTr/zjn/zzv/7YT/74QmovQ1AAAAAnRSTlMAAHaTzTgAAAJ7SURBVDjLxZRte9IwFIYPgcjLKrU2ZS6QgLgV0JI5VlFgllEcEzbb2aX//6+YtrCxa+j0g3o+pLme3DlJnp4EcklAbjgDgBzveao1angKaz1t4UYNArIEKAohBNuj6y4QzNwEg5w4sH2CPTVLTYVms1gawAN2ZxdgFsI6NBSMCEq7fNngng8MgPBlIL+1fD+RDVKsoWlGm80emNrTSzwpqsORcA7IAW2zk0Qc2jwwxbu6HfEFAKWJWDtejt8LdCTlRMYK8zzl3rM9OziRV9eUCPHZ9+V5Oj2xjnPMO01EcJo5t85dLBazThXBn+zzL4jJJlEYzgC2T67OjkJAUUV7ILoW6AIhgnT9TkSWeyAKfUQizl4CiFQcrroOanDseclfozy1OAoqlLUqvhyNfVVucJNTS/e79ql+Ek+ocEbKT+kpcW+P2rfx1fXkE3faMvZltrph5Os1amBMMUyn924S/hozq5d5vBHzrDlW5VEyzC3x3vnqAP6dyf8KvLtEMFMBP4k7UHPRzSyczy8u9DL6BYiGBI/mAHr0wamMNNdFu0HFWYcYHwR9Vi4XhhaxdLRardY0vQc1115xhZFCr/9WoP3oO+edTuVFyjXE0QbEH9vd7uKo0Gq0GWWFjhd7sZSxTB8C+sZTVZuAGLWDlaiP7cNTeiwq6v5Nxl/KrDWWGQn+LDxXoKpbx2TRcmnbwe1JHMf+K/qc8v2ywF6S1Iv98DzJmC+lx1ksnMvLq0m9bpmmSetfWYE5zplUcXa27WNmEqmpu672rD5WeuEfG54Vpsk567EOo6o+jaJKTbA2GFQfgQClUi+NzWuRL1UHA20HuDMMA+D/1uNvxg9vVFWM3BfcZAAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "872",
+    "id": 872,
+    "sortid": 428.01,
     "identifier": "lopunny-mega",
     "name": "Mega Lopunny",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAHMJ3jJAAAAeFBMVEUAAAD///8xMTEyMjIzMjI0MzI0NDM1MzM1NTM2NTQ3NTRSUlJTU1JUU1JUVFNVVVRVVVVjWlKDY0qEY0qEY0uFZEuGZUuGZkyzclK0c1K1c1K3dFPEs3LFtHPGtXPHt3T1e4z2e4v3e4z89Jv8/Pz99Zv/9pz/95z1RUnLAAAAAnRSTlMAAHaTzTgAAAGrSURBVDjLzZLbdpswEEWPxKUMQlYBtzYnXFJTMf//h32AxDh20rx0NXrS2tqaM5olGGOMgQEAmEQVMEjQYuPGmO0MiIQBRMXsT18LaPAADEwznl1bBqxlZ7vSnft4iwJbkoGlctv+9Dz1gIGpGl7AZa0rVS9s1ogRn4r4OwSgecZiwdbKBhFD9I5JcYWJG0j/VPUDkb9AEQyHo5tyOUWfXa/D1kEAQGQHIQ77oM/3+Q8g3q4NWgUTTW4hFtep0t5Cq8t4IYs9HKshBrqTllc4Vo78zjj7rNhg2faH8onfWoszJ7uZArGH5ngY0S/xR/oaBEEXVSBnNnJtvg71OuRrS4DE6c2LAKCX/zD5LyiuM7BaALAZUBR3v2AvlrNOluyc6uDtByLKUUMXVKPryOx9MU/bsMTJObaeZNDFPhJzN4xH7+lj9OzCokvM7iumqRsPx8qRZPf7wtaVpSOZLJO9EcumKfu+RP7csfp1OToLIOdJdUgfPAbS9L047yadRguZe+dJtumdCABJXdfVPMvL1aYReSRKHXTJ8eHAt2UPwyyfESGC9yp+9f/4B653Hycm0U5FAAAAAElFTkSuQmCC",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "873",
+    "id": 873,
+    "sortid": 475.01,
     "identifier": "gallade-mega",
     "name": "Mega Gallade",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAHMJ3jJAAAAyVBMVEUAAAD///8xMTEyMjIyMzMzMjIzNDQ0MjI0NDM1NTU2NTQ3NTRCcnJCc3NCe1JDc3NDdHRDe1JDfFNDfFRDfVRSUlJSU1JSU1NTU1NTVFRUUlJUVFRVVVVam5tanJtanJxarGNarWNbnZ1rc2ttdW1udm5ycnJ6xMR7xcV7xsabk4ydlY2kQkKlQkKmQkOmRESnRUWzs7u7u6y8vKy8vK29va29va6/v6/cQlrcQ1rdQ1veQlrfRV38/Pz9/f3+/f3+/v7//f3////Oo8QtAAAAAnRSTlMAAHaTzTgAAAHrSURBVDjLxZMNc5swDIYVrfnAJE6bxiOMUMLSrnhbsi6MwcagVP//R82GQmhC2t3uupk73XuvH8uWZaCnB/RgADpyHcWvQmvQupq9LbUUOk5cpmdZPfuI9AADRCjlxnXWQJX7jS3dce+A7ZYgQW+qZSSDWsq5n0FauTyHPpbSWizFQwXAbsfOHyU0GTq2+BNTLZdyUOepTZwHvn9FZttEIeVqSRmAkTbmKJpY78IwMu62SWOyschjsu3cNlo5gTEAQh3/4pyvYAKYdeX7IymJUh6a+GYuAw/wKckl92eYPSV5EPgrfXMGNuaGcy7Wsanrr0384rxf/YxUSkr3yyNhCSFCI73fmrXJwsnUKRbekhK2J8dThyj3Ptp5+0j4nTFC13NZuyJ15Ug6tk2oJuD12vFvQV0JDgZNR6Hd2kMQzFsp5eBFcFQ+BzXOngfN3VsuZcBns6szMAhPZ0TF8bmvBqeaww6wL7n+FLcgMiqMUjwC+xvnQl4GMzGk6zzTf6za/yExD0HzcxSFVnAhwrUTOiNV2HBD9+nwKCOGn0JrMpmKbSQ8YYc53dE2SczjM2KJ3cRFTDcKLeL8h9FdNWPCia6zLCuWruvatued59jdGfbhq74VlqmimXBdxk61sH7DWcZOduY/vscXx2/cXDLljNLz0QAAAABJRU5ErkJggg==",
-    "gender_rate": "0",
-    "rarity": "15"
+    "gender_rate": 0,
+    "rarity": 15
   },
   {
-    "id": "874",
+    "id": 874,
+    "sortid": 531.01,
     "identifier": "audino-mega",
     "name": "Mega Audino",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAHMJ3jJAAAA2FBMVEUAAAD///8xMTEyMjI0MzM0NDI0NDM1NDQ1NTU2NTQ3NTRSUlJUU1JUVFNUVFRVVFRVVVRVVVWEjJuEjJyGjp6bk4usejmtezmufDqufTqvfTu7a1q9a1q9bFy+bVu+bVzEu7PFvLTGvbXHvbTHvrXHv7fMrHLMu2vNrHPNrXTNvGvOrXPOvGvOvWvPrnTPr3bPvm3Pv27fZoXt5azu5qzu5q3v56zv563v5678xMz8/Pz9/f3+xc3+3eX+/f3+/v7/xs7/3eb/3uf/3+f//f7//v3//v7///9MOFjeAAAAAnRSTlMAAHaTzTgAAAG/SURBVDjLxZJdd9JQEEXPXAVygyDRFIulFmJaNDQYG2BasJRGm/P//5EPwGpSSeXBj3k6a2dnZm5yISIiEAEEIg+BQCSPHomIQBJAIOPACMQsFwKB3T3dNRD1gfomdj/HPWyiHa3W21hw90YYABsXgYPGNt6TuoluqtOdMPQ8bqONsqNtBCwqpx0EkWbYVgGatySdLFT3EV425/qD1LRkwuGMk3emBNdx54zep9yUTNiBf2ZLgw7f8y9AGC0efQvdoPErNNd3jgOgZgoQIcncZKoF+LLzkSRVC6+bY9VkzVDdYs+uO1HVqSkNAnw/bk7jMvTy4Tkjj7a4Ur+lKy9q35XMk1H6YZU1bbknBk3/BE8GbS5PEf7hj/yvRQC1Op7WXtHodeMgEfUwy8wBopsG9EnScYCGyWJNzP6OJvVzkuQ5syzUyYXZ27E2bupVkvALSTLUyYW7d7TbHb9KE1W9+v4QhjpN3eodXZiZP1P9mh6/v6w9c2q8yMn8DdnUXi9yHKdKbNy2hsPOit5y2WotSVMh2pv+KJ7rvE/Sez0MjmzlaAtr2u3o9PT22421z+wIANbaxWJgq//Mf7yPv6mfPUI3Vgwg3CgAAAAASUVORK5CYII=",
-    "gender_rate": "4",
-    "rarity": "15"
+    "gender_rate": 4,
+    "rarity": 15
   },
   {
-    "id": "875",
+    "id": 875,
+    "sortid": 719.01,
     "identifier": "diancie-mega",
     "name": "Mega Diancie",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAKlBMVEX///8ICAgxMTFSUlKDg4u9rDnNvbTNxc3eMUHmg4v25mL/rLT/1f/////VDVORAAAAAXRSTlMAQObYZgAAAOZJREFUeNrtzUGWwyAMA9BGciGK8f2vO4ZhNm1Cupld9fzM5ls8vvmf4EMFx/1BVxRT5zSsoFx0oY+vK9NFNG8i15XDtTaK15VN6dRIcQUNapKcNLtxlDdyp6HYtSsQjsP2ttMTLt0DpdhucF1KiwEfoDG994uLwgLkixAN7DDsvNA6Q7hrlFpE2BWEUa7juJFApPh1dQERUYOM55OstQInziwLC1LN1EHfoJUeiN5pH4o8bZxOzmHklBApzV6dgU0OuKRcbcqX1nGIdLk995TbcO8B/vaUmw25TMptm18tE1n8zcf5AYbcCqcMOVIYAAAAAElFTkSuQmCC",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "876",
+    "id": 876,
+    "sortid": 382.01,
     "identifier": "kyogre-primal",
     "name": "Primal Kyogre",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAHMJ3jJAAAA9lBMVEX///8YlMYZk8QZk8UZlMYblscxMTExMzQyMjIyMjMyMzQyNDQ0NDQ0NDU2NTQ3NTRKu+1Kve9LvO1LvO5LvO9NvO1Nvu1Nvu5NvvBSUlJSU1RSVFVSWpNSWpRSW5VScrtSc7xSc71Sdb5TVFVTdL5UVFRUVVVUXJVUXZZUdb5VVVRVVVVVW5RVc7xVdb1Vdr1rk+VrlOdrlehtluhuluZului7u7O8vLS8vLW8vLa9vbW/vLTM3PTN3PXN3ffO3vbO3vf07Ur8ZFz8/Pz9Y1r9Y1v9zZX9zpb99Z399p799579/f7/Y1r/ZV3/zpT/z5X/95z/957YaCJ3AAAAAXRSTlMAQObYZgAAAbNJREFUOMvdk+130jAUxh8UQhu6pIzqSEnW3ujwBUfNxAFaus7Xok7Y///P+EHGBspRP3iO8/l485yb3Of+AtyUKXoKCLscP5HJFDjQJuxQB480AGD5ubKniVyVxbtT/LmYPwEA9p4XR23OSwAoF/GZTABA2HNrr14pQAp/T0EA4K6pMaPluijvxCOXDdOI+jFXsfx+4ubOWaoU2+wg8jIXyad7F+Mfmou3ArdSrQ7AJmY9qe8DnjZNba5Dmrw59HhWTJWKPIZ0xhkAqfVo7rJhj6KUU3WFCXducUlt0jJZk8Nc4aylaW3j5tDaZrObUotvZpyXQkQfL7bCF0CSzgbi/0n+H9h9a7VzFjB/t63ZMabG4JuvE62l3PoUweTZa+MDYHG//9jomlJKeSsY2N7aLbWuH9b1Azeaz51zNB33IrL7ccrA06fjWF3zAilZNr90L4fL5eKDahM9oTOVEFF8w7TCbfmicA+rqiDK1L55JSUgpZTblDw/OXHO2fB+aC1RXOc7xxUiDLuNxl6jzENF9uDAHh97wU6zyHMBgFEUfSln6oj9KnWRqMFA/R614hay/Q2phTGVC3dcPwAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "877",
+    "id": 877,
+    "sortid": 383.01,
     "identifier": "groudon-primal",
     "name": "Primal Groudon",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAHMJ3jJAAABAlBMVEX///8xMTEyMTAyMjIyMjMzMTAzMTIzMjEzMjIzMzM0MTE0MjE0MjI0MzI0NDQ1MzE1MzI1NTM1NTU2NTQ3NTM3NTRSUlJTUlJTU1NTU1RUVFRVUlNVU1NVVVNVVVVja3pja3tka3tkbHxmbnxmbn5yKjlzKTlzKjp0Kjp0Kzt1Kzp2LTuDg5OEhJOEhJSGg5SGhJSGhpSLMVKMMVKMMlKMMlOOMlOOM1OONVO7u7u8vLy9vb3cOVrcOlrdOVrdOlveOVrfO1rfPFvtg1rthFrthFvug1ruhFvvg1rvhFrwhlv89Iv8/Pz99Yz9/Pz9/f3+9Iz+943/9Yz/9oz/94z///9x2P37AAAAAXRSTlMAQObYZgAAAhBJREFUOMvVU2170lAMvQFWBItYqqG8bK04XkSKymWszN4aoOLAVVjb/f+/YluQgdvj3Bcfd/IlN/c0uUlOGdsHfgGbMaP3wU1O7BATkznshoUfn7P7QPDLsxXAjGSJ2M//gEtkjwVReusBYqUWpYz9tG6+fbe2Iq+qS95CdyoJZT6+5MVdC48vdgBZlu/GfN/y6558cM/JExxAcMakTqeTxNJnGR36csgh8KzRwni5aYDBfLVylSU/12aF27SqGjfK8+zJQQpDhN+DQohwGKYPYpyPQmoY/XgpMsDmG6jVkLBPsWAc2soG7IJHJirYkOZr6zwJls4MfFXp+bSoa5bl1HvJOA1DZliacCibVqBt1n3zOcu6cFod+ATut+LtfJsFxGkwkWbF/WdFNy/CcHCnL3U8foLb+HcAUiJLP8wbTf2p79AxR0X5k45EWZTp2PNJcxcNFLufnhLb8V4PysOaWIY1emP2AIFoIz8gKbIW7Fcm20ZFo0Gub4KNOMhIjBWs97zFW6M9oiRl0PV0ELlK9EZ/XdDNT22Lc772A1fLbVmlVSQ3w4AjBmYfpkQOn+Xcr43K2g8nbdfFo61wrk4uqob+LMrbhdLq1D3nM2UyknAetBd1vZfd1U1dqeP4BPMunKyqFygH04A4uBGreO+Q8s1ZE1Kp1Hda0pJzyD4wfHUsrsX1EP5in2qM/0VcPwG3WU3NImoB4QAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "878",
+    "id": 878,
+    "sortid": 720.01,
     "identifier": "hoopa-unbound",
     "name": "Hoopa (Unbound)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAMFBMVEUAAADyjpAxMTFSUlJqYlp7g4uDUlqcpL2kWnvFxf/NtDHVWpTeUgj25nP/////ALswDUmVAAAAAnRSTlMAAHaTzTgAAAErSURBVHgB3dThDpRADATgc2Zv2lLL+z+u3T00igfeLxOdJsumfCnpHx5fPsw/Af9a0PnIeaZf0R99PJAz7ngPB15PQbxxS2JBNSTfOXQmHBsActtEEbN/YmURS26DmdlUQvcHfnER1rKWZHh6U6nZ4QC83JMTYt4ZER5eJMcYPEAdF0YAy/l8HVl91uEAi6ifRx8Oe3DCjVhuq2p5Wqodv+7cuZHMWtDMyk7OOSLMGHSXF1siOu3OsLOTTMnzgM+uhmcZzSJlpszKBkDwdydqj/1wKeUkOLuGzuyQ1VJt6zDvpTilst24kJCo5ITMBe9Gstanl7xyLZHJqj5cymx3KZWr6O66c24ySTFluztohCEi2e5e4tEVGfYHie/7X8GT37zdR/Ls/qtf8zdW8g1p3jDnRQAAAABJRU5ErkJggg==",
-    "gender_rate": "-1",
-    "rarity": "3"
+    "gender_rate": -1,
+    "rarity": 3
   },
   {
-    "id": "879",
+    "id": 879,
+    "sortid": 25.01,
     "identifier": "pikachu-cosplay",
     "name": "Cosplay Pikachu",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAHMJ3jJAAAAbFBMVEX///8xMTEyMjIzMjEzMzI0MjE0MzE1NDE2NTQ3NTRSUlJUVFJVU1JVVVKbg0KchEKehkKkazGkazK3dSq7kyLEpCrGpSnGpSrHpirHpy301DH1Y1L11DL21TH21TL3Y1L3ZVL31TL31jH8/PxppeqkAAAAAXRSTlMAQObYZgAAAQRJREFUOMvtk9tOwzAQRMeBJs6GQKF4W4J74fD//8hDoygpTUGoLyDO02o0WlvjsTShcklqo86xyZIkNENQWRwn7vBB7vQDSsn6ETz1m0B1r3peDeaoqxIkqZhqXiuYm42zgo6QfOJ7ThygvTlZGROYfinFEMqIRpJsmlK4VzCzZjFN6ZbGfawJXniovRxr9ZLqjVCmSW4Gr6yeTl/Ic/s5z9TBmSqEqH+u+T0sDJOFCz5fH39SCG42by2rTSVVYObeNGkxsw4AluwsuXuq545lB5v3AqhUJ/fZK5YZYL8HtsU6zdckxpic3JJha48X+xST07ZADl8FGWPsOrrv1TP++RZ/APLPEY7911HyAAAAAElFTkSuQmCC",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "880",
+    "id": 880,
+    "sortid": 25.02,
     "identifier": "pikachu-belle",
     "name": "Cosplay Pikachu (Belle)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAHMJ3jJAAAA8FBMVEX///8xMTExMTIxMjMxUZIxUpIxUpQyU5UzMjAzMzI0MzE0NDM0NDQ0NTY0NTc0UpI0VJI0VJU1Nzg2Nzk2ODk4crw5crs5c706dL07c7o7dL08db5RUVFRUlNSUlJTU1FTU1NUVFFUVFNUVFSCg4yEhIyFhYyKs92Ntt6dhUHDoynDoyrDw6PDxKTEoynExKPGpSnGxqXGxqbb28Pc3MXd3cXz0zHz0zL0YlL00zH01DP11DH3Y1L3ZFH31jH58eH78+P78+T79OX7+/v7/P389OX8/Pz99uX9/f39/f7+9uX+9uf+/fv/9+b/9+f///+KmK2yAAAAAXRSTlMAQObYZgAAAYNJREFUOMvdU9tSwjAQTVQiSgmi0qikWyoKilhTUBQv0WpV1Er+/29MAZ2W+zg+MJ6HnZ2Ts5vsJQgN4PesEpEFhobwERn3LbIrJpoAQBT3vRt++ZOCKozmxWtm4OA61ul64C7Dou+25IazNMh60Qi87zBsoN8Cd0co6mGqD+KM7R4xZaAaQJyVEnaD1EkitmE6V8SEs7VkykpFkQLDaJFA/cwo1/WfR8j6u+5GNiHDtBQVw+MV1SDcqSqUtSHGUrDDYtUQIh2Pb0nHZWWS4OixXG8TaZI46ZeuIWdZ4CWHdrr/UmL5oX42zzt5wryRCT+pxer7H05wrsKw39WYLd16+Gxu3x9uzry17g22O8thfFrKXZHmYAZKRV+T1myAsVLK9YEbqiJjgaF1wgY3PeHaltRbI8IiC8quGFqoIZ0UocFNYrUdRiYJqV9ua6W8u81Z0JaOuTyx4OZedfWxW04F+p0WpMjSlOZwkx0AaGm+wNi0zaMYNyudSBbMs6Bajv43vgBECS1tALy9LQAAAABJRU5ErkJggg==",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "881",
+    "id": 881,
+    "sortid": 25.03,
     "identifier": "pikachu-libre",
     "name": "Cosplay Pikachu (Libre)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA5FBMVEX///8xMTE0NDQ4NzM5NTE6ODA7OTE7Ozs7REU7RUY8REU8RUU8RUY8Rkc9RUY9Rkc9Rkg9R0g+OTE+PDE+Pj4+R0hQUFBSUlJXVlFYVFBZVlFaUlNaWFBdVFJdWFBdW1CWf0GchEKeaDGfhUCfh0GigkOiikGjh0GobzG1f0G1jiK9lCG9niq/S1q/oCzCliLEoyvGpSnHx8fKqSrKqzfrzDHtYlLtzjTy0TPznjHz8/P0aFD00jD1oDT19fX3Y1L3a1D31jH42T75ozP7+fL8qDv/pTH/qTH/qz7/+vP//fP////ZgcC6AAAAAXRSTlMAQObYZgAAAQZJREFUeNrtzVtTwjAQhuFslCgeCKhkUawFxdZDSS21EkTBWK1V/v//MTrKXdJrZniv9uKZb8m6FanR+L/abZfbEfB37QrhkoCwvBDscjuSv7DF9yJEIVrWwWRgYLMphEjQBBa3D6cbxmUZojRQUourP2bPE84zrY1LpGRWt/j6LCY9rX2ZmGyOwOK1LOM4DwLKXK7eu/8o4rda3M+BGBlx26AahOHtkXjqF9f8RwKxdKiUusgeXvLwRPDI8frGT7UK5vOwg0NxxYi1GmVpenfpqTF28ficE0dsOu2MtY84xE3iCjwPfeNGXUrcUZQSZ7N3BFIlGRuV5ZkZrG7rYOkqAkrWrU7f9I0e4yo842kAAAAASUVORK5CYII=",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "882",
+    "id": 882,
+    "sortid": 25.04,
     "identifier": "pikachu-phd",
     "name": "Cosplay Pikachu (Ph. D.)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAA51BMVEX///8xMTE0NDQ1NTU2OjU6ODA6Ojo7OTE7Q0U7REU7RUY8PDw8RUU8RUY9RUY9Rkc9Rkg9R0g+PDE+Pj4+R0hQUFBSUlJUUlFUVFRVWVRWVFJYVFBZWVlaWFBbW1tdVFJdW1BdXV1oUDloaGhqampra2tuVDt3rWh5r2p7tWt9sWqAtGeHaFCJalKLcFSMa1KYgUOobzG1jiK1ra23r6+9niq9tbW/oCzCurrGpSnKqSrKqzfU1NTd29Pe3t7rzDHtzjTvzjLy0TP00zH19fX3Y1L3a1D31jH7+/v8+vL/9vX//fP////HwMiyAAAAAXRSTlMAQObYZgAAAR1JREFUeAHt0MtSwjAUxvGkIBUUS4EcSr3YWot4iahQCvVClMJB7fs/j3FTVyeumeG/+ha/OZkJ27UdOUfl7HYN7lDwvykMkgNvlhM4Kev8MopclzHXaSYAQriEi6I4jqOo1RJCzEHHiYsVz4tjr5IsAFINU4twjTsAr2ItlqjdPE1tyr34UsqLBIMgnesox/gbjPzB+zKQ0ja5xuJM+XkPEUYDpmXiUAfxAaEAROX3rF/JGVH7A1Wo1msEKZzE8PRTkKHC1SrLfXl1+igcSu5ZdpZ9f51/FnBzD8eTcX2fUdmvz6Eqwrzvw2Q6HY/r9A/dDoMwL/Jcu2mtxsgO+tdDCGez2aammSmrWgU42Ww67P8spTqlM9Zus+1p1w88hiYaecCbCQAAAABJRU5ErkJggg==",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "883",
+    "id": 883,
+    "sortid": 25.05,
     "identifier": "pikachu-pop-star",
     "name": "Cosplay Pikachu (Pop Star)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAHMJ3jJAAAA+VBMVEX///8xMTEyMTEyMTIyMjEzMTIzMjAzMjIzMzM0MzE0MzM0NDQ0NTY0NTdRUVFSUlJTUlNTU1FUUVJUUlNUU1RUVFFUVVeFgouFhY2dhUGjUZKjUpKlUpSlU5KlU5SlajKlazClbDOmUpSmU5WmVJKmVJW6kiHDoynEoynFoyrGoyrGpSnGpizLy8vOzM3Ozs7TMXnTMXrUNX/VMnnWMXrWMXvWMnvWM3nWM3zWNH3seqvteqzte6zueazve63z0zH00zH10zL11DH20zL21TD3Y1L3ZFH31DH31jH7+/v8/Pz9u9T9vNT+utT+u9X++/z+/fv/vdb///+ArkNXAAAAAXRSTlMAQObYZgAAAVhJREFUOMvtkltTwkAMhc+ioBW2KyooWG94qbqggLZUaltEwKAC2v//Y3woYIvAOA4vOn4PO5kzJ9lMEiBMw5IAsMkwjTIBgF3HdKoMfJjYVGv6WHfwA+KACCLNIV0GoUeERBDyYzJHXs6xUNj4Ccii6hp9MKELEbJxohYtj3obcrZLndtXKxat2D3V3MEhfikcAFJRzVABQA1NScAxHYurLC0+1ezJktGPkyJlIpztkaQci2o8R0qD4qnIPHn6gdrb7wfRz/N9u5FxBxNd+pptFmNfl1lewT+LPIfx1lOqYLNc1Z51eWMAAGdMTwsxxZqtbIhKzxrcOa4Z9yjDdJkW54lp5bKCeUQ14zHXJEWXcuKgwu15RCTfkh6RAj7HGDip036qGb01fbYPPG8XLvZetp79nXv36ig221ja1zS7sC7q5sBPzp8iK12vsq5fbCnfmzr763f1ARI7KokKJ4uCAAAAAElFTkSuQmCC",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "884",
+    "id": 884,
+    "sortid": 25.06,
     "identifier": "pikachu-rock-star",
     "name": "Cosplay Pikachu (Rock Star)",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAHMJ3jJAAAAolBMVEX///8xMTEyMTEyMjEzMTAzMjA0MzE0NDQ0NTY0NTdRUVFSUlJSU1FTUVFTUVJTU1FTU1NUVFFqqzGDg4uEhIqEhIyFg4uFhYqSQVGSQlKUQVGUQlKVRFGchEGdhUGjajGsrLStrbW6kiHDoynEoynEpCrFoynGpSnMMSHMMiLNMSHOMSHz0zH00zH10zH11DH21TD3Y1L3ZFH31DH31jH+/fu0D3DAAAAAAXRSTlMAQObYZgAAASlJREFUOMvtlNFOg0AQRXdQsMPSItS1K9SWuqVbgSKt4///miCVAAFNTF803oeBDGeWzOUGxjqydFUdYEPa5VXFPRsRMDgPvthR3LQ5+4GwmZOUKl3fZkTCPAMOTdvwJQVN+ZRk6ooBV7y9C9Iyze+E7sw+bel0L26N/pHhPp2xX6oPeye9pl09sNsuoYGPVcvlrS6GBUFgaW22hzNKglUUd3q4Iuuw2HT9RLegYxStey/3/YOX9nOFcpYGA8m1gf3rknFoDJ3YHMYzg6r+6AigXM6HUZShAarkMCMPlHb51hw5UeZEyyQNcm8e616g2lz5lyD9dlNeFtFGxKNgTdLp+FpyJWiObwxypwvy5kKI5+na+NIc3yl3fQjD5PpbIwHsMV8G4L+eq3efUhfZ4eHwKQAAAABJRU5ErkJggg==",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "885",
+    "id": 885,
+    "sortid": 521.01,
     "identifier": "unfezant-female",
     "name": "Unfezant",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAdVBMVEX///8xMTEyMjI2NjZSUlJqampsbGySmqOUnKWta0K7u7u9vb2Tm6Rra2urakKra0I1NTW8vLxTUlFRUVHz8ylUVFF1RBBsa2q1YxC6uroyMTEzMzO9vLqVnaO+vr739yn19SqrakH8/Pv////GnSmUnKPEmimaCq/VAAAAAXRSTlMAQObYZgAAAMdJREFUeNrt0ccOgzAQBFDGuNCcQBrppP//J2YgSDl54RZFYg4+PVk7u9GUH6cE0L4DLIbx3gMGA46sC90QzJJkhHN0VZ50MAYQhEu67f1s8ZkiDFeP52VzI6QrCIOuaU5Vnluv2/JFEJar9etIxmgnVuKMvdOUSqq96/+rrIa8n97lNjtwQfJp5ot2gMzCSPBaz2vtPBcvH5IyTdOFKQad0XpGydqQXOmUAbCcpXsyIexZdvv89pA9Z1RjnFNOYQxEFEdT/iVvKpYJlEH1ZYgAAAAASUVORK5CYII=",
-    "gender_rate": "8",
-    "rarity": "45"
+    "gender_rate": 8,
+    "rarity": 45
   },
   {
-    "id": "886",
+    "id": 886,
+    "sortid": 592.01,
     "identifier": "frillish-female",
     "name": "Frillish",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAb1BMVEX/////ve80MzQxMTH/5//75Ps0MzP/5v42NzfOc4zskqPvlKb7uuwzMjL8u+z+u+xRUVFUVFTOdI3UUlzWU1w1NzfvlKVxgvN1hPbEq7PGrbb8vO/85PzMcov+u+3+vO3+5f3+5v1TU1NUU1PTUVk1byURAAAAAXRSTlMAQObYZgAAAKFJREFUeNrt0UcOwzAMBECzqLiX9F7//8YgVHIldTXgPQ8WXKlYMqNsslQkckg50I2HB+bA4Xx8UoZrAjODtx0EhmDL+O5B4vXBRdydYN0bMDrwQwewX/VQtzqst6/LFWAqxSmSkdxUlnesWlIliWYsYnXzRNaLU7oDAqqljSxJzeqgAD9JpM5hHjuR5m6H//Osz0m9Is1edAJt+W1eMpN8AOYGBbrNs266AAAAAElFTkSuQmCC",
-    "gender_rate": "8",
-    "rarity": "190"
+    "gender_rate": 8,
+    "rarity": 190
   },
   {
-    "id": "887",
+    "id": 887,
+    "sortid": 593.01,
     "identifier": "jellicent-female",
     "name": "Jellicent",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAAAolBMVEX/////rfcxMTE1NTWMbHzGxuf75Ps0MzT/5v7/5/+Ma3vFxOU2Njbcg7TnSyz85Pz9q/X9rPX95fz+q/P+5v7Dw+Q0MjSKanmNbH3ExOTehLYzMzNUVFSNa3syMTK2dJ2NbHzehLUzMjPehbblTCnmSirmSivnSimdy0n7q/OdzUyycZq0cpu1dJ39rfS2c51RUVH+5f1SUlJTU1SNanlUU1RKoDZFAAAAAXRSTlMAQObYZgAAAQFJREFUeAHt0sWShEAMBuBN2nGH8XV3ef9X26Tn2nRxm8v8lQPy1U8FuDjn5MkWMtQGcQnUSjZmgetl2k2NiXcKxCfrOLC+jjl9qME6HohJdkULPlGZ6cPd4ztA0X7UHuKMG9M33/h862svG2dm9u2UrIqH1jeud41zQZmhdk7J/P63orYkSbswzPS2JMh3p5zbFB2rTWBjgL+SHUtyLAOOoCP5XXp49NMewx+F6NB3vool1wkMWb4qPlfEZJIq+VoPqMN7H/WYJPnVbo/4wm/dzkgxVmBvvgAGvx85huGV7Hb1U4I1fEYM556sDfYbEo5l7E8XPEIbTXJByHLZCXPOP3TXEBLA33hjAAAAAElFTkSuQmCC",
-    "gender_rate": "8",
-    "rarity": "60"
+    "gender_rate": 8,
+    "rarity": 60
   },
   {
-    "id": "888",
+    "id": 888,
+    "sortid": 668.01,
     "identifier": "pyroar-female",
     "name": "Pyroar",
     "sprite": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAMAAAC7IEhfAAABlVBMVEUAAGExMTE2NzfFm2tSUlJrWlqGOUKGP0epeVGselKte1LEm2vFmmoyMjLGnGv2OTL/xjH3OzGGPEJSQkKGXDo0MzKrelJTUlJUU1LDmmnDmmpqWVlqWlprWlnFnGo0MzH1OjJtXFv3OTH/xDE7PDyBWTk7PD3CmWnEmmrBmWmCOUGDOEGDWTgzMjGFOkKFO0KFO0OFWzn4PDGGOkJEo7GGPENRUVAzMjJSUVE1MjFTQ0OqeVE1NDGEWzlUUVHFmmk1NDJUVFNVU1HGmmrGm2pVU1LMoDHMozHPozHPpDHPpjE4Nzc4ODj3PzdsW1r5+/r7wjH8+/v9wzH9xTFtW1k4ODnEmmlVUlI5ODlRUVFVVVTFm2o5OTk6PDyEO0OqeVLGm2ureVCreVGreVKrelGEWjmre1KselEyMjFTU1LxODDyOTD0ODEzMzI3NjaDWjqEOUKtfFJTUlFSUVJSUlFUUlH0OTD1OTFUUlKufFOufVSufVXBmGkzMzNtXFrCmWrDmWiFWzszMTH+xDL/wTHEmWnEmWpqnJ3KAAAAAXRSTlMAQObYZgAAAZBJREFUeAHt0EW/2kAUhvGZM3HPvRf3JAhtqVBpKdACdXd3d3f3fu6epKvChLJodzwbNn/eM7+Qef+6Uq83m9vrOKUOiZIWFiQpxnXQ+Xu8SEpt37dtvgQXnYdJONf2PVuW7z3mwYe7HAdZuexJ9rfQESLLHLd/+VFnN7rhHZRS5LhBduVhx0XHloQDth050+TAWvPizmOuvYWJFsWTcshEkScDeve7uzqdrzBKwpABcOW+Za9evrl8nAmACuco/vIkXF11f62VeSeY6DbjVZMkKKFia+K0wtYbyQ9Hzj6jeBWrbMTXBqIxSCTGJt8ztmPdobepXMhyrzNfPp8P/68ZmRN/Tp4RNiVvrbn0NNoTrCUcxEBXYfyVGx5t7XdHebGAMK1b+m8AMPHKav1m/5R+sNCgi4s/itYDEldAnw9146NaBwBlm6XdjpdNVkyee/I1+loavi1eKifTn7YPws+vaJRMCVaoqYZBCSg3pg3i0PVrI/0KkgCmupqivsgWW+TvBVDt/jxNZukC3pz3P/sF8qEzXLRRAxAAAAAASUVORK5CYII=",
-    "gender_rate": "8",
-    "rarity": "65"
+    "gender_rate": 8,
+    "rarity": 65
   }
 ]


### PR DESCRIPTION
This adds a sorting ID to every Pokémon, ensuring
different formes of different Pokémon stay together
in the Pokédex when sorting by ID. This will also allow
for easier updating to Pokémon Sun/Moon, as the ID and
sort ID no longer have to be the same, making the ID more
of an internal thing for Pokémon fetching.