### PR TITLE
Don't boot extensions on blogs unless explicitly specified

### DIFF
--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -1,14 +1,15 @@
 //* TITLE No Recommended **//
-//* VERSION 2.2.4 **//
+//* VERSION 2.2.5 **//
 //* DESCRIPTION Removes recommended posts **//
 //* DETAILS This extension removes recommended posts from your dashboard. To remove Recommended Blogs on the sidebar, please use Tweaks extension. **//
-//* DEVELOPER STUDIOXENIX **//
+//* DEVELOPER New-XKit **//
 //* FRAME false **//
 //* BETA false **//
 
 XKit.extensions.norecommended = new Object({
 
 	running: false,
+	onblog: true,
 
 	run: function() {
 		this.running = true;

--- a/Extensions/retags.js
+++ b/Extensions/retags.js
@@ -1,6 +1,6 @@
 //* TITLE       Retags **//
 //* DEVELOPER   new-xkit **//
-//* VERSION     1.2.5 **//
+//* VERSION     1.2.6 **//
 //* DESCRIPTION Adds tags to reblog notes **//
 //* FRAME       false **//
 //* SLOW        false **//
@@ -8,6 +8,7 @@
 
 XKit.extensions.retags = {
 	running: false,
+	onblog: true,
 	api_key: XKit.api_key,
 	selectors: '.type_2,.type_8,.type_6,.reblog:not(.ui_avatar_link, .retags_has_processed),.is_reblog,.is_reblog_naked,.notification_reblog,.is_reply,.is_answer,.is_user_mention,.notification_user_mention',
 	blog_name: "",

--- a/Extensions/xkit_main.js
+++ b/Extensions/xkit_main.js
@@ -1,7 +1,7 @@
 //* TITLE XKit Main **//
-//* VERSION 1.3.4 **//
+//* VERSION 1.3.5 **//
 //* DESCRIPTION Boots XKit up **//
-//* DEVELOPER STUDIOXENIX **//
+//* DEVELOPER New-XKit **//
 (function() {
 	if (typeof XKit.extensions.xkit_main !== "undefined") { return; }
 	XKit.extensions.xkit_main = new Object({
@@ -175,6 +175,18 @@
 
 			try {
 				eval(xkit_main.script + "\n//# sourceURL=xkit/" + extension_id + ".js");
+				if (document.location.href.indexOf("www.tumblr.com") === -1 && XKit.extensions[extension_id].onblog !== true) {
+					// Doesn't want to be run on blog page, quit.
+					if (XKit.extensions.xkit_main.disabled_extensions === "") {
+						XKit.extensions.xkit_main.disabled_extensions = extension_id + "(on blog)";
+					} else {
+						XKit.extensions.xkit_main.disabled_extensions = XKit.extensions.xkit_main.disabled_extensions + ", " + extension_id + "(on blog)";
+					}
+					if (!dont_run_next) {
+						XKit.extensions.xkit_main.run_next_extension();
+					}
+					return;
+				}
 				if (XKit.installed.enabled(extension_id) === true) {
 					if (XKit.extensions.xkit_main.enabled_extensions === "") {
 						XKit.extensions.xkit_main.enabled_extensions = extension_id;

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 6.8.11 **//
+//* VERSION 6.8.12 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -8,6 +8,7 @@ XKit.api_key = "kZSI0VnPBJom8cpIeTFw4huEh9gGbq4KfWKY7z5QECutAAki6D";
 XKit.extensions.xkit_patches = new Object({
 
 	running: false,
+	onblog: true,
 
 	preferences: {
 		debug_mode: {


### PR DESCRIPTION
Assumes that the only time XKit boots outside of `www.tumblr.com` and not in an iframe is on a user blog, and refuses to run extensions that don't (or shouldn't) affect themes - most prominently Tweaks (part of #1078).
Only XKit Patches, Retags and No Recommended whitelisted for on-blog use so far; hopefully I'm not forgetting anything!