### PR TITLE
Fix various extension options (unneeded, typos, improper labelling)

### DIFF
--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1,5 +1,5 @@
 //* TITLE Blacklist **//
-//* VERSION 2.9.4 **//
+//* VERSION 2.9.5 **//
 //* DESCRIPTION Clean your dash **//
 //* DETAILS This extension allows you to block posts based on the words you specify. If a post has the text you've written in the post itself or it's tags, it will be replaced by a warning, or won't be shown on your dashboard, depending on your settings. **//
 //* DEVELOPER new-xkit **//
@@ -43,7 +43,8 @@ XKit.extensions.blacklist = new Object({
 			value: true
 		},
 		"right_click": {
-			text: "Enable alt + click on highlighted text to add words (experimental)",
+			text: "Enable alt + click on highlighted text to add words",
+			experimental: true,
 			default: false,
 			value: false
 		},
@@ -92,7 +93,8 @@ XKit.extensions.blacklist = new Object({
 			value: false
 		},
 		"use_improved": {
-			text: "Use improved checking (might slow down your computer)",
+			text: "Use improved checking",
+			slow: true,
 			default: true,
 			value: true
 		},

--- a/Extensions/highlighter.js
+++ b/Extensions/highlighter.js
@@ -1,5 +1,5 @@
 //* TITLE Highlighter **//
-//* VERSION 0.1.3 **//
+//* VERSION 0.1.4 **//
 //* DESCRIPTION Don't miss things **//
 //* DETAILS The cousin of Blacklister, this extension highlights posts depending on the words you decide. When a word you add is found on a post, the post will get a yellow-ish background. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -18,7 +18,8 @@ XKit.extensions.highlighter = new Object({
 			type: "separator"
 		},
 		"use_improved": {
-			text: "Use improved checking (might slow down your computer)",
+			text: "Use improved checking",
+			slow: true,
 			default: true,
 			value: true
 		},

--- a/Extensions/lethe.js
+++ b/Extensions/lethe.js
@@ -1,5 +1,5 @@
 //* TITLE Hermes **//
-//* VERSION 1.2.2 **//
+//* VERSION 1.2.3 **//
 //* DESCRIPTION Helps speed up your Tumblr experience **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -14,13 +14,6 @@ function Lethe() {
 	this.running = false;
 	this.scrollWaiting = false;
 	this.hiddenPosts = [];
-	this.preferences = {
-		'sep0': {
-			text: 'Options',
-			type: 'separator'
-		}
-	};
-
 }
 
 /**

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.3.6 **//
+//* VERSION 4.3.7 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -43,7 +43,7 @@ XKit.extensions.one_click_postage = new Object({
 			experimental: true
 		},
 		"sep_5": {
-			text: "AlreadyReblogged <a id=\"xkit-alreadyreblogged-help\" href=\"#\" onclick=\"return false\">what is this?</a>",
+			text: "AlreadyReblogged&emsp;<a id=\"xkit-alreadyreblogged-help\" href=\"#\" onclick=\"return false\">what is this?</a>",
 			type: "separator",
 		},
 		"enable_alreadyreblogged": {
@@ -122,7 +122,8 @@ XKit.extensions.one_click_postage = new Object({
 			value: false
 		},
 		"allow_resize": {
-			text: "Allow resizing of the caption box vertically (experimental)",
+			text: "Allow resizing of the caption box vertically",
+			experimental: true,
 			default: false,
 			value: false
 		},

--- a/Extensions/one_click_reply.js
+++ b/Extensions/one_click_reply.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Reply **//
-//* VERSION 2.1.1 **//
+//* VERSION 2.1.2 **//
 //* DESCRIPTION Lets you reply to notifications **//
 //* DEVELOPER new-xkit **//
 //* DETAILS To use this extension, hover over a notification and click on the Reply button. If Multi-Reply is on, hold down the ALT key while clicking on the Reply button to select/deselect posts and reply to all of them at once. **//
@@ -43,7 +43,7 @@ XKit.extensions.one_click_reply = new Object({
 			type: "separator"
 		},
 		"mention_people": {
-			text: "Use the 'mentioning' feature of Tumblr on replies (extremely experimental)",
+			text: "Use the 'mentioning' feature of Tumblr on replies",
 			default: false,
 			value: false,
 			experimental: true,

--- a/Extensions/quick_tags.js
+++ b/Extensions/quick_tags.js
@@ -1,5 +1,5 @@
 //* TITLE Quick Tags **//
-//* VERSION 0.5.9 **//
+//* VERSION 0.5.10 **//
 //* DESCRIPTION Quickly add tags to posts **//
 //* DETAILS Allows you to create tag bundles and add tags to posts without leaving the dashboard. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -39,7 +39,7 @@ XKit.extensions.quick_tags = new Object({
 			default: false
 		},
 		"hide_new_bundle_button": {
-			text: "Hides the new bundle button at the end of One-Click Postage",
+			text: "Hide the new bundle button at the end of One-Click Postage",
 			value: false,
 			default: false
 		},

--- a/Extensions/show_more.js
+++ b/Extensions/show_more.js
@@ -1,5 +1,5 @@
 //* TITLE User Menus+ **//
-//* VERSION 2.5.6 **//
+//* VERSION 2.5.7 **//
 //* DESCRIPTION More options on the user menu **//
 //* DEVELOPER new-xkit **//
 //* DETAILS This extension adds additional options to the user menu (the one that appears under user avatars on your dashboard), such as Avatar Magnifier, links to their Liked Posts page if they have them enabled. Note that this extension, especially the Show Likes and Show Submit options use a lot of network and might slow your computer down. **//
@@ -50,15 +50,6 @@ XKit.extensions.show_more = new Object({
 			text: "Show Submit button if user has their submit box enabled",
 			default: false,
 			value: false
-		},
-		"sep2": {
-			text: "In-Dashboard Asks",
-			type: "separator",
-		},
-		"enable_anon": {
-			text: "Enable sending anonymous messages from the dashboard",
-			default: true,
-			value: true
 		}
 	},
 
@@ -655,48 +646,6 @@ XKit.extensions.show_more = new Object({
 				}, 100 + (submit_delay_count * 100));
 
 				submit_delay_count++;
-
-			});
-
-		}
-
-		if (XKit.extensions.show_more.preferences.enable_anon.value) {
-
-			var anon_delay_count = 0;
-
-			$(".post_avatar").not(".xkit-show-more-anons-done").each(function() {
-
-				$(this).addClass("xkit-show-more-anons-done");
-
-				var username = $(this).parent().attr('data-tumblelog-name');
-
-				if (typeof XKit.extensions.show_more.anon_available[username] === "boolean") {
-					return;
-				}
-
-				var m_url = "https://www.tumblr.com/ask_form/" + username + ".tumblr.com";
-
-				if (typeof username === "undefined" || username === "") {
-					return;
-				}
-
-				// Temporarily set it to false while we fetch pages.
-				XKit.extensions.show_more.anon_available[username] = false;
-
-				setTimeout(function() {
-					GM_xmlhttpRequest({
-						url: m_url,
-						onload: function(data) {
-							if ($("#ask_anonymously", data).length > 0) {
-								XKit.extensions.show_more.anon_available[username] = true;
-							} else {
-								XKit.console.add("No anon messages for " + username);
-							}
-						}
-					});
-				}, 100 + (anon_delay_count * 100));
-
-				anon_delay_count++;
 
 			});
 

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Tweaks **//
-//* VERSION 5.5.5 **//
+//* VERSION 5.5.6 **//
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -59,12 +59,6 @@ XKit.extensions.tweaks = new Object({
 			default: false,
 			value: false,
 			desktop_only: true
-		},
-		"photo_replies": {
-			text: "Auto-enable photo replies on all posts I create",
-			default: false,
-			value: false,
-			experimental: true
 		},
 		"sep001": {
 			text: "Post / Post Editor tweaks",
@@ -241,7 +235,7 @@ XKit.extensions.tweaks = new Object({
 			value: true
 		},
 		"responsive_dash": {
-			text: "Make the dashboard resize with the window.",
+			text: "Make the dashboard resize with the window",
 			default: false,
 			value: false
 		},
@@ -279,12 +273,6 @@ XKit.extensions.tweaks = new Object({
 		},
 		"hide_radar": {
 			text: "Hide the Tumblr radar",
-			default: false,
-			value: false,
-			desktop_only: true
-		},
-		"hide_find_blogs": {
-			text: "Hide \"Find Blogs\" button",
 			default: false,
 			value: false,
 			desktop_only: true
@@ -449,12 +437,6 @@ XKit.extensions.tweaks = new Object({
 			$(".radar_header").parent().css("display", "none");
 		}
 
-		if (XKit.extensions.tweaks.preferences.photo_replies.value) {
-			this.run_interval = setInterval(function() {
-				$("#allow_photo_replies").attr('checked', true);
-			}, 3000);
-		}
-
 		if (XKit.extensions.tweaks.preferences.real_red.value) {
 			XKit.extensions.tweaks.add_css(" .like.liked.post_control:after { background-position: 4px 3px !important; background-size: auto auto !important; background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAARCAYAAAA/mJfHAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6RDQzQ0MxODI5Qzc4MTFFMzg1NkE5NjNCNTgyRjU3NjEiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6RDQzQ0MxODM5Qzc4MTFFMzg1NkE5NjNCNTgyRjU3NjEiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDpENDNDQzE4MDlDNzgxMUUzODU2QTk2M0I1ODJGNTc2MSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDpENDNDQzE4MTlDNzgxMUUzODU2QTk2M0I1ODJGNTc2MSIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Poem3hoAAAEdSURBVHjaYtypzQADjEBsDcQGQPweiLcD8TsGTCAExF5ALADEF4D4KBD/B0mwQBVoAPEKINZH0vQFiMuAeDqSWCYQdwExD5LYRSCOAOIbTEBCEIh3oxnEANUwDaoZBHqhfB40dfpQ/YIglxUCsQwDblAKxJZAbINHDUh/PshlPgyEgQ0RanxBhikyUAcoMjFQDzCCDHtEJcMeMUFjghpgF8iwuUD8h0KDQPrnggy7DsRTKDRsCizRgkA5EB8n06DjUP0MMMN+AbEfEJ8j0aBzUH2/kA0DgTdA7ADEa4g0aDVU/RuYAHo6+wzEoUCcBWVjA5+h8mHoanAlWlBJoQXE69DE10LFp2PThC8HPAHiYGgmXwSlQ6DiWAFAgAEALHgzuY5LA00AAAAASUVORK5CYII=);  } #tab_switching .tab_notice, #header .tab .tab_notice, .popover_blogs .tab_notice, .blog_menu .selected_blog .tab_notice { background-color: #bb2502; }", "xkit_tweaks_real_red");
 		}
@@ -568,10 +550,6 @@ XKit.extensions.tweaks = new Object({
 
 		if (XKit.extensions.tweaks.preferences.hide_section_headers.value) {
 			XKit.extensions.tweaks.add_css(".controls_section li.section_header { display: none; } ", "xkit_tweaks_hide_section_headers");
-		}
-
-		if (XKit.extensions.tweaks.preferences.hide_find_blogs.value) {
-			$("a.spotlight").parent().css("display", "none");
 		}
 
 		if (XKit.extensions.tweaks.preferences.always_show_move_to_top.value) {

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 7.4.5 **//
+//* VERSION 7.4.6 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER new-xkit **//
 
@@ -1421,7 +1421,7 @@ XKit.extensions.xkit_preferences = new Object({
 			var m_ext = XKit.installed.get(XKit.extensions.xkit_preferences.current_open_extension_panel);
 
 			XKit.window.show("Uninstall " + m_ext.title + "?",
-				"This extension will be completely deleted from your computer." +
+				"This extension will be completely deleted from your computer. " +
 				"If you change your mind, you can re-download it from the extension gallery later.",
 				"question", '<div id="xkit-extension-yes-uninstall" class="xkit-button default">Yes, uninstall</div>' +
 				'<div id="xkit-close-message" class="xkit-button">Cancel</div>');


### PR DESCRIPTION
Removes:
- Hermes' unneeded options header
- "Anonymous asks from the dashboard" (very old; now vanilla tumblr), resolves #247 
- Photo replies auto-enabling in tweaks (remember photo replies?)
- Hide Find Blogs button tweak (such a button no longer exists)

Fixes a few typos and makes AlreadyReblogged's "what is this?" button look nicer

Properly labels anything marked as "(might slow down your computer)" or "(experimental)" (now uses the proper icon)