### PR TITLE
Give Audio+ Popout the Tumblr Mobile Look

### DIFF
--- a/Extensions/audio_plus.css
+++ b/Extensions/audio_plus.css
@@ -109,10 +109,6 @@
 }
 
 /*To push up audio player and footer elements*/
-.xkit_audio_plus_popout_showing .messaging-conversation-popovers {
-	transform: translateY(-45px) !important;
-}
-
 .xkit_audio_plus_popout_showing .pinned_sidebar_footer, 
 .xkit_audio_plus_popout_showing .messaging-open-conversations, 
 .xkit_audio_plus_popout_showing .toastr {
@@ -128,7 +124,5 @@
 .xkit_audio_plus_popout_showing .messaging-open-conversations, 
 .xkit_audio_plus_popout_showing .messaging-minimized-conversations, 
 .xkit_audio_plus_popout_showing .toastr {
-	transition: 
-		bottom .15s ease-in, 
-		transform .15s ease-in !important;
+	transition: bottom .15s ease-in;
 }

--- a/Extensions/audio_plus.css
+++ b/Extensions/audio_plus.css
@@ -34,34 +34,61 @@
 }
 
 .xkit-audio-plus-controls {
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	position: fixed;
-	bottom: 50px;
-	left: 50%;
-	transform: translateX(245px) translateY(0px);
-
+	width: 100%;
+	height: 45px;
+	padding: 5px;
+	bottom: -45px;
 	z-index: 10000;
-	width: 85px;
-	height: 85px;
-	border-radius: 42.5px;
-	display: none;
-	padding: 14px 27px;
 }
 
 .xkit-audio-plus-controls.showing {
-	display: block;
+	bottom: 0px;
+}
+
+.audio-player .play-pause {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 45px;
+	height: 45px;
+}
+
+.xkit-audio-plus-controls.audio-player {
+	min-height: unset;
+}
+
+.xkit-audio-plus-controls .audio-info {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	margin: 0;
+}
+
+.xkit-audio-plus-controls .audio-info * {
+	display: inline-block;
+	margin-left: 10px;
+	font-size: 13px;
+}
+
+.audio-player .play-pause .icon {
+	display: contents;
 }
 
 /* The following three heavily use Tumblr's dock_button styles */
 #xkit-audio-plus-controls-undock-container {
-	position: fixed;
-	right: -1.5px;
-
-	background-color: #748089;
+	display: flex;
+	justify-self: flex-end;
+	position: relative;
+	background-color: unset;
+	width: 45px;
+	height: 45px;
 	border-radius: 100%;
 	font-size: 12px;
 	cursor: pointer;
-	height: 21px;
-	width: 21px;
 	color: #fff;
 }
 
@@ -74,17 +101,34 @@
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	font-weight: 400;
-
-	margin-left: -3.5px;
-	margin-top: -3.5px;
-	position: absolute;
-	line-height: 8px;
-	height: 7px;
-	width: 7px;
-	left: 50%;
-	top: 50%;
-
 	font-size: 12px;
 	cursor: pointer;
 	color: #fff;
+	margin: auto;
+	transform: scale(2);
+}
+
+/*To push up audio player and footer elements*/
+.xkit_audio_plus_popout_showing .messaging-conversation-popovers {
+	transform: translateY(-45px) !important;
+}
+
+.xkit_audio_plus_popout_showing .pinned_sidebar_footer, 
+.xkit_audio_plus_popout_showing .messaging-open-conversations, 
+.xkit_audio_plus_popout_showing .toastr {
+	bottom: 45px !important;
+}
+
+.xkit_audio_plus_popout_showing .messaging-minimized-conversations {
+	bottom: calc(15px + 45px) !important;
+}
+
+.xkit-audio-plus-controls, 
+.xkit_audio_plus_popout_showing .pinned_sidebar_footer, 
+.xkit_audio_plus_popout_showing .messaging-open-conversations, 
+.xkit_audio_plus_popout_showing .messaging-minimized-conversations, 
+.xkit_audio_plus_popout_showing .toastr {
+	transition: 
+		bottom .15s ease-in, 
+		transform .15s ease-in !important;
 }

