### PR TITLE
draw activity line in Old Stats

### DIFF
--- a/Extensions/old_stats.css
+++ b/Extensions/old_stats.css
@@ -1,4 +1,4 @@
-.control-item.control-anchor .hide_overflow::before{
+.control-item.control-anchor .hide_overflow::before {
 	font-family: tumblr-icons, None;
 	font-size: 24px;
 	line-height: 0;
@@ -7,30 +7,33 @@
 	top: 3px; left: 1px;
 }
 
-.control-item.control-anchor.posts .hide_overflow::before{
+.control-item.control-anchor.posts .hide_overflow::before {
 	content: "\EA8B\2002";
 }
-.control-item.control-anchor.followers .hide_overflow::before{
+.control-item.control-anchor.followers .hide_overflow::before {
 	content: "\EA44\2002";
 }
-.control-item.control-anchor.activity .hide_overflow::before{
+.control-item.control-anchor.activity .hide_overflow::before {
 	content: "\EA01\2002";
 	left: 5px;
 	margin-right: 11px;
 }
-.control-item.control-anchor.members .hide_overflow::before{
+.control-item.control-anchor.members .hide_overflow::before {
 	content: "\EA59\2002";
 	font-size: 21px;
 	top: 2px; left: 2px;
 	margin-right: 5px;
 }
-.control-item.control-anchor.queue .hide_overflow::before{
+.control-item.control-anchor.queue .hide_overflow::before {
 	content: "\EA8D\2002";
 	left: -1px;
 }
-.control-item.control-anchor.drafts .hide_overflow::before{
+.control-item.control-anchor.drafts .hide_overflow::before {
 	content: "\EA25\2002";
 }
-.control-item.control-anchor.customize .hide_overflow::before{
+.control-item.control-anchor.processing .hide_overflow::before {
+	content: "\EA8C\2002";
+}
+.control-item.control-anchor.customize .hide_overflow::before {
 	content: "\EAB3\2002";
 }

--- a/Extensions/old_stats.js
+++ b/Extensions/old_stats.js
@@ -1,5 +1,5 @@
 //* TITLE Old Stats **//
-//* VERSION 0.4.0 **//
+//* VERSION 0.4.1 **//
 //* DESCRIPTION Blog stats where they were **//
 //* DEVELOPER New-XKit **//
 //* FRAME false **//
@@ -33,8 +33,18 @@ XKit.extensions.old_stats = new Object({
 				console.log("old_stats: Couldn't fetch blog info.");
 			},
 			onload: function(response) {
-				$(".recommended_tumblelogs").before($("#dashboard_controls_open_blog", response.responseText));
-				$("#dashboard_controls_open_blog").css("margin", "0 0 18px");
+				$(".recommended_tumblelogs").before($("#dashboard_controls_open_blog", response.responseText).css("margin", "0 0 18px"));
+				$("#dashboard_controls_open_blog [data-sparkline]").prepend('<canvas id="old_stats_canvas" width="72" height="30" style="display: inline-block; width: 36px; height: 15px; vertical-align: top;">');
+				var sparkline = JSON.parse($("#dashboard_controls_open_blog [data-sparkline]").attr("data-sparkline"));
+				var sparkpx = (Math.max.apply(Math, sparkline) - Math.min.apply(Math, sparkline)) / 30;
+				var canvas = document.getElementById("old_stats_canvas").getContext("2d");
+				canvas.strokeStyle = "#FFFFFF";
+				canvas.lineWidth = 3.5;
+				canvas.moveTo(0, 30 - (sparkline[0] / sparkpx));
+				for (var i = 0; i < sparkline.length; i++) {
+					canvas.lineTo((i + 0.5) * (72 / sparkline.length), 30 - (sparkline[i] / sparkpx));
+					canvas.stroke();
+				}
 				XKit.extensions.old_stats.done = true;
 			}
 		});


### PR DESCRIPTION
not perfect but almost! and much better than nothing. followup of #1512 

vanilla | emulated
:---: | :---: 
![screenshot 2018-03-15 at 11 22 51](https://user-images.githubusercontent.com/28949509/37460525-5c7be15a-2843-11e8-8164-51018426110d.png) | ![screenshot 2018-03-15 at 11 22 31](https://user-images.githubusercontent.com/28949509/37460534-617b0fb4-2843-11e8-9889-94ad7534d822.png)
___
additional notes: the `Tumblr.ActivitySparkline` function is almost certainly the way it gets drawn normally, but I've been unable to figure out how to use it. It always spits out
`Uncaught TypeError: this._ensureElement is not a function`
with everything I've tried, and I doubt there's documentation for this stuff

