### PR TITLE
closes #951 - Fix autotagging for new chat posts

### DIFF
--- a/Extensions/auto_tagger.js
+++ b/Extensions/auto_tagger.js
@@ -1,5 +1,5 @@
 //* TITLE Auto Tagger **//
-//* VERSION 0.7.1 **//
+//* VERSION 0.7.2 **//
 //* DESCRIPTION Tags posts automatically. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS This extension allows you to automatically add tags to posts based on state (reblogged, original, queued) or post type (audio, video, etc) and keeping original tags while reblogging a post. **//
@@ -354,7 +354,7 @@ XKit.extensions.auto_tagger = new Object({
 			return XKit.extensions.auto_tagger.preferences.tag_for_link.value;
 		}
 
-		if (obj.type === "conversation" && XKit.extensions.auto_tagger.preferences.tag_for_chat.value !== "") {
+		if ((obj.type === "chat" || obj.type === "conversation") && XKit.extensions.auto_tagger.preferences.tag_for_chat.value !== "") {
 			return XKit.extensions.auto_tagger.preferences.tag_for_chat.value;
 		}
 


### PR DESCRIPTION
Weird that a new chat post and a reblogged chat post are considered different objects - I'm wondering if a better solution would be to modify the creation of a fake object so that it'll return 'conversation' instead of 'chat' in the new post check. Any thoughts?

```
		if (original) {
			// Create fake post object:
			var type = XKit.interface.post_window.type();
			post_object = {type: type, tags: '', owner: ''};
```