### PR TITLE
[Tweaks] Slim ask answer notes properly

### DIFF
--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Tweaks **//
-//* VERSION 5.7.3 **/
+//* VERSION 5.7.4 **/
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -344,6 +344,10 @@ XKit.extensions.tweaks = new Object({
 			// Fit the activity text back where it was
 			".ui_notes .activity-notification .activity-notification__activity" +
 				"{ transform: translate(-10px); }" +
+
+			// Remove ask responses (currently always blank, and messes up the activity dropdown)
+			".ui_notes .activity-notification .activity-notification__activity_response.is_part_answer" +
+				"{ display: none; }" +
 
 			// Remove the speech bubble from conversational notes and put it back in the right place
 			".ui_notes .activity-notification .activity-notification__activity .activity-notification__activity_message.conversational" +


### PR DESCRIPTION
tumblr has an element within ask answer notes which from the class name looks like it's supposed to contain the answerer's response, but always contains nothing and messes up the activity dropdown when slimmed, so the tweak now also gets rid of it

| Before | After |
| :-----: | :----: |
| ![ugly](https://user-images.githubusercontent.com/28949509/44149032-7bc5dad0-a092-11e8-9953-9b9a517f88d4.png) | ![nice](https://user-images.githubusercontent.com/28949509/44149048-83b6f81e-a092-11e8-9c94-83ed4c7b4f85.png) |