### PR TITLE
downgrade safari framework_version pop-up

### DIFF
--- a/Extensions/dist/page/framework_version.json
+++ b/Extensions/dist/page/framework_version.json
@@ -1,1 +1,1 @@
-{"server":"up","frameworks":[{"name":"firefox","version":"7.8.1"},{"name":"chrome","version":"7.8.1"},{"name":"safari","version":"7.8.1"}]}
+{"server":"up","frameworks":[{"name":"firefox","version":"7.8.1"},{"name":"chrome","version":"7.8.1"},{"name":"safari","version":"7.7.3"}]}


### PR DESCRIPTION
Until 7.8 has made it into the app store, we shouldn't warn for outdated versions.