### PR TITLE
bump extension versions

### DIFF
--- a/Extensions/activity_plus.js
+++ b/Extensions/activity_plus.js
@@ -1,5 +1,5 @@
 //* TITLE Activity+ **//
-//* VERSION 0.3.7 **//
+//* VERSION 0.3.8 **//
 //* DESCRIPTION Tweaks for the Activity page **//
 //* DETAILS This extension brings a couple of tweaks for the Activity page, such as the ability to filter notes by type and showing timestamps. **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/alternative_timestamps.js
+++ b/Extensions/alternative_timestamps.js
@@ -1,5 +1,5 @@
 //* TITLE Alternative Timestamps **//
-//* VERSION 1.1.2 **//
+//* VERSION 1.1.3 **//
 //* DESCRIPTION Adds timestamps to dashboard posts using a parsing method **//
 //* DETAILS This version of Timestamps uses parsing methods to display the timestamp instead of AJAX calls. Currently only in English. **//
 //* DEVELOPER jesskay **//

--- a/Extensions/audio_downloader.js
+++ b/Extensions/audio_downloader.js
@@ -1,5 +1,5 @@
 //* TITLE Audio Downloader **//
-//* VERSION 2.0.3 **//
+//* VERSION 2.0.4 **//
 //* DESCRIPTION Lets you download audio posts hosted on Tumblr **//
 //* DEVELOPER STUDIOXENIX **//
 //* FRAME false **//

--- a/Extensions/audio_plus.js
+++ b/Extensions/audio_plus.js
@@ -1,5 +1,5 @@
 //* TITLE Audio+ **//
-//* VERSION 0.4.4 **//
+//* VERSION 0.4.5 **//
 //* DESCRIPTION Enhancements for the Audio Player **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//

--- a/Extensions/auto_tagger.js
+++ b/Extensions/auto_tagger.js
@@ -1,5 +1,5 @@
 //* TITLE Auto Tagger **//
-//* VERSION 0.7.1 **//
+//* VERSION 0.7.2 **//
 //* DESCRIPTION Tags posts automatically. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS This extension allows you to automatically add tags to posts based on state (reblogged, original, queued) or post type (audio, video, etc) and keeping original tags while reblogging a post. **//

--- a/Extensions/autoscroll.js
+++ b/Extensions/autoscroll.js
@@ -1,5 +1,5 @@
 //* TITLE Auto Scroll **//
-//* VERSION 1.2.0 **//
+//* VERSION 1.2.1 **//
 //* DESCRIPTION Scrolls the page at a variable pace. **//
 //* DETAILS Automatically scrolls the dashboard. **//
 //* DEVELOPER Fr33dan **//

--- a/Extensions/bookmarker.js
+++ b/Extensions/bookmarker.js
@@ -1,5 +1,5 @@
 //* TITLE Bookmarker **//
-//* VERSION 2.3.5 **//
+//* VERSION 2.3.6 **//
 //* DESCRIPTION Dashboard Time Machine **//
 //* DEVELOPER new-xkit **//
 //* DETAILS The Bookmarker extension allows you to bookmark posts and get back to them whenever you want to. Just click on the Bookmark icon on posts and the post will be added to your Bookmark List on your sidebar. **//

--- a/Extensions/classic_header.js
+++ b/Extensions/classic_header.js
@@ -1,5 +1,5 @@
 //* TITLE Header Options **//
-//* VERSION 2.4.2 **//
+//* VERSION 2.4.3 **//
 //* DESCRIPTION Customize the header. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS This extension adds your blogs on the top of the page, so you can easily switch between blogs. The blog limit on the header is five, but you can limit this to three blogs and turn off the blog title bubble from the settings. **//

--- a/Extensions/classic_tags.js
+++ b/Extensions/classic_tags.js
@@ -1,5 +1,5 @@
 //* TITLE Tag Tracking+ **//
-//* VERSION 1.6.4 **//
+//* VERSION 1.6.5 **//
 //* DESCRIPTION Shows your tracked tags on your sidebar **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//

--- a/Extensions/cleanfeed.js
+++ b/Extensions/cleanfeed.js
@@ -1,5 +1,5 @@
 //* TITLE CleanFeed **//
