### PR TITLE
Change `DEVELOPER` field to fix support links, fix bug in `titles` extension

### DIFF
--- a/Extensions/dont_stretch_photosets.js
+++ b/Extensions/dont_stretch_photosets.js
@@ -1,7 +1,7 @@
 //* TITLE Don't stretch photosets **//
-//* VERSION 1.0.0 **//
+//* VERSION 1.0.1 **//
 //* DESCRIPTION Don't allow images in photosets to be stretched past their “natural” length. **//
-//* DEVELOPER Rebecca Turner **//
+//* DEVELOPER 9999years **//
 //* FRAME false **//
 //* BETA false **//
 

--- a/Extensions/sharp_corners.js
+++ b/Extensions/sharp_corners.js
@@ -1,7 +1,7 @@
 //* TITLE sharplr **//
-//* VERSION 1.0.0 **//
+//* VERSION 1.0.1 **//
 //* DESCRIPTION No rounded corners, anywhere. The opposite of bubblr. **//
-//* DEVELOPER Rebecca Turner **//
+//* DEVELOPER 9999years **//
 //* FRAME false **//
 //* BETA false **//
 

--- a/Extensions/titles.js
+++ b/Extensions/titles.js
@@ -1,7 +1,7 @@
 //* TITLE Tab titles **//
-//* VERSION 1.0.0 **//
+//* VERSION 1.0.1 **//
 //* DESCRIPTION Descriptive tab titles, rather than just “Tumblr” **//
-//* DEVELOPER Rebecca Turner **//
+//* DEVELOPER 9999years **//
 //* FRAME false **//
 //* BETA false **//
 
@@ -63,7 +63,7 @@ XKit.extensions.titles = new Object({
 	// Gets a new page title from an array of directory names. This actually
 	// has to be a function() and not a lambda because it uses `this`.
 	getTitle: function(pathComponents) {
-		let fn = this.titleFuncs[pathComponents[0]];
+		let fn = this.titleForPath[pathComponents[0]];
 		if (fn) {
 			return fn(pathComponents);
 		} else {

--- a/Extensions/transparent_img_hover.js
+++ b/Extensions/transparent_img_hover.js
@@ -1,7 +1,7 @@
 //* TITLE Show transparency **//
-//* VERSION 1.0.0 **//
+//* VERSION 1.0.1 **//
 //* DESCRIPTION Makes the backgrounds of images blue when you hover over them so you can see transparency without dragging the image. **//
-//* DEVELOPER Rebecca Turner **//
+//* DEVELOPER 9999years **//
 //* FRAME false **//
 //* BETA false **//
 


### PR DESCRIPTION
# Changed
- Currently, XKit displays a link to `github.com/RebeccaTurner` for my extensions (`dont_stretch_photosets`, `sharp_corners`, `titles`, `transparent_img_hover`). By renaming the `DEVELOPER` field to `9999years`, this link should (?) be corrected (unless there's “weird” behavior I don’t know about).
- Bumped version in all those extensions to 1.0.1 (the next patch release in all cases), following semver.

# Fixed:
- `titles` didn’t work because one instance of `titleFuncs` wasn't renamed to `titleForPath`.

# To-do
- Should ownership go to the XKit team? I’m glad to maintain (and [pretty easy to get in touch with](https://becca.ooo/contact/)), but should issues go to (e.g.) this repository rather than somewhere else?
