### PR TITLE
Accurately describe Blacklist-related Highlighter option

### DIFF
--- a/Extensions/highlighter.js
+++ b/Extensions/highlighter.js
@@ -1,5 +1,5 @@
 //* TITLE Highlighter **//
-//* VERSION 0.1.2 **//
+//* VERSION 0.1.3 **//
 //* DESCRIPTION Don't miss things **//
 //* DETAILS The cousin of Blacklister, this extension highlights posts depending on the words you decide. When a word you add is found on a post, the post will get a yellow-ish background. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -28,7 +28,7 @@ XKit.extensions.highlighter = new Object({
 			value: true
 		},
 		"check_for_blocking": {
-			text: "Don't unblock posts if it were blocked by the Blacklist extension",
+			text: "Don't highlight posts hidden by Blacklist",
 			default: true,
 			value: true
 		},


### PR DESCRIPTION
having 2 whitelists could be confusing and detrimental to some users, so the option's description now fits its behaviour (rather than making its behaviour fit its description)
resolves #1460 