### PR TITLE
Fix up a few sidebar controls

### DIFF
--- a/Extensions/bookmarker.js
+++ b/Extensions/bookmarker.js
@@ -1,5 +1,5 @@
 //* TITLE Bookmarker **//
-//* VERSION 2.3.7 **//
+//* VERSION 2.3.8 **//
 //* DESCRIPTION Dashboard Time Machine **//
 //* DEVELOPER new-xkit **//
 //* DETAILS The Bookmarker extension allows you to bookmark posts and get back to them whenever you want to. Just click on the Bookmark icon on posts and the post will be added to your Bookmark List on your sidebar. **//
@@ -26,11 +26,6 @@ XKit.extensions.bookmarker = new Object({
 		sep1: {
 			text: "Displaying bookmarks",
 			type: "separator"
-		},
-		display_on_top: {
-			text: "On dashboard, show my bookmarks after my blog information",
-			default: false,
-			value: false
 		},
 		display_non_relative: {
 			text: "Instead of relative time, use the following format:",
@@ -124,19 +119,11 @@ XKit.extensions.bookmarker = new Object({
 
 		if (document.location.href.indexOf("?bookmark=true") !== -1) {
 			$("#right_column").prepend(m_html);
+			$("#xbookmarks").css("margin-top", "0");
+			$("#xbookmarker_small_links").css("margin-bottom", "18px");
 		} else {
-			if (XKit.extensions.bookmarker.preferences.display_on_top.value === true) {
-				$("ul.controls_section:first").after(m_html);
-			} else {
-				if ($("#tumblr_radar").length > 0) {
-					//$("#tumblr_radar").before(m_html);
-					$(".controls_section_radar").before(m_html);
-				} else {
-					$("#right_column").append(m_html);
-				}
-			}
+			$(".controls_section:eq(1)").before(m_html);
 		}
-
 
 		$("#xbookmarks").prepend("<li class=\"section_header selected\">BOOKMARKS</li>");
 		$("#xbookmarks").slideDown('fast');
@@ -436,6 +423,7 @@ XKit.extensions.bookmarker = new Object({
 		$("#xbookmarks").remove();
 		$("#xbookmarker_small_links").remove();
 		$(".xbookmarker_post_icon").remove();
+		$(".xbookmarker_done").removeClass("xbookmarker_done");
 		XKit.tools.remove_css("bookmarker");
 		XKit.tools.remove_css("bookmarker_new_layout");
 		XKit.post_listener.remove("bookmarker");

--- a/Extensions/classic_tags.js
+++ b/Extensions/classic_tags.js
@@ -1,5 +1,5 @@
 //* TITLE Tag Tracking+ **//
-//* VERSION 1.6.4 **//
+//* VERSION 1.6.5 **//
 //* DESCRIPTION Shows your tracked tags on your sidebar **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -299,7 +299,7 @@ XKit.extensions.classic_tags = new Object({
 			if (total_tag_count >= 21 && XKit.extensions.classic_tags.preferences.turn_off_warning.value !== true) {
 
 				m_html = "<div class=\"classic-tags-too-much-tags-error\"><b>Too Many Tracked Tags:</b><br> After around 20 tags, Tumblr stops updating the status of all your tracked tags until you untrack some. Please track less than 20 tags for this extension to work.</div>";
-				m_html = '<ul class="controls_section" id="xtags"><li class=\"section_header selected\">TRACKED TAGS</li>' + m_html + '</ul>';
+				m_html = '<ul class="controls_section" id="xtags"><li class=\"section_header selected\">Tracked Tags</li>' + m_html + '</ul>';
 
 				if (document.location.href.indexOf('/tagged/') !== -1) {
 
@@ -309,15 +309,9 @@ XKit.extensions.classic_tags = new Object({
 
 					if (XKit.extensions.classic_tags.preferences.prepend_sidebar.value === true) {
 						$("#right_column").prepend(m_html);
-					} else if ($("ul.controls_section:eq(1)").length > 0) {
-						if ($("#xim_small_links").length > 0) {
-							$("#xim_small_links").after(m_html);
-						} else {
-							$("ul.controls_section:eq(1)").after(m_html);
-						}
+						$("#xtags").css("margin", "0 0 18px");
 					} else {
-						//$("#right_column").append(m_html);
-						$(".controls_section_radar").before(m_html);
+						$(".controls_section:eq(1)").before(m_html);
 					}
 				}
 
@@ -352,13 +346,13 @@ XKit.extensions.classic_tags = new Object({
 			m_html = '<ul class="controls_section ' + extra_class + '" id="xtags"><li class=\"section_header selected\">TRACKED TAGS</li>' + m_html + '</ul>';
 
 			if (document.location.href.indexOf('/tagged/') !== -1) {
-				$("#right_column").children(".tag_controls").after(m_html);
+				$("#related_tags_show_more").after(m_html);
+				$("#xtags").css("margin-bottom", "18px");
 			} else if (XKit.extensions.classic_tags.preferences.prepend_sidebar.value === true) {
-			    $("#right_column").prepend(m_html);
-			} else if ($("#xim_small_links").length > 0) {
-				$("#xim_small_links").after(m_html);
-			} else {
 				$("#right_column").prepend(m_html);
+				$("#xtags").css("margin", "0 0 18px");
+			} else {
+				$(".controls_section:eq(1)").before(m_html);
 			}
 		}
 

--- a/Extensions/cleanfeed.js
+++ b/Extensions/cleanfeed.js
@@ -1,5 +1,5 @@
 //* TITLE CleanFeed **//
-//* VERSION 1.5.3 **//
+//* VERSION 1.5.4 **//
 //* DESCRIPTION Browse safely in public **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS This extension, when enabled, hides photo posts until you hover over them. Useful to browse Tumblr in a workspace or in public, and not worry about NSFW stuff appearing. You can also set it to hide avatars and not show non-text posts at all. To activate or disable it, click on the CleanFeed button on your sidebar. It will remember it's on/off setting. **//
@@ -75,7 +75,7 @@ XKit.extensions.cleanfeed = new Object({
 
 
 		var xf_html = '<ul class="controls_section" id="xcleanfeed_ul">' +
-			'<li class="section_header selected">CLEANFEED</li>' +
+			'<li class="section_header selected">Cleanfeed</li>' +
 			'<li class="no_push" style="height: 36px;"><a href="#" id="xcleanfeed_button">' +
 			'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Filtering</div>' +
 			'<div class="count" id="xcleanfeedstatus" style="padding-top: 8px;">' + XKit.extensions.cleanfeed.lbl_off + '</div>' +
@@ -86,7 +86,7 @@ XKit.extensions.cleanfeed = new Object({
 				'<a id="xkit-cleanfeed-mode-change" href="#">change/help</a>' +
 			'</div>' +
 			'</ul>';
-		$("ul.controls_section:first").before(xf_html);
+		$(".controls_section:eq(1)").before(xf_html);
 
 		XKit.extensions.cleanfeed.update_button();
 

--- a/Extensions/drafts_plus.js
+++ b/Extensions/drafts_plus.js
@@ -1,5 +1,5 @@
 //* TITLE Drafts+ **//
-//* VERSION 0.2.5 **//
+//* VERSION 0.2.6 **//
 //* DESCRIPTION Enhancements for Drafts page **//
 //* DEVELOPER STUDIOXENIX **//
 //* FRAME false **//
@@ -17,7 +17,7 @@ XKit.extensions.drafts_plus = new Object({
 		XKit.tools.init_css("drafts_plus");
 
 		var xf_html = '<ul class="controls_section" id="drafts_plus_sidebar">' +
-			'<li class="section_header selected">DRAFTS TOOLS</li>' +
+			'<li class="section_header selected">Drafts Tools</li>' +
 			'<li class="" id="drafts_plus_mass_edit_li"">' +
 				'<a href="#" class="customize" id="drafts_plus_mass_edit_button">' +
 					'<div class="hide_overflow">Mass Edit Mode</div>' +
@@ -30,7 +30,7 @@ XKit.extensions.drafts_plus = new Object({
 			'</li>' +
 			'</ul>';
 
-		$("ul.controls_section:eq(1)").before(xf_html);
+		$(".controls_section:eq(1)").before(xf_html);
 
 		$("#drafts_plus_mass_edit_button").click(function() {
 

--- a/Extensions/find_blogs.js
+++ b/Extensions/find_blogs.js
@@ -1,5 +1,5 @@
 //* TITLE Find Blogs **//
-//* VERSION 1.2.2 **//
+//* VERSION 1.2.3 **//
 //* DESCRIPTION Lets you find similar blogs **//
 //* DETAILS Requires User Menus+ to be installed. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -110,11 +110,11 @@ XKit.extensions.find_blogs = new Object({
 		if (XKit.interface.where().user_url === "") { return; }
 
 		var xf_html = '<ul class="controls_section" id="find_blogs_ul">' +
-			'<li class="section_header selected">FIND BLOGS</li>' +
+			'<li class="section_header selected">Find Blogs</li>' +
 			'<li class="no_push" style="height: 36px;"><a href="#" onclick="return false;" id="find_blogs_button">' +
 				'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Similar to ' + XKit.interface.where().user_url + '<span class="sub_control link_arrow arrow_right"></span></div>' +
 			'</a></li></ul>';
-		$("ul.controls_section:first").before(xf_html);
+		$(".controls_section:eq(1)").before(xf_html);
 
 		$("#find_blogs_button").click(function() {
 

--- a/Extensions/mass_deleter.js
+++ b/Extensions/mass_deleter.js
@@ -1,5 +1,5 @@
 //* TITLE Mass Deleter **//
-//* VERSION 0.2.0 **//
+//* VERSION 0.2.1 **//
 //* DESCRIPTION Mass unlike likes / delete drafts **//
 //* DETAILS Used to mass unlike posts or delete drafts. Please use with caution, especially Mass Unlike part is extremely experimental. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -56,7 +56,7 @@ XKit.extensions.mass_deleter = new Object({
 		} else {
 
 			xf_html = '<ul class="controls_section" id="xkit-mass-deleter-ul">' +
-				'<li class="section_header selected">MASS DELETER</li>' +
+				'<li class="section_header selected">Mass Deleter</li>' +
 				'<li class="no_push">' +
 					'<a href="#" class="customize xkit-mass-deleter" onclick="return false;" id="xkit-mass-deleter-100">' +
 						'<div class="hide_overflow">Delete 100 Drafts</div>' +
@@ -68,7 +68,7 @@ XKit.extensions.mass_deleter = new Object({
 					'</a>' +
 				'</li>' +
 				'</ul>';
-			$("ul.controls_section:eq(1)").before(xf_html);
+			$(".controls_section:eq(1)").before(xf_html);
 
 		}
 
@@ -271,7 +271,8 @@ XKit.extensions.mass_deleter = new Object({
 				'</a>' +
 			'</li>' +
 			'</ul>';
-		$("ul.controls_section:eq(1)").before(xf_html);
+		$(".controls_section:eq(1)").before(xf_html);
+		$("#xkit-mass-deleter-ul").css("margin", "18px 0");
 
 		$("#xkit-mass-deleter-100").click(function() {
 			XKit.extensions.mass_deleter.unlike_likes(100);

--- a/Extensions/outbox.js
+++ b/Extensions/outbox.js
@@ -1,5 +1,5 @@
 //* TITLE Outbox **//
-//* VERSION 0.11.1 **//
+//* VERSION 0.11.2 **//
 //* DESCRIPTION Saves your sent replies and asks. **//
 //* DETAILS This extension stores and lets you view the last 50 asks you've answered privately. Please keep in mind that this is a highly experimental extension, so if you hit a bug, please send the XKit blog an ask with the problem you've found. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -149,7 +149,7 @@ XKit.extensions.outbox = new Object({
 			'<li class="" style="height: 36px;"><a href="#" id="xkit-outbox-button">' +
 				'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">My Outbox</div>' +
 			'</a></li></ul>';
-		$("ul.controls_section:last").before(xf_html);
+		$(".controls_section:last").before(xf_html);
 
 		$(".controls_section.inbox").prepend("<li class=\"section_header selected\">INCOMING</li>");
 

--- a/Extensions/people_notifier.js
+++ b/Extensions/people_notifier.js
@@ -1,5 +1,5 @@
 //* TITLE Blog Tracker **//
-//* VERSION 0.6.3 **//
+//* VERSION 0.6.4 **//
 //* DESCRIPTION Track people like tags **//
 //* DEVELOPER new-xkit **//
 //* DETAILS Blog Tracker lets you track blogs like you can track tags. Add them on your dashboard, and it will let you know how many new posts they've made the last time you've checked their blogs, or if they've changed their URLs.<br><br>Please be aware that the more blogs you add, the longer it will take to track them all. **//
@@ -337,21 +337,11 @@ XKit.extensions.people_notifier = new Object({
 			}
 		}
 
-		m_html = m_html + '<li id="xkit-people-notifier-new-btn" class="no_push xkit-people-notifier-new" style="height: 36px;"><a class="members"><div class="" style="color: ' + text_color + ' !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Add a new person</div></a></li>';
+		m_html = m_html + '<li id="xkit-people-notifier-new-btn" class="no_push xkit-people-notifier-new" style="height: 36px; cursor: pointer;"><a class="members"><div style="color: ' + text_color + ' !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Add a new person</div></a></li>';
 
-		m_html = '<ul class="controls_section" id="xpeoplenotifier"><li class=\"section_header selected\">TRACKED BLOGS</li>' + m_html + '</ul>';
+		m_html = '<ul class="controls_section" id="xpeoplenotifier"><li class=\"section_header selected\">Tracked Blogs</li>' + m_html + '</ul>';
 
-		if ($("ul.controls_section:first").length > 0) {
-			if ($("#xim_small_links").length > 0) {
-				$("#xim_small_links").after(m_html);
-			} else if ($(".controls_section_radar").length > 0) {
-				$(".controls_section_radar").before(m_html);
-			} else {
-				$("#right_column").append(m_html);
-			}
-		} else {
-			$("#right_column").append(m_html);
-		}
+		$(".controls_section:eq(1)").before(m_html);
 
 		$(document).on("mouseenter", ".xkit-people-notifier-person", function() {
 			$(this).find(".xkit-people-notifier.close").css("display", "");
@@ -554,6 +544,8 @@ XKit.extensions.people_notifier = new Object({
 
 	destroy: function() {
 		XKit.tools.remove_css("people_notifier");
+
+		$("#xpeoplenotifier").remove();
 
 		$(document).off("mouseenter", ".xkit-people-notifier-person");
 		$(document).off("mouseleave", ".xkit-people-notifier-person");

--- a/Extensions/post_limit_checker.js
+++ b/Extensions/post_limit_checker.js
@@ -1,5 +1,5 @@
 //* TITLE Post Limit Checker **//
-//* VERSION 0.3.2 **//
+//* VERSION 0.3.3 **//
 //* DESCRIPTION Are you close to the limit? **//
 //* DETAILS Shows you how many posts you can reblog today. **//
 //* DEVELOPER new-xkit **//
@@ -25,7 +25,7 @@ XKit.extensions.post_limit_checker = new Object({
 					'</a></li>' +
 				'</ul>';
 
-		$("ul.controls_section:first").before(xf_html);
+		$(".controls_section:eq(1)").before(xf_html);
 
 		$("#post_limit_checker_view").click(function() {
 

--- a/Extensions/search_likes.js
+++ b/Extensions/search_likes.js
@@ -1,5 +1,5 @@
 //* TITLE Search Likes **//
-//* VERSION 0.3.2 **//
+//* VERSION 0.3.3 **//
 //* DESCRIPTION Lets you search likes **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS This is a very experimental extension that lets you search the posts you've liked by URL or text. Just go to your likes page, then click on Search button to get started. **//
@@ -28,9 +28,9 @@ XKit.extensions.search_likes = new Object({
 					"<input type=\"text\" placeholder=\"Enter URL/text...\" id=\"xkit-search-likes-input\">" +
 				"</div>";
 
-			m_html = '<ul class="controls_section" id="xkit-search-likes-ul"><li class=\"section_header selected\">SEARCH LIKES</li>' + m_html + '</ul>';
+			m_html = '<ul class="controls_section" id="xkit-search-likes-ul"><li class=\"section_header selected\">Search Likes</li>' + m_html + '</ul>';
 
-			$("ul.controls_section:first").after(m_html);
+			$(".controls_section:eq(1)").after(m_html);
 			$("#xkit-search-likes-ul").before(x_html);
 
 			$("#xkit-search-likes-button").click(function() {

--- a/Extensions/separator.js
+++ b/Extensions/separator.js
@@ -1,5 +1,5 @@
 //* TITLE Separator **//
-//* VERSION 1.1.4 **//
+//* VERSION 1.1.5 **//
 //* DESCRIPTION Where were we again? **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS A simple extension that puts a divider showing where you left off on your dashboard. **//
@@ -44,11 +44,11 @@ XKit.extensions.separator = new Object({
 		if (XKit.extensions.separator.preferences.jump_to.value === true) {
 
 			var xf_html = '<ul class="controls_section" id="separator_ul">' +
-				'<li class="section_header selected">SEPARATOR</li>' +
+				'<li class="section_header selected">Separator</li>' +
 				'<li class="no_push" style="height: 36px;"><a href="#" id="separator_button">' +
 					'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Go to last viewed post<span class="sub_control link_arrow arrow_right"></span></div>' +
 				'</a></li></ul>';
-			$("ul.controls_section:first").before(xf_html);
+			$(".controls_section:eq(1)").before(xf_html);
 
 
 			$("#separator_button").click(function() {

--- a/Extensions/show_originals.js
+++ b/Extensions/show_originals.js
@@ -1,5 +1,5 @@
 //* TITLE Show Originals **//
-//* VERSION 1.2.3 **//
+//* VERSION 1.2.4 **//
 //* DESCRIPTION Only shows non-reblogged posts **//
 //* DETAILS This is a really experimental extension allows you see original (non-reblogged) posts made by users on your dashboard. Please keep in mind that if you don't have enough people creating new posts on your dashboard, it might slow down your computer. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -55,13 +55,13 @@ XKit.extensions.show_originals = new Object({
 		XKit.extensions.show_originals.status = XKit.storage.get("show_originals", "status", "false");
 
 		var xf_html = '<ul class="controls_section" id="xshow_originals_ul">' +
-			'<li class="section_header selected">SHOW ORIGINALS</li>' +
+			'<li class="section_header selected">Show Originals</li>' +
 			'<li class="no_push" style="height:36px;"><a href="#" id="xshoworiginals_button">' +
 			'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Originals Only</div>' +
 			'<div class="count" id="xshoworiginalsstatus" style="padding-top: 8px;">' + XKit.extensions.show_originals.lbl_off + '</div>' +
 			'<div id="xshoworiginalsindicator">&nbsp;</div>' +
 			'</a></li></ul>';
-		$("ul.controls_section:first").before(xf_html);
+		$(".controls_section:eq(1)").before(xf_html);
 
 		XKit.extensions.show_originals.update_button();
 

--- a/Extensions/shuffle_queue.js
+++ b/Extensions/shuffle_queue.js
@@ -1,5 +1,5 @@
 //* TITLE Enhanced Queue **//
-//* VERSION 2.0.6 **//
+//* VERSION 2.0.7 **//
 //* DESCRIPTION Additions to the Queue page. **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS Go to your queue and click on the Shuffle button on the sidebar to shuffle the posts. Note that only the posts you see will be shuffled. If you have more than 15 posts on your queue, scroll down and load more posts in order to shuffle them too. Or click on Shrink Posts button to quickly rearrange them. **//
@@ -20,18 +20,6 @@ XKit.extensions.shuffle_queue = new Object({
 
 		this.running = true;
 
-		/*xf_html = '<ul class="controls_section" id="xshufflequeue_sidebar">' +
-			'<li class="">' +
-				'<a href="#" class="queue" id="xshufflequeue_button">' +
-					'<div class="hide_overflow">Shuffle</div>' +
-					'<div class="count">&nbsp;</div>' +
-				'</a>' +
-			'</li>' +
-			'</ul>';
-
-		$("ul.controls_section:eq(1)").before(xf_html);*/
-
-
 		var xf_html = '<ul class="controls_section" id="queue_plus_ul">' +
 					'<li class="section_header selected">Queue+</li>' +
 					'<li class="no_push" style="height: 36px;"><a href="#" id="xshufflequeue_button">' +
@@ -50,7 +38,7 @@ XKit.extensions.shuffle_queue = new Object({
 
 		setTimeout(function() {
 
-			$("ul.controls_section:eq(1)").before(xf_html);
+			$(".controls_section:eq(1)").before(xf_html);
 
 			$("#xshufflequeue_button").click(function(event) {
 				XKit.extensions.shuffle_queue.shuffle();

--- a/Extensions/stats.js
+++ b/Extensions/stats.js
@@ -1,5 +1,5 @@
 //* TITLE XStats **//
-//* VERSION 0.3.6 **//
+//* VERSION 0.3.7 **//
 //* DESCRIPTION The XKit Statistics Tool **//
 //* DETAILS This extension allows you to view statistics regarding your dashboard, such as the percentage of post types, top 4 posters, and more. In the future, it will allow you to view statistics regarding your and others blogs. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -29,7 +29,7 @@ XKit.extensions.stats = new Object({
 
 		if ($('#xstats_ul').length === 0) {
 			var xf_html = '<ul class="controls_section" id="xstats_ul">' +
-				'<li class="section_header selected">XSTATS</li>' +
+				'<li class="section_header selected">XStats</li>' +
 				'<li class="no_push" style="height: 36px;"><a href="#" id="xstats_dashboard_stats">' +
 				'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Dashboard Stats</div>' +
 				'</a></li>' +
@@ -37,7 +37,7 @@ XKit.extensions.stats = new Object({
 				'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Blog Stats</div>' +
 				'</a></li>' +
 				'</ul>';
-			$("ul.controls_section:first").before(xf_html);
+			$(".controls_section:eq(1)").before(xf_html);
 		}
 
 		$("#xstats_dashboard_stats").click(function() {

--- a/Extensions/tag_replacer.js
+++ b/Extensions/tag_replacer.js
@@ -1,5 +1,5 @@
 //* TITLE Tag Replacer **//
-//* VERSION 0.4.8 **//
+//* VERSION 0.4.9 **//
 //* DESCRIPTION Replace old tags! **//
 //* DETAILS Allows you to bulk replace tags of posts. Go to your Posts page on your dashboard and click on the button on the sidebar and enter the tag you want replaced, and the new tag, and Tag Replacer will take care of the rest. **//
 //* DEVELOPER new-xkit **//
@@ -28,7 +28,7 @@ XKit.extensions.tag_replacer = new Object({
 				'<li class="no_push" style="height: 36px;"><a data-url="' + XKit.interface.where().user_url + '" href="#" id="tag_replacer_button">' +
 				'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Replace a tag<span class="sub_control link_arrow icon_right icon_arrow_carrot_right"></span></div>' +
 				'</a></li></ul>';
-			$("div.small_links").after(xf_html);
+			$(".controls_section:eq(1)").before(xf_html);
 		}
 
 		$("#tag_replacer_button").click(function() {

--- a/Extensions/theme_editor.js
+++ b/Extensions/theme_editor.js
@@ -1,5 +1,5 @@
 //* TITLE Theme Editor **//
-//* VERSION 0.1.6 **//
+//* VERSION 0.1.7 **//
 //* DESCRIPTION For theme developers **//
 //* DETAILS If you are good with CSS, hop in and make your own theme.<br><br>When installed, this extension disables the standard Themes extension, and adds a button on your sidebar on your dashboard that lets you write and load your own theme. When you are done, you can submit it to xkit-dev.tumblr.com so it can be added to the theme gallery.<br><br>This extension is <b>not recommended</b> for people without CSS/HTML experience and only provided for XKit theme developers. Please disable Themes and Yoohoo! extensions before using. For better editing, Textarea Code Formatter for Chrome or Tabinta for Firefox is recommended. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -36,7 +36,7 @@ XKit.extensions.theme_editor = new Object({
 			'<li class="no_push"><a href="#" class="customize" id="xkit-theme-editor-button">' +
 			'<div class="hide_overflow">Edit Theme</div>' +
 			'</a></li></ul>';
-		$("ul.controls_section:eq(1)").before(xf_html);
+		$(".controls_section:eq(1)").before(xf_html);
 
 		$("#xkit-theme-editor-button").click(function() {
 

--- a/Extensions/view_on_dash.js
+++ b/Extensions/view_on_dash.js
@@ -1,5 +1,5 @@
 //* TITLE View On Dash **//
-//* VERSION 0.7.12 **//
+//* VERSION 0.7.13 **//
 //* DESCRIPTION View blogs on your dash **//
 //* DEVELOPER new-xkit **//
 //* DETAILS This is a preview version of an extension, missing most features due to legal/technical reasons for now. It lets you view the last 20 posts a person has made on their blogs right on your dashboard. If you have User Menus+ installed, you can also access it from their user menu under their avatar. **//
@@ -53,7 +53,7 @@ XKit.extensions.view_on_dash = new Object({
 				'<li class="no_push"><a href="#" id="view_on_dash_button">' +
 					'<div class="hide_overflow">View on Dash<span class="sub_control link_arrow arrow_right"></span></div>' +
 				'</a></li></ul>';
-			$("ul.controls_section:eq(1)").before(xf_html);
+			$(".controls_section:eq(1)").before(xf_html);
 
 			$("#view_on_dash_button").click(function() {
 

--- a/Extensions/xinbox.js
+++ b/Extensions/xinbox.js
@@ -1,5 +1,5 @@
 //* TITLE XInbox **//
-//* VERSION 1.9.11 **//
+//* VERSION 1.9.12 **//
 //* DESCRIPTION Enhances your Inbox experience **//
 //* DEVELOPER new-xkit **//
 //* DETAILS XInbox allows you to tag posts before posting them, and see all your messages at once, and lets you delete multiple messages at once using the Mass Editor mode. To use this mode, go to your Inbox and click on the Mass Editor Mode button on your sidebar, click on the messages you want to delete then click the Delete Messages button.  **//
@@ -226,6 +226,10 @@ XKit.extensions.xinbox = new Object({
 			XKit.tools.add_css(m_css, "xkit_inbox_slim_fan_mail");
 		}
 
+		if (this.preferences.mass_editor.value || this.preferences.inbox_search.value) {
+			$(".controls_section:first").after('<ul class="controls_section" id="xinbox_sidebar"><li class="section_header selected">Inbox Tools</li></ul>');
+		}
+
 		if (XKit.extensions.xinbox.preferences.mass_editor.value === true) {
 			XKit.extensions.xinbox.init_mass_editor();
 		}
@@ -238,8 +242,6 @@ XKit.extensions.xinbox = new Object({
 		if (XKit.extensions.xinbox.preferences.inbox_search.value === true) {
 			XKit.extensions.xinbox.init_inbox_search();
 		}
-
-		$("#xinbox_sidebar").prepend("<li class=\"section_header selected\">INBOX TOOLS</li>");
 
 	},
 
@@ -296,17 +298,12 @@ XKit.extensions.xinbox = new Object({
 
 	init_inbox_search: function() {
 
-		var m_html = '<li class="" id="xinbox_search_li" style="height: 36px;">' +
+		var m_html = '<li id="xinbox_search_li" style="height: 36px;">' +
 				'<a href="#" class="customize" id="xinbox_search_button">' +
 					'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Search Inbox..</div>' +
 				'</a>' +
 				'</li>';
-
-		if ($("#xinbox_sidebar").length > 0) {
-
-			$("#xinbox_sidebar").append(m_html);
-
-		}
+		$("#xinbox_sidebar").append(m_html);
 
 		var x_html = "<div id=\"xinbox-search-box\"><input type=\"text\" placeholder=\"Enter URL/text...\" id=\"xinbox-search-box-input\"></div>";
 		$("#xinbox_sidebar").before(x_html);
@@ -500,19 +497,14 @@ XKit.extensions.xinbox = new Object({
 
 	init_mass_editor: function() {
 
-		if (XKit.interface.where().inbox !== true) {
-			return;
-		}
-
-		var xf_html = '<ul class="controls_section" id="xinbox_sidebar">' +
+		var xf_html =
 			'<li class="" id="xinbox_mass_edit_li" style="height: 36px;">' +
 				'<a href="#" class="customize" id="xinbox_mass_edit_button">' +
 					'<div class="hide_overflow" style="color: rgba(255, 255, 255, 0.5) !important; font-weight: bold; padding-left: 10px; padding-top: 8px;">Mass Edit Mode</div>' +
 				'</a>' +
-			'</li>' +
-			'</ul>';
+			'</li>';
 
-		$("ul.controls_section:eq(0)").before(xf_html);
+		$("#xinbox_sidebar").append(xf_html);
 
 		$("#xinbox_mass_edit_button").click(function() {
 
@@ -1035,6 +1027,7 @@ XKit.extensions.xinbox = new Object({
 	destroy: function() {
 		$("#inbox_button > a").attr("href", "https://www.tumblr.com/inbox");
 		$("#xinbox_sidebar").remove();
+		$("#xinbox-search-box").remove();
 		XKit.post_listener.remove("xinbox");
 		$(document).off("click", "[id^='ask_answer_link_']");
 		clearInterval(XKit.extensions.xinbox.notification_check_interval);


### PR DESCRIPTION
can you BELIEVE we still have XIM-referencing code

anyway, by specifying `ul.controls_section` instead of just `.controls_section`, the View on Dash sidebar button never appears on the dashboard, and there were a few other extensions with that code in SO

affected extensions:
- Bookmarker
    - Retired stale `display_on_top` option
    - Made the margins smarter when the controls are prepended
    - Unrelated, fixed `destroy()` logic so changing preferences stops breaking the "add bookmark" button on posts
- Tag Tracking+
    - Moved controls to a nicer-fitting place when on a /tagged/ page
    - Made margins smarter when prepending
- Cleanfeed
    - Moved controls to mid-sidebar
- Drafts+
- Find Blogs
    - Moved controls to mid-sidebar
- Mass Deleter
    - Made the margins nicer for mass unliking controls (since tumblr's CSS sucks for the likes page sidebar specifically)
- Outbox
- Blog Tracker
    - Made the "Add a person" button more obviously a button
    - Fixed `destroy()` logic to remove sidebar controls
- Post Limit Checker
    - Moved controls to mid-sidebar
- Search Likes
    - Moved controls to mid-sidebar
- Separator
    - Moved controls to mid-sidebar
- Show Originals
    - Moved controls to mid-sidebar
- Enhanced Queue
- XStats
    - Moved controls to mid-sidebar
- Tag Replacer
    - No behavioural changes whatsoever, uniformity is just nice
- Theme Editor
    - Fixed a bug where the "Edit Theme" button would only appear after Old Stats had done its thing
- View on Dash
    - Fixed a bug where the "View on Dash" button would... oh you know
- XInbox
    - Fixed a bug where the Inbox Search feature would only work if you also had the Mass Inbox Editor enabled
    - Moved controls to under blog list as to not combine the two visually