### PR TITLE
Improve get_posts()'s "is it mine?" logic

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 6.8.9 **//
+//* VERSION 6.8.10 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -1788,8 +1788,9 @@ XKit.extensions.xkit_patches = new Object({
 				var posts = [];
 
 				var selector = ".post";
+				var where = XKit.interface.where();
 
-				if (mine && !XKit.interface.where().channel) {
+				if (mine && !where.channel && !where.drafts && !where.queue) {
 					selector = ".post.is_mine";
 				}
 


### PR DESCRIPTION
resolves #597 which i'm now regretting renaming.
as noted by that issue and a couple people from the support channel on Discord, Quick Tags doesn't run on drafted or queued posts unless you made them yourself, which is a problem because group blogs are a thing.

doesn't fix posts on the dashboard posted by other members, but that would require using `get_posts("tag", false, true)`, which seems kinda inefficient to me?