### PR TITLE
Escape post crushes text before sending it to the server

### DIFF
--- a/Extensions/post_crushes.js
+++ b/Extensions/post_crushes.js
@@ -1,5 +1,5 @@
 //* TITLE Post Crushes **//
-//* VERSION 2.0.4 **//
+//* VERSION 2.0.5 **//
 //* DESCRIPTION Lets you share your Tumblr Crushes **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS To use this extension, go to the 'Following' page on your dashboard, and click on the 'Post My Crushes' button below your Tumblr Crushes. **//
@@ -177,7 +177,7 @@ XKit.extensions.post_crushes = new Object({
 			var m_text = $.trim($("#xkit-post-crushes-additional-text").val());
 
 			if (m_text !== "") {
-				m_object["post[two]"] = send_txt + "<p>" + m_text + "</p>";
+				m_object["post[two]"] = send_txt + "<p>" + XKit.tools.escape_html(m_text) + "</p>";
 			} else {
 				m_object["post[two]"] = send_txt;
 			}


### PR DESCRIPTION
Escape post crushes text before sending it to the server. This fixes a bug where Tumblr would reject our post, because it was malformed in some way.

>`skyler` hi! I've been having an issue with Post Crushes for a while now. Says the server returned a non-JSON?
`skyler` I've tried uninstalling and updating both, but neither solved it.
[...]
`skyler` oh ok, wait, weird. I tried to generate the error and this time I left off the text in the "post caption" optional text box and it posted fine. It still won't post with text in that box and it won't queue or save to drafts. But at least it does post if I leave that text box blank. *shrug
`skyler` I wrote: My crushes! Follow these wonderful people. <3