### PR TITLE
fix View on Dash for new post listener

### DIFF
--- a/Extensions/view_on_dash.js
+++ b/Extensions/view_on_dash.js
@@ -1,5 +1,5 @@
 //* TITLE View On Dash **//
-//* VERSION 0.7.11 **//
+//* VERSION 0.7.12 **//
 //* DESCRIPTION View blogs on your dash **//
 //* DEVELOPER new-xkit **//
 //* DETAILS This is a preview version of an extension, missing most features due to legal/technical reasons for now. It lets you view the last 20 posts a person has made on their blogs right on your dashboard. If you have User Menus+ installed, you can also access it from their user menu under their avatar. **//
@@ -722,8 +722,6 @@ XKit.extensions.view_on_dash = new Object({
 						$("#view-on-dash-back").removeClass("disabled");
 
 					}
-
-					XKit.post_listener.run_callbacks();
 
 					$(".view-on-dash-post-type").unbind("click");
 					$(".view-on-dash-post-type").bind("click", function() {


### PR DESCRIPTION
I missed an old post listener function (`XKit.post_listener.run_callbacks()`) in View on Dash which entirely breaks the extension. Made redundant by the new MutationObserver-based Post Listener.
If `grep` is telling the truth it's the only call to it I missed