### PR TITLE
Separator extension improvements

### DIFF
--- a/Extensions/separator.css
+++ b/Extensions/separator.css
@@ -8,3 +8,15 @@
 	border-top: 3px solid rgba(255, 255, 255, 0.33);
 	border-bottom: none;
 }
+
+#xkit-separator-controls > li.item {
+	border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+#xkit-separator-controls > li.item > a {
+	color: rgba(255, 255, 255, 0.6);
+	display: block;
+	padding: 0 10px;
+	line-height: 36px;
+	font-weight: 700;
+}

--- a/Extensions/separator.css
+++ b/Extensions/separator.css
@@ -1,10 +1,10 @@
-#xkit-post-separator {
+#xkit-separator-line {
+	border-top: 1px dotted rgba(0, 0, 0, 0.33);
+	border-bottom: 1px dotted rgba(255, 255, 255, 0.23);
+	margin: 0 0 20px;
+}
 
-	border-top: 1px dotted rgba(0,0,0,0.33);
-	border-bottom: 1px dotted rgba(255,255,255,0.23);
-	height: 0px;
-	overflow: hidden;
-	margin-top: 10px;
-	margin-bottom: 20px;
-
+#xkit-separator-line.xkit-separator-bold-line {
+	border-top: 3px solid rgba(255, 255, 255, 0.33);
+	border-bottom: none;
 }

--- a/Extensions/separator.js
+++ b/Extensions/separator.js
@@ -1,213 +1,392 @@
 //* TITLE Separator **//
-//* VERSION 1.1.6 **//
-//* DESCRIPTION Where were we again? **//
+//* VERSION 2.0.0 **//
+//* DESCRIPTION Marks where you left off on your dashboard **//
 //* DEVELOPER STUDIOXENIX **//
-//* DETAILS A simple extension that puts a divider showing where you left off on your dashboard. **//
 //* FRAME false **//
+//* SLOW false **//
 //* BETA false **//
 
