### PR TITLE
Mutual Checker 2

### DIFF
--- a/Extensions/mutualchecker.js
+++ b/Extensions/mutualchecker.js
@@ -1,15 +1,15 @@
 //* TITLE Mutual Checker **//
-//* VERSION 1.1.0 **//
-//* DESCRIPTION Adds an icon next to usernames to indicate if they follow you **//
-//* DETAILS Does what it says on the tin! Made from fresh, distilled Profiler juice. **//
-//* DEVELOPER new-xkit **//
+//* VERSION 2.0.0 **//
+//* DESCRIPTION A simple way to see who follows you back **//
+//* DETAILS Adds a small icon and "[user] follows you" hovertext to URLs you see in post headers (when appropriate).<br><br>Only checks the URL when the person directly made/reblogged/submitted/published the post, and doesn't work on sideblogs. **//
+//* DEVELOPER New-XKit **//
 //* FRAME false **//
 //* BETA false **//
 
 XKit.extensions.mutualchecker = new Object({
 	
 	running: false,
-	users: {},
+	mutuals: {},
 	
 	preferences: {
 		"main_blog": {
@@ -25,91 +25,92 @@ XKit.extensions.mutualchecker = new Object({
 		}
 	},
 
+	cpanel: function() {
+		$("select[data-setting-id=\"main_blog\"] option").first().remove();
+	},
+
 	run: function() {
 		this.running = true;
-		if (this.preferences.main_blog.value === "") {
-			this.preferences.main_blog.value = XKit.tools.get_blogs()[0];
+		var blogs = XKit.tools.get_blogs();
+		if ($.inArray(this.preferences.main_blog.value, blogs) === -1) {
+			this.preferences.main_blog.value = blogs[0];
 		}
 		XKit.tools.init_css("mutualchecker");
-		XKit.extensions.mutualchecker.add_post_icons();
-		XKit.extensions.mutualchecker.add_follower_icons();
-		XKit.post_listener.add("mutualchecker", XKit.extensions.mutualchecker.add_post_icons);
+		this.add_follower_icons();
+		this.add_post_icons();
+		XKit.post_listener.add("mutualchecker", this.add_post_icons);
 	},
 
 	add_follower_icons: function() {
+		var following = XKit.interface.where().following;
 		$(".follower").each(function() {
-			var url = $(this).find(".name").text();
-			var name_div = $(this).find(".name");
-			XKit.interface.is_following(url, XKit.extensions.mutualchecker.preferences.main_blog.value).then(function(follow) {
-				if (follow) {
-					XKit.extensions.mutualchecker.add_label(name_div, url);
-				}
-			});
+			if (following || !$(this).find(".follow_button").length) {
+				var $name_div = $(this).find(".name-link");
+				var url = $name_div.text();
+				XKit.interface.is_following(url, XKit.extensions.mutualchecker.preferences.main_blog.value).then(function(follow) {
+					if (follow) {
+						XKit.extensions.mutualchecker.add_label($name_div, url);
+					}
+				});
+			}
 		});
 	},
 
 	add_post_icons: function() {
 		$(XKit.interface.get_posts("mutualchecker-done")).each(function() {
-			$(this).addClass("mutualchecker-done");
-			var post = XKit.interface.post($(this));
-			if (!XKit.interface.where().inbox && post.is_mine) { return; }
-
-			if (!XKit.interface.where().dashboard) {
-				var json_info = $(this).find(".post_avatar_link, .post-info-tumblelog a").attr('data-tumblelog-popover');
+			var $post = $(this).addClass("mutualchecker-done"), json_obj;
+			if ($post.hasClass("is_private_answer")) {
 				try {
-					var json_obj = JSON.parse(json_info);
-					if (!json_obj.following) { return; }
-					post.owner = json_obj.name;
+					json_obj = JSON.parse($post.find(".post_avatar_link").attr("data-tumblelog-popover"));
 				} catch (e) {
 					return;
 				}
-			}
-
-			var name_div = {};
-			$(this).find(".post_header .post_info_link:not(.reblog_info)").each(function() {
-				try {
-					var link_json = JSON.parse($(this).attr("data-peepr"));
-					if (link_json.tumblelog === post.owner) {
-						name_div = $(this).first();
-						return false;
+				XKit.extensions.mutualchecker.check(json_obj, $post.find(".post_info_submissions").first());
+			} else {
+				$post.find(".post_info_link[data-tumblelog-popover]:not(.reblog_icon + .post_info_link), .post-info-tumblelog > a[data-tumblelog-popover]").each(function() {
+					var $link = $(this);
+					try {
+						json_obj = JSON.parse($link.attr("data-tumblelog-popover"));
+					} catch (e) {
+						return;
 					}
-				} catch (e) {
-					return false;
-				}
-			});
-
-			if (name_div.length == undefined) {
-				name_div = $(this).find(".post_info_submissions, .post-info-tumblelog a").first();
-			}
-			if (!name_div.length) { return; }
-
-			if (typeof XKit.extensions.mutualchecker.users[post.owner] === "undefined") {
-				XKit.interface.is_following(post.owner, XKit.extensions.mutualchecker.preferences.main_blog.value).then(function(follow) {
-					if (follow) {
-						XKit.extensions.mutualchecker.add_label(name_div, post.owner);
-						XKit.extensions.mutualchecker.users[post.owner] = true;
-					} else {
-						XKit.extensions.mutualchecker.users[post.owner] = false;
-					}
+					XKit.extensions.mutualchecker.check(json_obj, $link);
 				});
-			} else if (XKit.extensions.mutualchecker.users[post.owner]) {
-				XKit.extensions.mutualchecker.add_label(name_div, post.owner);
 			}
 		});
 	},
 
-	add_label: function(name_div, user) {
-		if ($(name_div).hasClass("post_info_submissions")) {
-			name_div.html('<span class="mutuals' + ( XKit.extensions.mutualchecker.preferences.put_in_front.value ? " mutuals-front" : "") + '">' + user + '</span>' + name_div.text().trim().substring(user.length));
+	check: function(json_obj, $link) {
+		if (json_obj.following && !json_obj.customizable) {
+			if (typeof this.mutuals[json_obj.name] === "undefined") {
+				XKit.interface.is_following(json_obj.name, this.preferences.main_blog.value).then(function(follow) {
+					if (follow) {
+						XKit.extensions.mutualchecker.add_label($link, json_obj.name);
+						XKit.extensions.mutualchecker.mutuals[json_obj.name] = true;
+					} else {
+						XKit.extensions.mutualchecker.mutuals[json_obj.name] = false;
+					}
+				});
+			} else if (this.mutuals[json_obj.name]) {
+				this.add_label($link, json_obj.name);
+			}
+		}
+	},
+
+	add_label: function($name_div, user) {
+		if ($name_div.hasClass("post_info_submissions")) {
+			$name_div.html('<span class="mutuals' + ( XKit.extensions.mutualchecker.preferences.put_in_front.value ? " mutuals-front" : "") + '">' + user + '</span>' + $name_div.text().trim().substring(user.length));
 		} else {
-			name_div.addClass("mutuals").attr("title", user + " follows you");
-			if (XKit.extensions.mutualchecker.preferences.put_in_front.value) { name_div.addClass("mutuals-front"); }
+			$name_div.addClass("mutuals").attr("title", user + " follows you");
+			if (XKit.extensions.mutualchecker.preferences.put_in_front.value) {
+				$name_div.addClass("mutuals-front");
+			}
 		}
 	},
 
 	destroy: function() {
 		this.running = false;
-		this.users = {};
+		this.mutuals = {};
 		XKit.post_listener.remove("mutualchecker");
 		$(".mutuals").removeAttr("title").removeClass("mutuals").removeClass("mutuals-front");
 		$(".mutualchecker-done").removeClass("mutualchecker-done");


### PR DESCRIPTION
Fixes
- Simplifies internal logic
    - Variable names are much nicer
    - Most usernames are now processed directly
- Adds a failsafe for when the user changes their URL (essentially resets the extension if the chosen blog is no longer in the user's posession)
- Removes the "Default action" option in the extension's preferences

Features
- Nicer and more helpful description/details
- Icons are now added to /followers pages
- Submitter URLs are now checked