### PR TITLE
Redesign Audio Plus Popout to look like Tumblr's Docked Video Popouts

### DIFF
--- a/Extensions/audio_plus.css
+++ b/Extensions/audio_plus.css
@@ -1,3 +1,5 @@
+.post_full .post_media { position: relative; }
+
 .xkit-audio-plus-slider-container {
 	position: absolute;
 	bottom: 7px;
@@ -11,8 +13,6 @@
 	z-index: 89;
 	opacity: 0.65;
 }
-
-.post_full .post_media { position: relative; }
 
 .xkit-audio-plus-slider-container:hover {
 	opacity: 1;
@@ -51,7 +51,6 @@
 		opacity .15s cubic-bezier(.165,.84,.44,1);
 }
 
-/*on search screen*/
 #search_actions_search .xkit-audio-plus-pseudo-post {
 	left: calc(50% + 289px);
 }
@@ -63,28 +62,20 @@
 }
 
 .xkit-audio-plus-pseudo-post.showing.video_is_docked {
-	bottom: 297px;
+	bottom: 300px;
 }
 
 .xkit-audio-plus-controls {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	position: fixed;
+	position: relative;
 	width: 100%;
 	height: 85px;
+	min-height: unset;
 	padding: 5px;
-	bottom: -45px;
+	bottom: 0px;
 	z-index: 10000;
-}
-
-.xkit-audio-plus-controls {
-	position: relative;
-	bottom: 0px;
-}
-
-.xkit-audio-plus-controls.showing {
-	bottom: 0px;
 }
 
 .audio-player .play-pause {
@@ -92,10 +83,7 @@
 	align-items: center;
 	justify-content: center;
 	width: 45px;
-}
-
-.xkit-audio-plus-controls.audio-player {
-	min-height: unset;
+	height: 45px;
 }
 
 .xkit-audio-plus-controls .audio-info {

--- a/Extensions/audio_plus.css
+++ b/Extensions/audio_plus.css
@@ -33,7 +33,7 @@
 	border-radius: 6px;
 }
 
-.right_column.has_docked_audio {
+#right_column.has_docked_audio {
 	opacity: 0.3;
 }
 

--- a/Extensions/audio_plus.css
+++ b/Extensions/audio_plus.css
@@ -65,7 +65,7 @@
 	z-index: 99999;
 }
 
-.xkit-audio-plus-pseudo-post.showing.video_is_docked {
+.xkit-audio-plus-pseudo-post.showing {
 	bottom: 300px;
 }
 

--- a/Extensions/audio_plus.css
+++ b/Extensions/audio_plus.css
@@ -65,10 +65,6 @@
 	z-index: 99999;
 }
 
-.xkit-audio-plus-pseudo-post.showing {
-	bottom: 300px;
-}
-
 .xkit-audio-plus-controls {
 	display: flex;
 	align-items: center;

--- a/Extensions/audio_plus.css
+++ b/Extensions/audio_plus.css
@@ -33,6 +33,10 @@
 	border-radius: 6px;
 }
 
+.right_column.has_docked_audio {
+	opacity: 0.3;
+}
+
 .xkit-audio-plus-pseudo-post {
 	display: block;
 	position: fixed;

--- a/Extensions/audio_plus.css
+++ b/Extensions/audio_plus.css
@@ -33,36 +33,110 @@
 	border-radius: 6px;
 }
 
