### PR TITLE
fix Mutual Checker details in gallery

### DIFF
--- a/Extensions/mutualchecker.js
+++ b/Extensions/mutualchecker.js
@@ -1,7 +1,7 @@
 //* TITLE Mutual Checker **//
 //* VERSION 2.0.0 **//
 //* DESCRIPTION A simple way to see who follows you back **//
-//* DETAILS Adds a small icon and "[user] follows you" hovertext to URLs you see in post headers (when appropriate).<br><br>Only checks the URL when the person directly made/reblogged/submitted/published the post, and doesn't work on sideblogs. **//
+//* DETAILS Adds a small icon and '[user] follows you' hovertext to URLs you see in post headers (when appropriate).<br><br>Only checks the URL when the person directly made/reblogged/submitted/published the post, and doesn't work on sideblogs. **//
 //* DEVELOPER New-XKit **//
 //* FRAME false **//
 //* BETA false **//


### PR DESCRIPTION
looks like using double-quotes in an extension's details is a Mistake. hopefully single quotes won't have any issues. no version bump as this only affects the gallery
![screenshot 2018-04-07 at 18 04 49](https://user-images.githubusercontent.com/28949509/38457884-3e914b82-3a8e-11e8-9bd2-eddecb5fa825.png)
![screenshot 2018-04-07 at 18 05 30](https://user-images.githubusercontent.com/28949509/38457890-463b37bc-3a8e-11e8-9d45-0d74392f4873.png)
