### PR TITLE
Fix typo in the OCP popup's markup for those who use the non-reversed UI

### DIFF
--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.3.5 **//
+//* VERSION 4.3.6 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -591,7 +591,7 @@ XKit.extensions.one_click_postage = new Object({
 						"<div id=\"x1cpostage_reblog\"><i>&nbsp;</i></div>" +
 						"<div id=\"x1cpostage_queue\"><i>&nbsp;</i></div>" +
 						"<div id=\"x1cpostage_draft\"><i>&nbsp;</i></div>" +
-						"<textarea id=\"x1cpostage_caption\" + m_remove_box_style + placeholder=\"caption\"></textarea>" +
+						"<textarea id=\"x1cpostage_caption\" " + m_remove_box_style + " placeholder=\"caption\"></textarea>" +
 						"<div id=\"x1cpostage_replace\" " + m_remove_box_style + "><div>&nbsp;</div>replace caption, not append</div>" +
 						m_remove_button +
 						"<input id=\"x1cpostage_tags\" placeholder=\"tags (comma separated)\" />" +


### PR DESCRIPTION
(I'm too lazy to rewrite this with template strings.)