### PR TITLE
Use <span> instead of <a> for Timestamps help popup

### DIFF
--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -1,5 +1,5 @@
 //* TITLE Timestamps **//
-//* VERSION 2.7.6 **//
+//* VERSION 2.7.7 **//
 //* DESCRIPTION See when a post has been made. **//
 //* DETAILS This extension lets you see when a post was made, in full date or relative time (eg: 5 minutes ago). It also works on asks, and you can format your timestamps. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -37,7 +37,7 @@ XKit.extensions.timestamps = new Object({
 			type: "separator"
 		},
 		format: {
-			text: "Timestamp format (<a id=\"xkit-timestamps-format-help\" href=\"#\" onclick=\"return false\">what is this?</a>)",
+			text: "Timestamp format (<span id=\"xkit-timestamps-format-help\" style=\"text-decoration: underline; cursor: pointer;\">what is this?</span>)",
 			type: "text",
 			default: "MMMM Do YYYY, h:mm:ss a",
 			value: "MMMM Do YYYY, h:mm:ss a"


### PR DESCRIPTION
Avoids scrolling user's browser to top of page on click