### PR TITLE
Pin npm version to 5.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "4.2"
 before_install:
-  - npm install -g npm@latest
+  - npm install -g npm@5.3.0
   - npm install -g gulp
 after_script:
   - ./travis-autobuild-extensions.sh


### PR DESCRIPTION
This is a stopgap for build failures described in npm/npm#18395.