### PR TITLE
Resolve positioning issue for preferences pane

### DIFF
--- a/Extensions/accesskit.js
+++ b/Extensions/accesskit.js
@@ -1,5 +1,5 @@
 //* TITLE AccessKit **//
-//* VERSION 1.2.2 **//
+//* VERSION 1.2.3 **//
 //* DESCRIPTION Accessibility tools for Tumblr **//
 //* DETAILS Provides accessibility tools for XKit and your dashboard, such as increased font sizes, more contrast on icons and more. **//
 //* DEVELOPER new-xkit **//
@@ -153,7 +153,7 @@ XKit.extensions.accesskit = new Object({
 
 		if (m_filters !== "") {
 
-			m_css = m_css + " html { filter: " + m_filters + "; } ";
+			m_css = m_css + "html {height: 100%; } body { height: 100%; filter: " + m_filters + "; } ";
 
 		}
 


### PR DESCRIPTION
Resolves #1245 -- This was only broken in Firefox, and there's a bug filed in Mozilla's bugtracker for positioning issues for fixed attributes when grayscale is enabled: https://bugzilla.mozilla.org/show_bug.cgi?id=1106895

Fun facts to know and tell.

The bug discussion thread mentions a workaround of explicitly setting `html` and `body` to `height: 100%`, which seemed to resolve our immediate issue.