-//* VERSION 1.5.3 **//
+//* VERSION 1.5.4 **//
 //* DESCRIPTION Browse safely in public **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS This extension, when enabled, hides photo posts until you hover over them. Useful to browse Tumblr in a workspace or in public, and not worry about NSFW stuff appearing. You can also set it to hide avatars and not show non-text posts at all. To activate or disable it, click on the CleanFeed button on your sidebar. It will remember it's on/off setting. **//

--- a/Extensions/colorquotes.js
+++ b/Extensions/colorquotes.js
@@ -1,5 +1,5 @@
 //* TITLE Color Quotes **//
-//* VERSION 1.1.1 **//
+//* VERSION 1.1.2 **//
 //* DESCRIPTION Color Quotes has moved to Reblog Display Options **//
 //* DEVELOPER STUDIOXENIX **//
 //* FRAME false **//

--- a/Extensions/disable_gifs.js
+++ b/Extensions/disable_gifs.js
@@ -1,5 +1,5 @@
 //* TITLE Disable Gifs **//
-//* VERSION 0.3.1 **//
+//* VERSION 0.3.2 **//
 //* DESCRIPTION Stops GIFs on dashboard **//
 //* DETAILS This is a very early preview version of an extension that allows you to stop the GIFs from playing on your dashboard. If you still would like to view them, you can click on the Play button on the post. Please note that for now, this extension can't stop GIFs added to text posts. **//
 //* DEVELOPER new-xkit **//

--- a/Extensions/drafts_plus.js
+++ b/Extensions/drafts_plus.js
@@ -1,5 +1,5 @@
 //* TITLE Drafts+ **//
-//* VERSION 0.2.4 **//
+//* VERSION 0.2.5 **//
 //* DESCRIPTION Enhancements for Drafts page **//
 //* DEVELOPER STUDIOXENIX **//
 //* FRAME false **//

--- a/Extensions/elevator.js
+++ b/Extensions/elevator.js
@@ -1,5 +1,5 @@
 //* TITLE Elevator **//
-//* VERSION 0.0.3 **//
+//* VERSION 0.0.4 **//
 //* DESCRIPTION Scroll to top the old-fashioned way **//
 //* DETAILS Makes the scroll to top button scroll slowly and play elevator music. **//
 //* DEVELOPER hobinjk **//

--- a/Extensions/find_blogs.js
+++ b/Extensions/find_blogs.js
@@ -1,5 +1,5 @@
 //* TITLE Find Blogs **//
-//* VERSION 1.2.1 **//
+//* VERSION 1.2.2 **//
 //* DESCRIPTION Lets you find similar blogs **//
 //* DEVELOPER STUDIOXENIX **//
 //* FRAME false **//

--- a/Extensions/find_inactives.js
+++ b/Extensions/find_inactives.js
@@ -1,5 +1,5 @@
 //* TITLE Find Inactives **//
-//* VERSION 0.3.1 **//
+//* VERSION 0.3.2 **//
 //* DESCRIPTION Find the inactive blogs you follow **//
 //* DEVELOPER new-xkit **//
 //* DETAILS This extension lets you find blogs that haven't been updated in a certain amount of time. Just go to list of blogs you follow, then click on &quot;Find Inactive Blogs&quot; button below your Crushes to get started. **//

--- a/Extensions/glowing_follow.js
+++ b/Extensions/glowing_follow.js
@@ -1,5 +1,5 @@
 //* TITLE Glowing Follow **//
-//* VERSION 1.0.7 **//
+//* VERSION 1.0.8 **//
 //* DESCRIPTION Glowing plusses on non-mutual followers' blogs **//
 //* DETAILS Makes the Follow button on people's blogs glow if they are following you and you are not following them. Before proceeding, please keep in mind that sometimes, ignorance is bliss. **//
 //* DEVELOPER new-xkit **//

--- a/Extensions/highlighter.js
+++ b/Extensions/highlighter.js
@@ -1,5 +1,5 @@
 //* TITLE Highlighter **//
-//* VERSION 0.1.2 **//
+//* VERSION 0.1.3 **//
 //* DESCRIPTION Don't miss things **//
 //* DETAILS The cousin of Blacklister, this extension highlights posts depending on the words you decide. When a word you add is found on a post, the post will get a yellow-ish background. **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/jk_across_pages.js
