### PR TITLE
fix create_control_button in 7.9.0

### DIFF
--- a/xkit.css
+++ b/xkit.css
@@ -163,7 +163,6 @@
 
 .xkit-interface-control-button:after {
 	content: "" !important;
-	background: none !important;
 	background-repeat: no-repeat !important;
 	background-position: 50% -1px;
 }


### PR DESCRIPTION
An unintended side-effect of moving all of XKit Patches' CSS to `xkit.css` is that all custom control buttons have `background: none !important` affixed on a different level, which means `XKit.interface.create_control_button`'s CSS was no longer good enough and all control buttons were entirely invisible.

![image](https://user-images.githubusercontent.com/28949509/47264059-3cb7d200-d506-11e8-8434-139557f280e7.png)

 Using more specific classes in this function makes control buttons visible again, and as far as I can see, makes 7.9.0 completely ready to release.