### PR TITLE
Fix broken activityplus timestamp styling

### DIFF
--- a/Extensions/activity_plus.css
+++ b/Extensions/activity_plus.css
@@ -33,12 +33,15 @@
 	background: rgb(250,250,250);
 }
 
+.activity-notification {
+    flex-wrap: wrap;
+}
+
 .xkit-activity-plus-timestamp {
 	font-size: 11px;
 	text-align: left;
 	padding: 2px 8px 2px 53px;
 	width: 100%;
-
 }
 
 #xkit-activity-plus-note-filter {

--- a/Extensions/activity_plus.js
+++ b/Extensions/activity_plus.js
@@ -1,5 +1,5 @@
 //* TITLE Activity+ **//
-//* VERSION 0.3.9 **//
+//* VERSION 0.3.10 **//
 //* DESCRIPTION Tweaks for the Activity page **//
 //* DETAILS This extension brings a couple of tweaks for the Activity page, such as the ability to filter notes by type and showing timestamps. **//
 //* DEVELOPER STUDIOXENIX **//


### PR DESCRIPTION
Currently, without retags enabled, it looks like this:
![image](https://user-images.githubusercontent.com/233815/27396235-6efc0084-5680-11e7-80f2-7cf0ee28fcb5.png)

this is because retags was including a critical flex-wrap property that we didn't notice also was required for timestamps to work.