### PR TITLE
Timestamps OP Update

### DIFF
--- a/Extensions/timestamps.css
+++ b/Extensions/timestamps.css
@@ -29,14 +29,42 @@
 }
 
 .xtimestamp {
+	display: inline-block;
 	position: relative;
-	top: -9px;
+	border-radius: 3px;
+	padding: 0 5px;
 	color: rgb(168,177,184);
 	text-align: left;
 	font-weight: normal !important;
 	font-size: 11px;
-	margin-bottom: 10px;
-	margin-left: 20px;
+}
+
+.xtimestamp-this-year {
+	padding: 0;
+}
+
+.xtimestamp-1-year {
+	background-color: #EEE;
+}
+
+.xtimestamp-2-year {
+	background-color: #DDD;
+	color: hsl(206, 10%, 50%);
+}
+
+.xtimestamp-3-year {
+	background-color: #CCC;
+	color: hsl(206, 10%, 50%);
+}
+
+.xtimestamp-4-year {
+	background-color: #BBB;
+	color: hsl(206, 10%, 50%);
+}
+
+.xtimestamp-5plus-year {
+	background-color: #AAA;
+	color: hsl(206, 10%, 100%);
 }
 
 .xtimestamp.xtimestamp_loading {

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -222,16 +222,8 @@ XKit.extensions.timestamps = new Object({
 						var post = data.response.posts[0];
 						var date = moment(new Date(post.timestamp * 1000));
 
-						XKit.extensions.timestamps.set_age(date, date_element);
-/*
-						if (date.year() == moment().year()) {
-							date_element.addClass("xtimestamp-this-year");
-						} else if (date.year() == moment().year()-5) {
-							date_element.addClass("xtimestamp-5plus-year");
-						} else {
-							date_element.addClass("xtimestamp-" + (moment().year() - date.year()) + "-year");
-						}
-*/
+						XKit.extensions.timestamps.add_age(date, date_element);
+
 						date_element.html(self.format_date(date));
 						date_element.removeClass("xtimestamp_loading");
 						XKit.storage.set("timestamps", "xkit_timestamp_cache_" + post_id, post.timestamp);
@@ -247,13 +239,15 @@ XKit.extensions.timestamps = new Object({
 		}
 	},
 
-	set_age: function(date, date_element) {
-		if (date.year() == moment().year()) {
+	add_age: function(date, date_element) {
+		var this_year = moment().year();
+		
+		if (date.year() == this_year) {
 			date_element.addClass("xtimestamp-this-year");
-		} else if (date.year() == moment().year()-5) {
+		} else if (date.year() == this_year - 5) {
 			date_element.addClass("xtimestamp-5plus-year");
 		} else {
-			date_element.addClass("xtimestamp-" + (moment().year() - date.year()) + "-year");
+			date_element.addClass("xtimestamp-" + (this_year - date.year()) + "-year");
 		}
 	},
 
@@ -272,7 +266,7 @@ XKit.extensions.timestamps = new Object({
 		if (!cached_date.isValid()) {
 			return false;
 		}
-		this.set_age(moment(new Date(cached * 1000)), date_element);
+		this.add_age(moment(new Date(cached * 1000)), date_element);
 		date_element.html(this.format_date(cached_date));
 		date_element.removeClass("xtimestamp_loading");
 		return true;

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -1,5 +1,5 @@
 //* TITLE Timestamps **//
-//* VERSION 2.8.1 **//
+//* VERSION 2.9.0 **//
 //* DESCRIPTION See when a post has been made. **//
 //* DETAILS This extension lets you see when a post was made, in full date or relative time (eg: 5 minutes ago). It also works on asks, and you can format your timestamps. **//
 //* DEVELOPER New-XKit **//
@@ -32,7 +32,7 @@ XKit.extensions.timestamps = new Object({
 			value: false
 		},
 		only_absolute: {
-			text: "Only show absolute time (eg: 16/02/2019 11:00 AM)",
+			text: "Only show absolute time (eg: 01/01/20XX 12:00 PM)",
 			default: false,
 			value: false
 		},

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -162,35 +162,14 @@ XKit.extensions.timestamps = new Object({
 					var post_id = post.attr('data-post-id');
 					var blog_name = post.attr('data-tumblelog-name');
 				} else {
-/*
-					try {
-						var post_id = post.attr('data-root_id');
-						var op_json = JSON.parse(post.attr('data-json'));
-						var blog_name = op_json['tumblelog-root-data'].name;
-					} catch(e) {
-						try {
-							var post_source = post.find(".post-source-link");
-							var op_json = JSON.parse(post_source.attr("data-peepr"));
-							var post_id = op_json['postId'];
-							var blog_name = op_json['tumblelog'];
-						} catch(e2) {
-							console.error("from XKit's timestamps: " + e2.name + ": " + e2.message);
-							var post_id = post.attr('data-post-id');
-							var blog_name = post.attr('data-tumblelog-name');
-						}
-					}
-*/
 					try {
 						var post_id = post.attr('data-root_id');
 						var op_json = JSON.parse(post.attr('data-json'));
 						var blog_name = op_json['tumblelog-root-data'].name;
 					} catch(e) { //most probably in peepr
-						console.log(post);
 						peepr_data = XKit.extensions.timestamps.checkPeepr(post);
 						var post_id = peepr_data[0];
 						var blog_name = peepr_data[1];
-						console.log(post_id);
-						console.log(blog_name);
 					}
 				}
 			} else {
@@ -216,8 +195,7 @@ XKit.extensions.timestamps = new Object({
 	},
 
 	checkPeepr: function(post) {
-		if (post.find(".post-source-link").length) {
-			console.log('im in');
+		if (post.find(".post-source-link").length) { //get op data from source link
 			var post_source = post.find(".post-source-link");
 			if (post_source.attr("data-peepr")) {
 				var op_json = JSON.parse(post_source.attr("data-peepr"));
@@ -235,13 +213,12 @@ XKit.extensions.timestamps = new Object({
 					var blog_name = "";
 				}
 			}
-		} else if (post.find(".reblog_info").length) { //user reblogged themselves probs?
+		} else if (post.find(".reblog_info").length) { //user reblogged themselves?
 			var post_source = post.find(".reblog_info");
 			var op_json = JSON.parse(post_source.attr("data-peepr"));
 			var post_id = op_json['postId'];
 			var blog_name = op_json['tumblelog'];
 		} else { //no source AND no reblog info = original post
-			console.log('im NOT in');
 			var post_id = post.attr('data-post-id');
 			var blog_name = post.attr('data-tumblelog-name');
 		}

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -151,19 +151,24 @@ XKit.extensions.timestamps = new Object({
 				return;
 			}
 
-			if (post.hasClass("is_original")) {
-				var post_id = post.attr('data-post-id');
-				var blog_name = post.attr('data-tumblelog-name');
-			} else {
-				try {
-					var post_id = post.attr('data-root_id');
-					var blog_json = JSON.parse(post.attr('data-json'));
-					var blog_name = blog_json['tumblelog-root-data'].name;
-				} catch(e) {
-					console.error("from XKit's timestamps: " + e.name + ": " + e.message);
+			if (this.preferences.op_timestamps) {
+				if (post.hasClass("is_original")) {
 					var post_id = post.attr('data-post-id');
 					var blog_name = post.attr('data-tumblelog-name');
+				} else {
+					try {
+						var post_id = post.attr('data-root_id');
+						var blog_json = JSON.parse(post.attr('data-json'));
+						var blog_name = blog_json['tumblelog-root-data'].name;
+					} catch(e) {
+						console.error("from XKit's timestamps: " + e.name + ": " + e.message);
+						var post_id = post.attr('data-post-id');
+						var blog_name = post.attr('data-tumblelog-name');
+					}
 				}
+			} else {
+				var post_id = post.attr('data-post-id');				if (post.hasClass("is_original")) {
+				var blog_name = post.attr('data-tumblelog-name');
 			}
 
 			if (XKit.extensions.timestamps.in_search && !$("#search_posts").hasClass("posts_view_list")) {
@@ -171,7 +176,6 @@ XKit.extensions.timestamps = new Object({
 				post.find(".post-info-tumblelogs").prepend(in_search_html);
 			} else {
 				var normal_html = '<div class="xkit_timestamp_' + post_id + ' xtimestamp xtimestamp_loading">&nbsp;</div>';
-				//var normal_html = '<br><div class="xkit_timestamp_' + post_id + ' xtimestamp xtimestamp_loading">&nbsp;</div>';
 				//post.find(".post_content").prepend(normal_html);
 				post.find(".post_wrapper .post_header").append(normal_html);
 			}
@@ -208,12 +212,6 @@ XKit.extensions.timestamps = new Object({
 						var data = JSON.parse(response.responseText);
 						var post = data.response.posts[0];
 						var date = moment(new Date(post.timestamp * 1000));
-						console.log(date.year());
-
-						//switch (date.year()) {
-						//	case moment().year()-1:
-						//		date_element.addClass("xtimestamp-this-year");
-						//}
 
 						if (date.year() == moment().year()) {
 							date_element.addClass("xtimestamp-this-year");

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -163,18 +163,18 @@ XKit.extensions.timestamps = new Object({
 					var blog_name = post.attr('data-tumblelog-name');
 				} else {
 					try {
-						var post_id = post.attr('data-root_id');
+						post_id = post.attr('data-root_id');
 						var op_json = JSON.parse(post.attr('data-json'));
-						var blog_name = op_json['tumblelog-root-data'].name;
-					} catch(e) { //most probably in peepr
-						peepr_data = XKit.extensions.timestamps.checkPeepr(post);
-						var post_id = peepr_data[0];
-						var blog_name = peepr_data[1];
+						blog_name = op_json['tumblelog-root-data'].name;
+					} catch (e) { //most probably in peepr
+						var peepr_data = XKit.extensions.timestamps.checkPeepr(post);
+						post_id = peepr_data[0];
+						blog_name = peepr_data[1];
 					}
 				}
 			} else {
-				var post_id = post.attr('data-post-id');
-				var blog_name = post.attr('data-tumblelog-name');
+				post_id = post.attr('data-post-id');
+				blog_name = post.attr('data-tumblelog-name');
 			}
 
 			if (XKit.extensions.timestamps.in_search && !$("#search_posts").hasClass("posts_view_list")) {
@@ -199,28 +199,28 @@ XKit.extensions.timestamps = new Object({
 			var post_source = post.find(".post-source-link");
 			if (post_source.attr("data-peepr")) {
 				var op_json = JSON.parse(post_source.attr("data-peepr"));
-				var post_id = op_json['postId'];
-				var blog_name = op_json['tumblelog'];
+				var post_id = op_json.postId;
+				var blog_name = op_json.tumblelog;
 			} else { //source link is a custom url
 				if (post.hasClass("is_photo")) { //last-ditch effort to get op data
 					var post_url = post.find(".post_media img").attr("data-pin-url");
 					var split_url = post_url.split("/");
-					var post_id = split_url[4];
+					post_id = split_url[4];
 					var blog_url = split_url[2].split(".");
-					var blog_name = blog_url[0];
+					blog_name = blog_url[0];
 				} else {
-					var post_id = "";
-					var blog_name = "";
+					post_id = "";
+					blog_name = "";
 				}
 			}
 		} else if (post.find(".reblog_info").length) { //user reblogged themselves?
-			var post_source = post.find(".reblog_info");
-			var op_json = JSON.parse(post_source.attr("data-peepr"));
-			var post_id = op_json['postId'];
-			var blog_name = op_json['tumblelog'];
+			post_source = post.find(".reblog_info");
+			op_json = JSON.parse(post_source.attr("data-peepr"));
+			post_id = op_json.postId;
+			blog_name = op_json.tumblelog;
 		} else { //no source AND no reblog info = original post
-			var post_id = post.attr('data-post-id');
-			var blog_name = post.attr('data-tumblelog-name');
+			post_id = post.attr('data-post-id');
+			blog_name = post.attr('data-tumblelog-name');
 		}
 
 		return [post_id, blog_name];

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -21,6 +21,11 @@ XKit.extensions.timestamps = new Object({
 			default: false,
 			value: false
 		},
+		below_header: {
+			text: "Show timestamps below the header",
+			default: true,
+			value: true
+		},
 		only_relative: {
 			text: "Only show relative time (eg: 5 minutes ago)",
 			default: false,
@@ -37,7 +42,7 @@ XKit.extensions.timestamps = new Object({
 			value: false
 		},
 		op_timestamps: {
-			text: "Show timestamps for the source / original post.",
+			text: "Show timestamps for the source / original post",
 			default: false,
 			value: false
 		},
@@ -104,8 +109,9 @@ XKit.extensions.timestamps = new Object({
 		this.check_quota();
 		try {
 			if (this.is_compatible()) {
-				//XKit.tools.add_css('#posts .post .post_content { padding-top: 0px; }', "timestamps");
-				//XKit.tools.add_css('#posts .post .post_wrapper .post_header { padding-top: 0px; }', "timestamps");
+				if (this.preferences.below_header.value) {
+					XKit.tools.add_css('.xtimestamp { top: -9px; margin-left: 20px; }', "timestamps");
+				}
 				XKit.post_listener.add("timestamps", this.add_timestamps);
 				this.add_timestamps();
 
@@ -151,7 +157,7 @@ XKit.extensions.timestamps = new Object({
 				return;
 			}
 
-			if (this.preferences.op_timestamps) {
+			if (XKit.extensions.timestamps.preferences.op_timestamps.value) {
 				if (post.hasClass("is_original")) {
 					var post_id = post.attr('data-post-id');
 					var blog_name = post.attr('data-tumblelog-name');
@@ -167,7 +173,7 @@ XKit.extensions.timestamps = new Object({
 					}
 				}
 			} else {
-				var post_id = post.attr('data-post-id');				if (post.hasClass("is_original")) {
+				var post_id = post.attr('data-post-id');
 				var blog_name = post.attr('data-tumblelog-name');
 			}
 
@@ -176,8 +182,11 @@ XKit.extensions.timestamps = new Object({
 				post.find(".post-info-tumblelogs").prepend(in_search_html);
 			} else {
 				var normal_html = '<div class="xkit_timestamp_' + post_id + ' xtimestamp xtimestamp_loading">&nbsp;</div>';
-				//post.find(".post_content").prepend(normal_html);
-				post.find(".post_wrapper .post_header").append(normal_html);
+				if (XKit.extensions.timestamps.preferences.below_header.value) {
+					post.find(".post_content").prepend(normal_html);
+				} else {
+					post.find(".post_wrapper .post_header").append(normal_html);
+				}
 			}
 
 			var note = $(".xkit_timestamp_" + post_id);
@@ -213,6 +222,8 @@ XKit.extensions.timestamps = new Object({
 						var post = data.response.posts[0];
 						var date = moment(new Date(post.timestamp * 1000));
 
+						XKit.extensions.timestamps.set_age(date, date_element);
+/*
 						if (date.year() == moment().year()) {
 							date_element.addClass("xtimestamp-this-year");
 						} else if (date.year() == moment().year()-5) {
@@ -220,7 +231,7 @@ XKit.extensions.timestamps = new Object({
 						} else {
 							date_element.addClass("xtimestamp-" + (moment().year() - date.year()) + "-year");
 						}
-
+*/
 						date_element.html(self.format_date(date));
 						date_element.removeClass("xtimestamp_loading");
 						XKit.storage.set("timestamps", "xkit_timestamp_cache_" + post_id, post.timestamp);
@@ -233,6 +244,16 @@ XKit.extensions.timestamps = new Object({
 		} catch (e) {
 			console.error('Unable to load timestamp for post ' + post_id);
 			XKit.extensions.timestamps.show_failed(date_element);
+		}
+	},
+
+	set_age: function(date, date_element) {
+		if (date.year() == moment().year()) {
+			date_element.addClass("xtimestamp-this-year");
+		} else if (date.year() == moment().year()-5) {
+			date_element.addClass("xtimestamp-5plus-year");
+		} else {
+			date_element.addClass("xtimestamp-" + (moment().year() - date.year()) + "-year");
 		}
 	},
 
@@ -251,6 +272,7 @@ XKit.extensions.timestamps = new Object({
 		if (!cached_date.isValid()) {
 			return false;
 		}
+		this.set_age(moment(new Date(cached * 1000)), date_element);
 		date_element.html(this.format_date(cached_date));
 		date_element.removeClass("xtimestamp_loading");
 		return true;

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -1,5 +1,5 @@
 //* TITLE Timestamps **//
-//* VERSION 2.8.1 **//
+//* VERSION 2.9.0 **//
 //* DESCRIPTION See when a post has been made. **//
 //* DETAILS This extension lets you see when a post was made, in full date or relative time (eg: 5 minutes ago). It also works on asks, and you can format your timestamps. **//
 //* DEVELOPER New-XKit **//


### PR DESCRIPTION
Gave Timestamps a few more features!

New features:
* Users can set time to be absolute only
* Users can display the timestamp next to the header
* Users can choose to only see timestamps for original posts
* Timestamps now display how old they are!

![look_at_that_padding_work_dayum](https://user-images.githubusercontent.com/42635772/52908663-7b03a900-32ce-11e9-96cc-5d69270f1d26.PNG)
Known bugs:
* Peepr post headers have a maximum width that cuts off long timestamps (ie with both relative and absolute time displayed); can fix by changing CSS for peepr post headers, but seems outside scope of this extension?
* Peepr posts are structured differently to dashboard posts, and have much less information, so when users only want op timestamps and they click to the peepr, they might get some inaccurate data; tried my best to write logic for the million ways a peepr can structure its data, but I suspect there are still cases I don't know about