+++ b/Extensions/jk_across_pages.js
@@ -1,5 +1,5 @@
 //* TITLE J/K Across Pages **//
-//* VERSION 1.1.3 **//
+//* VERSION 1.1.4 **//
 //* DESCRIPTION Allow Tumblr's J/K navigation to move between pages **//
 //* DEVELOPER beiju **//
 //* FRAME false **//

--- a/Extensions/lethe.js
+++ b/Extensions/lethe.js
@@ -1,5 +1,5 @@
 //* TITLE Hermes **//
-//* VERSION 1.2.2 **//
+//* VERSION 1.2.3 **//
 //* DESCRIPTION Helps speed up your Tumblr experience **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//

--- a/Extensions/mass_deleter.js
+++ b/Extensions/mass_deleter.js
@@ -1,5 +1,5 @@
 //* TITLE Mass Deleter **//
-//* VERSION 0.1.3 **//
+//* VERSION 0.1.4 **//
 //* DESCRIPTION Mass unlike likes / delete drafts **//
 //* DETAILS Used to mass unlike posts or delete drafts. Please use with caution, especially Mass Unlike part is extremely experimental. **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/notificationblock.js
+++ b/Extensions/notificationblock.js
@@ -1,5 +1,5 @@
 //* TITLE NotificationBlock **//
-//* VERSION 1.3.4 **//
+//* VERSION 1.3.5 **//
 //* DESCRIPTION Blocks notifications from a post **//
 //* DEVELOPER new-xkit **//
 //* DETAILS One post got way too popular and now just annoying you? Click on the notification block icon on that post to hide the notifications from that post. If you have Go-To-Dash installed, you can click on a notification, then click View button on top-right corner to quickly go back to the post on your dashboard.  **//

--- a/Extensions/old_notifications.js
+++ b/Extensions/old_notifications.js
@@ -1,5 +1,5 @@
 //* TITLE Classic Notifications **//
-//* VERSION 0.6 REV B **//
+//* VERSION 0.6.3 **//
 //* DESCRIPTION Notifications where they were **//
 //* DETAILS This is a very experimental extension that brings back the notifications to your blog pages (ie: www.tumblr.com/blog/xkit-extension), just the way it was before Tumblr's Activity update. Only the last 10 notifications are displayed. **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/old_stats.js
+++ b/Extensions/old_stats.js
@@ -1,5 +1,5 @@
 //* TITLE Old Stats **//
-//* VERSION 0.2.2 **//
+//* VERSION 0.2.3 **//
 //* DESCRIPTION  **//
 //* DEVELOPER STUDIOXENIX **//
 //* FRAME false **//

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.3.3 **//
+//* VERSION 4.3.4 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//

--- a/Extensions/one_click_reply.js
+++ b/Extensions/one_click_reply.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Reply **//
-//* VERSION 2.0.9 **//
+//* VERSION 2.0.10 **//
 //* DESCRIPTION Lets you reply to notifications **//
 //* DEVELOPER new-xkit **//
 //* DETAILS To use this extension, hover over a notification and click on the Reply button. If Multi-Reply is on, hold down the ALT key while clicking on the Reply button to select/deselect posts and reply to all of them at once. **//

--- a/Extensions/outbox.js
+++ b/Extensions/outbox.js
@@ -1,5 +1,5 @@
 //* TITLE Outbox **//
-//* VERSION 0.10.0 **//
+//* VERSION 0.10.1 **//
 //* DESCRIPTION Saves your sent replies and asks. **//
 //* DETAILS This extension stores and lets you view the last 50 asks you've answered privately. Please keep in mind that this is a highly experimental extension, so if you hit a bug, please send the XKit blog an ask with the problem you've found. **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/pokes.js
+++ b/Extensions/pokes.js
@@ -1,5 +1,5 @@
 //* TITLE Pokés **//
-//* VERSION 0.11.3 **//
+//* VERSION 0.11.4 **//
 //* DESCRIPTION Gotta catch them all! **//
 //* DETAILS Randomly spawns Pokémon on your dash for you to collect. **//
 //* DEVELOPER new-xkit **//

