### PR TITLE
Hide online indicators from the Messaging popdown

### DIFF
--- a/Extensions/messaging_tweaks.js
+++ b/Extensions/messaging_tweaks.js
@@ -373,7 +373,7 @@ XKit.extensions.messaging_tweaks = new Object({
 			XKit.tools.add_css(".messaging-share-post-search, .messaging-share-post-main {display:none;}", "messaging_tweaks");
 		}
 		if (XKit.extensions.messaging_tweaks.preferences.hide_online_indicators.value) {
-			$(".status-indicator-wrapper, .chat-status-banner").hide();
+			XKit.tools.add_css(".status-indicator-wrapper, .chat-status-banner {display:none;}", "messaging_tweaks");
 		}
 		if (XKit.extensions.messaging_tweaks.preferences.make_icons_round.value) {
 			XKit.tools.add_css(".avatar > img { border-radius: 30px !important; transition: border-radius 0.5s; }", "messaging_tweaks");
@@ -426,7 +426,6 @@ XKit.extensions.messaging_tweaks = new Object({
 		}
 		$(".true-icon").removeClass("true-icon");
 		$(".tab.iconic.tab_messaging").show();
-		$(".status-indicator-wrapper, .chat-status-banner").hide();
 		$(".xkit-others_messaging_message, .xkit-my_messaging_message").each(function() {
 			var msg_div = $(this).find(".message-bubble .message");
 			msg_div.find("img").each(function() {

--- a/Extensions/messaging_tweaks.js
+++ b/Extensions/messaging_tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Messaging Tweaks **//
-//* VERSION 1.7.3 **//
+//* VERSION 1.8.0 **//
 //* DESCRIPTION Helpful tweaks for Tumblr IM **//
 //* DETAILS This adds a few helpful tweaks to the Tumblr IM, for example minimising the chat, hiding the IM icon or changing the looks of the chat window. **//
 //* DEVELOPER New-XKit **//
@@ -37,6 +37,11 @@ XKit.extensions.messaging_tweaks = new Object({
 		},
 		"hide_send_post": {
 			text: "Hide the send post through IM in the post share menu",
+			default: false,
+			value: false
+		},
+		"hide_online_indicators": {
+			text: "Hide online indicators from the messaging popout",
 			default: false,
 			value: false
 		},
@@ -168,6 +173,7 @@ XKit.extensions.messaging_tweaks = new Object({
 	do_messages: function() {
 		XKit.extensions.messaging_tweaks.observer.disconnect();
 		var icons = $(".messaging-conversation-popovers .avatar:not(.xkit-my_messaging_icon, .xkit-others_messaging_icon)");
+
 		function img_onload(msg_div, emoji_text, emoji) {
 			msg_div.html(msg_div.html().replace(new RegExp(emoji_text, "g"), emoji.outerHTML));
 		}
@@ -225,15 +231,15 @@ XKit.extensions.messaging_tweaks = new Object({
 			XKit.extensions.messaging_tweaks.first_chat_open = true;
 			XKit.extensions.messaging_tweaks.read_message_count = 0;
 			if (XKit.extensions.messaging_tweaks.preferences.allow_minimising.value) {
-				$(".messaging-conversation-popovers").animate({bottom: "0px"}, "fast");
+				$(".messaging-conversation-popovers").animate({ bottom: "0px" }, "fast");
 				$(".conversation-header-main").on("click.minimise_header", function(e) {
 					if (e.target !== this) { return; }
 					if (!$(this).hasClass("minimised")) {
-						$(".messaging-conversation-popovers").animate({bottom: "-404px"});
+						$(".messaging-conversation-popovers").animate({ bottom: "-404px" });
 						$(this).addClass("minimised");
 					} else {
 						document.title = "Tumblr";
-						$(".messaging-conversation-popovers").animate({bottom: "0px"});
+						$(".messaging-conversation-popovers").animate({ bottom: "0px" });
 						$(this).removeClass("minimised");
 					}
 				});
@@ -269,12 +275,12 @@ XKit.extensions.messaging_tweaks = new Object({
 		}
 
 		if ($(".conversation-main").get(0) !== null && typeof($(".conversation-main").get(0)) !== "undefined") {
-			XKit.extensions.messaging_tweaks.observer.observe($(".conversation-main").get(0), {subtree: true, childList: true});
+			XKit.extensions.messaging_tweaks.observer.observe($(".conversation-main").get(0), { subtree: true, childList: true });
 		}
 	},
 
 	hook_chat_window: function() {
-		XKit.extensions.messaging_tweaks.observer.observe($(".conversation-main").get(0), {subtree: true, childList: true});
+		XKit.extensions.messaging_tweaks.observer.observe($(".conversation-main").get(0), { subtree: true, childList: true });
 		XKit.extensions.messaging_tweaks.read_message_count = $(".xkit-others_messaging_icon").length;
 	},
 
@@ -287,11 +293,11 @@ XKit.extensions.messaging_tweaks = new Object({
 			$(document).on("keydown.minimise_header", function(e) {
 				if (!e.altKey) { return; }
 				if (e.which === 40) {
-					$(".messaging-conversation-popovers").animate({bottom: "-404px"});
+					$(".messaging-conversation-popovers").animate({ bottom: "-404px" });
 					$(this).addClass("minimised");
 				} else if (e.which === 38) {
 					document.title = "Tumblr";
-					$(".messaging-conversation-popovers").animate({bottom: "0px"});
+					$(".messaging-conversation-popovers").animate({ bottom: "0px" });
 					$(this).removeClass("minimised");
 				}
 			});
@@ -320,7 +326,7 @@ XKit.extensions.messaging_tweaks = new Object({
 							return;
 						}
 					}
-				// Check if chat window has been removed
+					// Check if chat window has been removed
 				} else if (mutation.removedNodes.length) {
 					for (i = 0; i < mutation.removedNodes.length; i++) {
 						node = $(mutation.removedNodes[i]);
@@ -365,6 +371,9 @@ XKit.extensions.messaging_tweaks = new Object({
 		}
 		if (XKit.extensions.messaging_tweaks.preferences.hide_send_post.value) {
 			XKit.tools.add_css(".messaging-share-post-search, .messaging-share-post-main {display:none;}", "messaging_tweaks");
+		}
+		if (XKit.extensions.messaging_tweaks.preferences.hide_online_indicators.value) {
+			$(".inbox-row.status-indicator-wrapper").hide();
 		}
 		if (XKit.extensions.messaging_tweaks.preferences.make_icons_round.value) {
 			XKit.tools.add_css(".avatar > img { border-radius: 30px !important; transition: border-radius 0.5s; }", "messaging_tweaks");
@@ -417,6 +426,7 @@ XKit.extensions.messaging_tweaks = new Object({
 		}
 		$(".true-icon").removeClass("true-icon");
 		$(".tab.iconic.tab_messaging").show();
+		$(".inbox-row.status-indicator-wrapper").show();
 		$(".xkit-others_messaging_message, .xkit-my_messaging_message").each(function() {
 			var msg_div = $(this).find(".message-bubble .message");
 			msg_div.find("img").each(function() {
@@ -431,7 +441,7 @@ XKit.extensions.messaging_tweaks = new Object({
 		$(".xkit-my_messaging_icon").removeClass("xkit-my_messaging_icon");
 		XKit.tools.remove_css("messaging_tweaks");
 		if ($(".conversation-header-main").hasClass("minimised")) {
-			$(".messaging-conversation-popovers").animate({bottom: "0px"});
+			$(".messaging-conversation-popovers").animate({ bottom: "0px" });
 			$(".conversation-header-main").removeClass("minimised");
 		}
 		$(".conversation-header-main").off("click.minimise_header");

--- a/Extensions/messaging_tweaks.js
+++ b/Extensions/messaging_tweaks.js
@@ -373,7 +373,7 @@ XKit.extensions.messaging_tweaks = new Object({
 			XKit.tools.add_css(".messaging-share-post-search, .messaging-share-post-main {display:none;}", "messaging_tweaks");
 		}
 		if (XKit.extensions.messaging_tweaks.preferences.hide_online_indicators.value) {
-			$(".inbox-row.status-indicator-wrapper").hide();
+			$(".status-indicator-wrapper, .chat-status-banner").hide();
 		}
 		if (XKit.extensions.messaging_tweaks.preferences.make_icons_round.value) {
 			XKit.tools.add_css(".avatar > img { border-radius: 30px !important; transition: border-radius 0.5s; }", "messaging_tweaks");
@@ -426,7 +426,7 @@ XKit.extensions.messaging_tweaks = new Object({
 		}
 		$(".true-icon").removeClass("true-icon");
 		$(".tab.iconic.tab_messaging").show();
-		$(".inbox-row.status-indicator-wrapper").show();
+		$(".status-indicator-wrapper, .chat-status-banner").hide();
 		$(".xkit-others_messaging_message, .xkit-my_messaging_message").each(function() {
 			var msg_div = $(this).find(".message-bubble .message");
 			msg_div.find("img").each(function() {


### PR DESCRIPTION
Requested in support chat, seemed like an easy enough fix to me to write it up in five minutes or less.