### PR TITLE
OCP on Firefox: Increased delay on popup closing

### DIFF
--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1115,7 +1115,7 @@ XKit.extensions.one_click_postage = new Object({
 			return;
 		}
 		
-		delay = 700;
+		var delay = 700;
 		// Firefox list menus make the popup unable to detect the cursor on top of them
 		// Increased delay lets user pick a blog without the menu closing so suddenly
 		if (XKit.browser().firefox) {

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.3.4 **//
+//* VERSION 4.3.5 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -1114,6 +1114,14 @@ XKit.extensions.one_click_postage = new Object({
 			}
 			return;
 		}
+		
+		// Firefox list menus make the popup unable to detect the cursor on top of them
+		// Increased delay lets user pick a blog without the menu closing so suddenly
+		if (XKit.browser().firefox) {
+			var delay = 3000;
+		} else {
+			var delay = 700;
+		}
 
 		XKit.extensions.one_click_postage.menu_closer_int = setTimeout(function() {
 			if (XKit.extensions.one_click_postage.user_on_box === false) {
@@ -1124,7 +1132,7 @@ XKit.extensions.one_click_postage = new Object({
 					$("#x1cpostage_box").slideUp('fast');
 				}
 			}
-		}, 700);
+		}, delay);
 
 		/* eslint-enable no-undef */
 	},

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1115,12 +1115,11 @@ XKit.extensions.one_click_postage = new Object({
 			return;
 		}
 		
+		delay = 700;
 		// Firefox list menus make the popup unable to detect the cursor on top of them
 		// Increased delay lets user pick a blog without the menu closing so suddenly
 		if (XKit.browser().firefox) {
-			var delay = 3000;
-		} else {
-			var delay = 700;
+			delay = 3000;
 		}
 
 		XKit.extensions.one_click_postage.menu_closer_int = setTimeout(function() {


### PR DESCRIPTION
As reported and experienced, the list menu on Firefox prevents the page directly underneath from detecting the cursor at all. To remedy this, the popup now closes slower (3s, not 0.7s) on Firefox only, allowing the user more time to pick a blog.