-.xkit-audio-plus-controls {
+.xkit-audio-plus-pseudo-post {
+	display: block;
 	position: fixed;
-	bottom: 50px;
-	left: 50%;
-	transform: translateX(245px) translateY(0px);
+	background: white;
+	height: auto;
+	width: 300px;
+	border-radius: 3px;
+	padding: 15px 0;
+	left: calc(50% + 178px);
+	bottom: 15px;
+	opacity: 0;
+	z-index: -99999;
+	transition:
+		bottom .15s cubic-bezier(.165,.84,.44,1),
+		transform .15s cubic-bezier(.165,.84,.44,1), 
+		opacity .15s cubic-bezier(.165,.84,.44,1);
+}
 
-	z-index: 10000;
-	width: 85px;
+/*on search screen*/
+#search_actions_search .xkit-audio-plus-pseudo-post {
+	left: calc(50% + 289px);
+}
+
+.xkit-audio-plus-pseudo-post.showing {
+	bottom: 20px;
+	opacity: 1;
+	z-index: 99999;
+}
+
+.xkit-audio-plus-pseudo-post.showing.video_is_docked {
+	bottom: 297px;
+}
+
+.xkit-audio-plus-controls {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	position: fixed;
+	width: 100%;
 	height: 85px;
-	border-radius: 42.5px;
-	display: none;
-	padding: 14px 27px;
+	padding: 5px;
+	bottom: -45px;
+	z-index: 10000;
+}
+
+.xkit-audio-plus-controls {
+	position: relative;
+	bottom: 0px;
 }
 
 .xkit-audio-plus-controls.showing {
-	display: block;
+	bottom: 0px;
+}
+
+.audio-player .play-pause {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 45px;
+}
+
+.xkit-audio-plus-controls.audio-player {
+	min-height: unset;
+}
+
+.xkit-audio-plus-controls .audio-info {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	margin: 0;
+	user-select: none;
+}
+
+.xkit-audio-plus-controls .audio-info * {
+	display: inline-block;
+	margin-left: 10px;
+	font-size: 13px;
+}
+
+.xkit-audio-plus-controls .audio-info .track-name {
+	font-size: 15px;
+}
+
+.audio-player .play-pause .icon {
+	display: contents;
 }
 
 /* The following three heavily use Tumblr's dock_button styles */
 #xkit-audio-plus-controls-undock-container {
-	position: fixed;
-	right: -1.5px;
-
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	justify-self: flex-end;
+	position: absolute;
 	background-color: #748089;
-	border-radius: 100%;
+	width: 21px;
+	height: 21px;
+	top: -10px;
+	right: -10px;
+	border-radius: 50%;
 	font-size: 12px;
 	cursor: pointer;
-	height: 21px;
-	width: 21px;
 	color: #fff;
+	z-index: 99999;
 }
 
 #xkit-audio-plus-controls-undock::before {
@@ -74,16 +148,6 @@
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	font-weight: 400;
-
-	margin-left: -3.5px;
-	margin-top: -3.5px;
-	position: absolute;
-	line-height: 8px;
-	height: 7px;
-	width: 7px;
-	left: 50%;
-	top: 50%;
-
 	font-size: 12px;
 	cursor: pointer;
 	color: #fff;

--- a/Extensions/audio_plus.css
+++ b/Extensions/audio_plus.css
@@ -10,7 +10,7 @@
 	border-radius: 6px;
 	padding-left: 35px;
 	padding-right: 5px;
-	z-index: 89;
+	z-index: 77;
 	opacity: 0.65;
 }
 

--- a/Extensions/audio_plus.css
+++ b/Extensions/audio_plus.css
@@ -48,7 +48,7 @@
 	left: calc(50% + 178px);
 	bottom: 15px;
 	opacity: 0;
-	z-index: -99999;
+	z-index: -1;
 	transition:
 		bottom .15s cubic-bezier(.165,.84,.44,1),
 		transform .15s cubic-bezier(.165,.84,.44,1), 
@@ -62,7 +62,12 @@
 .xkit-audio-plus-pseudo-post.showing {
 	bottom: 20px;
 	opacity: 1;
-	z-index: 99999;
+	z-index: 78;
+}
+
+.peepr .xkit-audio-plus-pseudo-post {
+	opacity: 0;
+	z-index: -1;
 }
 
 .xkit-audio-plus-controls {
@@ -75,7 +80,7 @@
 	min-height: unset;
 	padding: 5px;
 	bottom: 0px;
-	z-index: 10000;
+	z-index: 1;
 }
 
 .audio-player .play-pause {
@@ -124,7 +129,7 @@
 	font-size: 12px;
 	cursor: pointer;
 	color: #fff;
-	z-index: 99999;
+	z-index: 2;
 }
 
 #xkit-audio-plus-controls-undock::before {

--- a/Extensions/audio_plus.js
+++ b/Extensions/audio_plus.js
@@ -211,7 +211,7 @@ XKit.extensions.audio_plus = {
 		}
 		controls.classList.remove("showing");
 		audio_plus.current_player = null;
