### PR TITLE
Activity Feed Slim Tweak

### DIFF
--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -99,8 +99,13 @@ XKit.extensions.tweaks = new Object({
 			text: "User Interface tweaks",
 			type: "separator",
 		},
-		"fix_activity_feed": {
-			text: "Re-slim the Activity feed and highlight notes from mutuals",
+		"highlight_mutuals": {
+			text: "Make notes from mutuals more obviously highlighted",
+			default: false,
+			value: false
+		},
+		"slim_activity_feed": {
+			text: "Re-slim the Activity feed",
 			default: false,
 			value: false,
 			experimental: true
@@ -315,9 +320,8 @@ XKit.extensions.tweaks = new Object({
 	run: function() {
 		this.running = true;
 	
-		if (XKit.extensions.tweaks.preferences.fix_activity_feed.value) {
-			XKit.tools.add_css(".activity-notification.is_friend{ background-color: #f3f8fb; }" +
-			".ui_notes .activity-notification{ padding: 10px; }" +
+		if (XKit.extensions.tweaks.preferences.slim_activity_feed.value) {
+			XKit.tools.add_css(".ui_notes .activity-notification{ padding: 10px; }" +
 			".ui_notes .activity-notification .activity-notification__activity .activity-notification__activity_message{ display: block; }" +
 			".ui_notes .activity-notification .activity-notification__activity, .ui_notes .activity-notification .activity-notification__activity .activity-notification__activity_message.conversational{ transform: translate(-10px) }" +
 			".ui_notes .activity-notification .activity-notification__icon{	padding: 0; }" +
@@ -331,7 +335,11 @@ XKit.extensions.tweaks = new Object({
 			".ui_notes .activity-notification .activity-notification__icon .ui_post_badge.conversation{ background-position: -786px -85px; }" +
 			".ui_notes .activity-notification .activity-notification__icon .ui_post_badge.audio{ background-position: -785px -114px; }" +
 			".activity-notification div.retags{ margin: 3px 0 0 !important; padding-left: 41px !important; }",
-			"tweaks_fix_activity_feed");
+			"tweaks_slim_activity_feed");
+		}
+		
+		if (XKit.extensions.tweaks.preferences.highlight_mutuals.value) {
+			XKit.tools.add_css(".activity-notification.is_friend{ background-color: #f3f8fb; }", "tweaks_highlight_mutuals");
 		}
 
 		if (XKit.extensions.tweaks.preferences.old_sidebar_width.value) {
@@ -913,7 +921,8 @@ XKit.extensions.tweaks = new Object({
 
 		this.running = false;
 		XKit.tools.remove_css("xkit_tweaks");
-		XKit.tools.remove_css("tweaks_fix_activity_feed");
+		XKit.tools.remove_css("tweaks_slim_activity_feed");
+		XKit.tools.remove_css("tweaks_highlight_mutuals");
 		XKit.tools.remove_css("tweaks_old_sidebar_width");
 		XKit.tools.remove_css("tweaks_old_photo_margins");
 		XKit.tools.remove_css("tweaks_no_mobile_banner");

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -99,11 +99,6 @@ XKit.extensions.tweaks = new Object({
 			text: "User Interface tweaks",
 			type: "separator",
 		},
-		"highlight_mutuals": {
-			text: "Make notes from mutuals more obviously highlighted",
-			default: false,
-			value: false
-		},
 		"slim_activity_feed": {
 			text: "Re-slim the Activity feed",
 			default: false,
@@ -338,10 +333,6 @@ XKit.extensions.tweaks = new Object({
 			"tweaks_slim_activity_feed");
 		}
 		
-		if (XKit.extensions.tweaks.preferences.highlight_mutuals.value) {
-			XKit.tools.add_css(".activity-notification.is_friend{ background-color: #f3f8fb; }", "tweaks_highlight_mutuals");
-		}
-
 		if (XKit.extensions.tweaks.preferences.old_sidebar_width.value) {
 			XKit.tools.add_css(".right_column, .toastr .toast-kit, .small_links {width: 250px !important;} " +
 			".left_column{margin-left:75px;} #sidebar_footer_nav{margin-left: -420px !important;} .pagination{padding-left:160px;}",
@@ -922,7 +913,6 @@ XKit.extensions.tweaks = new Object({
 		this.running = false;
 		XKit.tools.remove_css("xkit_tweaks");
 		XKit.tools.remove_css("tweaks_slim_activity_feed");
-		XKit.tools.remove_css("tweaks_highlight_mutuals");
 		XKit.tools.remove_css("tweaks_old_sidebar_width");
 		XKit.tools.remove_css("tweaks_old_photo_margins");
 		XKit.tools.remove_css("tweaks_no_mobile_banner");

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -319,6 +319,7 @@ XKit.extensions.tweaks = new Object({
 			XKit.tools.add_css(".ui_notes .activity-notification{ padding: 10px; }" +
 			".ui_notes .activity-notification .activity-notification__activity .activity-notification__activity_message{ display: block; }" +
 			".ui_notes .activity-notification .activity-notification__activity, .ui_notes .activity-notification .activity-notification__activity .activity-notification__activity_message.conversational{ transform: translate(-10px) }" +
+			".xkit-activity-plus-timestamp{ transform: translate(-53px, 6px) }" +
 			".ui_notes .activity-notification .activity-notification__icon{	padding: 0; }" +
 			".ui_notes .activity-notification .activity-notification__activity .activity-notification__activity_message .activity-notification__activity_response{ padding: 10px; }" +
 			".ui_notes .activity-notification .activity-notification__avatar .ui_avatar{ margin: 0; }" +

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -320,7 +320,7 @@ XKit.extensions.tweaks = new Object({
 			".ui_notes .activity-notification .activity-notification__activity .activity-notification__activity_message{ display: block; }" +
 			".ui_notes .activity-notification .activity-notification__activity, .ui_notes .activity-notification .activity-notification__activity .activity-notification__activity_message.conversational{ transform: translate(-10px) }" +
 			".xkit-activity-plus-timestamp{ transform: translate(-53px, 6px) }" +
-			".ui_notes .activity-notification .activity-notification__icon{	padding: 0; }" +
+			".ui_notes .activity-notification .activity-notification__icon{	padding: 0; min-width: 25px; }" +
 			".ui_notes .activity-notification .activity-notification__activity .activity-notification__activity_message .activity-notification__activity_response{ padding: 10px; }" +
 			".ui_notes .activity-notification .activity-notification__avatar .ui_avatar{ margin: 0; }" +
 			".ui_notes .activity-notification .activity-notification__icon .ui_post_badge{ width: 25px; height: 25px; }" +

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Tweaks **//
-//* VERSION 5.4.3 **//
+//* VERSION 5.5.0 **//
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -98,6 +98,12 @@ XKit.extensions.tweaks = new Object({
 		"sep1": {
 			text: "User Interface tweaks",
 			type: "separator",
+		},
+		"fix_activity_feed": {
+			text: "Re-slim the Activity feed and highlight notes from mutuals",
+			default: false,
+			value: false,
+			experimental: true
 		},
 		"old_sidebar_width": {
 			text: "Return the sidebar to its original width",
@@ -308,6 +314,25 @@ XKit.extensions.tweaks = new Object({
 
 	run: function() {
 		this.running = true;
+	
+		if (XKit.extensions.tweaks.preferences.fix_activity_feed.value) {
+			XKit.tools.add_css(".activity-notification.is_friend{ background-color: #f3f8fb; }" +
+			".ui_notes .activity-notification{ padding: 10px; }" +
+			".ui_notes .activity-notification .activity-notification__activity .activity-notification__activity_message{ display: block; }" +
+			".ui_notes .activity-notification .activity-notification__activity, .ui_notes .activity-notification .activity-notification__activity .activity-notification__activity_message.conversational{ transform: translate(-10px) }" +
+			".ui_notes .activity-notification .activity-notification__icon{	padding: 0; }" +
+			".ui_notes .activity-notification .activity-notification__activity .activity-notification__activity_message .activity-notification__activity_response{ padding: 10px; }" +
+			".ui_notes .activity-notification .activity-notification__avatar .ui_avatar{ margin: 0; }" +
+			".ui_notes .activity-notification .activity-notification__icon .ui_post_badge{ width: 25px; height: 25px; }" +
+			".ui_notes .activity-notification .activity-notification__icon .ui_post_badge.regular{ background-position: -784px -2px; }" +
+			".ui_notes .activity-notification .activity-notification__icon .ui_post_badge.quote{ background-position: -784px -30px; }" +
+			".ui_notes .activity-notification .activity-notification__icon .ui_post_badge.ask_answer{ background-position: -785px -171px; }" +
+			".ui_notes .activity-notification .activity-notification__icon .ui_post_badge.link{ background-position: -785px -58px; }" +
+			".ui_notes .activity-notification .activity-notification__icon .ui_post_badge.conversation{ background-position: -786px -85px; }" +
+			".ui_notes .activity-notification .activity-notification__icon .ui_post_badge.audio{ background-position: -785px -114px; }" +
+			".activity-notification div.retags{ margin: 3px 0 0; padding-left: 41px; }",
+			"tweaks_fix_activity_feed");
+		}
 
 		if (XKit.extensions.tweaks.preferences.old_sidebar_width.value) {
 			XKit.tools.add_css(".right_column, .toastr .toast-kit, .small_links {width: 250px !important;} " +
@@ -888,6 +913,7 @@ XKit.extensions.tweaks = new Object({
 
 		this.running = false;
 		XKit.tools.remove_css("xkit_tweaks");
+		XKit.tools.remove_css("tweaks_fix_activity_feed");
 		XKit.tools.remove_css("tweaks_old_sidebar_width");
 		XKit.tools.remove_css("tweaks_old_photo_margins");
 		XKit.tools.remove_css("tweaks_no_mobile_banner");

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -330,7 +330,7 @@ XKit.extensions.tweaks = new Object({
 			".ui_notes .activity-notification .activity-notification__icon .ui_post_badge.link{ background-position: -785px -58px; }" +
 			".ui_notes .activity-notification .activity-notification__icon .ui_post_badge.conversation{ background-position: -786px -85px; }" +
 			".ui_notes .activity-notification .activity-notification__icon .ui_post_badge.audio{ background-position: -785px -114px; }" +
-			".activity-notification div.retags{ margin: 3px 0 0; padding-left: 41px; }",
+			".activity-notification div.retags{ margin: 3px 0 0 !important; padding-left: 41px !important; }",
 			"tweaks_fix_activity_feed");
 		}
 

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -319,7 +319,6 @@ XKit.extensions.tweaks = new Object({
 			XKit.tools.add_css(".ui_notes .activity-notification{ padding: 10px; }" +
 			".ui_notes .activity-notification .activity-notification__activity .activity-notification__activity_message{ display: block; }" +
 			".ui_notes .activity-notification .activity-notification__activity, .ui_notes .activity-notification .activity-notification__activity .activity-notification__activity_message.conversational{ transform: translate(-10px) }" +
-			".xkit-activity-plus-timestamp{ transform: translate(-53px, 6px) }" +
 			".ui_notes .activity-notification .activity-notification__icon{	padding: 0; min-width: 25px; }" +
 			".ui_notes .activity-notification .activity-notification__activity .activity-notification__activity_message .activity-notification__activity_response{ padding: 10px; }" +
 			".ui_notes .activity-notification .activity-notification__avatar .ui_avatar{ margin: 0; }" +
@@ -330,7 +329,8 @@ XKit.extensions.tweaks = new Object({
 			".ui_notes .activity-notification .activity-notification__icon .ui_post_badge.link{ background-position: -785px -58px; }" +
 			".ui_notes .activity-notification .activity-notification__icon .ui_post_badge.conversation{ background-position: -786px -85px; }" +
 			".ui_notes .activity-notification .activity-notification__icon .ui_post_badge.audio{ background-position: -785px -114px; }" +
-			".activity-notification div.retags{ margin: 3px 0 0 !important; padding-left: 41px !important; }",
+			".activity-notification div.retags{ margin: 3px 0 0 !important; padding-left: 41px !important; }" +
+			".xkit-activity-plus-timestamp{ transform: translate(-13px) }",
 			"tweaks_slim_activity_feed");
 		}
 		


### PR DESCRIPTION
Adds a tweak to re-slim the activity feed back to normal, and highlight mutuals' notes
Now not enabled by default
Tried to add readability
Added the Experimental tag in case imminent feature re-introductions break this or make it ugly