--- a/Extensions/post_limit_checker.js
+++ b/Extensions/post_limit_checker.js
@@ -1,5 +1,5 @@
 //* TITLE Post Limit Checker **//
-//* VERSION 0.3.2 **//
+//* VERSION 0.3.3 **//
 //* DESCRIPTION Are you close to the limit? **//
 //* DETAILS Shows you how many posts you can reblog today. **//
 //* DEVELOPER new-xkit **//

--- a/Extensions/profiler.js
+++ b/Extensions/profiler.js
@@ -1,5 +1,5 @@
 //* TITLE Profiler **//
-//* VERSION 1.2.5 **//
+//* VERSION 1.2.6 **//
 //* DESCRIPTION The User Inspection Gadget **//
 //* DETAILS Select Profiler option from the User Menu to see information such as when they started blogging, how many posts they have, timezone, and more.<br><br>Requires User Menus+ to be installed. **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/quick_tags.js
+++ b/Extensions/quick_tags.js
@@ -1,5 +1,5 @@
 //* TITLE Quick Tags **//
-//* VERSION 0.5.8 **//
+//* VERSION 0.5.9 **//
 //* DESCRIPTION Quickly add tags to posts **//
 //* DETAILS Allows you to create tag bundles and add tags to posts without leaving the dashboard. **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/read_more_now.js
+++ b/Extensions/read_more_now.js
@@ -1,5 +1,5 @@
 //* TITLE Read More Now **//
-//* VERSION 1.4.7 **//
+//* VERSION 1.4.8 **//
 //* DESCRIPTION Read Mores in your dash **//
 //* DETAILS This extension allows you to read 'Read More' posts without leaving your dash. Just click on the 'Read More Now!' button on posts and XKit will automatically load and display the post on your dashboard. **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/reblog_as_text.js
+++ b/Extensions/reblog_as_text.js
@@ -1,5 +1,5 @@
 //* TITLE Reblog As Text **//
-//* VERSION 1.1.1 **//
+//* VERSION 1.1.2 **//
 //* DESCRIPTION Text posts remain text **//
 //* DETAILS This post allows you to always reblog text posts as text posts, and not as links. **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/reblog_yourself.js
+++ b/Extensions/reblog_yourself.js
@@ -1,5 +1,5 @@
 //* TITLE Reblog Yourself **//
-//* VERSION 1.3.1 **//
+//* VERSION 1.3.2 **//
 //* DESCRIPTION Allows you to reblog posts back to your blog **//
 //* DEVELOPER STUDIOXENIX **//
 //* FRAME false **//

--- a/Extensions/retags.js
+++ b/Extensions/retags.js
@@ -1,6 +1,6 @@
 //* TITLE       Retags **//
 //* DEVELOPER   new-xkit **//
-//* VERSION     1.1.3 **//
+//* VERSION     1.1.4 **//
 //* DESCRIPTION Adds tags to reblog notes **//
 //* FRAME       false **//
 //* SLOW        false **//

--- a/Extensions/separator.js
+++ b/Extensions/separator.js
@@ -1,5 +1,5 @@
 //* TITLE Separator **//
-//* VERSION 1.1.3 **//
+//* VERSION 1.1.4 **//
 //* DESCRIPTION Where were we again? **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS A simple extension that puts a divider showing where you left off on your dashboard. **//

--- a/Extensions/shorten_posts.js
+++ b/Extensions/shorten_posts.js
@@ -1,5 +1,5 @@
 //* TITLE Shorten Posts **//
-//* VERSION 0.2.3 **//
+//* VERSION 0.2.4 **//
 //* DESCRIPTION Makes scrolling easier **//
 //* DETAILS This extension shortens long posts, so if you are interested, you can just click on Show Full Post button to see it all, or scroll down if you are not interested. Useful for screens where long posts take a lot of space, and making it hard to scroll down.<br><br>By default, this extension shortens text posts. You can toggle settings to choose which types of posts to shorten. (This will 'cut off' long, vertical posts.) **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/show_more.js
+++ b/Extensions/show_more.js
@@ -1,5 +1,5 @@
 //* TITLE User Menus+ **//
