### PR TITLE
don't attempt to TF2-ise reblog icons in video docks

### DIFF
--- a/Extensions/tf2_reblogs.js
+++ b/Extensions/tf2_reblogs.js
@@ -1,5 +1,5 @@
 //* TITLE Tumblr Fortress 2 **//
-//* VERSION 1.2.0 **//
+//* VERSION 1.2.1 **//
 //* DESCRIPTION Replaces reblog icons with TF2 kill icons **//
 //* DEVELOPER circlejourney **//
 //* FRAME false **//
@@ -36,7 +36,9 @@ XKit.extensions.tf2_reblogs = new Object({
 	change_icon: function() {
 		$(".reblog_icon").each(function() {
 			var iconurl = XKit.extensions.tf2_reblogs.icons[$(this).parents("div.post").attr("data-post-id") % XKit.extensions.tf2_reblogs.icons.length];
-			$(this).replaceWith('<img class="tf2_icon" src="' + iconurl + '" style="vertical-align: top; margin: 0 5px; max-height: 20px;">');
+			if (iconurl) {
+				$(this).replaceWith('<img class="tf2_icon" src="' + iconurl + '" style="vertical-align: top; margin: 0 5px; max-height: 20px;">');
+			}
 		});
 	},
 


### PR DESCRIPTION
currently, Tumblr Fortress 2 looks for any reblog icon when there are new posts, and tries to apply an icon based on post ID for consistency. however, when a video is docked to the side, the first `div.post` parent it comes across has no post ID and applies `src="undefined"` as a result, which obviously doesn't look great:

![image](https://user-images.githubusercontent.com/28949509/44627251-49fb7a80-a922-11e8-97d7-617c9143ee46.png)

this *could* be fixed by instead looking for the `div.post_full` parent since side-docked videos are technically still inside the post they came from, but
1) it never activates straight away since the post listener doesn't pick up on video docking
2) there's even less space in the video dock header than the full post header

so now the extension simply checks if it actually got an icon before trying to apply it, leaving docked video reblog icons alone