### PR TITLE
new XKit Preferences feature: Extension Packages

### DIFF
--- a/Extensions/xkit_preferences.css
+++ b/Extensions/xkit_preferences.css
@@ -717,7 +717,7 @@
 
 }
 
-#xkit-extensions-panel-left .xkit-extension {
+#xkit-extensions-panel-left .xkit-extension, #packages-ui .xkit-extension {
 
 	height: 50px;
 	line-height: 50px;
@@ -727,7 +727,7 @@
 
 }
 
-#xkit-extensions-panel-left .xkit-extension.iconic {
+#xkit-extensions-panel-left .xkit-extension.iconic, #packages-ui .xkit-extension.iconic {
 
 	display: inline-block;
 	float: left;
@@ -747,7 +747,7 @@
 
 #xkit-extensions-panel-left .xkit-extension.iconic.selected { opacity: 1; }
 
-#xkit-extensions-panel-left .xkit-extension.iconic .icon {
+#xkit-extensions-panel-left .xkit-extension.iconic .icon, #packages-ui .xkit-extension.iconic .icon {
 
 	top: 6px; left: 6px;
 
@@ -791,7 +791,7 @@
 
 }
 
-#xkit-extensions-panel-left .xkit-extension:hover {
+#xkit-extensions-panel-left .xkit-extension:hover, #packages-ui .xkit-extension:hover {
 
 	background-color: rgb(240,240,240);
 
@@ -810,7 +810,7 @@
 
 }
 
-#xkit-extensions-panel-left .xkit-extension .icon {
+#xkit-extensions-panel-left .xkit-extension .icon, #packages-ui .xkit-extension .icon {
 
 	position: absolute;
 	top: 9px; left: 12px;
@@ -820,7 +820,7 @@
 
 }
 
-#xkit-extensions-panel-left .xkit-extension .icon-mask {
+#xkit-extensions-panel-left .xkit-extension .icon-mask, #packages-ui .xkit-extension .icon-mask {
 
 	/*position: absolute;
 	top: 9px; left: 12px;
@@ -1210,7 +1210,7 @@
 	font-weight: normal;
 }
 
-#xkit-extensions-panel-left .xkit-extension {
+#xkit-extensions-panel-left .xkit-extension, #packages-ui .xkit-extension {
 	background: white;
 	border-bottom: 0;
 }


### PR DESCRIPTION
Adds an interface in the control panel's "Other" tab for importing and exporting user-made XKit extensions. Any valid extension can be installed and any non-gallery extension can be exported, and installation prompts exist, including an overwrite warning.

![image](https://user-images.githubusercontent.com/28949509/34449725-7d1c77e8-ecf3-11e7-922d-d43d590ce8dd.png)
(my list shows a few gallery extensions because I've bumped their version numbers in my copies of them, and the extension list is fixed at iconic to encourage users to make icons for their extensions)

We know that third-party extensions exist floating around unpublished for whatever reasons, and while the XKit Editor does provide the same functionality, it's not a very clean-feeling method - and more importantly doesn't give us any potential protection steps with installing unpublished third-party extensions.

I assume this won't be looked at for a while but in case it is, I do plan to work on some basic protections when importing extensions, such as enforcing the same rules as XKit Packs. Check back soon or bug me to work on it!