### PR TITLE
don't request permission for all sites in WebExtension

### DIFF
--- a/WebExtension/manifest.json
+++ b/WebExtension/manifest.json
@@ -23,7 +23,7 @@
   "minimum_chrome_version": "44.0",
   "name": "New XKit",
   "author": "New XKit Team",
-  "permissions": ["*://*/*", "*://*/", "unlimitedStorage", "storage", "http://*.tumblr.com/", "https://*.tumblr.com/" ],
+  "permissions": ["storage", "unlimitedStorage", "*://*.tumblr.com/*", "https://new-xkit.github.io/XKit/*", "https://cloud.new-xkit.com/*" ],
   "version": "7.9.0",
   "web_accessible_resources": [ "manifest.json", "editor.js" ],
   "applications": {


### PR DESCRIPTION
inspired by one ask that was uneasy about granting "all sites" permissions to XKit and many NoScript users unable to install XKit without help

while 7.9.0 does provide an installation troubleshooting tool, I still think it's a good idea to tell users what addresses XKit needs to communicate with in order to function *before* it tries to use them.