### PR TITLE
Introduce XKit.blog_listener for cacheless blog fetching

### DIFF
--- a/Extensions/mutualchecker.js
+++ b/Extensions/mutualchecker.js
@@ -34,8 +34,7 @@ XKit.extensions.mutualchecker = new Object({
 		XKit.blog_listener.add("mutualchecker", this.init);
 	},
 
-	init: function() {
-		var blogs = XKit.tools.get_blogs();
+	init: function(blogs) {
 		if ($.inArray(this.preferences.main_blog.value, blogs) === -1) {
 			this.preferences.main_blog.value = blogs[0];
 		}

--- a/Extensions/mutualchecker.js
+++ b/Extensions/mutualchecker.js
@@ -1,5 +1,5 @@
 //* TITLE Mutual Checker **//
-//* VERSION 2.0.0 **//
+//* VERSION 2.0.1 **//
 //* DESCRIPTION A simple way to see who follows you back **//
 //* DETAILS Adds a small icon and '[user] follows you' hovertext to URLs you see in post headers (when appropriate).<br><br>Only checks the URL when the person directly made/reblogged/submitted/published the post, and doesn't work on sideblogs. **//
 //* DEVELOPER New-XKit **//
@@ -31,6 +31,10 @@ XKit.extensions.mutualchecker = new Object({
 
 	run: function() {
 		this.running = true;
+		XKit.blog_listener.add("mutualchecker", this.init);
+	},
+
+	init: function() {
 		var blogs = XKit.tools.get_blogs();
 		if ($.inArray(this.preferences.main_blog.value, blogs) === -1) {
 			this.preferences.main_blog.value = blogs[0];
@@ -67,7 +71,7 @@ XKit.extensions.mutualchecker = new Object({
 				}
 				XKit.extensions.mutualchecker.check(json_obj, $post.find(".post_info_submissions").first());
 			} else {
-				$post.find(".post_info_link[data-tumblelog-popover]:not(.reblog_icon + .post_info_link), .post-info-tumblelog > a[data-tumblelog-popover]").each(function() {
+				$post.find(".post_info_link[data-tumblelog-popover]:not(.reblog_icon + .post_info_link, .tf2_icon + .post_info_link), .post-info-tumblelog > a[data-tumblelog-popover]").each(function() {
 					var $link = $(this);
 					try {
 						json_obj = JSON.parse($link.attr("data-tumblelog-popover"));

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.4.3 **//
+//* VERSION 4.4.4 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -583,6 +583,11 @@ XKit.extensions.one_click_postage = new Object({
 					"#x1cpostage_reblog, #x1cpostage_queue, #x1cpostage_draft { height: 32px; }";
 			XKit.tools.add_css(slim_css, "one_click_postage_slim");
 		}
+
+		XKit.blog_listener.add("one_click_postage", this.init);
+	},
+
+	init: function() {
 
 		var m_remove_button = "<div id=\"x1cpostage_remove_caption\">remove caption</div>";
 

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -587,7 +587,7 @@ XKit.extensions.one_click_postage = new Object({
 		XKit.blog_listener.add("one_click_postage", this.init);
 	},
 
-	init: function() {
+	init: function(m_blogs) {
 
 		var m_remove_button = "<div id=\"x1cpostage_remove_caption\">remove caption</div>";
 
@@ -655,7 +655,6 @@ XKit.extensions.one_click_postage = new Object({
 			$("#x1cpostage_box").removeClass("xkit_x1cpostage_queue_press");
 		});
 
-		var m_blogs = XKit.tools.get_blogs();
 		var m_blogselector_html = "";
 
 		XKit.extensions.one_click_postage.blogs_list = m_blogs;

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -145,7 +145,7 @@ XKit.extensions.xkit_patches = new Object({
 				done: false,
 				add: function(extension, func) {
 					if (this.done) {
-						func.call(XKit.extensions[extension]);
+						func.call(XKit.extensions[extension], XKit.blogs_from_tumblr);
 					} else {
 						XKit.blog_listener.callbacks[extension] = func;
 					}
@@ -160,7 +160,7 @@ XKit.extensions.xkit_patches = new Object({
 						XKit.blog_listener.done = true;
 						var callbacks = XKit.blog_listener.callbacks;
 						for (var extension in callbacks) {
-							callbacks[extension].call(XKit.extensions[extension]);
+							callbacks[extension].call(XKit.extensions[extension], XKit.blogs_from_tumblr);
 						}
 					}
 				}

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.0.2 **//
+//* VERSION 7.1.0 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -57,7 +57,7 @@ XKit.extensions.xkit_patches = new Object({
 			XKit.storage.max_area_size = 153600;
 		}
 
-		window.addEventListener("message", XKit.tools.blog_list_message_listener);
+		window.addEventListener("message", XKit.blog_listener.eventHandler);
 
 		XKit.tools.add_function(function() {
 			var blogs = [];
@@ -139,6 +139,33 @@ XKit.extensions.xkit_patches = new Object({
 
 	patches: {
 		"7.9.0": function() {
+
+			XKit.blog_listener = {
+				callbacks: {},
+				done: false,
+				add: function(extension, func) {
+					if (this.done) {
+						func.call(XKit.extensions[extension]);
+					} else {
+						XKit.blog_listener.callbacks[extension] = func;
+					}
+				},
+				eventHandler: function(e) {
+					if (e.origin == window.location.protocol + "//" + window.location.host && e.data.hasOwnProperty("xkit_blogs")) {
+						window.removeEventListener("message", XKit.blog_listener.eventHandler);
+
+						XKit.blogs_from_tumblr = e.data.xkit_blogs.map(XKit.tools.escape_html);
+						XKit.tools.set_setting('xkit_cached_blogs', XKit.blogs_from_tumblr.join(';'));
+
+						XKit.blog_listener.done = true;
+						var callbacks = XKit.blog_listener.callbacks;
+						for (var extension in callbacks) {
+							callbacks[extension].call(XKit.extensions[extension]);
+						}
+					}
+				}
+			};
+
 			XKit.tools.Nx_XHR = function(details) {
 				details.timestamp = new Date().getTime() + Math.random();
 
@@ -250,15 +277,6 @@ XKit.extensions.xkit_patches = new Object({
 					version.patch = parseInt(versionSplit[2]);
 				}
 				return version;
-			};
-
-			XKit.tools.blog_list_message_listener = function(e) {
-				if (e.origin == window.location.protocol + "//" + window.location.host &&
-			e.data.hasOwnProperty("xkit_blogs")) {
-
-					XKit.blogs_from_tumblr = e.data.xkit_blogs.map(XKit.tools.escape_html);
-					XKit.tools.set_setting('xkit_cached_blogs', XKit.blogs_from_tumblr.join(';'));
-				}
 			};
 
 			/**
@@ -2829,7 +2847,6 @@ XKit.extensions.xkit_patches = new Object({
 
 	destroy: function() {
 		// console.log = XKit.log_back;
-		window.removeEventListener("message", XKit.extensions.xkit_patches.blog_list_message_listener);
 		XKit.tools.remove_css("xkit_patches");
 		this.running = false;
 	}


### PR DESCRIPTION
many users have been complaining about switching accounts needing a refresh for One-Click Postage to get a correct list of blogs again, and as helpfully pointed out by one ask, this has been occurring since XKit Main 2.0.0 was released

turns out, the problem is that xkit main now boots everything too fast! XKit Patches handles the blog list scraping, but XKit Main is now running everything so quickly that One-Click Postage gets booted before the blog scraper code completes its task - but of course once it's done, it stores the result, allowing consecutive `get_blogs` calls to behave properly.

this is fixed by binding OCP's initialisation to the blog message listener, which I've moved to the new `XKit.blog_listener` object to better organise related data