### PR TITLE
Fix the layout of very tall videos on the dash

### DIFF
--- a/Extensions/vanilla_video.js
+++ b/Extensions/vanilla_video.js
@@ -1,5 +1,5 @@
 //* TITLE Vanilla Videos **//
-//* VERSION 0.0.4 **//
+//* VERSION 0.1.0 **//
 //* DESCRIPTION Make the video player unexciting **//
 //* DETAILS Use the browser-default video player that won't follow you, loop, or autoplay. Only works on Tumblr's player. **//
 //* DEVELOPER new-xkit **//
@@ -35,8 +35,11 @@ XKit.extensions.vanilla_video = {
 					newVideo.appendChild(clonedSource);
 				});
 				newVideo.controls = true;
-				newVideo.style.width = '100%';
-
+				newVideo.style = "width: 100%;" +
+								 "display: block;" +
+								 "margin: auto;" +
+								 "max-height: 600px;" +
+								 "background: #333;";
 				videoEmbed.replaceWith(newVideo);
 			});
 		});


### PR DESCRIPTION
It used to be that if you were using vanilla videos, the vertical format videos would be *super* tall, and alsmot impossible to see all on one screen. 600px is just an arbitrary number, but I think it's a pretty reasonable one.

from the support chat:

>DarkPuck has joined.
`DarkPuck` I had a question about the Vanilla Videos extenson.
`DarkPuck` *extension
`DarkPuck` I installed it to prevent videos on my dash from automatically playing, but it has the unfortunate side effect of stretching out vertical videos unti they're as wide as my dashboard -- and taller than my laptop
`DarkPuck` 's screen.
`DarkPuck` Is there any way that could be fixed?

![image](https://cloud.githubusercontent.com/assets/233815/21058945/4855b322-be0e-11e6-8f79-b30746ebefd1.png)

