### PR TITLE
Remove references to `xkitcs.com` and fallback download mechanism

### DIFF
--- a/Extensions/xcloud.js
+++ b/Extensions/xcloud.js
@@ -717,7 +717,6 @@ XKit.extensions.xcloud = new Object({
 
 		//Grab the gallery to check available extensions.
 		//We want to exclude unavailable extensions since the install script will make the whole thing partially succeed.
-		// Also to make this backwards compatible we need to use the page function which will go to xkitcs.com for XKit 7.5 and gh_pages for New-XKit
 		XKit.download.page('gallery.php', function(gallery_json) {
 			if (gallery_json.errors) {
 				XKit.extensions.xcloud.hide_overlay();

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 6.8.10 **//
+//* VERSION 6.8.11 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -2434,6 +2434,61 @@ XKit.extensions.xkit_patches = new Object({
 				}, 5000);
 			}
 		};
+
+		// Expedited fix for #1509; revert after updated XKit extension has been widely installed.
+		XKit.download.github_fetch = function(path, callback) {
+			var url = 'https://new-xkit.github.io/XKit/Extensions/dist/' + path;
+			GM_xmlhttpRequest({
+				method: "GET",
+				url: url,
+				onerror: function(response) {
+					XKit.console.add("Unable to download '" + path + "'");
+					callback({errors: true, server_down: true});
+				},
+				onload: function(response) {
+					// We are done!
+					var mdata = {};
+					try {
+						mdata = jQuery.parseJSON(response.responseText);
+					} catch (e) {
+						// Server returned bad thingy.
+						XKit.console.add("Unable to download '" + path +
+									"', server returned non-json object." + e.message);
+						callback({errors: true, server_down: true});
+						return;
+					}
+					callback(mdata);
+				}
+			});
+		};
+		XKit.download.extension = function(extension_id, callback) {
+			XKit.download.github_fetch(extension_id + '.json', callback);
+		};
+		XKit.download.page = function(page, callback) {
+			if (page === 'list.php') {
+				XKit.download.github_fetch('page/list.json', callback);
+				return;
+			}
+			if (page === 'gallery.php') {
+				XKit.download.github_fetch('page/gallery.json', callback);
+				return;
+			}
+			if (page === 'themes/index.php') {
+				XKit.download.github_fetch('page/themes.json', callback);
+				return;
+			}
+			if (page === 'paperboy/index.php') {
+				XKit.download.github_fetch('page/paperboy.json', callback);
+				return;
+			}
+			if (page === 'framework_version.php') {
+				XKit.download.github_fetch('page/framework_version.json', callback);
+				return;
+			}
+		};
+		delete XKit.servers;
+		delete XKit.download.try_count;
+		delete XKit.download.max_try_count;
 
 	},
 

--- a/Safari/Info.plist
+++ b/Safari/Info.plist
@@ -63,7 +63,6 @@
 				<string>*.txmblr.com</string>
 				<string>*.xkit.info</string>
 				<string>new-xkit.github.io</string>
-				<string>*.xkitcs.com</string>
 			</array>
 			<key>Include Secure Pages</key>
 			<true/>


### PR DESCRIPTION
  - Removed `XKit.servers`, which is only used by `XKit.download.page`.
  - Removed `XKit.download.try_count` and `XKit.download.max_try_count`, which is only used by `XKit.download.page`.
  - Removed `fallback` as the third parameter from `XKit.download.github_fetch`, which is only used by `XKit.download.extension` and `XKit.download.page`. On error, we invoke the callback with the object `{errors: true, server_down: true}`, which is the documented approach for extensions to test for failures.
  - Removed `fallingBack` as the third parameter from `XKit.download.page`; no extensions explicitly use this third parameter.
  - Removed remaining fallback mechanism from `XKit.download.extension` and `XKit.download.page`.

Replacing the legacy paths from each extension can happen later. This PR is mainly focussed on avoiding access to the now-defunct `xkitcs.com`.

Fixes #1509.

Sanity tested by invoking `xkit_updates` both with and without blackholing `new-xkit.github.io`; no regressions.