### PR TITLE
stop Retags running on the Activity dropdown 3 times

### DIFF
--- a/Extensions/retags.js
+++ b/Extensions/retags.js
@@ -1,6 +1,6 @@
 //* TITLE       Retags **//
 //* DEVELOPER   new-xkit **//
-//* VERSION     1.2.2 **//
+//* VERSION     1.2.3 **//
 //* DESCRIPTION Adds tags to reblog notes **//
 //* FRAME       false **//
 //* SLOW        false **//
@@ -9,7 +9,7 @@
 XKit.extensions.retags = {
 	running: false,
 	api_key: XKit.api_key,
-	selectors: '.type_2,.type_8,.type_6,.reblog:not(.ui_avatar_link),.is_reblog,.notification_reblog,.is_reply,.is_answer,.is_user_mention,.notification_user_mention',
+	selectors: '.type_2,.type_8,.type_6,.reblog:not(.ui_avatar_link, .retags_has_processed),.is_reblog,.notification_reblog,.is_reply,.is_answer,.is_user_mention,.notification_user_mention',
 	blog_name: "",
 
 	run: function() {
@@ -91,7 +91,7 @@ XKit.extensions.retags = {
 
 	tag: function(elements) {
 		$(elements).each(function() {
-			var $element = $(this),	retagClass, $target, url, host, id;
+			var $element = $(this).addClass("retags_has_processed"), retagClass, $target, url, host, id;
 			if ($element.find('div.retags').length) {
 				return false;
 			}


### PR DESCRIPTION
For some reason the way tumblr loads the Activity dropdown(?) triggers Retags' mutation observer a good total of three times for no obvious reason, causing the two "You are running multiple copies of Retags" errors after it's already added tags to the note.
(First two methods inefficient/insufficient, redacted)
Now adds a class to each note the extension begins processing and doesn't run on notes found with that class, much like other extensions which affect posts
Resolves #1361 