### PR TITLE
move css load before posts check

### DIFF
--- a/Extensions/quick_tags.js
+++ b/Extensions/quick_tags.js
@@ -1,5 +1,5 @@
 //* TITLE Quick Tags **//
-//* VERSION 0.5.8 **//
+//* VERSION 0.5.9 **//
 //* DESCRIPTION Quickly add tags to posts **//
 //* DETAILS Allows you to create tag bundles and add tags to posts without leaving the dashboard. **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/quick_tags.js
+++ b/Extensions/quick_tags.js
@@ -68,9 +68,9 @@ XKit.extensions.quick_tags = new Object({
 	run: function() {
 		this.running = true;
 
-		if (!$(".post.post_full, .post.post_brick").length) { return; }
-
 		XKit.tools.init_css("quick_tags");
+		
+		if (!$(".post.post_full, .post.post_brick").length) { return; }
 
 		XKit.interface.post_window.create_control_button("xkit-quick-tags-window", this.button_icon, "Quick Tags in a window!");
 		XKit.interface.create_control_button("xkit-quick-tags", this.button_icon, "Quick Tags!", "", this.button_ok_icon);


### PR DESCRIPTION
https://github.com/new-xkit/XKit/issues/655

CSS wasn't loading on other pages (except for dashboard) because the run function exits if posts cannot be found (and therefore can't reach init_css). Moved the CSS load to before this check so that it shows on all pages.