### PR TITLE
run XKit Patches on older XKit versions (pre-7.8.1)

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.0.0 **//
+//* VERSION 7.0.1 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -22,11 +22,11 @@ XKit.extensions.xkit_patches = new Object({
 		for (var i in this.patches) {
 			to_run.unshift(i);
 			if (i === XKit.version) {
-				for (var x in to_run) {
-					this.patches[to_run[x]]();
-				}
 				break;
 			}
+		}
+		for (var x in to_run) {
+			this.patches[to_run[x]]();
 		}
 
 		// Identify retina screen displays. Unused anywhere else


### PR DESCRIPTION
i am a huge idiot and made xkit patches only run on XKit 7.8.1+, breaking older installations. now it will run all patches if it doesn't find its own version-specific patches function (as intended)