### PR TITLE
Pull 7.7.6 due to e10s issues

### DIFF
--- a/Extensions/dist/page/FirefoxUpdate.rdf
+++ b/Extensions/dist/page/FirefoxUpdate.rdf
@@ -12,7 +12,7 @@
         <!-- Each li is a different version of the same add-on -->
         <RDF:li>
           <RDF:Description>
-            <em:version>7.7.6</em:version> <!-- This is the version number of the add-on -->
+            <em:version>7.7.5</em:version> <!-- This is the version number of the add-on -->
 
             <!-- One targetApplication for each application the add-on is compatible with -->
             <em:targetApplication>
@@ -22,7 +22,7 @@
                 <em:maxVersion>*</em:maxVersion>
 
                 <!-- This is where this version of the add-on will be downloaded from -->
-                <em:updateLink>https://github.com/new-xkit/XKit/releases/download/firefox-v7.7.6/new_xkit-7.7.6.xpi</em:updateLink>
+                <em:updateLink>https://github.com/new-xkit/XKit/releases/download/firefox-v7.7.5/new_xkit-7.7.5.xpi</em:updateLink>
 
                 <!-- A page describing what is new in this updated version -->
                 <!-- <em:updateInfoURL></em:updateInfoURL> -->
@@ -37,7 +37,7 @@
                 <em:maxVersion>*</em:maxVersion>
 
                 <!-- This is where this version of the add-on will be downloaded from -->
-                <em:updateLink>https://github.com/new-xkit/XKit/releases/download/firefox-v7.7.6/new_xkit-7.7.6.xpi</em:updateLink>
+                <em:updateLink>https://github.com/new-xkit/XKit/releases/download/firefox-v7.7.5/new_xkit-7.7.5.xpi</em:updateLink>
 
                 <!-- A page describing what is new in this updated version -->
                 <!-- <em:updateInfoURL></em:updateInfoURL> -->

--- a/Extensions/dist/page/framework_version.json
+++ b/Extensions/dist/page/framework_version.json
@@ -1,1 +1,1 @@
-{"server":"up","frameworks":[{"name":"firefox","version":"7.7.6"},{"name":"chrome","version":"7.7.1"}]}
+{"server":"up","frameworks":[{"name":"firefox","version":"7.7.5"},{"name":"chrome","version":"7.7.1"}]}


### PR DESCRIPTION
Migrating preferences doesn't work on browsers with e10s disabled.

this is a critical issue since it wipes the settings of people affected, and occasionally even freezes the tumblr dashboard and prevents any interaction with the page.