### PR TITLE
XKit.svc

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,6 +2,7 @@
   parserOptions:
     ecmaVersion: 6
   env:
+    es6: true
     browser: true
     jquery: true
   extends: eslint:recommended
@@ -41,7 +42,6 @@
       - before: true
         after: true
   globals:
-    Promise: true
     _: true
     XKit: true
     XBridge: true

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -41,6 +41,7 @@
       - before: true
         after: true
   globals:
+    Promise: true,
     _: true
     XKit: true
     XBridge: true

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -41,7 +41,7 @@
       - before: true
         after: true
   globals:
-    Promise: true,
+    Promise: true
     _: true
     XKit: true
     XBridge: true

--- a/Extensions/mutualchecker.js
+++ b/Extensions/mutualchecker.js
@@ -1,7 +1,7 @@
 //* TITLE Mutual Checker **//
-//* VERSION 2.0.1 **//
+//* VERSION 2.0.2 **//
 //* DESCRIPTION A simple way to see who follows you back **//
-//* DETAILS Adds a small icon and '[user] follows you' hovertext to URLs you see in post headers (when appropriate).<br><br>Only checks the URL when the person directly made/reblogged/submitted/published the post, and doesn't work on sideblogs. **//
+//* DETAILS Adds a small icon and &quot;[user] follows you&quot; hovertext to URLs you see in post headers (when appropriate).<br><br>Only checks the URL when the person directly made/reblogged/submitted/published the post, and doesn't work on group blogs. **//
 //* DEVELOPER New-XKit **//
 //* FRAME false **//
 //* BETA false **//

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -161,18 +161,16 @@ XKit.extensions.xkit_patches = new Object({
 			 * @return {Promise<Boolean>}
 			 */
 			XKit.interface.is_following = function(username, blog) {
-				return new Promise(resolve => {
-					XKit.svc.conversations.participant_info({
-						"q": username,
-						"participant": blog
-					})
-					.then(response => resolve(response.json().response.is_blog_following_you))
-					.catch(() => XKit.svc.blog.followed_by({
-						"query": username,
-						"tumblelog": blog
-					}))
-					.then(response => resolve(response.json().response.is_friend));
-				});
+				return XKit.svc.conversations.participant_info({
+					"q": username,
+					"participant": blog
+				})
+				.then(response => response.json().response.is_blog_following_you)
+				.catch(() => XKit.svc.blog.followed_by({
+					"query": username,
+					"tumblelog": blog
+				})
+				.then(response => response.json().response.is_friend));
 			};
 
 			XKit.blog_listener = {

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -166,11 +166,12 @@ XKit.extensions.xkit_patches = new Object({
 					"participant": blog
 				})
 				.then(response => response.json().response.is_blog_following_you)
-				.catch(() => XKit.svc.blog.followed_by({
-					"query": username,
-					"tumblelog": blog
-				})
-				.then(response => response.json().response.is_friend));
+				.catch(() =>
+					XKit.svc.blog.followed_by({
+						"query": username,
+						"tumblelog": blog
+					})
+					.then(response => response.json().response.is_friend));
 			};
 
 			XKit.blog_listener = {

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -166,12 +166,12 @@ XKit.extensions.xkit_patches = new Object({
 						"q": username,
 						"participant": blog
 					})
-					.then(response => resolve(response.responseObj.response.is_blog_following_you))
+					.then(response => resolve(response.responseJson.response.is_blog_following_you))
 					.catch(() => XKit.svc.blog.followed_by({
 						"query": username,
 						"tumblelog": blog
 					}))
-					.then(response => resolve(response.responseObj.response.is_friend));
+					.then(response => resolve(response.responseJson.response.is_friend));
 				});
 			};
 
@@ -246,7 +246,7 @@ XKit.extensions.xkit_patches = new Object({
 							response: {
 								status: xhr.status,
 								responseText: xhr.response,
-								responseObj: (() => {
+								responseJson: (() => {
 									try {
 										return JSON.parse(xhr.response);
 									} catch (e) { return null; }

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -200,6 +200,11 @@ XKit.extensions.xkit_patches = new Object({
 							response: {
 								status: xhr.status,
 								responseText: xhr.response,
+								responseObj: (() => {
+									try {
+										return JSON.parse(xhr.response);
+									} catch (e) { return null; }
+								})(),
 								headers: cur_headers
 							},
 							timestamp: "xkit_" + request.timestamp,

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -271,11 +271,7 @@ XKit.extensions.xkit_patches = new Object({
 							XKit.interface.kitty.set(response.headers["x-tumblr-kittens"]);
 						}
 
-						response.json = function() {
-							try {
-								return JSON.parse(response.responseText);
-							} catch (err) { return null; }
-						};
+						response.json = () => JSON.parse(response.responseText);
 
 						if (success && response.status >= 200 && response.status < 300) {
 							details.onload(response);


### PR DESCRIPTION
The start of a collection of promise functions to streamline requests.

First up, we've got `conversations.participant_info` and `blog.followed_by`, used to rewrite `XKit.interface.is_following` with support for sideblogs; messaging data is used by default, then the old method as a fallback for group blogs.

Replaces & closes #1603; gives Mutual Checker and Profiler sideblog support without changes to their code.

To further streamline response reading, Nx_XHR's response object now also includes `responseObj`, a json parsing of the responseText or `null` if that fails. This is entirely safe to use in `onload`/resolved promises if the endpoint returns json, and can be much more easily type-tested in `onerror`/rejected promises rather than doing try/catch every time.

This also fixes Mutual Checker not working with SessionBox. Probably resolves #1590 since Nx_XHR is more reliable than requests made directly within addons.