-XKit.extensions.separator = new Object({
+// # Motivation
+// Some of us like to catch up with all the posts that we’ve missed since we last checked our dashboard.
+// Placing a visual separator to show where we left off helps with that.
+//
+// # Approach
+// For each context (dashboard, specific blog, or specific tag) we track the newest post we’ve previously witnessed.
+// This is our “goal post” (above which we’ll place the separator).
+// When we return to the context, we track the set of posts that we’ve witnessed that’s newer than the goal post.
+// Once we reach the goal post, we place the separator.
+// We then reset the goal post (to the newest post in the contiguous interval of witnessed posts that’s touching the goal post).
+//
+// # Implementation-specific Caveats
+//   - We don’t actually track the set of discrete witnessed posts; we track a set of disjoint intervals representing contiguously witnessed posts.
+//     This approach should tolerate deleted posts.
+//     However, a witnessed post that’s subsequently been edited will still be treated as witnessed.
+//   - When endless scrolling is off, merging of seemingly disjoint intervals from adjacent pages relies on URL hints.
+//     If these hints are missing, we’ll fail to merge these intervals.
+//     Consequently, once the goal post resets, we’ll find it pointing to an older than expected post.
+//     The workaround is to manually trigger a goal post reset (with the separator controls).
+//     Hints might be missing if we manually browse to a page’s URL.
+//     They might also _go_ missing should Tumblr change their URL patterns.
+//   - When the same context is open in multiple tabs, behaviour may seem unpredictable.
 
-	running: false,
+XKit.extensions.separator = (function() {
+	"use strict";
 
-	check_for: "",
+	// Immutables
+	const DASHBOARD_PATH_REGEX = /^\/dashboard(?:\/(?:([2-9]|[1-9]\d+)\/(-?[1-9]\d*)\/?)?)?$/;
+	const LATEST_STORAGE_VERSION = 2;
+	const POST_ID_REGEX = /^[1-9]\d*$/;
+	const RECONCILE_ABORT = 0;
+	const RECONCILE_DEFER = -1;
 
-	preferences: {
+	// Mutables
+	let running = false;
+	let drawBoldLine = false;
+	let showControls = false;
 
-		"bold_line": {
-			text: "Use the thick line for separating",
-			default: false,
-			value: false
-		},
+	// Generic helper functions
 
-		"jump_to": {
-			text: "Show the \"Jump to Separator\" button (only works when endless scrolling is off)",
-			default: false,
-			value: false
-		},
+	function isSafePositiveInteger(value) {
+		return (Number.isSafeInteger(value) && (Math.sign(value) === 1));
+	}
 
-	},
+	function areSortedDisjointSafeIntegerIntervals(intervals) {
+		if (!Array.isArray(intervals)) { return false; }
+		let prevUpperEndpoint = Number.NEGATIVE_INFINITY;
+		for (const interval of intervals) {
+			if (!(Array.isArray(interval) && (interval.length === 2))) { return false; }
+			const [lowerEndpoint, upperEndpoint] = interval;
+			if (!(Number.isSafeInteger(lowerEndpoint) && Number.isSafeInteger(upperEndpoint))) { return false; }
+			if (!((prevUpperEndpoint < lowerEndpoint) && (lowerEndpoint < upperEndpoint))) { return false; }
+			prevUpperEndpoint = upperEndpoint;
+		}
+		return true;
+	}
 
-	run: function() {
-		this.running = true;
+	function addToSortedDisjointSafeIntegerIntervals(intervals, interval) {
+		// Assumed preconditions:
+		//   - `intervals` is a sorted disjoint set of safe integer intervals; and
+		//   - `interval` is a safe integer interval.
+		let spliceStart = 0, spliceDeleteCount = 0;
+		let preservedEndpoints = 0;
+		let [newLowerEndpoint, newUpperEndpoint] = interval;
+		for (const [oldLowerEndpoint, oldUpperEndpoint] of intervals) {
+			if (oldUpperEndpoint < newLowerEndpoint) { ++spliceStart; continue; }
+			if (newUpperEndpoint < oldLowerEndpoint) { break; }
+			if ((oldLowerEndpoint <= newLowerEndpoint) && (newLowerEndpoint <= oldUpperEndpoint)) {
+				newLowerEndpoint = oldLowerEndpoint;
+				++preservedEndpoints;
+			}
+			if ((oldLowerEndpoint <= newUpperEndpoint) && (newUpperEndpoint <= oldUpperEndpoint)) {
+				newUpperEndpoint = oldUpperEndpoint;
+				++preservedEndpoints;
+			}
+			++spliceDeleteCount;
+		}
+		const updated = (!((spliceDeleteCount === 1) && (preservedEndpoints === 2)));
+		if (updated) {
+			intervals.splice(spliceStart, spliceDeleteCount, [newLowerEndpoint, newUpperEndpoint]);
+		}
+		return updated;
+	}
 
-		if (XKit.interface.where().dashboard !== true) {return; }
+	function indexOfIntervalContainingValue(intervals, value) {
+		// Assumed preconditions:
+		//   - `intervals` is a sorted disjoint set of safe integer intervals; and
+		//   - `value` is a safe integer.
+		let index = 0;
+		for (const [lowerEndpoint, upperEndpoint] of intervals) {
+			if (upperEndpoint < value) { ++index; continue; }
+			if (value < lowerEndpoint) { break; }
+			return index;
+		}
+		return -1;
+	}
+
+	// Internal functions
+
+	function initContext() {
+		function validCursors({goalPostId, witnessedPostIds}) {
+			if (!Array.isArray(witnessedPostIds)) { return false; }
+			if (isSafePositiveInteger(goalPostId)) {
+				return areSortedDisjointSafeIntegerIntervals([[0, goalPostId], ...witnessedPostIds]);
+			}
+			return ((goalPostId === null) && (witnessedPostIds.length === 0));
+		}
+
+		const where = XKit.interface.where();
+
+		if (where.dashboard) {
+			let isFirstPage = false;
+			let augmentWithAdjacencyHints = (cursors, witnessedPostIds) => { return witnessedPostIds; };
+
+			// This approach isn’t foolproof.
+			// Tolerable URL paths are actually laxer than the defined pattern, but should never be seen in normal usage.
+			// For instance, page numbers may have leading zeroes.
+			// Also, a future post ID would mean we’re actually on the first page.
+			const pathGroups = location.pathname.match(DASHBOARD_PATH_REGEX);
+			if (pathGroups !== null) {
+				if ((pathGroups[1] === null) && (pathGroups[2] === null)) {
+					isFirstPage = true;
+				} else {
+					const signedPostId = Number(pathGroups[2]);
+					if (Number.isSafeInteger(signedPostId)) {
+						const postId = Math.abs(signedPostId);
+						if (Math.sign(signedPostId) === 1) {
+							augmentWithAdjacencyHints = (cursors, [oldestWitnessedPostId, newestWitnessedPostId]) => { return [oldestWitnessedPostId, postId]; };
+						} else {
+							augmentWithAdjacencyHints = (cursors, [oldestWitnessedPostId, newestWitnessedPostId]) => { return [postId, newestWitnessedPostId]; };
+						}
+					}
+				}
+			}
+
+			const loadCursors = () => {
+				const [goalPostId, witnessedPostIds] = JSON.parse(XKit.storage.get("separator", "cursors:dashboard", "[null,[]]"));
+				if (!validCursors({goalPostId, witnessedPostIds})) {
+					throw new Error("Loaded invalid cursors");
+				}
+				return {goalPostId, witnessedPostIds};
+			};
+			const saveCursors = ({goalPostId, witnessedPostIds}) => {
+				if (!validCursors({goalPostId, witnessedPostIds})) {
+					throw new Error("Attempted to save invalid cursors");
+				}
+				XKit.storage.set("separator", "cursors:dashboard", JSON.stringify([goalPostId, witnessedPostIds]));
+			};
+
+			return {
+				"shouldContinue": true,
+				"mayDefer": where.endless,
+				isFirstPage,
+				augmentWithAdjacencyHints,
+				loadCursors,
+				saveCursors,
+			};
+		}
+
+		return {"shouldContinue": false};
+	}
+
+	function upgradeStorage() {
+		const storageVersion = XKit.storage.get("separator", "version", 1);
+		if (!(isSafePositiveInteger(storageVersion) && (storageVersion <= LATEST_STORAGE_VERSION))) {
+			throw new Error("Unexpected storage version");
+		}
+
+		if (storageVersion < LATEST_STORAGE_VERSION) {
+			if (storageVersion <= 1) {
+				// Storage should be in v1 format; upgrading to v2 format.
+				const lastPost = XKit.storage.get("separator", "last_post");
+				XKit.storage.remove("separator", "last_post");
+				if (isSafePositiveInteger(lastPost)) {
+					XKit.storage.set("separator", "cursors:dashboard", JSON.stringify([lastPost, []]));
+				}
+			}
+
+			XKit.storage.set("separator", "version", LATEST_STORAGE_VERSION);
+		}
+	}
+
+	function enumerateDashboardPostIds() {
+		const postElems = document.querySelectorAll("#posts > .post_container > .post:not(.new_post_buttons)");
+		const postIds = [];
+		let prevPostId = Number.POSITIVE_INFINITY;
+		for (const postElem of postElems) {
+			if (!POST_ID_REGEX.test(postElem.dataset.id)) {
+				throw new Error("Failed to extract valid ID from post element");
+			}
+			const postId = Number(postElem.dataset.id);
+			if (!Number.isSafeInteger(postId)) {
+				throw new Error("Encountered post with much larger ID than expected");
+			}
+			if (prevPostId <= postId) {
+				throw new Error("Encountered post that violates the expectation that posts must be ordered by strictly decreasing IDs");
+			}
+			postIds.push(postId);
+			prevPostId = postId;
+		}
+		return postIds;
+	}
+
+	function reconcile(cursors, postIds, saveCursors, isFirstPage, augmentWithAdjacencyHints, initial) {
+		// Updates (and saves) `cursors` based on `postIds`.
+		//
+		// Returns:
+		//   - the best goal post ID from `postIds` above which to place the separator;
+		//   - `RECONCILE_DEFER` if `postIds` are newer than the goal post ID; or
+		//   - `RECONCILE_ABORT` for all other scenarios.
+		//
+		// Assumed preconditions:
+		//   - `cursors` is valid;
+		//   - `postIds` is a reverse sorted array of safe positive integers representing posts loaded into the DOM; and
+		//   - `saveCursors` and `augmentWithAdjacencyHints` are valid functions.
+
+		if (postIds.length === 0) {
+			// We could legitimately be dealing with an empty context, or we could be glitched.
+			// Best do nothing.
+			return RECONCILE_ABORT;
+		}
+
+		if (initial && (cursors.goalPostId === null)) {
+			// Looks like this is the first time we’ve visited this context.
+			// We’ll set the goal post to the newest witnessed post.
+			const newestWitnessedPostId = postIds[0];
+			cursors.goalPostId = newestWitnessedPostId;
+			saveCursors(cursors);
+			return newestWitnessedPostId;
+		}
+
+		// We should have a valid goal post from here on out.
+		if (!isSafePositiveInteger(cursors.goalPostId)) {
+			throw new Error("Invariants broken");
+		}
+
+		// This might not form a valid interval if `postIds` comprises a single post ID.
+		// We’ll account for this (when such cases are valid) shortly.
+		let oldestWitnessedPostId = postIds[postIds.length - 1], newestWitnessedPostId = postIds[0];
+
+		if (initial) {
+			if (newestWitnessedPostId < cursors.goalPostId) {
+				if (isFirstPage) {
+					// Looks like the original goal post was deleted.
+					// We’ll reset the goal post to whatever is newest on this first page.
+					cursors.goalPostId = newestWitnessedPostId;
+					cursors.witnessedPostIds = [];
+					saveCursors(cursors);
+					return newestWitnessedPostId;
+				}
+				// Looks like we’re trawling through past posts.
+				// No need to continue.
+				return RECONCILE_ABORT;
+			}
+
+			[oldestWitnessedPostId, newestWitnessedPostId] = augmentWithAdjacencyHints(cursors, [oldestWitnessedPostId, newestWitnessedPostId]);
+		}
+
+		// We should have a valid interval from here on out.
+		// (We’re assuming that there’ll always be at least two posts loaded into the DOM when endless scrolling is on.)
+		// (We’re also assuming that there’ll always be overlaps in loaded DOM posts for subsequent updates.)
+		if (newestWitnessedPostId <= oldestWitnessedPostId) {
+			throw new Error("Invariants broken");
+		}
+
+		const cursorsUpdated = addToSortedDisjointSafeIntegerIntervals(cursors.witnessedPostIds, [oldestWitnessedPostId, newestWitnessedPostId]);
+		const index = indexOfIntervalContainingValue(cursors.witnessedPostIds, cursors.goalPostId);
+
+		if (index === -1) {
+			// “Are we there _yet_?” / “Yes.” / “Really?” / “NO!”
+			if (cursorsUpdated) { saveCursors(cursors); }
+			return RECONCILE_DEFER;
+		}
+
+		// If we’ve reached the goal post, it should be in the first interval.
+		if (!(cursorsUpdated && (index === 0))) {
+			throw new Error("Invariants broken");
+		}
+
+		// Find the best goal post ID from `postIds`.
+		let bestGoalPostId = postIds[postIds.length - 1];
+		for (let i = postIds.length - 2; -1 < i; --i) {
+			const postId = postIds[i];
+			if (cursors.goalPostId < postId) { break; }
+			bestGoalPostId = postId;
+		}
+
+		// Update cursors.
+		const newGoalPostId = cursors.witnessedPostIds[0][1];
+		cursors.goalPostId = newGoalPostId;
+		cursors.witnessedPostIds.shift();
+		saveCursors(cursors);
+
+		return bestGoalPostId;
+	}
+
+	function insertSeparatorBeforePost(postId) {
+		// Assumed preconditions:
+		//   - `postId` is a safe positive integer.
+
+		if (document.getElementById("xkit-separator-line") !== null) {
+			throw new Error("Separator already exists");
+		}
+
+		const post = document.querySelector(`#posts > .post_container[data-pageable="post_${postId}"]`);
+		if (post === null) {
+			throw new Error("Failed to locate post element");
+		}
+
+		const line = document.createElement("li");
+		line.id = "xkit-separator-line";
+		if (drawBoldLine) {
+			line.className = "xkit-separator-bold-line";
+		}
+		post.parentNode.insertBefore(line, post);
+	}
+
+	// Exposed functions
+
+	function run() {
+		running = true;
+
+		const {shouldContinue, mayDefer, isFirstPage, augmentWithAdjacencyHints, loadCursors, saveCursors} = initContext();
+		if (!shouldContinue) { return; }
 
 		XKit.tools.init_css("separator");
 
-		if (XKit.extensions.separator.preferences.bold_line.value === true) {
-
-			XKit.tools.add_css(" #xkit-post-separator { border-top: 3px solid rgba(255,255,255,0.33) !important; border-bottom: 0 !important; } ", "separator-thick");
-
-		}
-
-		if (XKit.extensions.separator.preferences.jump_to.value === true) {
-
-			XKit.interface.sidebar.add({
-				id: "separator_sidebar",
-				title: "Separator",
-				items: [{
-					id: "separator_button",
-					text: "Go to last viewed post",
-					carrot: true
-				}]
-			});
-
-
-			$("#separator_button").click(function() {
-
-				if ($("#xkit-post-separator").length > 0) {
-
-					$('html,body').animate({
-						scrollTop: $("#xkit-post-separator").offset().top
-					}, 1000);
-
-				} else {
-
-					document.location = "http://www.tumblr.com/dashboard/100/" + (XKit.extensions.separator.check_for + 1);
-
-				}
-
-				return false;
-			});
-
-		}
-
-		var last_loaded_post = XKit.storage.get("separator", "last_post", "");
-
-		var current_last_post = $("body").find(".posts .post").not("#tumblr_radar").not(".new_post_buttons").first();
-
-		//$(last_loaded_post).css("background","red");
-
-		if (last_loaded_post !== "") {
-
-			XKit.extensions.separator.check_for = last_loaded_post;
-
-			if ($("#post_" + last_loaded_post).length > 0) {
-
-				XKit.extensions.separator.insert($("#post_" + last_loaded_post));
-
-			} else {
-
-				// Is it deleted?
-				if (XKit.extensions.separator.check_if_passed() === true) {
-
-					var find_closest = true;
-
-					if (typeof XKit.interface.where().endless !== "undefined") {
-						if (XKit.interface.where().endless === false) {
-							find_closest = false;
-						}
-					}
-
-					if (find_closest) {
-						XKit.extensions.separator.find_closest(100);
-					} else {
-						var current_last = $(".posts .post").first();
-						var current_last_id = $(current_last).attr('data-post-id');
-						if (current_last_id < XKit.extensions.separator.check_for) {
-							XKit.extensions.separator.find_closest(100);
-						} else {
-							return;
-						}
-					}
-
-				} else {
-
-					// Probably after scrolling.
-					XKit.post_listener.add("separator", XKit.extensions.separator.post_listener);
-
-				}
-
-			}
-
-		}
-
-		XKit.storage.set("separator", "last_post", $(current_last_post).attr('data-post-id'));
-
-	},
-
-	find_closest: function(distance) {
-
-		var found_post = false;
-
-		if (distance >= 5000000000) { return; }
-
-		$(".posts .post").not("#new_post").each(function() {
-
-			var m_id = $(this).attr('data-post-id');
-
-			if (m_id >= XKit.extensions.separator.check_for - distance && m_id <= XKit.extensions.separator.check_for + distance) {
-
-				XKit.extensions.separator.insert($(this));
-				found_post = true;
-
-				try {
-					// Just in case.
+		upgradeStorage();
+		const cursors = loadCursors();
+		const initialPostIds = enumerateDashboardPostIds();
+		const initialGoalPostId = reconcile(cursors, initialPostIds, saveCursors, isFirstPage, augmentWithAdjacencyHints, true);
+		if (isSafePositiveInteger(initialGoalPostId)) {
+			insertSeparatorBeforePost(initialGoalPostId);
+		} else if (mayDefer && (initialGoalPostId === RECONCILE_DEFER)) {
+			XKit.post_listener.add("separator", () => {
+				const updatedPostIds = enumerateDashboardPostIds();
+				// TODO: Handle exceptions (by removing the post listener), or make `reconcile` less dramatic.
+				const updatedGoalPostId = reconcile(cursors, updatedPostIds, saveCursors, isFirstPage, augmentWithAdjacencyHints, false);
+				if (isSafePositiveInteger(updatedGoalPostId)) {
+					insertSeparatorBeforePost(updatedGoalPostId);
+					// With endless scrolling, witnessing new posts still requires a reload.
+					// Since the cursors won’t change until we witness new posts, we no longer need this listener.
 					XKit.post_listener.remove("separator");
-				} catch (e) {
-					console.log("Unable to remove separator post listener.");
 				}
-
-				return false;
-
-			}
-
-		});
-
-		if (found_post) { return; }
-
-		XKit.extensions.separator.find_closest(distance * 5);
-
-
-	},
-
-	check_if_passed: function() {
-
-		var current_last = $(".posts .post").last();
-		var current_last_id = $(current_last).attr('data-post-id');
-
-		if (current_last_id < XKit.extensions.separator.check_for) {
-
-			// We scrolled way too much but still there is no post.
-			return true;
-
-		} else {
-
-			return false;
-
+			});
 		}
-
-	},
-
-	post_listener: function() {
-
-		if ($("#post_" + XKit.extensions.separator.check_for).length > 0) {
-
-			XKit.extensions.separator.insert($("#post_" + XKit.extensions.separator.check_for));
-			XKit.post_listener.remove("separator");
-
-		} else {
-
-			// It was probably deleted? Let's check for that.
-			XKit.extensions.separator.find_closest(100);
-
-		}
-
-	},
-
-	insert: function(div) {
-
-		$(div).parent().before("<div id=\"xkit-post-separator\">Here!</div>");
-
-	},
-
-	destroy: function() {
-		this.running = false;
-		$("#xkit-post-separator").remove();
-		XKit.interface.sidebar.remove("separator_sidebar");
-		XKit.post_listener.remove("separator");
-		XKit.tools.remove_css("separator");
-		XKit.tools.remove_css("separator-thick");
 	}
-});
+
+	function destroy() {
+		XKit.post_listener.remove("separator");
+
+		// We shouldn’t need to explicitly remove event listeners, since browsers are smart cookies.
+		const elems = document.querySelectorAll("#xkit-separator-line, #xkit-separator-controls");
+		for (const elem of elems) { elem.remove(); }
+
+		XKit.tools.remove_css("separator");
+
+		running = false;
+	}
+
+	// Exposed API object
+	const preferences = Object.freeze({
+		"bold_line": Object.freeze({
+			"text": "Draw the separator with a thicker line",
+			"default": false,
+			get value() { return drawBoldLine; },
+			set value(newValue) { drawBoldLine = newValue; },
+		}),
+		"jump_to": Object.freeze({
+			// We’re piggybacking off a legacy preference, hence the semantic mismatch between the key’s name and the preference’s current effect.
+			"text": "Show controls in the right column",
+			"default": false,
+			get value() { return showControls; },
+			set value(newValue) { showControls = newValue; },
+		}),
+	});
+	const api = Object.freeze({
+		get running() { return running; },
+		preferences,
+		run,
+		destroy,
+	});
+	return api;
+}());

--- a/Extensions/separator.js
+++ b/Extensions/separator.js
@@ -28,6 +28,18 @@
 //     Hints might be missing if we manually browse to a page’s URL.
 //     They might also _go_ missing should Tumblr change their URL patterns.
 //   - When the same context is open in multiple tabs, behaviour may seem unpredictable.
+//
+// # Checklist
+//   - [ ] Refactor once I eventually get around to adding separator support for channel views.
+//   - [ ] Check for whether this extension conflicts with any of the other extensions.
+//   - [ ] Add a per-context reset control (so users needn’t wipe the entire extension’s settings).
+//   - [ ] Add a per-context enable/disable control (so users can opt in/out of placing separators on the dashboard or specific tags).
+//   - [ ] Add visual indicators (so users know which posts have been witnessed, and roughly how far they are from the separator).
+//   - [ ] Deal with post IDs occasionally breaking the (assumed) strictly decreasing invariant.
+//         I’ve seen this a couple of times in tagged views; the “out-of-order” posts seem to share the same timestamp.
+//         My money is on those posts being queued (and thus having pre-assigned IDs), coupled with the views using timestamp ordering (and not ID ordering as first thought).
+//   - [ ] Explore alternative approaches to tracking witnessed posts.
+//         Per-post tracking would reduce confusion when switching contexts.
 
 "use strict";
 

--- a/Extensions/separator.js
+++ b/Extensions/separator.js
@@ -323,6 +323,7 @@ XKit.extensions.separator = (function() {
 		const postIds = [];
 		let prevPostId = Number.POSITIVE_INFINITY;
 		for (const postElem of postElems) {
+			if (postElem.querySelector("a.recommendation-reason-link[data-trending-id=\"staff-picks\"]") !== null) { continue; }
 			const postId = Number(postElem.dataset.id);
 			if (!isSafePositiveInteger(postId)) {
 				throw new Error("Failed to extract valid ID from post element");

--- a/Extensions/separator.js
+++ b/Extensions/separator.js
@@ -59,11 +59,13 @@ XKit.extensions.separator = (function() {
 	}
 
 	function isSnowflake(value) {
-		return ((typeof value === "bigint") && (value < (2n ** 64n)) && (value > -1));
+		// eslint-disable-next-line valid-typeof
+		return ((typeof value === "bigint") && (value < (BigInt(2) ** BigInt(64))) && (value > -1));
 	}
 
 	function isPositiveSnowflake(value) {
-		return ((typeof value === "bigint") && (value < (2n ** 64n)) && (value > 0));
+		// eslint-disable-next-line valid-typeof
+		return ((typeof value === "bigint") && (value < (BigInt(2) ** BigInt(64))) && (value > 0));
 	}
 
 	function areSortedDisjointSnowflakeIntervals(intervals) {
@@ -125,7 +127,7 @@ XKit.extensions.separator = (function() {
 		function validCursors({goalPostId, witnessedPostIds}) {
 			if (!Array.isArray(witnessedPostIds)) { return false; }
 			if (isPositiveSnowflake(goalPostId)) {
-				return areSortedDisjointSnowflakeIntervals([[0n, goalPostId], ...witnessedPostIds]);
+				return areSortedDisjointSnowflakeIntervals([[BigInt(0), goalPostId], ...witnessedPostIds]);
 			}
 			return ((goalPostId === null) && (witnessedPostIds.length === 0));
 		}
@@ -205,7 +207,7 @@ XKit.extensions.separator = (function() {
 					const jumpAnchor = document.createElement("a");
 					// We’ll assume nobody’s ever gonna be 1000 posts behind _and_ willing to work their way back through more than 100 pages in one go.
 					// Note that if we reached the goal post during initial reconciliation, then the URL will point to the new goal post, but the handler will take us to the old goal post.
-					jumpAnchor.href = `/dashboard/100/${cursors.goalPostId + 1n}`;
+					jumpAnchor.href = `/dashboard/100/${cursors.goalPostId + BigInt(1)}`;
 					jumpAnchor.textContent = "Go to last viewed post";
 					jumpAnchor.addEventListener("click", (event) => {
 						const line = document.getElementById("xkit-separator-line");

--- a/Extensions/separator.js
+++ b/Extensions/separator.js
@@ -1,7 +1,7 @@
 //* TITLE Separator **//
 //* VERSION 2.0.0 **//
 //* DESCRIPTION Marks where you left off on your dashboard **//
-//* DEVELOPER STUDIOXENIX **//
+//* DEVELOPER new-xkit **//
 //* FRAME false **//
 //* SLOW false **//
 //* BETA false **//
@@ -230,7 +230,7 @@ XKit.extensions.separator = (function() {
 	}
 
 	function enumerateDashboardPostIds() {
-		const postElems = document.querySelectorAll("#posts > .post_container > .post:not(.new_post_buttons)");
+		const postElems = document.querySelectorAll("#posts > .post_container > .post:not(.new_post_buttons):not(.sponsored_post)");
 		const postIds = [];
 		let prevPostId = Number.POSITIVE_INFINITY;
 		for (const postElem of postElems) {


### PR DESCRIPTION
This is a rewrite of the separator extension. It features a more robust algorithm for placing the separator and tracking read posts (at the expense of bookkeeping). It also semi-supports tagged views.

### Points of contention
  - The rewritten separator extension uses ES6 syntax and newish browser features (like `Map` and `URLSearchParams`), which'd leave users on older browsers in the lurch.

### Checklist
  - [ ] Improve reconciliation algorithm to accommodate for posts that _aren't_ arranged by strictly decreasing IDs; these posts typically appear to be published at the same time (at least to minute-level granularity)
  - [ ] Possible refactor once I eventually get around to adding separator support for channel views
  - [ ] Quick check for whether this extension conflicts with any of the other extensions
  - [ ] PR feedback
      - [ ] Documentation pass
  - [ ] Maybe add per-context reset control (so users needn't wipe the entire extension's settings)
  - [ ] Maybe add per-context enable/disable control (so users can opt in/out of placing separators on the dashboard or specific tags)
  - [ ] Maybe add visual indicators (so users know which posts have been witnessed, and roughly how far they are from the separator)