### PR TITLE
fix Activity line clipping in Old Stats

### DIFF
--- a/Extensions/old_stats.js
+++ b/Extensions/old_stats.js
@@ -1,5 +1,5 @@
 //* TITLE Old Stats **//
-//* VERSION 0.4.1 **//
+//* VERSION 0.4.2 **//
 //* DESCRIPTION Blog stats where they were **//
 //* DEVELOPER New-XKit **//
 //* FRAME false **//
@@ -36,13 +36,14 @@ XKit.extensions.old_stats = new Object({
 				$(".recommended_tumblelogs").before($("#dashboard_controls_open_blog", response.responseText).css("margin", "0 0 18px"));
 				$("#dashboard_controls_open_blog [data-sparkline]").prepend('<canvas id="old_stats_canvas" width="72" height="30" style="display: inline-block; width: 36px; height: 15px; vertical-align: top;">');
 				var sparkline = JSON.parse($("#dashboard_controls_open_blog [data-sparkline]").attr("data-sparkline"));
-				var sparkpx = (Math.max.apply(Math, sparkline) - Math.min.apply(Math, sparkline)) / 30;
+				var sparkmin = Math.min.apply(Math, sparkline);
+				var sparkpx = (Math.max.apply(Math, sparkline) - sparkmin) / 30;
 				var canvas = document.getElementById("old_stats_canvas").getContext("2d");
 				canvas.strokeStyle = "#FFFFFF";
 				canvas.lineWidth = 3.5;
-				canvas.moveTo(0, 30 - (sparkline[0] / sparkpx));
-				for (var i = 0; i < sparkline.length; i++) {
-					canvas.lineTo((i + 0.5) * (72 / sparkline.length), 30 - (sparkline[i] / sparkpx));
+				canvas.moveTo(0, 30 - ((sparkline[0] - sparkmin) / sparkpx));
+				for (var i = 1; i < sparkline.length; i++) {
+					canvas.lineTo(i * (72 / sparkline.length), 30 - ((sparkline[i] - sparkmin) / sparkpx));
 					canvas.stroke();
 				}
 				XKit.extensions.old_stats.done = true;


### PR DESCRIPTION
corrects the method for drawing the Activity sparkline so that it never tries to draw outside of the canvas, resulting in a sparkline which seems (almost) identical to that in the activity popover/account menu 

feels good feels organic

Old Stats | Popover
----- | -----
![screenshot 2018-04-25 at 19 45 00](https://user-images.githubusercontent.com/28949509/39266206-43e1498e-48c1-11e8-8956-5bcc9b595843.png) | ![screenshot 2018-04-25 at 19 45 09](https://user-images.githubusercontent.com/28949509/39266212-48ecc804-48c1-11e8-8ed8-d279779ec57a.png)
