### PR TITLE
Fix is_following on 7.7.6+

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 6.8.5 **//
+//* VERSION 6.8.6 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -2280,7 +2280,7 @@ XKit.extensions.xkit_patches = new Object({
 			is_following: function(username, blog) {
 				return $.ajax({
 					type: "GET",
-					url: "/svc/blog/followed_by",
+					url: "https://www.tumblr.com/svc/blog/followed_by",
 					data: "tumblelog=" + blog + "&query=" + username,
 					dataType: "json",
 				}).then(function(msg) {


### PR DESCRIPTION
Don't know why the ajax request is broken in the new versions, but it's mozilla, so I give up trying to use any kind of reason there
Adding the full url fixes everything and makes Profiler and Mutual Checker function perfectly again