### PR TITLE
Redress malformed selector in Find Inactives extension that seems to choke up Safari

### DIFF
--- a/Extensions/find_inactives.js
+++ b/Extensions/find_inactives.js
@@ -1,5 +1,5 @@
 //* TITLE Find Inactives **//
-//* VERSION 0.4.0 **//
+//* VERSION 0.4.1 **//
 //* DESCRIPTION Find the inactive blogs you follow **//
 //* DEVELOPER new-xkit **//
 //* DETAILS This extension lets you find blogs that haven't been updated in a certain amount of time. Just go to list of blogs you follow, then click on &quot;Find Inactive Blogs&quot; button below your Crushes to get started. **//

--- a/Extensions/find_inactives.js
+++ b/Extensions/find_inactives.js
@@ -336,7 +336,7 @@ XKit.extensions.find_inactives = new Object({
 	},
 	trigger_unfollow: function() {
 		var username = add_tag;
-		var removalTarget = jQuery('.find-inactives-blog[data-url="http://' + username + '.tumblr.com/');
+		var removalTarget = jQuery('.find-inactives-blog[data-url="http://' + username + '.tumblr.com/"]');
 		Tumblr.Dialog.confirm("Are you sure you want to unfollow <strong>" + username + "</strong>?", function() {
 			Tumblr.unfollow({
 				tumblelog: username,


### PR DESCRIPTION
Reported by `dorkstranger#4733`/`dorkstranger#2782`.