### PR TITLE
One Click Postage shortcuts for quick tags

### DIFF
--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.3.8 **//
+//* VERSION 4.3.9 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -577,7 +577,7 @@ XKit.extensions.one_click_postage = new Object({
 
 		if (this.preferences.show_reverse_ui.value) {
 			m_html = "<div id=\"x1cpostage_box\">" +
-						"<input id=\"x1cpostage_tags\" placeholder=\"tags (comma separated)\" />" +
+						"<textarea id=\"x1cpostage_tags\" placeholder=\"tags (comma separated)\" />" +
 						m_clear_tags_button +
 						"<textarea id=\"x1cpostage_caption\" " + m_remove_box_style + " placeholder=\"caption\"></textarea>" +
 						"<div id=\"x1cpostage_replace\" " + m_remove_box_style + "><div>&nbsp;</div>replace caption, not append</div>" +
@@ -596,7 +596,7 @@ XKit.extensions.one_click_postage = new Object({
 						"<textarea id=\"x1cpostage_caption\" " + m_remove_box_style + " placeholder=\"caption\"></textarea>" +
 						"<div id=\"x1cpostage_replace\" " + m_remove_box_style + "><div>&nbsp;</div>replace caption, not append</div>" +
 						m_remove_button +
-						"<input id=\"x1cpostage_tags\" placeholder=\"tags (comma separated)\" />" +
+						"<textarea id=\"x1cpostage_tags\" placeholder=\"tags (comma separated)\" />" +
 						m_clear_tags_button +
 					"</div>";
 		}
@@ -883,8 +883,8 @@ XKit.extensions.one_click_postage = new Object({
 			return false;
 		}
 
-		// 68 = D, 81 = Q, 82 = R, 84 = T
-		if (e.which !== 68 && e.which !== 81 && e.which !== 82 && e.which !== 84) {
+		// 68 = D, 81 = Q, 82 = R, 84 = T, 49-57 = 1-9
+		if (e.which !== 68 && e.which !== 81 && e.which !== 82 && e.which !== 84 && (e.which < 49 || e.which > 57)) {
 			return false;
 		}
 		if ($(e.target).is('input,textarea') || $(e.target).attr('contenteditable')) {
@@ -916,25 +916,35 @@ XKit.extensions.one_click_postage = new Object({
 			var parent_box = $(this).parentsUntil(".post").parent();
 			var box_pos = parent_box.offset().top;
 			if (box_pos <= screen_pos && box_pos + parent_box.innerHeight() > screen_pos) {
-				switch (e.which) {
-				case 68: // 68 = D
-					XKit.extensions.one_click_postage.open_menu($(this), true);
-					XKit.extensions.one_click_postage.post(1, false);
-					break;
-				case 81: // 81 = Q
-					XKit.extensions.one_click_postage.open_menu($(this), true);
-					XKit.extensions.one_click_postage.post(2, false);
-					break;
-				case 82: // 82 = R
-					XKit.extensions.one_click_postage.open_menu($(this), true);
-					XKit.extensions.one_click_postage.post(0, false);
-					break;
-				case 84: // 84 = T
-					XKit.extensions.one_click_postage.user_on_box = true;
-					XKit.extensions.one_click_postage.open_menu($(this), false, true);
-					$('#x1cpostage_tags').focus();
-					break;
+				if (XKit.extensions.one_click_postage.user_on_box && e.which >= 49 && e.which <= 57) { // 49-57 = 1-9
+					var index = e.which - 49;
+					var quickTags = $("#x1cpostage_quick_tags").find(".xkit-tag");
+					
+					if (quickTags.length > index) {
+						quickTags[index].click();
+					}
+				} else {
+					switch (e.which) {
+					case 68: // 68 = D
+						XKit.extensions.one_click_postage.open_menu($(this), true);
+						XKit.extensions.one_click_postage.post(1, false);
+						break;
+					case 81: // 81 = Q
+						XKit.extensions.one_click_postage.open_menu($(this), true);
+						XKit.extensions.one_click_postage.post(2, false);
+						break;
+					case 82: // 82 = R
+						XKit.extensions.one_click_postage.open_menu($(this), true);
+						XKit.extensions.one_click_postage.post(0, false);
+						break;
+					case 84: // 84 = T
+						XKit.extensions.one_click_postage.user_on_box = true;
+						XKit.extensions.one_click_postage.open_menu($(this), false, true);
+						$('#x1cpostage_tags').focus();
+						break;
+					}
 				}
+
 				e.preventDefault();
 				return false;
 			} else if (box_pos > screen_pos) {

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -27,7 +27,7 @@ XKit.extensions.one_click_postage = new Object({
 			type: "separator",
 		},
 		"enable_keyboard_shortcuts": {
-			text: "Use keyboard shortcuts (R/Q/D to reblog/queue/draft, T to tag, escape to close)",
+			text: "Use keyboard shortcuts (R/Q/D to reblog/queue/draft, T to tag, escape to close, 1-9 to add a Quick Tags bundle)",
 			default: false,
 			value: false
 		},

--- a/Extensions/quick_tags.js
+++ b/Extensions/quick_tags.js
@@ -277,7 +277,7 @@ XKit.extensions.quick_tags = new Object({
 
 				m_user_tags = m_user_tags + "<div " + add_data + " data-tags=\"" + m_tags + "\" class=\"xkit-tag user\"><div class=\"xkit-tag-name\">" + m_title;
 
-				if (showNumbers && tag < 10) {
+				if (showNumbers && tag < 9) {
 					// force javascript to treat tag as a number instead of string concatenation
 					var shortcutNumber = parseInt(tag) + 1;
 					m_user_tags = m_user_tags + "<span style=\"opacity:.7;float:right\">" +  shortcutNumber + "</span>";

--- a/Extensions/quick_tags.js
+++ b/Extensions/quick_tags.js
@@ -1,5 +1,5 @@
 //* TITLE Quick Tags **//
-//* VERSION 0.5.10 **//
+//* VERSION 0.5.11 **//
 //* DESCRIPTION Quickly add tags to posts **//
 //* DETAILS Allows you to create tag bundles and add tags to posts without leaving the dashboard. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -263,6 +263,8 @@ XKit.extensions.quick_tags = new Object({
 
 		if (user_tag_array.length !== 0) {
 
+			var showNumbers = for_one_click && typeof XKit.extensions.one_click_postage != "undefined" && XKit.extensions.one_click_postage.preferences.enable_keyboard_shortcuts.value;
+		
 			for (var tag in user_tag_array) {
 
 				var m_title = user_tag_array[tag].title;
@@ -273,7 +275,16 @@ XKit.extensions.quick_tags = new Object({
 					add_data = "data-one-click-postage=\"true\"";
 				}
 
-				m_user_tags = m_user_tags + "<div " + add_data + " data-tags=\"" + m_tags + "\" class=\"xkit-tag user\"><div class=\"xkit-tag-name\">" + m_title + "</div>";
+				m_user_tags = m_user_tags + "<div " + add_data + " data-tags=\"" + m_tags + "\" class=\"xkit-tag user\"><div class=\"xkit-tag-name\">" + m_title;
+
+				if (showNumbers && tag < 10) {
+					// force javascript to treat tag as a number instead of string concatenation
+					var shortcutNumber = parseInt(tag) + 1;
+					m_user_tags = m_user_tags + "<span style=\"opacity:.7;float:right\">" +  shortcutNumber + "</span>";
+				}
+				
+				m_user_tags = m_user_tags + "</div>";
+				
 				if (for_one_click !== true) {
 					m_user_tags = m_user_tags + "<div class=\"xkit-tag-data\">" + m_tags + "</div>";
 				}


### PR DESCRIPTION
Allow the user to use 1-9 as shortcuts to add quick tags.

When shortcuts are enabled, add 1-9 next to each of the first 9 quick tags to make it easy to see what shortcut would be applied.