### PR TITLE
Stop removing recommended posts in Tweaks

### DIFF
--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Tweaks **//
-//* VERSION 5.5.6 **//
+//* VERSION 5.5.7 **//
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -525,7 +525,7 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_recommended.value) {
-			XKit.extensions.tweaks.add_css("#recommended_tumblelogs, .recommended_tumblelogs, .trending_tumblelogs, .is_recommended, .recommended-unit-container { display: none !important; }", "xkit_tweaks_hide_recommended");
+			XKit.extensions.tweaks.add_css(".controls_section.recommended_tumblelogs { display: none !important; }", "xkit_tweaks_hide_recommended");
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_share_menu.value) {


### PR DESCRIPTION
removes unintentional behaviour where the "Hide Recommended blogs" sidebar tweak would target recommended posts (from tracked searches), something that the user can instead do with the No Recommended extension