### PR TITLE
give Old Stats some love

### DIFF
--- a/Extensions/old_stats.css
+++ b/Extensions/old_stats.css
@@ -1,0 +1,36 @@
+.control-item.control-anchor .hide_overflow::before{
+	font-family: tumblr-icons, None;
+	font-size: 24px;
+	line-height: 0;
+	font-weight: normal;
+	position: relative;
+	top: 3px; left: 1px;
+}
+
+.control-item.control-anchor.posts .hide_overflow::before{
+	content: "\EA8B\2002";
+}
+.control-item.control-anchor.followers .hide_overflow::before{
+	content: "\EA44\2002";
+}
+.control-item.control-anchor.activity .hide_overflow::before{
+	content: "\EA01\2002";
+	left: 5px;
+	margin-right: 11px;
+}
+.control-item.control-anchor.members .hide_overflow::before{
+	content: "\EA59\2002";
+	font-size: 21px;
+	top: 2px; left: 2px;
+	margin-right: 5px;
+}
+.control-item.control-anchor.queue .hide_overflow::before{
+	content: "\EA8D\2002";
+	left: -1px;
+}
+.control-item.control-anchor.drafts .hide_overflow::before{
+	content: "\EA25\2002";
+}
+.control-item.control-anchor.customize .hide_overflow::before{
+	content: "\EAB3\2002";
+}

--- a/Extensions/old_stats.js
+++ b/Extensions/old_stats.js
@@ -1,5 +1,5 @@
 //* TITLE Old Stats **//
-//* VERSION 0.3.0 **//
+//* VERSION 0.4.0 **//
 //* DESCRIPTION Blog stats where they were **//
 //* DEVELOPER New-XKit **//
 //* FRAME false **//
