### PR TITLE
add option for tumblr notifications in OCP

### DIFF
--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.3.11 **//
+//* VERSION 4.4.0 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -138,6 +138,11 @@ XKit.extensions.one_click_postage = new Object({
 		},
 		"dont_show_notifications": {
 			text: "Turn off the notifications displayed when successfully reblogged/queued/drafted",
+			default: false,
+			value: false
+		},
+		"use_toasts": {
+			text: "Use tumblr-style notifications instead of XKit ones",
 			default: false,
 			value: false
 		},
@@ -1459,7 +1464,11 @@ XKit.extensions.one_click_postage = new Object({
 								}
 							}
 							if (!XKit.extensions.one_click_postage.preferences.dont_show_notifications.value) {
-								XKit.notifications.add(mdata.message, "ok");
+								if (XKit.extensions.one_click_postage.preferences.use_toasts.value) {
+									XKit.toast.add(mdata.created_post, mdata.verbiage, mdata.post_tumblelog.name_or_id, mdata.post.id, mdata.post_context_page);
+								} else {
+									XKit.notifications.add(mdata.message, "ok");
+								}
 							}
 						}
 					} else {

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 6.8.11 **//
+//* VERSION 6.9.0 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -2547,4 +2547,58 @@ XKit.installed.when_running = function(extension, onRunning, onFailure) {
 		onRunning(XKit.extensions[extension]);
 	}
 	setTimeout(check, 0);
+};
+
+XKit.toast = {
+	count: 0,
+
+	/**
+	 * Simulates a tumblr notification ("toast")
+	 * @param {Boolean} created - true if post was not queued/drafted
+	 * @param {String} action - post action description (i.e. "Reblogged to ")
+	 * @param {String} url - tumblr blog name (for both notification and API)
+	 * @param {Integer/String} id - created post id for peepr (optional)
+	 * @param {String} crumb - arbitrary class for "crumb" (optional)
+	 */
+	add: function(created, action, url, id, crumb) {
+		var toastno = XKit.toast.count;
+		XKit.toast.count++;
+
+		if (created) {
+			action = "<strong>" + action;
+		} else {
+			action += "<strong>";
+		}
+
+		var endData = "}";
+		if (typeof id !== "undefined") {
+			endData = `,"postId": ${id}}`;
+		}
+		if (typeof crumb === "undefined") {
+			crumb = "";
+		}
+
+		var toast =
+			`<li class="toast blog-sub xtoast-${toastno}" data-subview="toast" data-peepr='{"tumblelog": "${url}"${endData}'>
+				<img class="toaster avatar" src="https://api.tumblr.com/v2/blog/${url}/avatar/128">
+				<div class="crumb ${crumb}"></div>
+				<span class="toast-bread">
+					${action}${url}</strong>
+				</span>
+			</li>`;
+
+		$(".toastr").addClass("show-toast");
+		$(".multi-toasts").append(toast);
+
+		var $toast = $(".xtoast-" + toastno);
+		setTimeout(function() {
+			$toast.addClass("fade-out");
+		}, 4000);
+		setTimeout(function() {
+			$toast.remove();
+			if (!$(".toast").length) {
+				$(".toastr").removeClass("show-toast");
+			}
+		}, 5000);
+	}
 };


### PR DESCRIPTION
Adds a function for using tumblr's notification system "toastr" to XKit Patches, and the option to use said function in One-Click Postage
Emulated toasts are just as peepr-compatible as real toasts, so this option can be used to instantly preview newly reblogged/queued/drafted posts when you want to, so it's not a purely aesthetic feature