### PR TITLE
Make vital iteration spec-compliant

### DIFF
--- a/Extensions/xkit_main.js
+++ b/Extensions/xkit_main.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Main **//
-//* VERSION 2.0.0 **//
+//* VERSION 2.0.1 **//
 //* DESCRIPTION Boots XKit up **//
 //* DEVELOPER New-XKit **//
 (function() {
@@ -26,10 +26,8 @@
 
 			console.log("Welcome from XKit Main " + XKit.installed.version('xkit_main'));
 
-			var installed = XKit.installed.list();
-
-			for (var x in installed) {
-				var extension = XKit.installed.get(installed[x]);
+			for (let x of XKit.installed.list()) {
+				var extension = XKit.installed.get(x);
 
 				if (extension.id === "xkit_main") {
 					continue;

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -10,15 +10,15 @@ XKit.extensions.xkit_patches = new Object({
 	run: function() {
 		this.running = true;
 
-		var to_run = [];
+		var relevant_versions = [];
 		for (let i of this.run_order.reverse()) {
-			to_run.push(i);
+			relevant_versions.unshift(i);
 			if (i == XKit.version) {
 				break;
 			}
 		}
 
-		for (let x of to_run.reverse()) {
+		for (let x of relevant_versions) {
 			this.patches[x]();
 		}
 

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.1.2 **//
+//* VERSION 7.1.3 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -19,14 +19,15 @@ XKit.extensions.xkit_patches = new Object({
 		this.running = true;
 
 		var to_run = [];
-		for (var i in this.patches) {
-			to_run.unshift(i);
-			if (i === XKit.version) {
+		for (let i of this.run_order.reverse()) {
+			to_run.push(i);
+			if (i == XKit.version) {
 				break;
 			}
 		}
-		for (var x in to_run) {
-			this.patches[to_run[x]]();
+
+		for (let x of to_run.reverse()) {
+			this.patches[x]();
 		}
 
 		// Identify retina screen displays. Unused anywhere else
@@ -135,6 +136,8 @@ XKit.extensions.xkit_patches = new Object({
 
 		}, 1000);
 	},
+
+	run_order: ["7.8.1", "7.8.2", "7.9.0"],
 
 	patches: {
 		"7.9.0": function() {

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -10,17 +10,11 @@ XKit.extensions.xkit_patches = new Object({
 	run: function() {
 		this.running = true;
 
-		var relevant_versions = [];
-		for (let i of this.run_order.reverse()) {
-			relevant_versions.unshift(i);
-			if (i == XKit.version) {
-				break;
-			}
-		}
-
-		for (let x of relevant_versions) {
+		this.run_order.filter(x => {
+			return this.run_order.indexOf(x) >= this.run_order.indexOf(XKit.version);
+		}).forEach(x => {
 			this.patches[x]();
-		}
+		});
 
 		// Identify retina screen displays. Unused anywhere else
 		try {

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -7,14 +7,6 @@ XKit.extensions.xkit_patches = new Object({
 
 	running: false,
 
-	preferences: {
-		debug_mode: {
-			text: "XKit Developer Mode",
-			default: true,
-			value: true
-		}
-	},
-
 	run: function() {
 		this.running = true;
 
@@ -60,6 +52,7 @@ XKit.extensions.xkit_patches = new Object({
 
 		window.addEventListener("message", XKit.blog_listener.eventHandler);
 
+		// Scrape Tumblr's data object now that we can run add_function
 		XKit.tools.add_function(function() {
 			var blogs = [];
 			try {
@@ -496,24 +489,6 @@ XKit.extensions.xkit_patches = new Object({
 					);
 				}
 			};
-
-			// Scrape Tumblr's data object now that we can run add_function
-			XKit.tools.add_function(function() {
-				var blogs = [];
-				try {
-					var models = Tumblr.dashboardControls.allTumblelogs;
-					models.filter(function(model) {
-						return model.attributes.hasOwnProperty("is_current");
-					}).forEach(function(model) {
-						blogs.push(model.attributes.name);
-					});
-					if (blogs.length) {
-						window.postMessage({
-							xkit_blogs: blogs,
-						}, window.location.protocol + "//" + window.location.host);
-					}
-				} catch (e) {}
-			}, true);
 
 			/**
 			 * @return {Object} The elements of XKit's storage as a map from setting key to


### PR DESCRIPTION
addresses @nightpool's initial concerns from #1614 

replaces the arbitrary-order `for-in` loops that run XKit Main and XKit Patches with fixed-order `for-of` loops, stops XKit Patches from iterating over an object directly, and as a result makes XKit Patches' run order much clearer.

also removes an accidental duplicate chunk of code that got left behind when xkit patches got restructured, and the unused `debug_mode` preference