### PR TITLE
post action Promise functions

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -41,6 +41,8 @@
       - before: true
         after: true
   globals:
+    Promise: true
+
     _: true
     XKit: true
     XBridge: true

--- a/Extensions/audio_downloader.js
+++ b/Extensions/audio_downloader.js
@@ -1,5 +1,5 @@
 //* TITLE Audio Downloader **//
-//* VERSION 2.1.1 **//
+//* VERSION 2.1.2 **//
 //* DESCRIPTION Lets you download audio posts hosted on Tumblr **//
 //* DEVELOPER STUDIOXENIX **//
 //* FRAME false **//
@@ -144,7 +144,7 @@ XKit.extensions.audio_downloader = new Object({
 			// Check if hosted by Tumblr:
 			if ($(this).find(".audio-player").length === 0) { return; }
 
-			var m_post = XKit.interface.post($(this));
+			var m_post = XKit.interface.parse_post($(this));
 
 			if (m_post.type !== "audio") { return; }
 

--- a/Extensions/audio_plus.js
+++ b/Extensions/audio_plus.js
@@ -1,5 +1,5 @@
 //* TITLE Audio+ **//
-//* VERSION 0.5.2 **//
+//* VERSION 0.5.3 **//
 //* DESCRIPTION Enhancements for the Audio Player **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -150,7 +150,7 @@ XKit.extensions.audio_plus = {
 		$(posts).each(function() {
 			$(this).addClass("audio_plus_done");
 
-			var m_post = XKit.interface.post($(this));
+			var m_post = XKit.interface.parse_post($(this));
 
 			if (!m_post || m_post.type !== "audio") { return; }
 

--- a/Extensions/convert_links.js
+++ b/Extensions/convert_links.js
@@ -1,5 +1,5 @@
 //* TITLE Convert Links **//
-//* VERSION 0.1 REV B **//
+//* VERSION 0.1.3 **//
 //* DESCRIPTION Clickable links on asks **//
 //* DETAILS This extension allows you to turn the 'encrypted' links that people can send you using asks to clickable ones. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -67,7 +67,7 @@ XKit.extensions.convert_links = new Object({
 
 			$(this).addClass("convert-links-done");
 
-			var m_post = XKit.interface.post($(this));
+			var m_post = XKit.interface.parse_post($(this));
 			if (m_post.type !== "note") { return; }
 
 			var this_id = m_post.id;

--- a/Extensions/disable_gifs.js
+++ b/Extensions/disable_gifs.js
@@ -1,5 +1,5 @@
 //* TITLE Disable Gifs **//
-//* VERSION 0.3.2 **//
+//* VERSION 0.3.3 **//
 //* DESCRIPTION Stops GIFs on dashboard **//
 //* DETAILS This is a very early preview version of an extension that allows you to stop the GIFs from playing on your dashboard. If you still would like to view them, you can click on the Play button on the post. Please note that for now, this extension can't stop GIFs added to text posts. **//
 //* DEVELOPER new-xkit **//
@@ -177,7 +177,7 @@ XKit.extensions.disable_gifs = new Object({
 
 		try {
 
-			var m_post = XKit.interface.post($(obj));
+			var m_post = XKit.interface.parse_post($(obj));
 			if (m_post.animated === true) { return true; }
 
 			if ($(obj).find(".image_thumbnail").length > 0) {
@@ -217,7 +217,7 @@ XKit.extensions.disable_gifs = new Object({
 
 			if ($(this).hasClass("xkit-dont-run-extensions")) { return; }
 
-			var m_post = XKit.interface.post($(this));
+			var m_post = XKit.interface.parse_post($(this));
 			// if (m_post.animated !== true) { return; }
 
 			if (XKit.extensions.disable_gifs.check_if_animated($(this)) === false) {

--- a/Extensions/limit_people.js
+++ b/Extensions/limit_people.js
@@ -1,5 +1,5 @@
 //* TITLE Limit People **//
-//* VERSION 0.2.4 **//
+//* VERSION 0.2.5 **//
 //* DESCRIPTION Limit the appearance of blogs on dash **//
 //* DETAILS Some people on your dashboard posting a lot? Limit people limits how many consecutive posts by the same person appear on your dashboard at once. If a user makes more than 2 consecutive posts, the rest will be hidden until you click on a button to show them. **//
 //* DEVELOPER new-xkit **//
@@ -90,7 +90,7 @@ XKit.extensions.limit_people = new Object({
 			
 			if ($(this).parents('.peepr-drawer').length > 0) { return; }
 			
-			var m_post = XKit.interface.post($(this));
+			var m_post = XKit.interface.parse_post($(this));
 			$(this).addClass("xkit-limit-people-checked");
 
 			if (XKit.extensions.limit_people.preferences.dont_limit_me.value === true) {

--- a/Extensions/mass_deleter.js
+++ b/Extensions/mass_deleter.js
@@ -1,5 +1,5 @@
 //* TITLE Mass Deleter **//
-//* VERSION 0.2.1 **//
+//* VERSION 0.2.2 **//
 //* DESCRIPTION Mass unlike likes / delete drafts **//
 //* DETAILS Used to mass unlike posts or delete drafts. Please use with caution, especially Mass Unlike part is extremely experimental. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -112,7 +112,7 @@ XKit.extensions.mass_deleter = new Object({
 
 		$(posts).each(function() {
 
-			var m_post = XKit.interface.post($(this));
+			var m_post = XKit.interface.parse_post($(this));
 			XKit.extensions.mass_deleter.delete_drafts_array.push(m_post.id + ";" + m_post.reblog_key);
 
 		});
@@ -231,7 +231,7 @@ XKit.extensions.mass_deleter = new Object({
 				XKit.extensions.mass_deleter.delete_next_current = 0;
 
 				$(".posts .post", m_div).each(function() {
-					var m_post = XKit.interface.post($(this));
+					var m_post = XKit.interface.parse_post($(this));
 					if (XKit.extensions.mass_deleter.delete_drafts_array.length >= XKit.extensions.mass_deleter.delete_drafts_limit) {
 						XKit.extensions.mass_deleter.delete_current_array();
 						stop_action = true;
@@ -313,7 +313,7 @@ XKit.extensions.mass_deleter = new Object({
 
 			$(posts).each(function() {
 
-				var m_post = XKit.interface.post($(this));
+				var m_post = XKit.interface.parse_post($(this));
 				XKit.extensions.mass_deleter.unlike_likes_array.push(m_post.id + ";" + m_post.reblog_key);
 
 			});
@@ -417,7 +417,7 @@ XKit.extensions.mass_deleter = new Object({
 				XKit.extensions.mass_deleter.unlike_next_current = 0;
 				XKit.extensions.mass_deleter.unlike_next_page_url = response.getResponseHeader("X-Next-Page");
 				$(".post_container .post", m_div).each(function() {
-					var m_post = XKit.interface.post($(this));
+					var m_post = XKit.interface.parse_post($(this));
 					if (XKit.extensions.mass_deleter.unlike_likes_array.length >= XKit.extensions.mass_deleter.unlike_likes_limit) {
 						XKit.extensions.mass_deleter.unlike_current_array();
 						stop_action = true;

--- a/Extensions/mute.js
+++ b/Extensions/mute.js
@@ -1,5 +1,5 @@
 //* TITLE Mute! **//
-//* VERSION 2.3.3 **//
+//* VERSION 2.3.4 **//
 //* DESCRIPTION Better than 'shut up!' **//
 //* DETAILS This extension allows you to hide text and answer posts by an user while still seeing their other posts. Useful if a blogger has nice posts but a bad personality. Please note that you'll need to re-mute them if a user changes their URL. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -386,7 +386,7 @@ XKit.extensions.mute = new Object({
 
 			$(this).addClass("xmute-done");
 
-			var m_post = XKit.interface.post($(this));
+			var m_post = XKit.interface.parse_post($(this));
 			if (m_post.is_mine === true) { return; }
 
 			if ($(this).hasClass("xkit_view_on_dash_post")) { return; }

--- a/Extensions/notificationblock.js
+++ b/Extensions/notificationblock.js
@@ -1,5 +1,5 @@
 //* TITLE NotificationBlock **//
-//* VERSION 1.3.5 **//
+//* VERSION 1.3.6 **//
 //* DESCRIPTION Blocks notifications from a post **//
 //* DEVELOPER new-xkit **//
 //* DETAILS One post got way too popular and now just annoying you? Click on the notification block icon on that post to hide the notifications from that post. If you have Go-To-Dash installed, you can click on a notification, then click View button on top-right corner to quickly go back to the post on your dashboard.  **//
@@ -343,7 +343,7 @@ XKit.extensions.notificationblock = new Object({
 
 				$(this).addClass("xnotificationblockchecked");
 
-				var m_post = XKit.interface.post($(this));
+				var m_post = XKit.interface.parse_post($(this));
 				if (m_post.is_mine !== true) { return; }
 
 				var this_id = m_post.id;

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -227,37 +227,31 @@ XKit.extensions.one_click_postage = new Object({
 			reblog_key: XKit.iframe.reblog_button()[0].pathname.split('/')[3]
 		};
 
-		XKit.interface.post.fetch(request).then(
-
-			function(data) {
-				if (data.errors === false) {
-					XKit.extensions.one_click_postage.in_blog_process(data, state, $button, request, false);
+		XKit.interface.post.fetch(request).then(function(data) {
+			if (data.errors === false) {
+				XKit.extensions.one_click_postage.in_blog_process(data, state, $button, request, false);
+			} else {
+				XKit.extensions.one_click_postage.show_error("OCP05-B", state);
+			}
+		}).catch(function(response) {
+			switch (response.status) {
+			case 401:
+				XKit.extensions.one_click_postage.show_error("OCP01-B", state);
+				break;
+			case 404:
+				XKit.extensions.one_click_postage.show_error("OCP02-B [Post Not Found]", state);
+				break;
+			default:
+				if (!retry_mode) {
+					setTimeout(function() { XKit.extensions.one_click_postage.in_blog_post($button, state, true); }, 500);
+					return;
 				} else {
-					XKit.extensions.one_click_postage.show_error("OCP05-B", state);
+					XKit.extensions.one_click_postage.show_error("OCP03-" + response.status + "-B", state);
 				}
-			},
-
-			function(response) {
-				switch (response.status) {
-				case 401:
-					XKit.extensions.one_click_postage.show_error("OCP01-B", state);
-					break;
-				case 404:
-					XKit.extensions.one_click_postage.show_error("OCP02-B [Post Not Found]", state);
-					break;
-				default:
-					if (!retry_mode) {
-						setTimeout(function() { XKit.extensions.one_click_postage.in_blog_post($button, state, true); }, 500);
-						return;
-					} else {
-						XKit.extensions.one_click_postage.show_error("OCP03-" + response.status + "-B", state);
-					}
-				}
-
-				$button.removeClass("xkit-button-working").addClass("xkit-button-error");
 			}
 
-		);
+			$button.removeClass("xkit-button-working").addClass("xkit-button-error");
+		});
 	},
 
 	in_blog_process: function(data, state, $button, post, retry_mode) {
@@ -286,44 +280,38 @@ XKit.extensions.one_click_postage = new Object({
 			"post[state]": state
 		};
 
-		XKit.interface.post.update(full_post).then(
+		XKit.interface.post.update(full_post).then(function(result) {
+			$button.removeClass("xkit-button-working");
 
-			function(result) {
-				$button.removeClass("xkit-button-working");
+			if (result.errors === false) {
+				$button.addClass("xkit-button-done");
+			} else {
+				$button.addClass("xkit-button-error");
+				XKit.extensions.one_click_postage.show_error("INOCP901", state);
+			}
+		}).catch(function(response) {
+			XKit.interface.kitty.set("");
 
-				if (result.errors === false) {
-					$button.addClass("xkit-button-done");
+			switch (response.status) {
+			case 401:
+				XKit.extensions.one_click_postage.show_error("INOCP101", state);
+				break;
+			case 404:
+				XKit.extensions.one_click_postage.show_error("INOCP104 Not Found", state);
+				break;
+			default:
+				if (!retry_mode) {
+					XKit.extensions.one_click_postage.in_blog_process(data, state, $button, post, true);
+					return;
 				} else {
-					$button.addClass("xkit-button-error");
-					XKit.extensions.one_click_postage.show_error("INOCP901", state);
+					XKit.extensions.one_click_postage.show_error("INOCP109-" + response.status, state);
 				}
-			},
-
-			function(response) {
-				XKit.interface.kitty.set("");
-
-				switch (response.status) {
-				case 401:
-					XKit.extensions.one_click_postage.show_error("INOCP101", state);
-					break;
-				case 404:
-					XKit.extensions.one_click_postage.show_error("INOCP104 Not Found", state);
-					break;
-				default:
-					if (!retry_mode) {
-						XKit.extensions.one_click_postage.in_blog_process(data, state, $button, post, true);
-						return;
-					} else {
-						XKit.extensions.one_click_postage.show_error("INOCP109-" + response.status, state);
-					}
-				}
-
-				$button
-					.removeClass("xkit-button-working")
-					.addClass("xkit-button-error");
 			}
 
-		);
+			$button
+				.removeClass("xkit-button-working")
+				.addClass("xkit-button-error");
+		});
 	},
 
 	/**
@@ -1047,37 +1035,31 @@ XKit.extensions.one_click_postage = new Object({
 			$button = $(this.last_object).find(".reblog_button, .post_control.reblog").addClass("xkit-one-click-reblog-working");
 		}
 
-		XKit.interface.post.fetch(request).then(
-
-			function(data) {
-				if (data.errors === false) {
-					XKit.extensions.one_click_postage.process(data, state, blog_id, caption, tags, $button, request, false, post.root_id, quick_queue_mode);
+		XKit.interface.post.fetch(request).then(function(data) {
+			if (data.errors === false) {
+				XKit.extensions.one_click_postage.process(data, state, blog_id, caption, tags, $button, request, false, post.root_id, quick_queue_mode);
+			} else {
+				XKit.extensions.one_click_postage.show_error("OCP05", state);
+			}
+		}).catch(function(response) {
+			switch (response.status) {
+			case 401:
+				XKit.extensions.one_click_postage.show_error("OCP01", state);
+				break;
+			case 404:
+				XKit.extensions.one_click_postage.show_error("OCP02 [Post Not Found]", state);
+				break;
+			default:
+				if (!retry_mode) {
+					setTimeout(function() { XKit.extensions.one_click_postage.post(state, true, quick_queue_mode); }, 500);
+					return;
 				} else {
-					XKit.extensions.one_click_postage.show_error("OCP05", state);
+					XKit.extensions.one_click_postage.show_error("OCP03-" + response.status, state);
 				}
-			},
-
-			function(response) {
-				switch (response.status) {
-				case 401:
-					XKit.extensions.one_click_postage.show_error("OCP01", state);
-					break;
-				case 404:
-					XKit.extensions.one_click_postage.show_error("OCP02 [Post Not Found]", state);
-					break;
-				default:
-					if (!retry_mode) {
-						setTimeout(function() { XKit.extensions.one_click_postage.post(state, true, quick_queue_mode); }, 500);
-						return;
-					} else {
-						XKit.extensions.one_click_postage.show_error("OCP03-" + response.status, state);
-					}
-				}
-
-				$button.removeClass("xkit-one-click-reblog-working");
 			}
 
-		);
+			$button.removeClass("xkit-one-click-reblog-working");
+		});
 	},
 
 	process: function(data, state, blog_id, caption, tags, $button, post, retry_mode, root_id, quick_queue_mode) {
@@ -1124,59 +1106,54 @@ XKit.extensions.one_click_postage = new Object({
 			full_post[caption_field] = XKit.tools.replace_all(full_post[caption_field], "&lt;br/&gt;", "<br/>");
 		}
 
-		XKit.interface.post.update(full_post).then(
+		XKit.interface.post.update(full_post).then(function(result) {
+			$button.removeClass("xkit-one-click-reblog-working");
 
-			function(result) {
-				$button.removeClass("xkit-one-click-reblog-working");
-
-				if (result.errors === false) {
-					if (XKit.extensions.one_click_postage.preferences.enable_alreadyreblogged.value) {
-						XKit.extensions.one_click_postage.add_to_alreadyreblogged(root_id);
-					}
-
-					if (XKit.extensions.one_click_postage.preferences.enable_alreadyreblogged.value || XKit.extensions.one_click_postage.preferences.dim_posts_after_reblog.value) {
-						if (!quick_queue_mode) {
-							XKit.extensions.one_click_postage.make_button_reblogged($button);
-						} else {
-							XKit.interface.switch_control_button($button, false);
-							XKit.interface.completed_control_button($button, true);
-						}
-					}
-
-					if (!XKit.extensions.one_click_postage.preferences.dont_show_notifications.value) {
-						if (XKit.extensions.one_click_postage.preferences.use_toasts.value) {
-							XKit.toast.add(result.created_post, result.verbiage, result.post_tumblelog.name_or_id, result.post.id, result.post_context_page);
-						} else {
-							XKit.notifications.add(result.message, "ok");
-						}
-					}
-				} else {
-					XKit.extensions.one_click_postage.show_error("OCP10", state);
+			if (result.errors === false) {
+				if (XKit.extensions.one_click_postage.preferences.enable_alreadyreblogged.value) {
+					XKit.extensions.one_click_postage.add_to_alreadyreblogged(root_id);
 				}
-			},
 
-			function(response) {
-				XKit.interface.kitty.set("");
-
-				switch (response.status) {
-				case 401:
-					XKit.extensions.one_click_postage.show_error("OCP06", state);
-					break;
-				case 404:
-					XKit.extensions.one_click_postage.show_error("OCP07", state);
-					break;
-				default:
-					if (!retry_mode) {
-						XKit.extensions.one_click_postage.process.apply(XKit.extensions.one_click_postage, arguments);
-						return;
+				if (XKit.extensions.one_click_postage.preferences.enable_alreadyreblogged.value || XKit.extensions.one_click_postage.preferences.dim_posts_after_reblog.value) {
+					if (!quick_queue_mode) {
+						XKit.extensions.one_click_postage.make_button_reblogged($button);
 					} else {
-						XKit.extensions.one_click_postage.show_error("OCP08-" + response.status, state);
+						XKit.interface.switch_control_button($button, false);
+						XKit.interface.completed_control_button($button, true);
 					}
 				}
 
-				$button.removeClass("xkit-one-click-reblog-working");
+				if (!XKit.extensions.one_click_postage.preferences.dont_show_notifications.value) {
+					if (XKit.extensions.one_click_postage.preferences.use_toasts.value) {
+						XKit.toast.add(result.created_post, result.verbiage, result.post_tumblelog.name_or_id, result.post.id, result.post_context_page);
+					} else {
+						XKit.notifications.add(result.message, "ok");
+					}
+				}
+			} else {
+				XKit.extensions.one_click_postage.show_error("OCP10", state);
 			}
-		);
+		}).catch(function(response) {
+			XKit.interface.kitty.set("");
+
+			switch (response.status) {
+			case 401:
+				XKit.extensions.one_click_postage.show_error("OCP06", state);
+				break;
+			case 404:
+				XKit.extensions.one_click_postage.show_error("OCP07", state);
+				break;
+			default:
+				if (!retry_mode) {
+					XKit.extensions.one_click_postage.process.apply(XKit.extensions.one_click_postage, arguments);
+					return;
+				} else {
+					XKit.extensions.one_click_postage.show_error("OCP08-" + response.status, state);
+				}
+			}
+
+			$button.removeClass("xkit-one-click-reblog-working");
+		});
 	},
 
 	add_to_alreadyreblogged: function(post_id) {

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -481,33 +481,35 @@ XKit.extensions.one_click_postage = new Object({
 
 		var blog_html = "";
 		for (var x in blogs) {
-			blog_html += '<option value="' + blogs[x] + '"' + (blogs[x] == this.default_blog_id ? ' selected' : '') + '>' + blogs[x] + '</option>';
+			blog_html += `<option value="${blogs[x]}" ${(blogs[x] == this.default_blog_id ? ' selected' : '')}>${blogs[x]}</option>`;
 		}
 
 		var ui_html = [
-			'<div id="x1cpostage_reblog"><i>&nbsp;</i></div>' + '<div id="x1cpostage_queue"><i>&nbsp;</i></div>' + '<div id="x1cpostage_draft"><i>&nbsp;</i></div>',
+			`<div id="x1cpostage_reblog"><i>&nbsp;</i></div>
+			<div id="x1cpostage_queue"><i>&nbsp;</i></div>
+			<div id="x1cpostage_draft"><i>&nbsp;</i></div>`,
 
 			(this.preferences.show_social.value ?
-				'<div id="xkit-1cp-social">' +
-					'<div data-site="facebook" id="xkit-1cp-social-facebook">&nbsp;</div>' +
-					'<div data-site="twitter" id="xkit-1cp-social-twitter">&nbsp;</div>' +
-				'</div>'
+				`<div id="xkit-1cp-social">
+					<div data-site="facebook" id="xkit-1cp-social-facebook">&nbsp;</div>
+					<div data-site="twitter" id="xkit-1cp-social-twitter">&nbsp;</div>
+				</div>`
 			: ''),
 
 			(this.preferences.show_blog_selector.value ?
-				'<select id="x1cpostage_blog">' + blog_html + '</select>'
+				`<select id="x1cpostage_blog">${blog_html}</select>`
 			: ''),
 
 			(this.preferences.show_caption.value ?
-				'<textarea id="x1cpostage_caption" placeholder="caption"></textarea>' +
-				'<div id="x1cpostage_replace"><div>&nbsp;</div>replace caption, not append</div>'
+				`<textarea id="x1cpostage_caption" placeholder="caption"></textarea>
+				<div id="x1cpostage_replace"><div>&nbsp;</div>replace caption, not append</div>`
 			: ''),
 
 			(this.preferences.show_caption_remover.value ?
 				'<div id="x1cpostage_remove_caption">remove caption</div>'
 			: ''),
 
-			'<div id="x1cpostage_quick_tags"' + (this.preferences.show_reverse_ui.value ? '' : ' class="xkit-no-reverse-ui"') + '></div>',
+			`<div id="x1cpostage_quick_tags"${this.preferences.show_reverse_ui.value ? '' : ' class="xkit-no-reverse-ui"'}></div>`,
 
 			'<input id="x1cpostage_tags" placeholder="tags (comma separated)"/>' +
 			(this.preferences.show_tag_remover.value ?

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.4.5 **//
+//* VERSION 4.4.6 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -998,7 +998,7 @@ XKit.extensions.one_click_postage = new Object({
 
 		if (XKit.extensions.one_click_postage.auto_tagger && typeof XKit.extensions.auto_tagger != "undefined") {
 			// Call Auto Tagger for tags. Specifies that this is a reblog
-			var post_obj = XKit.interface.post($(parent_box));
+			var post_obj = XKit.interface.parse_post($(parent_box));
 			var additional_tags = XKit.extensions.auto_tagger.return_tags(post_obj, false);
 			if (additional_tags !== "") {
 				setTimeout(function() {
@@ -1056,7 +1056,7 @@ XKit.extensions.one_click_postage = new Object({
 		$(obj).attr('title', '');
 
 		// Call Auto Tagger for tags. Will be "" if auto_tagger is disabled
-		var post_obj = XKit.interface.post($(parent_box));
+		var post_obj = XKit.interface.parse_post($(parent_box));
 		var state = 0; // reblog
 		var tags = $("#x1cpostage_tags").val();
 		if (!XKit.extensions.one_click_postage.auto_tagger_done) {
@@ -1177,7 +1177,7 @@ XKit.extensions.one_click_postage = new Object({
 		}
 
 		var form_key = XKit.interface.form_key();
-		var post = XKit.interface.post(XKit.extensions.one_click_postage.last_object);
+		var post = XKit.interface.parse_post(XKit.extensions.one_click_postage.last_object);
 		var post_id = post.id;
 		var reblog_key = post.reblog_key;
 		var channel_id = post.owner;

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -833,6 +833,7 @@ XKit.extensions.one_click_postage = new Object({
 						XKit.extensions.one_click_postage.user_on_box = true;
 						XKit.extensions.one_click_postage.open_menu($(this), false, true);
 						$('#x1cpostage_tags').focus();
+						break;
 					}
 				}
 
@@ -916,10 +917,9 @@ XKit.extensions.one_click_postage = new Object({
 
 		// Call Auto Tagger for tags. Will be "" if auto_tagger is disabled
 		if (!this.auto_tagger_done) {
-			var
-				post_obj = XKit.interface.parse_post($parent_box),
-				state = 0, // reblog
-				tags = $("#x1cpostage_tags").val();
+			var post_obj = XKit.interface.parse_post($parent_box);
+			var state = 0; // reblog
+			var tags = $("#x1cpostage_tags").val();
 
 			this.auto_tagger_done = true;
 			tags += (tags ? ", " : "") + this.get_auto_tagger_tags(post_obj, state, false);
@@ -1028,16 +1028,15 @@ XKit.extensions.one_click_postage = new Object({
 			return;
 		}
 
-		var
-			post = XKit.interface.parse_post(this.last_object),
-			blog_id = this.default_blog_id,
-			caption = $("#x1cpostage_caption").val() || "",
-			tags = $("#x1cpostage_tags").val() || "",
-			$button,
-			request = {
-				reblog_id: parseInt(post.id),
-				reblog_key: post.reblog_key
-			};
+		var post = XKit.interface.parse_post(this.last_object);
+		var blog_id = this.default_blog_id;
+		var caption = $("#x1cpostage_caption").val() || "";
+		var tags = $("#x1cpostage_tags").val() || "";
+		var $button;
+		var request = {
+			reblog_id: parseInt(post.id),
+			reblog_key: post.reblog_key
+		};
 
 		if (quick_queue_mode) {
 			caption = "";

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -642,7 +642,7 @@ XKit.extensions.one_click_postage = new Object({
 				$("#x1cpostage_replace").slideUp('fast');
 			}
 
-			$("#x1cpostage_caption").addClass("x1cpostage_remove_caption_on");
+			$("#x1cpostage_remove_caption").addClass("x1cpostage_remove_caption_on");
 			$("#x1cpostage_tags").css("border-top", "1px solid #abafbc");
 		});
 
@@ -901,8 +901,9 @@ XKit.extensions.one_click_postage = new Object({
 			$("#x1cpostage_replace").css("display", "none");
 		}
 
-		$("#x1cpostage_remove_caption").css("display", "block");
-		$("#x1cpostage_caption").removeClass("x1cpostage_remove_caption_on");
+		$("#x1cpostage_remove_caption")
+			.css("display", "block")
+			.removeClass("x1cpostage_remove_caption_on");
 		$("#x1cpostage_tags").css("border-top", "0");
 		$("#x1cpostage_caption").css("height", XKit.extensions.one_click_postage.caption_height + "px");
 
@@ -1088,7 +1089,7 @@ XKit.extensions.one_click_postage = new Object({
 			reblog_post_id: post.reblog_id,
 			reblog_key: post.reblog_key,
 			remove_reblog_tree:
-				$("#x1cpostage_caption").hasClass("x1cpostage_remove_caption_on") ||
+				$("#x1cpostage_remove_caption").hasClass("x1cpostage_remove_caption_on") ||
 				$("#x1cpostage_replace").hasClass("selected"),
 			"post[tags]": tags,
 			"post[type]": data.post.type,
@@ -1107,7 +1108,7 @@ XKit.extensions.one_click_postage = new Object({
 			caption_field = "post[three]";
 		}
 
-		if (!$("#x1cpostage_caption").hasClass("x1cpostage_remove_caption_on")) {
+		if (!$("#x1cpostage_remove_caption").hasClass("x1cpostage_remove_caption_on")) {
 			if (caption !== "" && typeof caption !== "undefined") {
 				if (this.preferences.enable_popup_html.value) {
 					full_post[caption_field] = "<p>" + caption + "</p>";
@@ -1115,6 +1116,8 @@ XKit.extensions.one_click_postage = new Object({
 					full_post[caption_field] = "<p>" + $("<div/>").text(caption).html() + "</p>";
 				}
 			}
+		} else {
+			full_post[caption_field] = "";
 		}
 
 		if (full_post[caption_field]) {

--- a/Extensions/people_notifier.js
+++ b/Extensions/people_notifier.js
@@ -1,5 +1,5 @@
 //* TITLE Blog Tracker **//
-//* VERSION 0.6.5 **//
+//* VERSION 0.6.6 **//
 //* DESCRIPTION Track people like tags **//
 //* DEVELOPER new-xkit **//
 //* DETAILS Blog Tracker lets you track blogs like you can track tags. Add them on your dashboard, and it will let you know how many new posts they've made the last time you've checked their blogs, or if they've changed their URLs.<br><br>Please be aware that the more blogs you add, the longer it will take to track them all. **//
@@ -122,7 +122,7 @@ XKit.extensions.people_notifier = new Object({
 
 			$(this).addClass("xkit-people-notifier-checked");
 
-			var m_post = XKit.interface.post($(this));
+			var m_post = XKit.interface.parse_post($(this));
 
 			if (XKit.extensions.people_notifier.check_if_in_list(m_post.owner) !== true) {
 				return;

--- a/Extensions/postarchive.js
+++ b/Extensions/postarchive.js
@@ -1,5 +1,5 @@
 //* TITLE Post Archiver **//
-//* VERSION 1.0.6 **//
+//* VERSION 1.0.7 **//
 //* DESCRIPTION Never lose a post again. **//
 //* DETAILS Post Archiver lets you save posts to your XKit.<br><br>Found a good recipe? Think those hotline numbers on that signal boost post might come in handy in the future?<br><br>Click on the save button, then click on the My Archive button on your sidebar anytime to access those posts. You can also name and categorize posts. **//
 //* DEVELOPER new-xkit **//
@@ -1263,7 +1263,7 @@ XKit.extensions.postarchive = {
 
 			$(this).addClass("xkit-postarchive-done");
 
-			var m_post = XKit.interface.post($(this));
+			var m_post = XKit.interface.parse_post($(this));
 
 			XKit.interface.add_control_button(this, "xkit-postarchive", `data-xkit-postarchive-tumblelog-key="${m_post.tumblelog_key}" data-xkit-postarchive-tumblelog-name="${m_post.owner}"`);
 

--- a/Extensions/postblock.js
+++ b/Extensions/postblock.js
@@ -1,5 +1,5 @@
 //* TITLE PostBlock **//
-//* VERSION 0.2.5 **//
+//* VERSION 0.2.6 **//
 //* DESCRIPTION Block the posts you don't like **//
 //* DETAILS This is an experimental extension that blocks posts you don't like on your dashboard. When you block a post, it will be hidden completely, including reblogs of it. **//
 //* DEVELOPER new-xkit **//
@@ -94,7 +94,7 @@ XKit.extensions.postblock = new Object({
 
 			$(this).addClass("xpostblocked");
 
-			var m_post = XKit.interface.post($(this));
+			var m_post = XKit.interface.parse_post($(this));
 			if (m_post.is_mine === true) { return; }
 
 			if (XKit.extensions.postblock.blacklisted.indexOf(m_post.root_id) !== -1) {

--- a/Extensions/profiler.js
+++ b/Extensions/profiler.js
@@ -1,5 +1,5 @@
 //* TITLE Profiler **//
-//* VERSION 1.2.6 **//
+//* VERSION 1.2.7 **//
 //* DESCRIPTION The User Inspection Gadget **//
 //* DETAILS Select Profiler option from the User Menu to see information such as when they started blogging, how many posts they have, timezone, and more.<br><br>Requires User Menus+ to be installed. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -75,7 +75,7 @@ XKit.extensions.profiler = new Object({
 
 			$(this).addClass("profiler-nicknamed");
 
-			var m_post = XKit.interface.post($(this));
+			var m_post = XKit.interface.parse_post($(this));
 
 			if (XKit.interface.where().inbox !== true) {
 				if (m_post.is_mine === true) { return; }

--- a/Extensions/replyviewer.js
+++ b/Extensions/replyviewer.js
@@ -1,5 +1,5 @@
 //* TITLE ReplyViewer **//
-//* VERSION 0.3.2 **//
+//* VERSION 0.3.3 **//
 //* DESCRIPTION View post replies easily **//
 //* DETAILS The close relative of TagViewer, this extension allows you to see what replies, answers and additional content added to it while reblogging on any post. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -280,7 +280,7 @@ XKit.extensions.replyviewer = new Object({
 
 			$(this).addClass("xkit-replyviewer-done");
 
-			var m_post = XKit.interface.post($(this));
+			var m_post = XKit.interface.parse_post($(this));
 
 			// Post has no notes, skip.
 			if (m_post.note_count === 0) { return; }

--- a/Extensions/servant.js
+++ b/Extensions/servant.js
@@ -1,5 +1,5 @@
 //* TITLE Servant **//
-//* VERSION 0.6.0 **//
+//* VERSION 0.6.1 **//
 //* DESCRIPTION XKit Personal Assistant **//
 //* DETAILS Automator for XKit: lets you create little Servants that does tasks for you when the conditions you've set are met. **//
 //* DEVELOPER new-xkit **//
@@ -187,7 +187,7 @@ XKit.extensions.servant = new Object({
 
 				var m_object = {};
 
-				var m_post = XKit.interface.post($(obj));
+				var m_post = XKit.interface.parse_post($(obj));
 				m_object.run = false;
 
 				if (typeof m_post === "undefined") {
@@ -217,7 +217,7 @@ XKit.extensions.servant = new Object({
 
 				var m_object = {};
 
-				var m_post = XKit.interface.post($(obj));
+				var m_post = XKit.interface.parse_post($(obj));
 				m_object.run = false;
 
 				if (typeof m_post === "undefined") {
@@ -253,7 +253,7 @@ XKit.extensions.servant = new Object({
 				if (search_for === "text") { search_for = "regular"; }
 				if (search_for === "chat") { search_for = "conversation"; }
 
-				var m_post = XKit.interface.post($(obj));
+				var m_post = XKit.interface.parse_post($(obj));
 				m_object.run = false;
 
 				if (typeof m_post === "undefined") {
@@ -289,7 +289,7 @@ XKit.extensions.servant = new Object({
 
 				var m_object = {};
 
-				var m_post = XKit.interface.post($(obj));
+				var m_post = XKit.interface.parse_post($(obj));
 				m_object.run = false;
 
 				if (typeof m_post === "undefined") {
@@ -319,7 +319,7 @@ XKit.extensions.servant = new Object({
 
 				var m_object = {};
 
-				var m_post = XKit.interface.post($(obj));
+				var m_post = XKit.interface.parse_post($(obj));
 				m_object.run = false;
 
 				if (typeof m_post === "undefined") {

--- a/Extensions/show_picture_size.js
+++ b/Extensions/show_picture_size.js
@@ -1,5 +1,5 @@
 //* TITLE Show Picture Size **//
-//* VERSION 1.0.3 **//
+//* VERSION 1.0.4 **//
 //* DESCRIPTION Shows the resolution of media post pictures in the upper right corner of the picture **//
 //* DEVELOPER TiMESPLiNTER **//
 //* FRAME false **//
@@ -34,7 +34,7 @@ XKit.extensions.show_picture_size = new Object({
 		var posts = XKit.interface.get_posts('xkit-show-picture-size');
 
 		$(posts).each(function() {
-			var post = XKit.interface.post($(this));
+			var post = XKit.interface.parse_post($(this));
 
 			if (post.type === 'photo') {
                 // Photo

--- a/Extensions/stats.js
+++ b/Extensions/stats.js
@@ -1,5 +1,5 @@
 //* TITLE XStats **//
-//* VERSION 0.3.7 **//
+//* VERSION 0.3.8 **//
 //* DESCRIPTION The XKit Statistics Tool **//
 //* DETAILS This extension allows you to view statistics regarding your dashboard, such as the percentage of post types, top 4 posters, and more. In the future, it will allow you to view statistics regarding your and others blogs. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -250,7 +250,7 @@ XKit.extensions.stats = new Object({
 				try {
 
 					$(".post.post_full:not('.is_mine')", response.responseText).each(function() {
-						posts.push(XKit.interface.post($(this)));
+						posts.push(XKit.interface.parse_post($(this)));
 					});
 
 					XKit.progress.value("stats-progress", posts.length);

--- a/Extensions/tagviewer.js
+++ b/Extensions/tagviewer.js
@@ -1,5 +1,5 @@
 //* TITLE TagViewer **//
-//* VERSION 0.4.4 **//
+//* VERSION 0.4.5 **//
 //* DESCRIPTION View post tags easily **//
 //* DEVELOPER new-xkit **//
 //* DETAILS This extension allows you to see what tags people added to a post while they reblogged it. It also provides access to the post, and to Tumblr search pages to find similar posts.<br><br>Based on the work of <a href='http://inklesspen.tumblr.com'>inklesspen</a> **//
@@ -279,7 +279,7 @@ XKit.extensions.tagviewer = new Object({
 
 			$(this).addClass("xkit-tagviewer-done");
 
-			var m_post = XKit.interface.post($(this));
+			var m_post = XKit.interface.parse_post($(this));
 
 			// Post has no notes, skip.
 			if (m_post.note_count === 0) { return; }

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -470,7 +470,8 @@ XKit.extensions.xkit_patches = new Object({
 								"X-Tumblr-Form-Key": XKit.interface.form_key(),
 								"X-Requested-With": "XMLHttpRequest"
 							},
-							json: true, data: JSON.stringify(post),
+							json: true,
+							data: JSON.stringify(post),
 							onerror: function(response) {
 								reject(response);
 							},
@@ -500,7 +501,8 @@ XKit.extensions.xkit_patches = new Object({
 									"X-Tumblr-Form-Key": XKit.interface.form_key(),
 									"X-Requested-With": "XMLHttpRequest"
 								},
-								json: true, data: JSON.stringify(post),
+								json: true,
+								data: JSON.stringify(post),
 								onerror: function(response) {
 									reject(response);
 								},
@@ -525,7 +527,8 @@ XKit.extensions.xkit_patches = new Object({
 								"X-Tumblr-Form-Key": XKit.interface.form_key(),
 								"X-Requested-With": "XMLHttpRequest"
 							},
-							json: true, data: JSON.stringify(post),
+							json: true,
+							data: JSON.stringify(post),
 							onerror: function(response) {
 								reject(response);
 							},
@@ -551,7 +554,7 @@ XKit.extensions.xkit_patches = new Object({
 								"X-Tumblr-Form-Key": XKit.interface.form_key(),
 								"X-Requested-With": "XMLHttpRequest"
 							},
-							json: false, data: $.param(post),
+							data: $.param(post),
 							onerror: function(response) {
 								reject(response);
 							},
@@ -577,7 +580,7 @@ XKit.extensions.xkit_patches = new Object({
 								"X-Tumblr-Form-Key": XKit.interface.form_key(),
 								"X-Requested-With": "XMLHttpRequest"
 							},
-							json: false, data: $.param(post),
+							data: $.param(post),
 							onerror: function(response) {
 								reject(response);
 							},

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -459,7 +459,7 @@ XKit.extensions.xkit_patches = new Object({
 
 			};
 
-			XKit.interface.post = { /* globals Promise */
+			XKit.interface.post = {
 
 				fetch: function(post) {
 					return new Promise(function(resolve, reject) {

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.1.3 **//
+//* VERSION 7.2.0 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -485,6 +485,150 @@ XKit.extensions.xkit_patches = new Object({
 					return m_error;
 				}
 
+			};
+
+			XKit.interface.post = { /* globals Promise */
+
+				fetch: function(post) {
+					return new Promise(function(resolve, reject) {
+						XKit.tools.Nx_XHR({
+							method: "POST",
+							url: "https://www.tumblr.com/svc/post/fetch",
+							headers: {
+								"X-Tumblr-Form-Key": XKit.interface.form_key()
+							},
+							json: true, data: JSON.stringify(post),
+							onerror: function(response) {
+								reject(response);
+							},
+							onload: function(response) {
+								try {
+									resolve(JSON.parse(response.responseText));
+								} catch (e) {
+									reject(response);
+								}
+							}
+						});
+					});
+				},
+
+				update: function(post) {
+					return new Promise(function(resolve, reject) {
+						XKit.interface.kitty.get(function(kitty) {
+							if (kitty.errors) {
+								reject(kitty);
+							}
+
+							XKit.tools.Nx_XHR({
+								method: "POST",
+								url: "https://www.tumblr.com/svc/post/update",
+								headers: {
+									"X-Tumblr-Puppies": kitty.kitten,
+									"X-Tumblr-Form-Key": XKit.interface.form_key(),
+									"X-Requested-With": "XMLHttpRequest"
+								},
+								json: true, data: JSON.stringify(post),
+								onerror: function(response) {
+									reject(response);
+								},
+								onload: function(response) {
+									try {
+										resolve(JSON.parse(response.responseText));
+									} catch (e) {
+										reject(response);
+									}
+								}
+							});
+						});
+					});
+				},
+
+				delete: function(post) {
+					return new Promise(function(resolve, reject) {
+						XKit.tools.Nx_XHR({
+							method: "POST",
+							url: "https://www.tumblr.com/svc/post/delete",
+							headers: {
+								"X-Tumblr-Form-Key": XKit.interface.form_key(),
+								"X-Requested-With": "XMLHttpRequest"
+							},
+							json: true, data: JSON.stringify(post),
+							onerror: function(response) {
+								reject(response);
+							},
+							onload: function(response) {
+								try {
+									resolve(JSON.parse(response.responseText));
+								} catch (e) {
+									this.onerror(response);
+								}
+							}
+						});
+					});
+				},
+
+				like: function(post) {
+
+					return new Promise(function(resolve, reject) {
+						var encodedPost = "";
+						for (var x in post) {
+							if (encodedPost.length) { encodedPost += "&"; }
+							encodedPost += $("<div/>").text(x).html() + "=" + post[x];
+						}
+
+						XKit.tools.Nx_XHR({
+							method: "POST",
+							url: "https://www.tumblr.com/svc/like",
+							headers: {
+								"Content-Type": "application/x-www-form-urlencoded",
+								"X-Tumblr-Form-Key": XKit.interface.form_key(),
+								"X-Requested-With": "XMLHttpRequest"
+							},
+							json: false, data: encodedPost,
+							onerror: function(response) {
+								reject(response);
+							},
+							onload: function(response) {
+								try {
+									resolve(JSON.parse(response.responseText));
+								} catch (e) {
+									this.onerror(response);
+								}
+							}
+						});
+					});
+				},
+
+				unlike: function(post) {
+					return new Promise(function(resolve, reject) {
+						var encodedPost = "";
+						for (var x in post) {
+							if (encodedPost.length) { encodedPost += "&"; }
+							encodedPost += $("<div/>").text(x).html() + "=" + post[x];
+						}
+
+						XKit.tools.Nx_XHR({
+							method: "POST",
+							url: "https://www.tumblr.com/svc/unlike",
+							headers: {
+								"Content-Type": "application/x-www-form-urlencoded",
+								"X-Tumblr-Form-Key": XKit.interface.form_key(),
+								"X-Requested-With": "XMLHttpRequest"
+							},
+							json: false, data: encodedPost,
+							onerror: function(response) {
+								reject(response);
+							},
+							onload: function(response) {
+								try {
+									resolve(JSON.parse(response.responseText));
+								} catch (e) {
+									this.onerror(response);
+								}
+							}
+						});
+					});
+				}
 			};
 		},
 		"7.8.2": function() {

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -467,7 +467,8 @@ XKit.extensions.xkit_patches = new Object({
 							method: "POST",
 							url: "https://www.tumblr.com/svc/post/fetch",
 							headers: {
-								"X-Tumblr-Form-Key": XKit.interface.form_key()
+								"X-Tumblr-Form-Key": XKit.interface.form_key(),
+								"X-Requested-With": "XMLHttpRequest"
 							},
 							json: true, data: JSON.stringify(post),
 							onerror: function(response) {
@@ -540,7 +541,6 @@ XKit.extensions.xkit_patches = new Object({
 				},
 
 				like: function(post) {
-
 					return new Promise(function(resolve, reject) {
 						var encodedPost = "";
 						for (var x in post) {

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.1.2 **//
+//* VERSION 7.1.3 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -176,7 +176,7 @@ XKit.extensions.xkit_patches = new Object({
 					xhr.open(request.method, request.url, request.async || true);
 
 					if (request.json === true) {
-						xhr.setRequestHeader("Content-type", "application/json");
+						xhr.setRequestHeader("Content-Type", "application/json");
 					}
 					for (var header in request.headers) {
 						xhr.setRequestHeader(header, request.headers[header]);
@@ -219,7 +219,7 @@ XKit.extensions.xkit_patches = new Object({
 							XKit.interface.kitty.set(e.data.response.headers["x-tumblr-kittens"]);
 						}
 
-						if (e.data.success) {
+						if (e.data.success && e.data.response.status == 200) {
 							details.onload(e.data.response);
 						} else {
 							details.onerror(e.data.response);

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.1.1 **//
+//* VERSION 7.1.2 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -1368,7 +1368,7 @@ XKit.extensions.xkit_patches = new Object({
 
 					/**
 					 * Set the tags of a post
-					 * @param {Object} post_obj - Interface Post Object provided by XKit.interface.post
+					 * @param {Object} post_obj - Interface Post Object provided by XKit.interface.parse_post
 					 * @param {String} tags - Comma-separated array of tags
 					 */
 					tags: function(post_obj, tags) {
@@ -1681,7 +1681,7 @@ XKit.extensions.xkit_patches = new Object({
 				},
 
 				/**
-				 * @param {Object} post_object - Interface Post Object provided by XKit.interface.post
+				 * @param {Object} post_object - Interface Post Object provided by XKit.interface.parse_post
 				 * @param {Function} func - Called on error or on completion with an object describing
 				 *                          the results of the fetch. The object has key error: true
 				 *                          if there is an error.
@@ -1859,7 +1859,7 @@ XKit.extensions.xkit_patches = new Object({
 
 					var m_text = XKit.interface.added_icon_text[XKit.interface.added_icon.indexOf(class_name)];
 
-					var post_obj = XKit.interface.post(obj);
+					var post_obj = XKit.interface.parse_post(obj);
 					var post_id = post_obj.id;
 					var post_type = post_obj.type;
 					var post_permalink = post_obj.permalink;
@@ -1890,9 +1890,9 @@ XKit.extensions.xkit_patches = new Object({
 					// Return a post object based on post ID.
 
 					if ($("body").find("#post_" + post_id).length > 0) {
-						return XKit.interface.post($("#post_" + post_id));
+						return XKit.interface.parse_post($("#post_" + post_id));
 					} else if ($(".mh_post").length > 0) {
-						return XKit.interface.post($(".mh_post"));
+						return XKit.interface.parse_post($(".mh_post"));
 					} else {
 						var m_error = {};
 						m_error.error = true;

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -516,7 +516,7 @@ XKit.extensions.xkit_patches = new Object({
 					return new Promise(function(resolve, reject) {
 						XKit.interface.kitty.get(function(kitty) {
 							if (kitty.errors) {
-								reject(kitty);
+								reject(kitty.response);
 							}
 
 							XKit.tools.Nx_XHR({

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -542,11 +542,6 @@ XKit.extensions.xkit_patches = new Object({
 
 				like: function(post) {
 					return new Promise(function(resolve, reject) {
-						var encodedPost = "";
-						for (var x in post) {
-							if (encodedPost.length) { encodedPost += "&"; }
-							encodedPost += $("<div/>").text(x).html() + "=" + post[x];
-						}
 
 						XKit.tools.Nx_XHR({
 							method: "POST",
@@ -556,7 +551,7 @@ XKit.extensions.xkit_patches = new Object({
 								"X-Tumblr-Form-Key": XKit.interface.form_key(),
 								"X-Requested-With": "XMLHttpRequest"
 							},
-							json: false, data: encodedPost,
+							json: false, data: $.param(post),
 							onerror: function(response) {
 								reject(response);
 							},
@@ -573,11 +568,6 @@ XKit.extensions.xkit_patches = new Object({
 
 				unlike: function(post) {
 					return new Promise(function(resolve, reject) {
-						var encodedPost = "";
-						for (var x in post) {
-							if (encodedPost.length) { encodedPost += "&"; }
-							encodedPost += $("<div/>").text(x).html() + "=" + post[x];
-						}
 
 						XKit.tools.Nx_XHR({
 							method: "POST",
@@ -587,7 +577,7 @@ XKit.extensions.xkit_patches = new Object({
 								"X-Tumblr-Form-Key": XKit.interface.form_key(),
 								"X-Requested-With": "XMLHttpRequest"
 							},
-							json: false, data: encodedPost,
+							json: false, data: $.param(post),
 							onerror: function(response) {
 								reject(response);
 							},

--- a/docs/API/XKit.interface.md
+++ b/docs/API/XKit.interface.md
@@ -36,7 +36,7 @@ $(posts).each(function() {
 });
 ```
 
-<a name="post" href="XKit.interface.md#post">#</a> XKit.interface.**post**(_post_)
+<a name="parse_post" href="XKit.interface.md#parse_post">#</a> XKit.interface.**parse_post**(_post_)
 
 Takes a post object (ie: `this`).
 
@@ -71,7 +71,7 @@ Example usage:
 var posts = XKit.interface.get_posts("quick-tags-not-done", true);
 $(posts).each(function() {
     // Do something here.
-    var post_object = XKit.interface.post(this);
+    var post_object = XKit.interface.parse_post(this);
     if (post_object.type === "regular") {
         $(this).css("background","red");
     }
@@ -82,7 +82,7 @@ This will get all the posts that is owned by the user, and turn the text posts r
 
 <a name="find_post" href="XKit.interface.md#find_post">#</a> XKit.interface.**find_post**(_post_id_)
 
-Wrapper for `XKit.interface.post()`. Supply the `post_id` , and if the post is in the dashboard, a Post Object will be returned. If not, a new object with the `error` set to `true` will be returned.
+Wrapper for `XKit.interface.parse_post()`. Supply the `post_id` , and if the post is in the dashboard, a Post Object will be returned. If not, a new object with the `error` set to `true` will be returned.
 
 Example usage:
 
@@ -318,7 +318,7 @@ if (XKit.interface.where().dashboard === true) {
 
 <a name="fetch" href="XKit.interface.md#fetch">#</a> XKit.interface.**fetch**(_post_, _callback_, _reblog_mode_)
 
-Makes a request to the Tumblr server to return their post object. `post` must be the result you get from `XKit.interface.post()` or `XKit.interface.find_post()`.
+Makes a request to the Tumblr server to return their post object. `post` must be the result you get from `XKit.interface.parse_post()` or `XKit.interface.find_post()`.
 When it's done, the callback will be called with the data or status information. `reblog_mode` **must be set to true** for posts not owned by the user.
 
 Example usage:


### PR DESCRIPTION
alternate title: "One-Click Postage but the variable names make sense"

This introduces 5 new Promise functions (`fetch`, `update`, `delete`, `like` and `unlike`) to `XKit.interface`, all under a single object, `XKit.interface.post`. That was already a function, but it's a misleading name for what it does - it doesn't post anything, it parses an existing post. Thus, it is now `XKit.interface.parse_post`.

The only motivating reason for this is that constructing XHRs manually in extensions is silly when the way we interact with posts is going to be the same for all extensions at any given time. If we have and use functions to fetch, update, delete, like and unlike posts, we can update those and fix however many extensions get broken by a Tumblr update without even needing to know the full extent of what's been affected.

The most obvious starting place to me to implement these new functions is One-Click Postage, since the current code is a mess - request variables are being declared as empty objects, filled with mostly unnecessary data, then being passed to a fresh (Nx_)XHR even though we know that we're always going to need to stringify the JSON, that it's always going to be `json: true`, that it's always going to be sent via `POST`, that we always need a kitty for `/svc/post/update`, and anything else I don't need to think about if I'm looking at *just* OCP's code.
This is of course true for a lot of other extensions but OCP being the most-used extension and a swamp code-wise doesn't sit right with me at all, so I'm PRing this as it is instead of looking to clean up everything in one go. 