### PR TITLE
minor XWidgets CSS update

### DIFF
--- a/Extensions/xwidgets.css
+++ b/Extensions/xwidgets.css
@@ -65,7 +65,7 @@ body .l-header-container {
 }
 
 body.xkit-widgets-opened {
-	padding-top: 150px;
+	padding-top: 140px;
 	-webkit-transition: padding-top 0.35s ease-in-out;
 	-moz-transition: padding-top 0.35s ease-in-out;
 	-o-transition: padding-top 0.35s ease-in-out;

--- a/Extensions/xwidgets.js
+++ b/Extensions/xwidgets.js
@@ -1,5 +1,5 @@
 //* TITLE XWidgets **//
-//* VERSION 0.3.1 **//
+//* VERSION 0.3.2 **//
 //* DESCRIPTION Widgets for your dashboard **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//


### PR DESCRIPTION
stops the dashboard being essentially scrolled 10px for no reason when you open the widgets drawer