### PR TITLE
New XCloud feature: AutoSync

### DIFF
--- a/Extensions/classic_header.js
+++ b/Extensions/classic_header.js
@@ -1,5 +1,5 @@
 //* TITLE Header Options **//
-//* VERSION 2.5.1 **//
+//* VERSION 2.5.2 **//
 //* DESCRIPTION Customize the header. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS This extension adds your blogs on the top of the page, so you can easily switch between blogs. The blog limit on the header is five, but you can limit this to three blogs and turn off the blog title bubble from the settings. **//
@@ -238,7 +238,7 @@ XKit.extensions.classic_header = new Object({
 						' style=\'background: ' + blog_icon + '\' title="' + blog_name + '">&nbsp;</a>' +
 						' <div class="selection_nipple"></div></div>';
 				});
-				XKit.storage.set("classic_header", "header_html", m_html);
+				XKit.storage.set("classic_header", "header_html", m_html, true);
 			} else {
 				if (XKit.storage.get("classic_header", "header_html", "") === "") {
 					return;

--- a/Extensions/read_posts.js
+++ b/Extensions/read_posts.js
@@ -1,5 +1,5 @@
 //* TITLE Read Posts **//
-//* VERSION 0.2.2 **//
+//* VERSION 0.2.3 **//
 //* DESCRIPTION Dim old posts **//
 //* DETAILS Dims the posts on the dashboard that you've already seen on previous page loads. **//
 //* DEVELOPER jesskay **//
@@ -71,7 +71,7 @@ XKit.extensions.read_posts = new Object({
 		}
 
 		read_posts.push(post_id);
-		XKit.storage.set('read_posts', 'read_posts', JSON.stringify(read_posts));
+		XKit.storage.set('read_posts', 'read_posts', JSON.stringify(read_posts), true);
 	},
 
 	post_is_read: function(post_id) {

--- a/Extensions/retags.js
+++ b/Extensions/retags.js
@@ -1,6 +1,6 @@
 //* TITLE       Retags **//
 //* DEVELOPER   new-xkit **//
-//* VERSION     1.2.4 **//
+//* VERSION     1.2.5 **//
 //* DESCRIPTION Adds tags to reblog notes **//
 //* FRAME       false **//
 //* SLOW        false **//
@@ -157,7 +157,7 @@ XKit.extensions.retags = {
 				if (XKit.extensions.retags.should_clear_posts()) {
 					XKit.extensions.retags.clear_old_posts();
 				}
-				XKit.storage.set('retags', cache_label, tags);
+				XKit.storage.set('retags', cache_label, tags, true);
 				deferred.resolve(tags);
 			},
 			onerror: function(error) {
@@ -230,7 +230,7 @@ XKit.extensions.retags = {
 
 		// And finally write back to storage!
 		settingKeys.forEach(function(key) {
-			XKit.storage.set('retags', key, cache[key].value);
+			XKit.storage.set('retags', key, cache[key].value, true);
 		});
 	},
 
@@ -246,13 +246,13 @@ XKit.extensions.retags = {
 		}
 		$('#retags-toggle').change(function() {
 			if ($(this).prop('checked')) {
-				XKit.storage.set('retags', toggle, 'true');
+				XKit.storage.set('retags', toggle, 'true', true);
 				XKit.extensions.retags.css_toggle.appendTo('head');
 				if (XKit.browser().mobile) {
 					XKit.extensions.retags.mobile_toggle.appendTo('head');
 				}
 			} else {
-				XKit.storage.set('retags', toggle, 'false');
+				XKit.storage.set('retags', toggle, 'false', true);
 				XKit.extensions.retags.css_toggle.detach();
 			}
 		});

--- a/Extensions/separator.js
+++ b/Extensions/separator.js
@@ -1,5 +1,5 @@
 //* TITLE Separator **//
-//* VERSION 1.1.3 **//
+//* VERSION 1.1.4 **//
 //* DESCRIPTION Where were we again? **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS A simple extension that puts a divider showing where you left off on your dashboard. **//
@@ -120,7 +120,7 @@ XKit.extensions.separator = new Object({
 
 		}
 
-		XKit.storage.set("separator", "last_post", $(current_last_post).attr('data-post-id'));
+		XKit.storage.set("separator", "last_post", $(current_last_post).attr('data-post-id'), true);
 
 	},
 

--- a/Extensions/show_more.js
+++ b/Extensions/show_more.js
@@ -1,5 +1,5 @@
 //* TITLE User Menus+ **//
-//* VERSION 2.5.7 **//
+//* VERSION 2.5.8 **//
 //* DESCRIPTION More options on the user menu **//
 //* DEVELOPER new-xkit **//
 //* DETAILS This extension adds additional options to the user menu (the one that appears under user avatars on your dashboard), such as Avatar Magnifier, links to their Liked Posts page if they have them enabled. Note that this extension, especially the Show Likes and Show Submit options use a lot of network and might slow your computer down. **//
@@ -77,7 +77,7 @@ XKit.extensions.show_more = new Object({
 			XKit.extensions.show_more.init_inbox_asks();
 		} else {
 			if ($("#dashboard_ask_template").length > 0) {
-				XKit.storage.set("show_more", "inbox_ask_template", $("#dashboard_ask_template")[0].outerHTML);
+				XKit.storage.set("show_more", "inbox_ask_template", $("#dashboard_ask_template")[0].outerHTML, true);
 			}
 		}
 

--- a/Extensions/show_originals.js
+++ b/Extensions/show_originals.js
@@ -1,5 +1,5 @@
 //* TITLE Show Originals **//
-//* VERSION 1.2.3 **//
+//* VERSION 1.2.4 **//
 //* DESCRIPTION Only shows non-reblogged posts **//
 //* DETAILS This is a really experimental extension allows you see original (non-reblogged) posts made by users on your dashboard. Please keep in mind that if you don't have enough people creating new posts on your dashboard, it might slow down your computer. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -99,7 +99,7 @@ XKit.extensions.show_originals = new Object({
 		}
 
 		XKit.extensions.show_originals.update_button();
-		XKit.storage.set("show_originals", "status", XKit.extensions.show_originals.status);
+		XKit.storage.set("show_originals", "status", XKit.extensions.show_originals.status, true);
 
 	},
 

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -1,5 +1,5 @@
 //* TITLE Timestamps **//
-//* VERSION 2.7.8 **//
+//* VERSION 2.7.9 **//
 //* DESCRIPTION See when a post has been made. **//
 //* DETAILS This extension lets you see when a post was made, in full date or relative time (eg: 5 minutes ago). It also works on asks, and you can format your timestamps. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -49,16 +49,16 @@ XKit.extensions.timestamps = new Object({
 		if (XKit.storage.size("timestamps") >= 800) {
 			XKit.storage.clear("timestamps");
 			if (this.preferences.only_relative.value) {
-				XKit.storage.set("timestamps", "extension__setting__only_relative", "true");
+				XKit.storage.set("timestamps", "extension__setting__only_relative", "true", true);
 			}
 			if (this.preferences.only_inbox.value) {
-				XKit.storage.set("timestamps", "extension__setting__only_inbox", "true");
+				XKit.storage.set("timestamps", "extension__setting__only_inbox", "true", true);
 			}
 			if (this.preferences.only_on_hover.value) {
-				XKit.storage.set("timestamps", "extension__setting__only_on_hover", "true");
+				XKit.storage.set("timestamps", "extension__setting__only_on_hover", "true", true);
 			}
 			if (this.preferences.format.value !== "") {
-				XKit.storage.set("timestamps", "extension__setting__format", this.preferences.format.value);
+				XKit.storage.set("timestamps", "extension__setting__format", this.preferences.format.value, true);
 			}
 		}
 
@@ -242,7 +242,7 @@ XKit.extensions.timestamps = new Object({
 				}
 
 				date_element.removeClass("xtimestamp_loading");
-				XKit.storage.set("timestamps", "xkit_timestamp_cache_" + post_id, date.unix());
+				XKit.storage.set("timestamps", "xkit_timestamp_cache_" + post_id, date.unix(), true);
 			}
 		});
 	},