-//* VERSION 2.5.5 **//
+//* VERSION 2.5.6 **//
 //* DESCRIPTION More options on the user menu **//
 //* DEVELOPER new-xkit **//
 //* DETAILS This extension adds additional options to the user menu (the one that appears under user avatars on your dashboard), such as Avatar Magnifier, links to their Liked Posts page if they have them enabled. Note that this extension, especially the Show Likes and Show Submit options use a lot of network and might slow your computer down. **//

--- a/Extensions/show_originals.js
+++ b/Extensions/show_originals.js
@@ -1,5 +1,5 @@
 //* TITLE Show Originals **//
-//* VERSION 1.2.3 **//
+//* VERSION 1.2.4 **//
 //* DESCRIPTION Only shows non-reblogged posts **//
 //* DETAILS This is a really experimental extension allows you see original (non-reblogged) posts made by users on your dashboard. Please keep in mind that if you don't have enough people creating new posts on your dashboard, it might slow down your computer. **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/shuffle_queue.js
+++ b/Extensions/shuffle_queue.js
@@ -1,5 +1,5 @@
 //* TITLE Enhanced Queue **//
-//* VERSION 2.0.6 **//
+//* VERSION 2.0.7 **//
 //* DESCRIPTION Additions to the Queue page. **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS Go to your queue and click on the Shuffle button on the sidebar to shuffle the posts. Note that only the posts you see will be shuffled. If you have more than 15 posts on your queue, scroll down and load more posts in order to shuffle them too. Or click on Shrink Posts button to quickly rearrange them. **//

--- a/Extensions/soft_refresh.js
+++ b/Extensions/soft_refresh.js
@@ -1,5 +1,5 @@
 //* TITLE Soft Refresh **//
-//* VERSION 0.5.7 **//
+//* VERSION 0.5.8 **//
 //* DESCRIPTION Refresh without refreshing **//
 //* DEVELOPER new-xkit **//
 //* DETAILS This extension allows you to see new posts on your dashboard without refreshing the page. When you get the New Posts bubble, click on the Tumblr logo, and new posts will appear on your dashboard.<br><br>If you still want to refresh the page completely (perform a Hard Refresh), hold the ALT key while clicking on logo and the page will refresh.<br><br>Please note that this extension is highly experimental, and might not work properly all the time. **//

--- a/Extensions/stats.js
+++ b/Extensions/stats.js
@@ -1,5 +1,5 @@
 //* TITLE XStats **//
-//* VERSION 0.3.4 **//
+//* VERSION 0.3.5 **//
 //* DESCRIPTION The XKit Statistics Tool **//
 //* DETAILS This extension allows you to view statistics regarding your dashboard, such as the percentage of post types, top 4 posters, and more. In the future, it will allow you to view statistics regarding your and others blogs. **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/tag_replacer.js
+++ b/Extensions/tag_replacer.js
@@ -1,5 +1,5 @@
 //* TITLE Tag Replacer **//
-//* VERSION 0.4.6 **//
+//* VERSION 0.4.7 **//
 //* DESCRIPTION Replace old tags! **//
 //* DETAILS Allows you to bulk replace tags of posts. Go to your Posts page on your dashboard and click on the button on the sidebar and enter the tag you want replaced, and the new tag, and Tag Replacer will take care of the rest. **//
 //* DEVELOPER new-xkit **//

--- a/Extensions/tagviewer.js
+++ b/Extensions/tagviewer.js
@@ -1,5 +1,5 @@
 //* TITLE TagViewer **//
-//* VERSION 0.4.2 **//
+//* VERSION 0.4.3 **//
 //* DESCRIPTION View post tags easily **//
 //* DEVELOPER new-xkit **//
 //* DETAILS This extension allows you to see what tags people added to a post while they reblogged it. It also provides access to the post, and to Tumblr search pages to find similar posts.<br><br>Based on the work of <a href='http://inklesspen.tumblr.com'>inklesspen</a> **//

--- a/Extensions/theme_editor.js
+++ b/Extensions/theme_editor.js
@@ -1,5 +1,5 @@
 //* TITLE Theme Editor **//
