### PR TITLE
Make the is_reblogged check for posts work on Peepr posts

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 6.8.6 **//
+//* VERSION 6.8.7 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -1902,7 +1902,7 @@ XKit.extensions.xkit_patches = new Object({
 				}
 
 				m_return.animated = $(obj).hasClass("is_animated");
-				m_return.is_reblogged = $(obj).hasClass("is_reblog");
+				m_return.is_reblogged = $(obj).hasClass("is_reblog") || $(obj).find(".reblog_info").length > 0;
 				m_return.is_mine = $(obj).hasClass("is_mine");
 				m_return.is_following = ($(obj).attr('data-following-tumblelog') === true);
 				m_return.can_edit = $(obj).find(".post_control.edit").length > 0;


### PR DESCRIPTION
Peepr does not have the `is_reblog` class or the `post-json` to check whether the posts are reblogs. The only surefire indication is the reblog indicator at the top of the post. This also fixes Servant's issue of marking all Peepr posts as original.