### PR TITLE
Fix ER double posting

### DIFF
--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -1,5 +1,5 @@
 //* TITLE Editable Reblogs **//
-//* VERSION 3.3.5 **//
+//* VERSION 3.3.6 **//
 //* DESCRIPTION Restores ability to edit previous reblogs of a post **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -190,7 +190,7 @@ XKit.extensions.editable_reblogs = new Object({
 	},
 
 	get_post_save_button: function() {
-		return $('.post-form--save-button');
+		return $('.post-form--save-button button');
 	},
 
 	wrap_html_links: function(html_text) {


### PR DESCRIPTION
We missed this in change in #1230, but we moved some code using saveButton out of the closure in which it was defined.

I fixed this as part of a last-minute change to #1236, but I screwed up the exact element I was supposed to be targeting.