### PR TITLE
Add simple connection test page

### DIFF
--- a/Test.md
+++ b/Test.md
@@ -1,0 +1,3 @@
+# Connection test successful!
+
+You may now close this tab and continue following other troubleshooting steps.


### PR DESCRIPTION
Currently, for troubleshooting purposes, we usually link to `https://new-xkit.github.io/XKit/` since that's the simplest URL to use for the purpose of a connection test. However since this is the dev README, either
1) users get confused trying to read/follow it, or 
2) we have to say "don't actually read it" when linking to it (which I've noticed doesn't always work anyway).

This simple page would eliminate both these problems and improve the troubleshooting experience for users, while keeping the URL simple/memorable enough to type out ourselves when not using bot commands or linking to the install troubleshooting post (which I've at least noticed myself doing plenty).

I would have included a note to say "this doesn't apply if you're reading on github.com", but I think the text makes it clear enough that stumbling upon the file independently isn't the context it's meant to be viewed in.