### PR TITLE
Prevent XKit from running on pages it's not supposed to run on

### DIFF
--- a/WebExtension/manifest.json
+++ b/WebExtension/manifest.json
@@ -2,9 +2,9 @@
    "content_scripts": [ {
       "all_frames": true,
       "css": [ "xkit.css" ],
-      "exclude_matches": [ "https://www.tumblr.com/upload/image*, http://www.tumblr.com/upload/image*" ],
+      "exclude_globs": [ "*.media.tumblr.com*", "*tumblr.com/upload/image*" ],
       "js": [ "bridge.js", "jquery.js", "tiptip.js", "moment.js", "nano.js", "xkit.js" ],
-      "matches": [ "http://*.tumblr.com/*", "https://*.tumblr.com/*" ]
+      "matches": [ "*://*.tumblr.com/*" ]
    } ],
    "description": "A fork of XKit, the extension framework for Tumblr.",
    "homepage_url": "https://github.com/new-xkit/XKit",


### PR DESCRIPTION
now XKit actually doesn't run on tumblr.com/upload/image* and media hosted by tumblr

Originally from the chrome-7.7.2 branch