-//* VERSION 0.1.6 **//
+//* VERSION 0.1.7 **//
 //* DESCRIPTION For theme developers **//
 //* DETAILS If you are good with CSS, hop in and make your own theme.<br><br>When installed, this extension disables the standard Themes extension, and adds a button on your sidebar on your dashboard that lets you write and load your own theme. When you are done, you can submit it to xkit-dev.tumblr.com so it can be added to the theme gallery.<br><br>This extension is <b>not recommended</b> for people without CSS/HTML experience and only provided for XKit theme developers. Please disable Themes and Yoohoo! extensions before using. For better editing, Textarea Code Formatter for Chrome or Tabinta for Firefox is recommended. **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/themes_plus.js
+++ b/Extensions/themes_plus.js
@@ -1,5 +1,5 @@
 //* TITLE Themes+ (preview) **//
-//* VERSION 0.2.6 **//
+//* VERSION 0.2.7 **//
 //* DESCRIPTION Customize More **//
 //* DETAILS Themes+ lets you customize your dashboard to your liking by letting you choose the colors, the images and options yourself. You can also export and import the themes you and others made. Please note that this is the preview edition, so it's lacking some functionality. **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Tweaks **//
-//* VERSION 5.4.1 **//
+//* VERSION 5.4.2 **//
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//

--- a/Extensions/view_my_tags.js
+++ b/Extensions/view_my_tags.js
@@ -1,5 +1,5 @@
 //* TITLE View My Tags **//
-//* VERSION 0.4.5 **//
+//* VERSION 0.4.6 **//
 //* DESCRIPTION Lets you view your recently used tags **//
 //* DEVELOPER STUDIOXENIX **//
 //* FRAME false **//

--- a/Extensions/xcloud.js
+++ b/Extensions/xcloud.js
@@ -1,5 +1,5 @@
 //* TITLE XCloud **//
-//* VERSION 1.1.1 **//
+//* VERSION 1.1.2 **//
 //* DESCRIPTION Sync XKit data on clouds **//
 //* DETAILS XCloud stores your XKit configuration on New-XKit servers so you can back up your data and synchronize it with other computers and browsers easily. Also compatable with STUDIOXENIX servers.**//
 //* DEVELOPER new-xkit **//

--- a/Extensions/xinbox.js
+++ b/Extensions/xinbox.js
@@ -1,5 +1,5 @@
 //* TITLE XInbox **//
-//* VERSION 1.9.6 **//
+//* VERSION 1.9.7 **//
 //* DESCRIPTION Enhances your Inbox experience **//
 //* DEVELOPER new-xkit **//
 //* DETAILS XInbox allows you to tag posts before posting them, and see all your messages at once, and lets you delete multiple messages at once using the Mass Editor mode. To use this mode, go to your Inbox and click on the Mass Editor Mode button on your sidebar, click on the messages you want to delete then click the Delete Messages button.  **//

--- a/Extensions/xkit_installer.js
+++ b/Extensions/xkit_installer.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Installer **//
-//* VERSION 6.9.4 **//
+//* VERSION 6.9.5 **//
 //* DESCRIPTION Lets you install XKit on your computer. **//
 //* DEVELOPER STUDIOXENIX **//
 XKit.extensions.xkit_installer = new Object({

--- a/Extensions/xkit_main.js
+++ b/Extensions/xkit_main.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Main **//
-//* VERSION 1.3.3 **//
+//* VERSION 1.3.4 **//
 //* DESCRIPTION Boots XKit up **//
 //* DEVELOPER STUDIOXENIX **//
 (function() {

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 6.8.0 **//
+//* VERSION 6.8.1 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 

--- a/Extensions/xkit_updates.js
+++ b/Extensions/xkit_updates.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Updates **//
-//* VERSION 2.0.3 **//
+//* VERSION 2.0.4 **//
 //* DESCRIPTION Provides automatic updating of extensions **//
 //* DEVELOPER new-xkit **//
 XKit.extensions.xkit_updates = new Object({

--- a/Extensions/xwidgets.js
+++ b/Extensions/xwidgets.js
@@ -1,5 +1,5 @@
 //* TITLE XWidgets **//
-//* VERSION 0.3.1 **//
+//* VERSION 0.3.2 **//
 //* DESCRIPTION Widgets for your dashboard **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//


### PR DESCRIPTION
Bump extension versions for the linting changes.

This bumps every version that was touched by non-whitespace linting changes. Sorry for the delay on this—I actually had it teed up a week ago, but lost track of it after we fixed the let-debacle.

Blocks #1247 