### PR TITLE
Prevent Retags from making note containers scroll horizontally

### DIFF
--- a/Extensions/retags.css
+++ b/Extensions/retags.css
@@ -34,6 +34,7 @@ label.retags .binary_switch_label {
 
 div.retags {
     white-space: normal;
+    overflow-wrap: break-word;
     margin-bottom: 10px;
     font-size: 12px;
     clear: both;

--- a/Extensions/retags.js
+++ b/Extensions/retags.js
@@ -1,6 +1,6 @@
 //* TITLE       Retags **//
 //* DEVELOPER   new-xkit **//
-//* VERSION     1.2.3 **//
+//* VERSION     1.2.4 **//
 //* DESCRIPTION Adds tags to reblog notes **//
 //* FRAME       false **//
 //* SLOW        false **//


### PR DESCRIPTION
Prevents ridiculously long tags with no spaces doing... this

![screenshot 2017-11-30 at 05 28 32](https://user-images.githubusercontent.com/28949509/33415950-e0f08c6a-d591-11e7-9402-85e5b3f19b6e.png)

(result:

![screenshot 2017-11-30 at 05 52 07](https://user-images.githubusercontent.com/28949509/33416091-a3f7eb40-d592-11e7-853f-3a634e825b5d.png)
)