@@ -10,8 +10,19 @@ XKit.extensions.old_stats = new Object({
 	running: false,
 	done: false,
 
+	preferences: {
+		"iconify": {
+			text: "Put the icons back on posts/followers/etc links",
+			default: true,
+			value: true
+		}
+	},
+
 	run: function() {
 		this.running = true;
+		if (this.preferences.iconify.value) {
+			XKit.tools.init_css("old_stats");
+		}
 		if ($("#dashboard_controls_open_blog").length) {
 			return;
 		}
@@ -31,6 +42,7 @@ XKit.extensions.old_stats = new Object({
 
 	destroy: function() {
 		this.running = false;
+		XKit.tools.remove_css("old_stats");
 		if (this.done) {
 			$("#dashboard_controls_open_blog").remove();
 		}

--- a/Extensions/old_stats.js
+++ b/Extensions/old_stats.js
@@ -1,109 +1,38 @@
 //* TITLE Old Stats **//
-//* VERSION 0.2.2 **//
-//* DESCRIPTION  **//
-//* DEVELOPER STUDIOXENIX **//
+//* VERSION 0.3.0 **//
+//* DESCRIPTION Blog stats where they were **//
+//* DEVELOPER New-XKit **//
 //* FRAME false **//
 //* BETA false **//
 
 XKit.extensions.old_stats = new Object({
 
 	running: false,
+	done: false,
 
 	run: function() {
 		this.running = true;
-		var m_user = XKit.interface.user();
-		var posts_show = " ";
-		var followers_show = " ";
-		var drafts_show	= " ";
-		var queue_show = " ";
-		var processing_show = " ";
-
-		if (XKit.interface.where().inbox) {
+		if ($("#dashboard_controls_open_blog").length) {
 			return;
 		}
-		if (XKit.interface.where().likes) {
-			return;
-		}
-
-		if (m_user.posts === 0) {
-			posts_show = " count_0 ";
-		}
-		if (m_user.followers === 0) {
-			followers_show = " count_0 ";
-		}
-		if (m_user.drafts === 0) {
-			drafts_show = " count_0 ";
-		}
-		if (m_user.processing === 0) {
-			processing_show = " count_0 ";
-		}
-		if (m_user.queue === 0) {
-			queue_show = " count_0 ";
-		}
-
-		var xf_html = '<ul data-blog-name="' + m_user.name + '" id="dashboard_controls_open_blog" class="controls_section">' +
-					'<li class="no_push selected_blog">' +
-						'<div class="open_blog with_subtitle">' +
-							'<a class="currently_selected_blog hide_overflow blog_title">' + m_user.name + '</a>' +
-							'<small>' +
-								'<div class="hide_overflow">' +
-									'<a target="_blank" href="http://' + m_user.name + '.tumblr.com/" class="open_blog_link" id="open_blog_link">' + m_user.title + '</a>' +
-								'</div>' +
-							'</small>' +
-						'</div>' +
-					'</li>' +
-					'<li class="controls_section_item' + posts_show + '" data-blog-controls-count="post_count" id="posts_control">' +
-						'<a class="control-item control-anchor posts" href="/blog/' + m_user.name + '">' +
-							'<div class="hide_overflow">Posts</div>' +
-							'<span class="count">' + m_user.posts.toLocaleString() + '</span>' +
-						'</a>' +
-					'</li>' +
-					'<li class="controls_section_item' + followers_show + '" data-blog-controls-count="follower_count">' +
-						'<a class="control-item control-anchor followers" href="/blog/' + m_user.name + '/followers">' +
-							'<div class="hide_overflow">Followers</div>' +
-							'<span class="count">' + m_user.followers.toLocaleString() + '</span>' +
-						'</a>' +
-					'</li>' +
-					'<li class="controls_section_item popover_menu_item_blog_details">' +
-						'<a class="control-item control-anchor activity" href="/blog/' + m_user.name + '/activity">' +
-							'<div class="hide_overflow" id="old_stats_activity">Activity</div>' +
-							'<span data-sparkline="' + m_user.activity + '" class="count sparkline">' +
-								'<canvas style="display: inline-block; vertical-align: top; height: 15px; width: 36px;" width="72" height="30"></canvas>' +
-							'</span>' +
-						'</a>' +
-					'</li>' +
-					'<li class="controls_section_item' + drafts_show + '" data-blog-controls-count="draft_count">' +
-						'<a class="control-item control-anchor drafts" href="/blog/' + m_user.name + '/drafts">' +
-							'<div class="hide_overflow">Drafts</div>' +
-							'<span class="count">' + m_user.drafts.toLocaleString() + '</span>' +
-							'</a>' +
-					'</li>' +
-					'<li class="controls_section_item' + processing_show + '" data-blog-controls-count="transcoding_count">' +
-						'<a class="control-item control-anchor queue" href="/blog/' + m_user.name + '/processing">' +
-							'<div class="hide_overflow">Processing</div>' +
-							'<span class="count">' + m_user.processing.toLocaleString() + '</span>' +
-						'</a>' +
-					'</li>' +
-					'<li class="controls_section_item' + queue_show + '" data-blog-controls-count="queued_post_count">' +
-						'<a class="control-item control-anchor queue" href="/blog/' + m_user.name + '/queue">' +
-							'<div class="hide_overflow">Queue</div>' +
-							'<span class="count">' + m_user.queue.toLocaleString() + '</span>' +
-						'</a>' +
-					'</li>' +
-					'<li class="controls_section_item no_push">' +
-						'<a class="control-item control-anchor customize" href="/settings/blog/' + m_user.name + '">' +
-							'<div class="hide_overflow">' +
-								'Edit appearance<i class="sub_control link_arrow icon_right icon_arrow_carrot_right"></i>' +
-							'</div>' +
-						'</a>' +
-					'</li>' +
-				'</ul>' +
-				'<ul id="xkit-dashboard-account" class="controls_section"></ul>';
-
-		$(".recommended_tumblelogs").before(xf_html);
-
+		GM_xmlhttpRequest({
+			method: "GET",
+			url: "https://www.tumblr.com/likes",
+			onerror: function(response) {
+				console.log("old_stats: Couldn't fetch blog info.");
+			},
+			onload: function(response) {
+				$(".recommended_tumblelogs").before($("#dashboard_controls_open_blog", response.responseText));
+				$("#dashboard_controls_open_blog").css("margin", "0 0 18px");
+				XKit.extensions.old_stats.done = true;
+			}
+		});
 	},
+
 	destroy: function() {
 		this.running = false;
+		if (this.done) {
+			$("#dashboard_controls_open_blog").remove();
+		}
 	}
 });


### PR DESCRIPTION
resolves #341, closes #956 

- Instead of trying (and failing) to build a statbox itself, now fetches the primary blog's statbox from /likes and displays it anywhere one isn't already present, with extra margins to make it nice and neat
- Adds a description for the extension
- Adds a default option to put icons back on all the blog links

the activity "sparkline" doesnt get drawn but that can be left for later, unless im missing something really obvious