### PR TITLE
Blacklist author fix

### DIFF
--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -516,7 +516,7 @@ XKit.extensions.blacklist = new Object({
 				var m_author = "";
 				if (XKit.extensions.blacklist.preferences.check_authors.value) {
 					try {
-						var post_info_links = $(this).find(".post_info_link, .reblog-tumblelog-name.inactive").map(function() {
+						var post_info_links = $(this).find(".post_info_link, .reblog-tumblelog-name").map(function() {
 							return $(this).text();
 						});
 

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1,5 +1,5 @@
 //* TITLE Blacklist **//
-//* VERSION 2.9.4 **//
+//* VERSION 2.9.5 **//
 //* DESCRIPTION Clean your dash **//
 //* DETAILS This extension allows you to block posts based on the words you specify. If a post has the text you've written in the post itself or it's tags, it will be replaced by a warning, or won't be shown on your dashboard, depending on your settings. **//
 //* DEVELOPER new-xkit **//

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -516,7 +516,7 @@ XKit.extensions.blacklist = new Object({
 				var m_author = "";
 				if (XKit.extensions.blacklist.preferences.check_authors.value) {
 					try {
-						var post_info_links = $(this).find(".post_info_link").map(function() {
+						var post_info_links = $(this).find(".post_info_link, .reblog-tumblelog-name.inactive").map(function() {
 							return $(this).text();
 						});
 
@@ -556,8 +556,8 @@ XKit.extensions.blacklist = new Object({
 					m_content = $(this).find(".caption").html();
 				}
 
-				if ($(this).find(".reblog-list-item").length > 0) {
-					m_content = $(this).find(".reblog-list-item").map(function() {
+				if ($(this).find(".reblog-content").length > 0) {
+					m_content = $(this).find(".reblog-content").map(function() {
 					    return $(this).html();
 					}).get().join(" ");
 				}


### PR DESCRIPTION
Blacklist wouldn't properly isolate authors within the reblog chain, and would treat them as normal text (and block the post when the setting wasn't selected)