### PR TITLE
Fix typo in No Recommended's added class

### DIFF
--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -1,5 +1,5 @@
 //* TITLE No Recommended **//
-//* VERSION 2.2.2 **//
+//* VERSION 2.2.3 **//
 //* DESCRIPTION Removes recommended posts **//
 //* DETAILS This extension removes recommended posts from your dashboard. To remove Recommended Blogs on the sidebar, please use Tweaks extension. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -52,7 +52,7 @@ XKit.extensions.norecommended = new Object({
 
 		$(".posts .post").not(".norecommended-done").each(function() {
 
-			$(this).addClass(".norecommended-done");
+			$(this).addClass("norecommended-done");
 
 			if ($(this).hasClass("is_recommended") || $(this).find(".post_info_recommended").length > 0 || $(this).find(".recommendation-reason-footer").length > 0 && $(this).attr("data-is_reblog") != 1) {
 				$(this).remove();


### PR DESCRIPTION
A period in a css class makes it impossible to match with standard css class selectors. It's also an easy to make typo.