### PR TITLE
Version 7.7.6

### DIFF
--- a/Extensions/dist/page/FirefoxUpdate.rdf
+++ b/Extensions/dist/page/FirefoxUpdate.rdf
@@ -12,17 +12,17 @@
         <!-- Each li is a different version of the same add-on -->
         <RDF:li>
           <RDF:Description>
-            <em:version>7.7.5-mp</em:version> <!-- This is the version number of the add-on -->
+            <em:version>7.7.6</em:version> <!-- This is the version number of the add-on -->
 
             <!-- One targetApplication for each application the add-on is compatible with -->
             <em:targetApplication>
               <RDF:Description>
                 <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
-                <em:minVersion>35.0</em:minVersion>
+                <em:minVersion>51.0a1</em:minVersion>
                 <em:maxVersion>*</em:maxVersion>
 
                 <!-- This is where this version of the add-on will be downloaded from -->
-                <em:updateLink>https://github.com/new-xkit/XKit/releases/download/firefox-v7.7.5/new_xkit-7.7.5.xpi</em:updateLink>
+                <em:updateLink>https://github.com/new-xkit/XKit/releases/download/firefox-v7.7.6/new_xkit-7.7.6.xpi</em:updateLink>
 
                 <!-- A page describing what is new in this updated version -->
                 <!-- <em:updateInfoURL></em:updateInfoURL> -->
@@ -33,11 +33,11 @@
             <em:targetApplication>
               <RDF:Description>
                 <em:id>{aa3c5121-dab2-40e2-81ca-7ea25febc110}</em:id>
-                <em:minVersion>35.0</em:minVersion>
+                <em:minVersion>51.0a1</em:minVersion>
                 <em:maxVersion>*</em:maxVersion>
 
                 <!-- This is where this version of the add-on will be downloaded from -->
-                <em:updateLink>https://github.com/new-xkit/XKit/releases/download/firefox-v7.7.5/new_xkit-7.7.5.xpi</em:updateLink>
+                <em:updateLink>https://github.com/new-xkit/XKit/releases/download/firefox-v7.7.6/new_xkit-7.7.6.xpi</em:updateLink>
 
                 <!-- A page describing what is new in this updated version -->
                 <!-- <em:updateInfoURL></em:updateInfoURL> -->

--- a/Extensions/dist/page/framework_version.json
+++ b/Extensions/dist/page/framework_version.json
@@ -1,1 +1,1 @@
-{"server":"up","frameworks":[{"name":"firefox","version":"7.7.1"},{"name":"chrome","version":"7.7.1"}]}
+{"server":"up","frameworks":[{"name":"firefox","version":"7.7.6"},{"name":"chrome","version":"7.7.1"}]}


### PR DESCRIPTION
Updates Chrome and Firefox versions, pointing FirefoxUpdate.rdf to the new release. Should be merged after #1291