@@ -270,7 +270,7 @@ XKit.extensions.timestamps = new Object({
 						var date = moment(new Date(post.timestamp * 1000));
 						date_element.html(self.format_date(date));
 						date_element.removeClass("xtimestamp_loading");
-						XKit.storage.set("timestamps", "xkit_timestamp_cache_" + post_id, post.timestamp);
+						XKit.storage.set("timestamps", "xkit_timestamp_cache_" + post_id, post.timestamp, true);
 					} catch (e) {
 						XKit.console.add('Unable to load timestamp for post ' + post_id);
 						self.show_failed(date_element);

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Tweaks **//
-//* VERSION 5.5.8 **//
+//* VERSION 5.5.9 **//
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -394,7 +394,7 @@ XKit.extensions.tweaks = new Object({
 						// Save this.
 							var m_to_save = $("#new_post_buttons")[0].outerHTML;
 							m_to_save = "!" + btoa(m_to_save);
-							XKit.storage.set("tweaks", "new_post_buttons_html", m_to_save);
+							XKit.storage.set("tweaks", "new_post_buttons_html", m_to_save, true);
 
 						} else {
 

--- a/Extensions/xcloud.js
+++ b/Extensions/xcloud.js
@@ -1,7 +1,7 @@
 //* TITLE XCloud **//
-//* VERSION 1.1.1 **//
+//* VERSION 1.2.0 **//
 //* DESCRIPTION Sync XKit data on clouds **//
-//* DETAILS XCloud stores your XKit configuration on New-XKit servers so you can back up your data and synchronize it with other computers and browsers easily. Also compatable with STUDIOXENIX servers.**//
+//* DETAILS XCloud stores your XKit configuration on New-XKit servers so you can back up your data and synchronize it with other computers and browsers easily. **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
 //* BETA false **//
@@ -14,7 +14,34 @@ XKit.extensions.xcloud = new Object({
 	useoldserver: true,
 	gallery_available: {},
 	extensions_upgraded: false,
+	preferences: {
+		"sep_0": {
+			text: "AutoSync&emsp;<a id=\"xkit-autosync-help\" href=\"#\" onclick=\"return false\">What is this?</a>",
+			type: "separator"
+		},
+		"shortcut": {
+			text: "Enable alt + C shortcut to use AutoSync",
+			default: false,
+			value: false,
+			experimental: true
+		}
+	},
 
+	cpanel: function() {
+		$("#xkit-autosync-help").click(function() {
+			XKit.window.show("What is AutoSync?", "AutoSync is a helpful tool that syncs your data in the right direction for you.<br/><br/>" +
+			"It's especially useful for travelling between computers; you can't accidentally upload an older config to XCloud if AutoSync is doing everything for you.<br/><br/>" +
+			"However, just switching this option on will make XKit think your current configuration is the newest, so please enable it on all your computers before using it, or it won't work as intended.",
+			"info", "<div class=\"xkit-button default\" id=\"xkit-close-message\">OK</div> <div class=\"xkit-button\" id=\"xkit-autosync-continue\">How does it work?</div>");
+			$("#xkit-autosync-continue").click(function() {
+				XKit.window.show("How does AutoSync work?", "Whenever XKit's storage system is written to, a timestamp is stored, which gets sent along with your settings when you upload to XCloud.<br/><br/>" +
+				"Provided your XCloud data has a timestamp, AutoSync can read it and determine whether your XCloud is newer or older than your current configuration.<br/><br/>" +
+				"If the timestamp is newer, it saves the data it received while checking the timestamp.<br/><br/>" +
+				"If the timestamp is older, it discards the data it receives and uploads your current config.",
+				"info", "<div class=\"xkit-button default\" id=\"xkit-close-message\">OK</div>");
+			});
+		});
+	},
 
 	get_xcloud_url: function() {
 		if (XKit.extensions.xcloud.useoldserver) {
@@ -30,6 +57,19 @@ XKit.extensions.xcloud = new Object({
 		XKit.tools.init_css("xcloud");
 		this.load_user_login();
 		$("#xkit-cp-tab-xcloud").css("display", "block");
+		if (this.preferences.shortcut.value === true) {
+			$(document).on('keydown', XKit.extensions.xcloud.key_down);
+		}
+	},
+
+	key_down: function(e) {
+		if (e.altKey === true && e.which === 67 && !$("#xcloud-overlay, #xkit-window, #xkit-control-panel").length > 0) {
+			if (XKit.storage.get("xkit_preferences", "launch_count") <= 5) {
+				XKit.extensions.xcloud.start_fetch(false);
+			} else {
+				XKit.extensions.xcloud.start_fetch(true);
+			}
+		}
 	},
 
 	reload_welcome_panel: function() {
@@ -461,7 +501,7 @@ XKit.extensions.xcloud = new Object({
 		$("#xcloud-restore-do").unbind("click");
 		$("#xcloud-restore-do").bind("click", function() {
 
-			XKit.extensions.xcloud.start_fetch();
+			XKit.extensions.xcloud.start_fetch(false);
 
 		});
 
@@ -498,7 +538,7 @@ XKit.extensions.xcloud = new Object({
 			if (this.files.length === 1) {
 				var reader  = new FileReader();
 				reader.addEventListener('loadend', function(result) {
-					self.process_restore({"data":result.currentTarget.result});
+					self.process_restore({"data":result.currentTarget.result}, false);
 				});
 				reader.readAsText(this.files[0]);
 			}
@@ -551,12 +591,21 @@ XKit.extensions.xcloud = new Object({
 
 	},
 
-	start_fetch: function() {
+	start_fetch: function(auto) {
 		var xcloud_url = this.get_xcloud_url();
 		XKit.extensions.xcloud.show_overlay(true);
 
 		var m_username = XKit.extensions.xcloud.username;
 		var m_password = XKit.extensions.xcloud.password;
+
+		if (m_username === "" || m_password === "") {
+			XKit.extensions.xcloud.hide_overlay();
+			XKit.window.show("AutoSync failure!",
+							"You don't seem to be logged into XCloud.<br/>" +
+							"Please log into XCloud before using AutoSync.",
+							"error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
+			return;
+		}
 
 		var fetchRequest = {
 			method: "GET",
@@ -579,12 +628,16 @@ XKit.extensions.xcloud = new Object({
 				}
 
 				if (data.errors === "false") {
-					XKit.extensions.xcloud.process_restore(data);
+					XKit.extensions.xcloud.process_restore(data, auto);
 
 				} else {
 
 					XKit.extensions.xcloud.hide_overlay();
 					var err_desc = "";
+					if (typeof data.error_code  === undefined) {
+						err_desc = "<br/>No error code was given.<br/>" +
+						"It might be that you have no XCloud data.";
+					}
 					if (data.error_code === "102") {
 						err_desc = "<br/>Usernames can only have letters and numbers.";
 					}
@@ -622,7 +675,7 @@ XKit.extensions.xcloud = new Object({
 	extensions_to_download_count: 0,
 	errors_list: [],
 
-	process_restore: function(mdata) {
+	process_restore: function(mdata, auto) {
 
 		var m_obj = null;
 		try {
@@ -642,7 +695,11 @@ XKit.extensions.xcloud = new Object({
 			return;
 		}
 
-		$("#xcloud-overlay-title").html("Restoring settings...");
+		if (auto) {
+			$("#xcloud-overlay-title").html("Checking timestamp...");
+		} else {
+			$("#xcloud-overlay-title").html("Restoring settings...");
+		}
 
 		XKit.extensions.xcloud.errors_list = [];
 		XKit.extensions.xcloud.extensions_to_download = [];
@@ -657,6 +714,12 @@ XKit.extensions.xcloud = new Object({
 			var mext = m_obj.settings[ext];
 
 			var extension_name = mext.extension;
+
+			if (auto && extension_name !== "xkit_preferences") {
+				continue;
+			} else if (auto) {
+				var localstamp = XKit.storage.get("xkit_preferences", "last_update");
+			}
 
 			XKit.console.add("Restoring settings of " + extension_name);
 
@@ -690,8 +753,29 @@ XKit.extensions.xcloud = new Object({
 			full_list.push(extension_name);
 
 
-			if (extension_name !== "xcloud") {
+			if (!auto && extension_name !== "xcloud" || auto && extension_name === "xkit_preferences") {
 				XKit.tools.set_setting("xkit_extension_storage__" + extension_name, JSON.stringify(extension_settings));
+				if (auto && XKit.storage.get("xkit_preferences", "last_update") === "") {
+					XKit.window.show("AutoSync failure!",
+					"Your XCloud data has no timestamp, so AutoSync can't tell if it's newer or older than your current configuration.<br/><br/>" +
+					"Please manually upload to XCloud once for AutoSync to work.",
+					"error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
+					return;
+				} else if (auto && XKit.storage.get("xkit_preferences", "last_update") < localstamp) {
+					XKit.storage.set("xkit_preferences", "last_update", localstamp, true);
+					XKit.extensions.xcloud.start_upload();
+					return;
+				} else if (auto && XKit.storage.get("xkit_preferences", "last_update") > localstamp) {
+					$("#xcloud-overlay-title").html("Restoring settings...");
+					auto = false;
+				} else if (auto) {
+					XKit.extensions.xcloud.hide_overlay();
+					XKit.window.show("All up to date!", "Your XKit configuration and XCloud data already match.", "info");
+					setTimeout(function() {
+						XKit.window.close();
+					}, 2000);
+					return;
+				}
 			}
 
 		}
@@ -811,12 +895,6 @@ XKit.extensions.xcloud = new Object({
 
 		for (var i = 0; i < installed.length; i++) {
 
-			// Skip internal extensions.
-			if (installed[i].substring(0, 5) === "xkit_") {
-				continue;
-			}
-
-
 			var m_data;
 
 			//XCloud data was being pushed up with user's md5 hash which is kind of a security issue.
@@ -918,7 +996,11 @@ XKit.extensions.xcloud = new Object({
 				}
 				if (mdata.errors === "false") {
 					XKit.extensions.xcloud.hide_overlay();
-					XKit.extensions.xcloud.change_panel("<div class=\"xcloud-title\" style=\"margin-top: 80px;\">All done!</div>Your XKit settings are now in sync with XCloud. <div id=\"xcloud-start-using\" class=\"xcloud-inline-button xkit-button default\">OK</div>");
+					if ($("#xkit-control-panel").length > 0) {
+						XKit.extensions.xcloud.change_panel("<div class=\"xcloud-title\" style=\"margin-top: 80px;\">All done!</div>Your XKit settings are now in sync with XCloud. <div id=\"xcloud-start-using\" class=\"xcloud-inline-button xkit-button default\">OK</div>");
+					} else {
+						XKit.notifications.add("<b>All done!</b><br/>Your XKit settings are now in sync with XCloud.", "ok");
+					}
 				} else {
 					XKit.extensions.xcloud.hide_overlay();
 					var err_desc = "";


### PR DESCRIPTION
Ported from #1400 so I can work on it more effectively (and without spamming the discord with each commit...)
> AutoSync compares your local data with XCloud data and sees which is newer, and automatically synchronises the two, replacing the old with the new. It's quick, it's automatic, and very useful for people hopping between computers all the time - no need to remember which computer you're even sitting at, just alt + C and the magic happens.

To-Do:
- [x] Re-check if the additions to XKit Preferences are even necessary
- [x] Remove the timestamp blacklist; instead add another parameter to XKit.storage.set
- [x] Look through every extension and add the new parameter as necessary