### PR TITLE
Don't run Tweaks on user blogs

### DIFF
--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Tweaks **//
-//* VERSION 5.7.0 **/
+//* VERSION 5.7.1 **/
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -11,8 +11,6 @@ XKit.extensions.tweaks = new Object({
 
 	running: false,
 	slow: true,
-	run_interval: 0,
-	run_interval_2: 0,
 	hide_bubble_interval: 0,
 
 	preferences: {
@@ -316,6 +314,8 @@ XKit.extensions.tweaks = new Object({
 	run: function() {
 		this.running = true;
 		this.css_to_add = "";
+
+		if (!XKit.interface.is_tumblr_page()) { return; }
 
 		this.addShowTagsObserver.disconnect();
 		var wrap_tags_all_lines = XKit.extensions.tweaks.preferences.wrap_tags.value;
@@ -959,8 +959,6 @@ XKit.extensions.tweaks = new Object({
 
 		XKit.post_listener.remove("tweaks");
 
-		clearInterval(this.run_interval);
-		clearInterval(this.run_interval_2);
 		clearInterval(this.hide_bubble_interval);
 
 		$(".xkit-small-blog-setting-link").remove();


### PR DESCRIPTION
replaces, closes #1486 because
1. `is_tumblr_page()` is better to use and we can't use that in XKit Main because not everyone can use XKit 7.9.0+
2. i dont want to rewrite that PR

fixes a lot of reported blog weirdness caused by #1594 and resolves part of #1078 

also removes two entirely unrelated but unused keys on the extension object