### PR TITLE
Display month/day/year for outbox messages

### DIFF
--- a/Extensions/outbox.js
+++ b/Extensions/outbox.js
@@ -1,5 +1,5 @@
 //* TITLE Outbox **//
-//* VERSION 0.10.0 **//
+//* VERSION 0.11.0 **//
 //* DESCRIPTION Saves your sent replies and asks. **//
 //* DETAILS This extension stores and lets you view the last 50 asks you've answered privately. Please keep in mind that this is a highly experimental extension, so if you hit a bug, please send the XKit blog an ask with the problem you've found. **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/outbox.js
+++ b/Extensions/outbox.js
@@ -399,7 +399,7 @@ XKit.extensions.outbox = new Object({
 			/* globals moment */
 			var moment_val = moment(obj.time);
 			m_day = moment_val.format('ddd');
-			m_date = moment_val.format('hh:mm a');
+			m_date = moment_val.format('MM/DD/YY hh:mm a');
 		} else {
 			m_day = "?";
 			m_date = "Unknown";
@@ -447,7 +447,7 @@ XKit.extensions.outbox = new Object({
 		if (obj.time !== "" && typeof obj.time !== "undefined") {
 			var moment_val = moment(obj.time);
 			m_day = moment_val.format('ddd');
-			m_date = moment_val.format('hh:mm a');
+			m_date = moment_val.format('MM/DD/YY hh:mm a');
 		} else {
 			m_day = "?";
 			m_date = "Unknown";
@@ -506,7 +506,7 @@ XKit.extensions.outbox = new Object({
 		if (obj.time !== "" && typeof obj.time !== "undefined") {
 			var moment_val = moment(obj.time);
 			m_day = moment_val.format('ddd');
-			m_date = moment_val.format('hh:mm a');
+			m_date = moment_val.format('MM/DD/YY hh:mm a');
 		} else {
 			m_day = "?";
 			m_date = "Unknown";


### PR DESCRIPTION
Before this commit, messages only displayed the day of the week and the time of day when the message was sent. That was confusing for messages older than one week. This will make the date more explicit.

Fixes #952