--- a/Extensions/audio_plus.js
+++ b/Extensions/audio_plus.js
@@ -1,5 +1,5 @@
 //* TITLE Audio+ **//
-//* VERSION 0.5.2 **//
+//* VERSION 0.5.3 **//
 //* DESCRIPTION Enhancements for the Audio Player **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -74,7 +74,26 @@ XKit.extensions.audio_plus = {
 		// Spoof audio_player class to get the Play/Pause button styles
 		controls.classList.add("audio-player");
 
+		var progress = document.createElement("div");
+		progress.classList.add("progress");
+			
+		var audio_info = document.createElement("div");
+		audio_info.classList.add("audio-info");
+		
+		var track_name = document.createElement("div");
+		track_name.classList.add("track-name");
+		
+		var track_artist = document.createElement("div");
+		track_artist.classList.add("track-artist");
+
+		var audio_image = document.createElement("div");
+		audio_image.classList.add("audio-image");
+		
+		controls.appendChild(progress);
 		controls.appendChild(playPause);
+		controls.appendChild(audio_info);
+		audio_info.appendChild(track_name);
+		audio_info.appendChild(track_artist);
 		controls.appendChild(controls_undock_container);
 
 		controls.addEventListener("click", function(event) {
@@ -86,6 +105,9 @@ XKit.extensions.audio_plus = {
 		}, false);
 
 		XKit.extensions.audio_plus.pop_out_controls = controls;
+		XKit.extensions.audio_plus.pop_out_controls_progress = progress;
+		XKit.extensions.audio_plus.pop_out_controls_track_name = track_name;
+		XKit.extensions.audio_plus.pop_out_controls_track_artist = track_artist;
 
 		document.body.appendChild(controls);
 	},
@@ -97,6 +119,7 @@ XKit.extensions.audio_plus = {
 			audio_plus.current_player.querySelector('audio').pause();
 		}
 		controls.classList.remove("showing");
+		document.body.classList.remove("xkit_audio_plus_popout_showing");
 		audio_plus.current_player = null;
 	},
 
@@ -196,8 +219,25 @@ XKit.extensions.audio_plus = {
 			return;
 		}
 
+		/*show progress in popout container*/
+		var progress = XKit.extensions.audio_plus.pop_out_controls_progress;
+		var targetNode = player.querySelector(".progress");
+		var config = {attributes: true};
+		var callback = function(mutations, observer) {
+			for (var mutation of mutations) {
+				progress.setAttribute("style", mutation.target.attributes.getNamedItem("style").value);
+			}
+		};
+
+		var observer = new MutationObserver(callback);
+		observer.observe(targetNode, config);
+
+		XKit.extensions.audio_plus.pop_out_controls_track_name.innerHTML = player.querySelector(".track-name").innerHTML;
+		XKit.extensions.audio_plus.pop_out_controls_track_artist.innerHTML = player.querySelector(".track-artist").innerHTML;
+
 		audio_plus.current_player = player;
 		audio_plus.pop_out_controls.classList.add("showing");
+		document.body.classList.add("xkit_audio_plus_popout_showing");
 		audio_plus.pop_out_controls.classList.add("playing");
 	},
 


### PR DESCRIPTION
What it says on the tin. Also has an updating progress bar, and more track information!

A possible issue that may come up is pushing up Tumblr footer elements to make room for the audio+ footer. To my knowledge, only the classes I captured below in the .css are footer elements.
There's also an issue with new XKit extensions. Unless a standard XKit class for footers is established, there might be issues with keeping this up to date to not obscure anything else.

![audio plus suggestion](https://user-images.githubusercontent.com/42635772/49200941-fe5dde80-f3f2-11e8-8a31-4ca0bf769edc.png)