### PR TITLE
Fix User Menus+ handling of all user links and mentions (closes #1331)

### DIFF
--- a/Extensions/show_more.js
+++ b/Extensions/show_more.js
@@ -1,5 +1,5 @@
 //* TITLE User Menus+ **//
-//* VERSION 2.5.5 **//
+//* VERSION 2.5.6 **//
 //* DESCRIPTION More options on the user menu **//
 //* DEVELOPER new-xkit **//
 //* DETAILS This extension adds additional options to the user menu (the one that appears under user avatars on your dashboard), such as Avatar Magnifier, links to their Liked Posts page if they have them enabled. Note that this extension, especially the Show Likes and Show Submit options use a lot of network and might slow your computer down. **//
@@ -430,20 +430,23 @@ XKit.extensions.show_more = new Object({
 		The regex has two capture groups, respectively the username and the path of the linked blog page.
 		https://xyz.tumblr.com links alway have a popover, while https://xyz.tumblr.com/foo/bar links do not have
 		a popover unless they're in a reblog header, in which case they have the post_info_link class.*/
-		var m_test = /https?:\/\/(?!www\.)([a-z0-9-]+)\.tumblr\.com([a-z0-9/-]*)/.exec(m_url);
+		var m_test, m_identifier, m_path;
 
+		m_test = /https?:\/\/(?!www\.)([a-z0-9-]+)\.tumblr\.com([a-z0-9/-]*)/.exec(m_url);
 		if (m_test) {
-			if (m_test[2] == "" || m_test[2] == "/" || $(m_obj).hasClass("post_info_link")) {
-				XKit.extensions.show_more.store_data_username(e, true, m_test[1]);
+			m_path = m_test[2];
+			if (m_path == "" || m_path == "/" || $(m_obj).hasClass("post_info_link")) {
+				m_identifier = m_test[1];
+				XKit.extensions.show_more.store_data_username(e, true, m_identifier);
+			}
+		} else {
+			/* handle tmblr.co links, which appear in mentions*/
+			m_test = /https?:\/\/tmblr\.co\/([A-Za-z0-9_-]+)/.exec(m_url);
+			if (m_test) {
+				m_identifier = m_test[1];
+				XKit.extensions.show_more.store_data_username(e, true, m_identifier, true);
 			}
 		}
-		/* handle tmblr.co links, which appear in mentions*/
-		m_test = /https?:\/\/tmblr\.co\/([A-Za-z0-9_-]+)/.exec(m_url);
-
-		if (m_test) {
-			XKit.extensions.show_more.store_data_username(e, true, m_test[1], true);
-		}
-
 	},
 
 	store_data_username: function(e, userlink_mode, blog_identifier, is_mention) {

--- a/Extensions/show_more.js
+++ b/Extensions/show_more.js
@@ -430,7 +430,7 @@ XKit.extensions.show_more = new Object({
 		The regex has two capture groups, respectively the username and the path of the linked blog page.
 		https://xyz.tumblr.com links alway have a popover, while https://xyz.tumblr.com/foo/bar links do not have
 		a popover unless they're in a reblog header, in which case they have the post_info_link class.*/
-		var m_test = /https?:\/\/(?!www)([a-z]+)\.tumblr\.com([a-z0-9/-]*)/.exec(m_url);
+		var m_test = /https?:\/\/(?!www)([a-z0-9-]+)\.tumblr\.com([a-z0-9/-]*)/.exec(m_url);
 
 		if (m_test) {
 			if (m_test[2] == "" || m_test[2] == "/" || $(m_obj).hasClass("post_info_link")) {

--- a/Extensions/show_more.js
+++ b/Extensions/show_more.js
@@ -426,13 +426,19 @@ XKit.extensions.show_more = new Object({
 
 		var m_url = $(m_obj).attr('href').toLowerCase();
 
-		if (m_url.substring(m_url.length - 1) === "/") {m_url = m_url.substring(0, m_url.length - 1); }
+		/*Test for a link to a tumblr blog in a form that will have a popover
+		The regex has two capture groups, respectively the username and the path of the linked blog page.
+		https://xyz.tumblr.com links alway have a popover, while https://xyz.tumblr.com/foo/bar links do not have
+		a popover unless they're in a reblog header, in which case they have the post_info_link class.*/
+		var userlink_re = /https?:\/\/(?!www)([a-z]+)\.tumblr\.com([a-z0-9\/-]*)/;
+		var test = userlink_re.exec(m_url);
 
-		if (m_url.substring(0, 7) === "http://" && m_url.substring(m_url.length - 11) === ".tumblr.com") {
-			var m_username = m_url.substring(7, m_url.length - 11);
-			XKit.extensions.show_more.store_data_username(e, true, m_username);
+		if (test) {
+			if (test[2] == "" || test[2] == "/" || $(m_obj).hasClass("post_info_link")) {
+				var m_username = test[1];
+				XKit.extensions.show_more.store_data_username(e, true, m_username);
+			}
 		}
-
 
 	},
 

--- a/Extensions/show_more.js
+++ b/Extensions/show_more.js
@@ -430,7 +430,7 @@ XKit.extensions.show_more = new Object({
 		The regex has two capture groups, respectively the username and the path of the linked blog page.
 		https://xyz.tumblr.com links alway have a popover, while https://xyz.tumblr.com/foo/bar links do not have
 		a popover unless they're in a reblog header, in which case they have the post_info_link class.*/
-		var m_test = /https?:\/\/(?!www)([a-z0-9-]+)\.tumblr\.com([a-z0-9/-]*)/.exec(m_url);
+		var m_test = /https?:\/\/(?!www\.)([a-z0-9-]+)\.tumblr\.com([a-z0-9/-]*)/.exec(m_url);
 
 		if (m_test) {
 			if (m_test[2] == "" || m_test[2] == "/" || $(m_obj).hasClass("post_info_link")) {


### PR DESCRIPTION
This fixes two cases - mentions, and links to usernames above reblogged text - where User Menus+ was not retrieving the appropriate information about a blog, breaking other extensions such as Profiler. 