### PR TITLE
[Old Stats] Add icon for "Review flagged posts"

### DIFF
--- a/Extensions/old_stats.css
+++ b/Extensions/old_stats.css
@@ -1,39 +1,35 @@
 .control-item.control-anchor .hide_overflow::before {
-	font-family: tumblr-icons, None;
-	font-size: 24px;
-	line-height: 0;
-	font-weight: normal;
-	position: relative;
-	top: 3px; left: 1px;
+	display: inline-block;
+	width: 25px;
+	vertical-align: sub;
+	margin-right: 0.5em;
+	font: normal 24px/0 tumblr-icons, Blank;
+	text-align: center;
 }
 
 .control-item.control-anchor.posts .hide_overflow::before {
-	content: "\EA8B\2002";
+	content: "\EA8B";
 }
 .control-item.control-anchor.followers .hide_overflow::before {
-	content: "\EA44\2002";
+	content: "\EA44";
 }
 .control-item.control-anchor.activity .hide_overflow::before {
-	content: "\EA01\2002";
-	left: 5px;
-	margin-right: 11px;
+	content: "\EA01";
 }
 .control-item.control-anchor.members .hide_overflow::before {
-	content: "\EA59\2002";
-	font-size: 21px;
-	top: 2px; left: 2px;
-	margin-right: 5px;
+	content: "\EA59";
 }
 .control-item.control-anchor.queue .hide_overflow::before {
-	content: "\EA8D\2002";
-	left: -1px;
+	content: "\EA8D";
+	margin-left: -2px;
+	padding-right: 2px;
 }
 .control-item.control-anchor.drafts .hide_overflow::before {
-	content: "\EA25\2002";
+	content: "\EA25";
 }
 .control-item.control-anchor.processing .hide_overflow::before {
-	content: "\EA8C\2002";
+	content: "\EA8C";
 }
 .control-item.control-anchor.customize .hide_overflow::before {
-	content: "\EAB3\2002";
+	content: "\EAB3";
 }

--- a/Extensions/old_stats.css
+++ b/Extensions/old_stats.css
@@ -19,16 +19,16 @@
 .control-item.control-anchor.members .hide_overflow::before {
 	content: "\EA59";
 }
-.control-item.control-anchor.queue .hide_overflow::before {
-	content: "\EA8D";
-	margin-left: -2px;
-	padding-right: 2px;
-}
 .control-item.control-anchor.drafts .hide_overflow::before {
 	content: "\EA25";
 }
 .control-item.control-anchor.processing .hide_overflow::before {
 	content: "\EA8C";
+}
+.control-item.control-anchor.queue .hide_overflow::before {
+	content: "\EA8D";
+	margin-left: -2px;
+	padding-right: 2px;
 }
 .control-item.control-anchor.customize .hide_overflow::before {
 	content: "\EAB3";

--- a/Extensions/old_stats.css
+++ b/Extensions/old_stats.css
@@ -30,6 +30,9 @@
 	margin-left: -2px;
 	padding-right: 2px;
 }
+.control-item.control-anchor.review .hide_overflow::before {
+	content: "\EABC";
+}
 .control-item.control-anchor.customize .hide_overflow::before {
 	content: "\EAB3";
 }

--- a/Extensions/old_stats.js
+++ b/Extensions/old_stats.js
@@ -1,5 +1,5 @@
 //* TITLE Old Stats **//
-//* VERSION 0.5.0 **//
+//* VERSION 0.5.1 **//
 //* DESCRIPTION Blog stats where they were **//
 //* DEVELOPER New-XKit **//
 //* FRAME false **//


### PR DESCRIPTION
Aligns icons more cleanly, fixes the "Activity" text being pushed more than other text, and adds the sensitive content icon to the "Review flagged posts" control item

| Before | After |
| :-----: | :-----: |
| ![bad](https://user-images.githubusercontent.com/28949509/50809464-7fb26600-12fb-11e9-8555-7c0d733a37d7.png) | ![good](https://user-images.githubusercontent.com/28949509/50809333-ceabcb80-12fa-11e9-83e8-ecdae5445bf3.png) |
