### PR TITLE
Add slash to Extensions path in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,12 +7,12 @@
 
 node_modules/
 
-Firefox/data/xkit/
-Extensions/dist/*.json
+/Firefox/data/xkit/
+/Extensions/dist/*.json
 
-Extensions/dist/page/gallery.json
-Extensions/dist/page/list.json
-Extensions/dist/page/themes.json
+/Extensions/dist/page/gallery.json
+/Extensions/dist/page/list.json
+/Extensions/dist/page/themes.json
 
 *.swp
 


### PR DESCRIPTION
This does nothing for git, but works around a bug (or lack of leniency)
in `ag` where the lack of a leading slash causes
`Extensions/dist/*.json` to be compared to `xkit_patches.json` instead
of `Extensions/dist/xkit_patches.json`.