### PR TITLE
[Old Stats] Only target relevant small_links

### DIFF
--- a/Extensions/old_stats.js
+++ b/Extensions/old_stats.js
@@ -1,5 +1,5 @@
 //* TITLE Old Stats **//
-//* VERSION 0.5.1 **//
+//* VERSION 1.0.0 **//
 //* DESCRIPTION Blog stats where they were **//
 //* DEVELOPER New-XKit **//
 //* FRAME false **//
@@ -19,7 +19,6 @@ XKit.extensions.old_stats = new Object({
 		},
 		"switcher": {
 			text: "Show the blog switcher",
-			experimental: true,
 			default: true,
 			value: true
 		}
@@ -76,7 +75,7 @@ XKit.extensions.old_stats = new Object({
 				console.error("[Old Stats] Couldn't fetch blog info.");
 			},
 			onload: function(response) {
-				$("#dashboard_controls_open_blog, .small_links").remove();
+				$("#dashboard_controls_open_blog, #dashboard_controls_open_blog + .small_links").remove();
 				$("#right_column").prepend($(".small_links", response.responseText).css("margin", "0 0 18px")).prepend($("#dashboard_controls_open_blog", response.responseText));
 				$("#dashboard_controls_open_blog .selected").removeClass("selected");
 				$("#dashboard_controls_open_blog [data-sparkline]").prepend('<canvas id="old_stats_canvas" width="72" height="30" style="display: inline-block; width: 36px; height: 15px; vertical-align: top;">');
@@ -142,7 +141,7 @@ XKit.extensions.old_stats = new Object({
 				$(".old_stats_blog").off("click").remove();
 				if (!loading) {
 					$("#dashboard_controls_open_blog").children().removeAttr("style");
-					$(".small_links").removeAttr("style").css("margin", "0 0 18px");
+					$("#dashboard_controls_open_blog + .small_links").removeAttr("style").css("margin", "0 0 18px");
 				} else {
 					$("#dashboard_controls_open_blog").append(
 						'<li class="controls_section_item selected_blog">' +
@@ -154,7 +153,7 @@ XKit.extensions.old_stats = new Object({
 				loading = false;
 			} else {
 				$("#dashboard_controls_open_blog").children(":not(.selected_blog)").css("display", "none");
-				$(".small_links").css("display", "none");
+				$("#dashboard_controls_open_blog + .small_links").css("display", "none");
 				var current_blog = $(".no_push.selected_blog .currently_selected_blog").html(), do_append = false;
 
 				for (var x in blogs) {
@@ -194,7 +193,7 @@ XKit.extensions.old_stats = new Object({
 		this.running = false;
 		XKit.tools.remove_css("old_stats");
 		if (this.done) {
-			$("#dashboard_controls_open_blog, .small_links").remove();
+			$("#dashboard_controls_open_blog, #dashboard_controls_open_blog + .small_links").remove();
 		}
 	}
 });


### PR DESCRIPTION
fixes a ~~bug~~ oversight where Old Stats removes *all* `.small_links` on the page rather than only the one after the blog stats when loading stats. this is usually unnoticeable but there's an important small link on /tagged/ pages and some extensions use small links too.

version bumped to 1.0.0 since i dont know why it wasnt before... i already rewrote this extension...

blog switcher is also no longer marked as experimental (no idea why it was in the first place, ive been using it very happily since i made it)