### PR TITLE
Add `applications` key to manifest; Re-indent manifest

### DIFF
--- a/WebExtension/manifest.json
+++ b/WebExtension/manifest.json
@@ -1,21 +1,27 @@
 {
-   "content_scripts": [ {
-      "all_frames": true,
-      "css": [ "xkit.css" ],
-      "exclude_matches": [ "https://www.tumblr.com/upload/image*, http://www.tumblr.com/upload/image*" ],
-      "js": [ "bridge.js", "jquery.js", "tiptip.js", "moment.js", "nano.js", "xkit.js" ],
-      "matches": [ "http://*.tumblr.com/*", "https://*.tumblr.com/*" ]
-   } ],
-   "description": "A fork of XKit, the extension framework for Tumblr.",
-   "homepage_url": "https://github.com/new-xkit/XKit",
-   "icons": {
-      "128": "icon.png"
-   },
-   "manifest_version": 2,
-   "minimum_chrome_version": "44.0",
-   "name": "New XKit",
-   "author": "New XKit Team",
-   "permissions": ["*://*/*", "*://*/", "unlimitedStorage", "storage", "http://*.tumblr.com/", "https://*.tumblr.com/" ],
-   "version": "7.7.1",
-   "web_accessible_resources": [ "manifest.json", "editor.js" ]
+  "content_scripts": [ {
+    "all_frames": true,
+    "run_at": "document_end",
+    "css": [ "xkit.css" ],
+    "exclude_matches": [ "https://www.tumblr.com/upload/image*, http://www.tumblr.com/upload/image*" ],
+    "js": [ "bridge.js", "jquery.js", "tiptip.js", "moment.js", "nano.js", "xkit.js" ],
+    "matches": [ "http://*.tumblr.com/*", "https://*.tumblr.com/*" ]
+  } ],
+  "description": "A fork of XKit, the extension framework for Tumblr.",
+  "homepage_url": "https://github.com/new-xkit/XKit",
+  "icons": {
+    "128": "icon.png"
+  },
+  "manifest_version": 2,
+  "minimum_chrome_version": "44.0",
+  "name": "New XKit",
+  "author": "New XKit Team",
+  "permissions": ["*://*/*", "*://*/", "unlimitedStorage", "storage", "http://*.tumblr.com/", "https://*.tumblr.com/" ],
+  "version": "7.7.1",
+  "web_accessible_resources": [ "manifest.json", "editor.js" ],
+  "applications": {
+    "gecko": {
+      "id": "@new-xkit"
+    }
+  }
 }


### PR DESCRIPTION
The `applications` key is necessary for Firefox to recognize that it's New XKit while developing locally (and possibly when uploaded to the store, I haven't tested that part). One minor drawback to this approach is that the presence of the `applications` key causes Chrome to warn that there's an unrecognized key present.

This PR also tells the injection of the scripts to happen at document_end instead of the default (which I think is document_idle). This should make XKit's startup process a bit more well-defined.