### PR TITLE
Move placement of Tag Replacer controls

### DIFF
--- a/Extensions/tag_replacer.js
+++ b/Extensions/tag_replacer.js
@@ -1,5 +1,5 @@
 //* TITLE Tag Replacer **//
-//* VERSION 0.4.6 **//
+//* VERSION 0.4.7 **//
 //* DESCRIPTION Replace old tags! **//
 //* DETAILS Allows you to bulk replace tags of posts. Go to your Posts page on your dashboard and click on the button on the sidebar and enter the tag you want replaced, and the new tag, and Tag Replacer will take care of the rest. **//
 //* DEVELOPER new-xkit **//
@@ -28,7 +28,7 @@ XKit.extensions.tag_replacer = new Object({
 				'<li class="no_push" style="height: 36px;"><a data-url="' + XKit.interface.where().user_url + '" href="#" id="tag_replacer_button">' +
 				'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Replace a tag<span class="sub_control link_arrow icon_right icon_arrow_carrot_right"></span></div>' +
 				'</a></li></ul>';
-			$("ul.controls_section:first").before(xf_html);
+			$("div.small_links").after(xf_html);
 		}
 
 		$("#tag_replacer_button").click(function() {


### PR DESCRIPTION
Puts the Tag Replacer activation button after the blog controls instead of before them (which currently makes the sidebar kinda ugly, and prevents some Old Sidebar CSS from working properly, resulting in two sets of blog links)