### PR TITLE
fix responsive_dash messing up themes that make heavy use of scrolling overflow

### DIFF
--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Tweaks **//
-//* VERSION 5.4.2 **//
+//* VERSION 5.4.3 **//
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -481,8 +481,15 @@ XKit.extensions.tweaks = new Object({
 			XKit.extensions.tweaks.add_css(".is_reblog small { font-size: 12px !important; }", "xkit_tweaks_larger_small_text_on_reblogs");
 		}
 
-		if (XKit.extensions.tweaks.preferences.responsive_dash.value) {
-			XKit.extensions.tweaks.add_css(".l-container--two-column-dashboard {padding-left: 0px!important;padding-right: 0px!important;}@media screen and (max-width: 899px) {.right_column {visibility: hidden;display: none;width: 0px!important;}#sidebar_footer_nav {visibility: hidden;}.l-content {width: 625px;}.l-container--two-column-dashboard {width: 645px!important;}}@media screen and (min-width: 644px) {html, body {overflow-x: hidden;}}");
+		if (XKit.extensions.tweaks.preferences.responsive_dash.value && XKit.interface.where().dashboard) {
+			XKit.extensions.tweaks.add_css(
+				".l-container--two-column-dashboard {padding-left: 0px!important;padding-right: 0px!important;}" +
+				"@media screen and (max-width: 899px) {" +
+					".right_column {visibility: hidden;display: none;width: 0px!important;}" +
+					"#sidebar_footer_nav {visibility: hidden;}" +
+					".l-content {width: 625px;}" +
+					".l-container--two-column-dashboard {width: 645px!important;}" +
+				"}");
 		}
 
 		if (XKit.extensions.tweaks.preferences.slim_popups.value) {


### PR DESCRIPTION
this comes up in support every so often.

fix is 2-pronged: remove the overflow: none that isn't actually even doing anything and scope responsive_dash to only run on the actual dashboard.