-		$("#right_column").removeClass("has_docked_audio")
+		$("#right_column").removeClass("has_docked_audio");
 	},
 
 	controls_click_callback: function() {
@@ -333,7 +333,7 @@ XKit.extensions.audio_plus = {
 		var ppIcon = this.pop_out_controls.querySelector('.play-pause').querySelector('.icon');
 		ppIcon.classList.remove("icon_play");
 		ppIcon.classList.add("icon_pause");
-		$("#right_column").addClass("has_docked_audio")
+		$("#right_column").addClass("has_docked_audio");
 	},
 
 	progress_observer: new MutationObserver(function(mutations, observer) {

--- a/Extensions/audio_plus.js
+++ b/Extensions/audio_plus.js
@@ -55,7 +55,6 @@ XKit.extensions.audio_plus = {
 
 		//keep tabs on whether there's a docked video post
 		if (this.can_see_docked_posts) {
-			this.video_is_docked = false;
 			var targetNode = document.getElementById("right_column");
 			var config = {attributes: true};
 			this.dock_observer.observe(targetNode, config);
@@ -66,11 +65,9 @@ XKit.extensions.audio_plus = {
 		for (var mutation of mutations) {
 			if (mutation.target.classList.contains("has_docked_post")) {
 				var docked_video = document.getElementById("posts").querySelector(".dockable_video_embed.docked");
-				XKit.extensions.audio_plus.video_is_docked = true;
 				XKit.extensions.audio_plus.timeout_counter = 0;
 				XKit.extensions.audio_plus.waiting_until_dock_ready = setInterval(function() {XKit.extensions.audio_plus.waitUntilDockReady(docked_video);}, 50);
 			} else {
-				XKit.extensions.audio_plus.video_is_docked = false;
 				XKit.extensions.audio_plus.pop_out_controls.style.transform = "";
 			}
 		}
@@ -79,7 +76,6 @@ XKit.extensions.audio_plus = {
 	waitUntilDockReady: function(docked_video) {
 		if (this.timeout_counter <= 40) { //40 * 50ms = 2s
 			this.timeout_counter++;
-			console.log(this.timeout_counter);
 		} else {
 			this.timeout_counter = 0;
 			clearInterval(this.waiting_until_dock_ready);

--- a/Extensions/audio_plus.js
+++ b/Extensions/audio_plus.js
@@ -124,38 +124,6 @@ XKit.extensions.audio_plus = {
 	},
 
 	create_pop_out_controls: function() {
-		const cl = {
-			controls: "xkit-audio-plus-controls audio-player",
-			progress: "progress",
-			playPause: "play-pause",
-			icon: "icon icon_pause",
-			audio_info: "audio-info",
-			track_name: "track-name",
-			track_artist: "track-artist",
-			audio_image: "audio-image",
-		}
-		
-		const id = {
-			controls_undock_container: "xkit-audio-plus-controls-undock-container",
-			controls_undock: "xkit-audio-plus-controls-undock",
-		}
-/*
-		const controls_markup = `
-			<div class="${cl.controls}">
-				<div class="${cl.progress}"></div>
-				<div class="${cl.playPause}">
-					<i class="${cl.icon}"></i>
-				</div>
-				<div class="${cl.audio_info}">
-					<div class="${cl.track_name}"></div>
-					<div class="${cl.track_artist}"></div>
-				</div>
-			</div>
-			<div id="${id.controls_undock_container}">
-				<div id="${id.controls_undock}"></div>
-			</div>
-		`
-*/
 		const controls_markup = `
 			<div class="xkit-audio-plus-controls audio-player">
 				<div class="progress"></div>
@@ -170,7 +138,7 @@ XKit.extensions.audio_plus = {
 			<div id="xkit-audio-plus-controls-undock-container">
 				<div id="xkit-audio-plus-controls-undock"></div>
 			</div>
-		`
+		`;
 		
 		var psuedo_post = document.createElement("div");
 		psuedo_post.classList.add("xkit-audio-plus-pseudo-post");
@@ -344,7 +312,7 @@ XKit.extensions.audio_plus = {
 		// Arbitrarily select the first if there are multiple
 		var player = audio_plus.audio_player_of_element(pause_icons[0]);
 		var player_bounds = player.getBoundingClientRect();
-		var pause_icon = pause_icons[0]
+		var pause_icon = pause_icons[0];
 
 		// If not completely off the screen
 		if (player_bounds.top > -player_bounds.height) {
@@ -394,7 +362,7 @@ XKit.extensions.audio_plus = {
 				if (XKit.extensions.audio_plus.scrubbing == false) {
 					XKit.extensions.audio_plus.pop_out_controls.classList.remove("playing");
 				}
-			} else if (mutation.target.classList.contains("icon_pause")){
+			} else if (mutation.target.classList.contains("icon_pause")) {
 				ppIcon.classList.remove("icon_play");
 				ppIcon.classList.add("icon_pause");
 				if (XKit.extensions.audio_plus.scrubbing == false) {

--- a/Extensions/audio_plus.js
+++ b/Extensions/audio_plus.js
@@ -55,9 +55,9 @@ XKit.extensions.audio_plus = {
 
 		//keep tabs on whether there's a docked video post
 		if (this.can_see_docked_posts) {
-			var targetDockNode = document.getElementById("right_column");
+			var targetNode = document.getElementById("right_column");
 			var config = {attributes: true};
-			this.dock_observer.observe(targetDockNode, config);
+			this.dock_observer.observe(targetNode, config);
 		}
 	},
 
@@ -310,9 +310,9 @@ XKit.extensions.audio_plus = {
 		}
 
 		//show progress in popout container
-		var targetProgressNode = player.querySelector(".progress");
+		var progress = player.querySelector(".progress");
 		var config = {attributes: true};
-		this.progress_observer.observe(targetProgressNode, config);
+		this.progress_observer.observe(progress, config);
 		this.icon_observer.observe(pause_icon, config);
 
 		if (player.querySelector(".track-name").innerHTML != "") {

--- a/Extensions/audio_plus.js
+++ b/Extensions/audio_plus.js
@@ -43,7 +43,7 @@ XKit.extensions.audio_plus = {
 		XKit.extensions.audio_plus.can_see_docked_posts = true;
 		try {
 			document.getElementById("right_column").hasAttribute;
-		} catch(error) {
+		} catch (error) {
 			XKit.extensions.audio_plus.can_see_docked_posts = false;
 		}
 
@@ -68,12 +68,12 @@ XKit.extensions.audio_plus = {
 					if (mutation.target.classList.contains("has_docked_post")) {
 						var docked_video = document.getElementById("posts").querySelector(".dockable_video_embed.docked");
 						audio_plus.timeout_counter = 0;
-						audio_plus.waiting_until_dock_ready = setInterval(function() {audio_plus.waitUntilDockReady(docked_video)}, 50);
+						audio_plus.waiting_until_dock_ready = setInterval(function() {audio_plus.waitUntilDockReady(docked_video);}, 50);
 					} else {
 						audio_plus.pop_out_controls.style.transform = "";
 					}
 				}
-			}
+			};
 			var observer_dock = new MutationObserver(callback);
 			observer_dock.observe(targetNode, config);
 		}
@@ -83,9 +83,9 @@ XKit.extensions.audio_plus = {
 		var audio = XKit.extensions.audio_plus.current_player.querySelector('audio');
 		var x = event.offsetX;
 		var total_w = elem.offsetWidth;
-		var width_per = (x/total_w);
-		progress.style.width = width_per*100 + "%";
-		audio.currentTime = width_per*audio.duration;
+		var width_per = (x / total_w);
+		progress.style.width = (width_per * 100) + "%";
+		audio.currentTime = (width_per * audio.duration);
 	},
 
 	scrubIfDown: function(elem, progress, event) {
@@ -170,10 +170,10 @@ XKit.extensions.audio_plus = {
 		audio_plus.mouseDown = false;
 		controls.onmousedown = function() { 
 			audio_plus.mouseDown = true;
-		}
+		};
 		document.body.onmouseup = function() {
 			audio_plus.mouseDown = false;
-		}
+		};
 		controls.addEventListener("mousemove", function(event) {
 			if (event.target === playPause) {
 				return;
@@ -348,14 +348,14 @@ XKit.extensions.audio_plus = {
 			for (var mutation of mutations) {
 				progress.setAttribute("style", mutation.target.attributes.getNamedItem("style").value);
 			}
-		}
+		};
 		var observer_progress = new MutationObserver(callback);
 		observer_progress.observe(targetNode, config);
 
 		if (player.querySelector(".track-name").innerHTML != "") {
 			audio_plus.pop_out_controls_track_name.innerHTML = player.querySelector(".track-name").innerHTML;
 		} else {
-			audio_plus.pop_out_controls_track_name.innerHTML = "Listen"
+			audio_plus.pop_out_controls_track_name.innerHTML = "Listen";
 		}
 		audio_plus.pop_out_controls_track_artist.innerHTML = player.querySelector(".track-artist").innerHTML;
 
@@ -377,5 +377,4 @@ XKit.extensions.audio_plus = {
 		XKit.post_listener.remove("audio_plus");
 		window.removeEventListener("scroll", this.handle_scroll, false);
 	}
-
 };

--- a/Extensions/audio_plus.js
+++ b/Extensions/audio_plus.js
@@ -64,7 +64,7 @@ XKit.extensions.audio_plus = {
 
 	dock_observer: new MutationObserver(function(mutations, observer) {
 		for (var mutation of mutations) {
-			if (document.getElementById("posts").querySelector(".dockable_video_embed.docked")) {
+			if (mutation.target.classList.contains("has_docked_post")) {
 				var docked_video = document.getElementById("posts").querySelector(".dockable_video_embed.docked");
 				XKit.extensions.audio_plus.video_is_docked = true;
 				XKit.extensions.audio_plus.timeout_counter = 0;
@@ -72,9 +72,6 @@ XKit.extensions.audio_plus = {
 			} else {
 				XKit.extensions.audio_plus.video_is_docked = false;
 				XKit.extensions.audio_plus.pop_out_controls.style.transform = "";
-				if (XKit.extensions.audio_plus.pop_out_controls.classList.contains("showing")) {
-					$("#right_column").addClass("has_docked_post");
-				}
 			}
 		}
 	}),
@@ -214,11 +211,7 @@ XKit.extensions.audio_plus = {
 		}
 		controls.classList.remove("showing");
 		audio_plus.current_player = null;
-		if (audio_plus.can_see_docked_posts && audio_plus.video_is_docked) {
-			//do nothing
-		} else {
-			$("#right_column").removeClass("has_docked_post");
-		}
+		$("#right_column").removeClass("has_docked_audio")
 	},
 
 	controls_click_callback: function() {
@@ -340,11 +333,7 @@ XKit.extensions.audio_plus = {
 		var ppIcon = this.pop_out_controls.querySelector('.play-pause').querySelector('.icon');
 		ppIcon.classList.remove("icon_play");
 		ppIcon.classList.add("icon_pause");
-		if (this.can_see_docked_posts && this.video_is_docked) {
-			//do nothing
-		} else {
-			$("#right_column").addClass("has_docked_post");
-		}
+		$("#right_column").addClass("has_docked_audio")
 	},
 
 	progress_observer: new MutationObserver(function(mutations, observer) {

--- a/Extensions/audio_plus.js
+++ b/Extensions/audio_plus.js
@@ -135,12 +135,12 @@ XKit.extensions.audio_plus = {
 			track_name: "'track-name'",
 			track_artist: "'track-artist'",
 			audio_image: "'audio-image'",
-		}
+		};
 		
 		const id = {
 			controls_undock_container: "'xkit-audio-plus-controls-undock-container'",
 			controls_undock: "'xkit-audio-plus-controls-undock'",
-		}
+		};
 		
 		const controls_markup = `
 			<div class=${cl.controls}>
@@ -156,7 +156,7 @@ XKit.extensions.audio_plus = {
 			<div id=${id.controls_undock_container}>
 				<div id=${id.controls_undock}></div>
 			</div>
-		`
+		`;
 		
 		var psuedo_post = document.createElement("div");
 		psuedo_post.classList.add("xkit-audio-plus-pseudo-post");

--- a/Extensions/audio_plus.js
+++ b/Extensions/audio_plus.js
@@ -170,9 +170,9 @@ XKit.extensions.audio_plus = {
 		controls.onmousedown = function() {
 			audio_plus.mouseDown = true;
 		};
-		document.body.onmouseup = function() {
+		document.body.addEventListener("mouseup", function() {
 			audio_plus.mouseDown = false;
-		};
+		}, false);
 		controls.addEventListener("mousemove", function(event) {
 			if (event.target === playPause) {
 				return;
@@ -213,7 +213,7 @@ XKit.extensions.audio_plus = {
 	controls_click_callback: function() {
 		var audio_plus = XKit.extensions.audio_plus;
 		var controls = audio_plus.pop_out_controls;
-		var ppIcon = controls.querySelector('.play-pause').querySelector('.icon');
+		var ppIcon = controls.querySelector('.play-pause .icon');
 		var audio = audio_plus.current_player.querySelector('audio');
 
 		if (!controls.classList.contains("showing")) {

--- a/Extensions/audio_plus.js
+++ b/Extensions/audio_plus.js
@@ -8,7 +8,13 @@
 XKit.extensions.audio_plus = {
 
 	running: false,
+
 	current_player: null,
+	timeout_counter: 0,
+	waiting_until_dock_ready: null,
+	pop_out_controls: null,
+	mouseDown: false,
+	scrubbing: false,
 
 	preferences: {
 		sep0: {
@@ -51,13 +57,13 @@ XKit.extensions.audio_plus = {
 		if (XKit.extensions.audio_plus.preferences.pop_out_player.value) {
 			window.addEventListener("scroll", XKit.extensions.audio_plus.handle_scroll, false);
 			XKit.extensions.audio_plus.create_pop_out_controls();
-		}
 
-		//keep tabs on whether there's a docked video post
-		if (this.can_see_docked_posts) {
-			var targetNode = document.getElementById("right_column");
-			var config = {attributes: true};
-			this.dock_observer.observe(targetNode, config);
+			//keep tabs on whether there's a docked video post
+			if (this.can_see_docked_posts) {
+				var targetNode = document.getElementById("right_column");
+				var config = {attributes: true};
+				this.dock_observer.observe(targetNode, config);
+			}
 		}
 	},
 
@@ -65,7 +71,6 @@ XKit.extensions.audio_plus = {
 		for (var mutation of mutations) {
 			if (mutation.target.classList.contains("has_docked_post")) {
 				var docked_video = document.getElementById("posts").querySelector(".dockable_video_embed.docked");
-				XKit.extensions.audio_plus.timeout_counter = 0;
 				XKit.extensions.audio_plus.waiting_until_dock_ready = setInterval(function() {XKit.extensions.audio_plus.waitUntilDockReady(docked_video);}, 50);
 			} else {
 				XKit.extensions.audio_plus.pop_out_controls.style.transform = "";
@@ -166,7 +171,6 @@ XKit.extensions.audio_plus = {
 		}, false);
 
 		//scrubbing
-		this.mouseDown = false;
 		controls.onmousedown = function() {
 			audio_plus.mouseDown = true;
 		};
@@ -181,7 +185,6 @@ XKit.extensions.audio_plus = {
 			}
 		}, false);
 
-		this.scrubbing = false;
 		controls.addEventListener("mouseup", function() {
 			if (event.target === playPause) {
 				return;

--- a/Extensions/audio_plus.js
+++ b/Extensions/audio_plus.js
@@ -325,7 +325,7 @@ XKit.extensions.audio_plus = {
 		this.current_player = player;
 		this.pop_out_controls.classList.add("showing");
 		this.pop_out_controls.classList.add("playing");
-		var ppIcon = this.pop_out_controls.querySelector('.play-pause').querySelector('.icon');
+		var ppIcon = this.pop_out_controls.querySelector('.play-pause .icon');
 		ppIcon.classList.remove("icon_play");
 		ppIcon.classList.add("icon_pause");
 		$("#right_column").addClass("has_docked_audio");
@@ -343,7 +343,7 @@ XKit.extensions.audio_plus = {
 
 	icon_observer: new MutationObserver(mutations => {
 		for (var mutation of mutations) {
-			var ppIcon = XKit.extensions.audio_plus.pop_out_controls.querySelector('.play-pause').querySelector('.icon');
+			var ppIcon = XKit.extensions.audio_plus.pop_out_controls.querySelector('.play-pause .icon');
 			if (mutation.target.classList.contains("icon_play")) {
 				ppIcon.classList.remove("icon_pause");
 				ppIcon.classList.add("icon_play");

--- a/Extensions/audio_plus.js
+++ b/Extensions/audio_plus.js
@@ -61,7 +61,7 @@ XKit.extensions.audio_plus = {
 		}
 	},
 
-	dock_observer: new MutationObserver(function(mutations, observer) {
+	dock_observer: new MutationObserver(mutations => {
 		for (var mutation of mutations) {
 			if (mutation.target.classList.contains("has_docked_post")) {
 				var docked_video = document.getElementById("posts").querySelector(".dockable_video_embed.docked");
@@ -332,7 +332,7 @@ XKit.extensions.audio_plus = {
 		$("#right_column").addClass("has_docked_audio");
 	},
 
-	progress_observer: new MutationObserver(function(mutations, observer) {
+	progress_observer:  new MutationObserver(mutations => {
 		for (var mutation of mutations) {
 			XKit.extensions.audio_plus.pop_out_controls_progress.setAttribute("style", mutation.target.attributes.getNamedItem("style").value);
 			//reset when audio is finished
@@ -342,7 +342,7 @@ XKit.extensions.audio_plus = {
 		}
 	}),
 
-	icon_observer: new MutationObserver(function(mutations, observer) {
+	icon_observer:  new MutationObserver(mutations => {
 		for (var mutation of mutations) {
 			var ppIcon = XKit.extensions.audio_plus.pop_out_controls.querySelector('.play-pause').querySelector('.icon');
 			if (mutation.target.classList.contains("icon_play")) {

--- a/Extensions/audio_plus.js
+++ b/Extensions/audio_plus.js
@@ -55,9 +55,9 @@ XKit.extensions.audio_plus = {
 
 		//keep tabs on whether there's a docked video post
 		if (this.can_see_docked_posts) {
-			var targetNode = document.getElementById("right_column");
+			var targetDockNode = document.getElementById("right_column");
 			var config = {attributes: true};
-			this.dock_observer.observe(targetNode, config);
+			this.dock_observer.observe(targetDockNode, config);
 		}
 	},
 
@@ -292,18 +292,17 @@ XKit.extensions.audio_plus = {
 	check_pop_out: function() {
 		var audio_plus = XKit.extensions.audio_plus;
 		audio_plus.scroll_waiting = false;
-
-		var pause_icons = document.querySelectorAll(".post_media .audio-player .icon_pause");
-		if (pause_icons.length) {
-			audio_plus.show_pop_out(pause_icons);
+		
+		// Arbitrarily select the first if there are multiple
+		var pause_icon = document.querySelectorAll(".post_media .audio-player .icon_pause")[0];
+		if (pause_icon) {
+			audio_plus.show_pop_out(pause_icon);
 		}
 	},
 
-	show_pop_out: function(pause_icons) {
-		// Arbitrarily select the first if there are multiple
-		var player = this.audio_player_of_element(pause_icons[0]);
+	show_pop_out: function(pause_icon) {
+		var player = this.audio_player_of_element(pause_icon);
 		var player_bounds = player.getBoundingClientRect();
-		var pause_icon = pause_icons[0];
 
 		// If not completely off the screen
 		if (player_bounds.top > -player_bounds.height) {
@@ -311,9 +310,9 @@ XKit.extensions.audio_plus = {
 		}
 
 		//show progress in popout container
-		var targetNode = player.querySelector(".progress");
+		var targetProgressNode = player.querySelector(".progress");
 		var config = {attributes: true};
-		this.progress_observer.observe(targetNode, config);
+		this.progress_observer.observe(targetProgressNode, config);
 		this.icon_observer.observe(pause_icon, config);
 
 		if (player.querySelector(".track-name").innerHTML != "") {
@@ -332,7 +331,7 @@ XKit.extensions.audio_plus = {
 		$("#right_column").addClass("has_docked_audio");
 	},
 
-	progress_observer:  new MutationObserver(mutations => {
+	progress_observer: new MutationObserver(mutations => {
 		for (var mutation of mutations) {
 			XKit.extensions.audio_plus.pop_out_controls_progress.setAttribute("style", mutation.target.attributes.getNamedItem("style").value);
 			//reset when audio is finished
@@ -342,7 +341,7 @@ XKit.extensions.audio_plus = {
 		}
 	}),
 
-	icon_observer:  new MutationObserver(mutations => {
+	icon_observer: new MutationObserver(mutations => {
 		for (var mutation of mutations) {
 			var ppIcon = XKit.extensions.audio_plus.pop_out_controls.querySelector('.play-pause').querySelector('.icon');
 			if (mutation.target.classList.contains("icon_play")) {


### PR DESCRIPTION
Ok, so this PR updates the Audio Plus popout to look more like Tumblr's own docked video popouts, plus adds some other features:
* Can move the progress bar around just like in the post itself! The post will update along with it
* It adjusts it's height when there's a docked video popout, so both are visible at all times

Hope it looks good! The docked audio post colour in the screenshots match my theme, but the committed .css uses Tumblr's standard white.

![audio plus docked](https://user-images.githubusercontent.com/42635772/49742274-47b00700-fcec-11e8-9666-1f5589b68d81.png)
![audio plus docked 2](https://user-images.githubusercontent.com/42635772/49742275-4979ca80-fcec-11e8-9300-d3e90972736c.png)