### PR TITLE
Use content's XHR if available

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 6.9.1 **//
+//* VERSION 6.10.0 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -2490,6 +2490,10 @@ XKit.extensions.xkit_patches = new Object({
 		delete XKit.download.try_count;
 		delete XKit.download.max_try_count;
 
+		// Expedited fix for #1540, can be removed once the webext is updated
+		if (typeof(content) !== 'undefined' && content.XMLHttpRequest) { // eslint-disable-line
+			XMLHttpRequest = content.XMLHttpRequest; // eslint-disable-line
+		}
 	},
 
 	/**


### PR DESCRIPTION
In versions of Firefox >= 58 use content.XMLHttpRequest to automatically
set these headers.

In Safari I tried to set Referer manually which is explicitly disallowed
by the spec and doesn't work. There's something with XPCNative that
might work for < 58 but it seemed very icky.

Progresses forward on #1540 but doesn't fix it yet, ideas/help/pull requests wanted