### PR TITLE
always display XInbox private answer reply button in the right place

### DIFF
--- a/Extensions/xinbox.js
+++ b/Extensions/xinbox.js
@@ -1,5 +1,5 @@
 //* TITLE XInbox **//
-//* VERSION 1.9.12 **//
+//* VERSION 1.9.13 **//
 //* DESCRIPTION Enhances your Inbox experience **//
 //* DEVELOPER new-xkit **//
 //* DETAILS XInbox allows you to tag posts before posting them, and see all your messages at once, and lets you delete multiple messages at once using the Mass Editor mode. To use this mode, go to your Inbox and click on the Mass Editor Mode button on your sidebar, click on the messages you want to delete then click the Delete Messages button.  **//
@@ -284,7 +284,7 @@ XKit.extensions.xinbox = new Object({
 				}
 
 				if (tumblelog_name !== "" && typeof tumblelog_name !== "undefined") {
-					XKit.interface.add_control_button($(this), "xkit-xinbox-pa-reply", " data-tumblelog-name=\"" + tumblelog_name + "\" data-tumblelog-name=\"" + tumblelog_name + "\" id=\"xinbox-reply-button-" + $(this).attr('data-post-id') + "\" data-json=\"" + $(this).find(".post_avatar_link").attr('data-tumblelog-popover') + "\"");
+					XKit.interface.add_control_button($(this), "xkit-xinbox-pa-reply", " data-tumblelog-name=\"" + tumblelog_name + "\" data-tumblelog-name=\"" + tumblelog_name + "\" id=\"xinbox-reply-button-" + $(this).attr('data-post-id') + "\"");
 				}
 
 			} catch (e) {


### PR DESCRIPTION
`data-json` was apparently not being escaped properly in some cases (or most, for me), resulting in the button either displaying much lower than it should or, more rarely, the option menu button being hidden

![image](https://user-images.githubusercontent.com/28949509/44627017-ac527c00-a91e-11e8-9c6e-4277212038d1.png) ![image](https://user-images.githubusercontent.com/28949509/44627015-96dd5200-a91e-11e8-82db-00d855e7fab2.png)

having `data-json` on this button doesn't seem to make any sense, so rather than try to always escape it properly, I've gone for the much easier approach of removing it completely