### PR TITLE
Add tweak to allow much wider post sources

### DIFF
--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -153,8 +153,8 @@ XKit.extensions.tweaks = new Object({
 			value: false
 		},
 		"wide_sources": {
-			text: "Increase max width of post sources to avoid truncation",
-			default: false,
+			text: "Increase max width of post sources to avoid shortening",
+			default: true,
 			value: false
 		},
 		"sep2": {
@@ -410,7 +410,7 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.wide_sources.value) {
-			XKit.tools.add_css("a.post-source-link { max-width: 400px !important }", "xkit_tweaks_wide_sources");
+			XKit.tools.add_css(".post-source-link { max-width: 400px !important }", "xkit_tweaks_wide_sources");
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_radar.value) {

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Tweaks **//
-//* VERSION 5.4.1 **//
+//* VERSION 5.4.2 **//
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -149,6 +149,11 @@ XKit.extensions.tweaks = new Object({
 		},
 		"border_asks": {
 			text: "Show border around ask posts and answers",
+			default: false,
+			value: false
+		},
+		"wide_sources": {
+			text: "Increase max width of post sources to avoid truncation",
 			default: false,
 			value: false
 		},
@@ -402,6 +407,10 @@ XKit.extensions.tweaks = new Object({
 
 		if (XKit.extensions.tweaks.preferences.border_asks.value) {
 			XKit.extensions.tweaks.add_css(".post-composer_note-post .note_item, .post_full.is_note .post-body .note_item, .post_full.is_note .post_body .note_item, .post_brick.is_note .note_item { border-color: #ccc } .post_full.is_note .nipple, .post-composer_note-post .nipple, .post_brick.is_note .nipple { border-left: 8px solid #ccc } .post_full.is_note .nipple::after, .post-composer_note-post .nipple::after, .post_brick.is_note .nipple::after { display: inline; position: absolute; content: ''; width: 0; height: 0; border-top: 8px solid transparent; border-bottom: 8px solid transparent; border-left: 8px solid #f2f2f2; right: 1px; top: -8px }", "xkit_tweaks_border_asks");
+		}
+
+		if (XKit.extensions.tweaks.preferences.wide_sources.value) {
+			XKit.tools.add_css("a.post-source-link { max-width: 400px !important }", "xkit_tweaks_wide_sources");
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_radar.value) {
@@ -877,6 +886,7 @@ XKit.extensions.tweaks = new Object({
 		XKit.tools.remove_css("tweaks_no_mobile_banner");
 		XKit.tools.remove_css("xkit_tweaks_larger_small_text_on_reblogs");
 		XKit.tools.remove_css("xkit_tweaks_hide_share");
+		XKit.tools.remove_css("xkit_tweaks_wide_sources");
 		XKit.post_listener.remove("tweaks_fix_hidden_post_height");
 		XKit.post_listener.remove("tweaks_dont_show_liked");
 		clearInterval(this.run_interval);

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -155,7 +155,7 @@ XKit.extensions.tweaks = new Object({
 		"wide_sources": {
 			text: "Increase max width of post sources to avoid shortening",
 			default: true,
-			value: false
+			value: true
 		},
 		"sep2": {
 			text: "Dashboard tweaks",


### PR DESCRIPTION
Tumblr sets post sources to have a max-width of 100px, which is very low. In particular there are blog usernames which are longer than this and get truncated with `...`. Tumblr also uses special source titles for SoundCloud and other areas that are almost inherently over 100px. This eliminates that issue while still truncating very long source names.

I'm fairly certain that the reason for the 100px setting is because post tags used to start on the same line as sources, but that was changed when they introduced multi-line tags.

This tweak's 400px is somewhat arbitrary; it avoids truncation on anything reasonable with ~75px of slack space left over in English. Should be sufficient for any localized variant of "Source" and minor Tumblr changes.