### PR TITLE
Tell Linguist that we made our extensions ourselves

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -179,3 +179,7 @@ Procfile    text
 
 ## LINGUIST
 Extensions/* linguist-generated=false
+Extensions/dist/*.json linguist-generated=true
+Extensions/dist/page/gallery.json linguist-generated=true
+Extensions/dist/page/list.json linguist-generated=true
+Extensions/dist/page/themes.json linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -176,3 +176,6 @@ Procfile    text
 ## EXECUTABLES
 *.exe binary
 *.pyc binary
+
+## LINGUIST
+Extensions/* linguist-generated=false


### PR DESCRIPTION
I got tired of seeing those "Diffs aren't generated for generated files by default" messages so now they should be gone for all extension files.