### PR TITLE
 [Timestamps] Rethink how preferences are presented

### DIFF
--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -27,7 +27,7 @@ XKit.extensions.timestamps = new Object({
 			value: true
 		},
 		op: {
-			text: "Show timestamps on reblogged original posts",
+			text: "On reblogs, show the timestamp of the original post",
 			default: true,
 			value: true
 		},

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -89,6 +89,7 @@ XKit.extensions.timestamps = new Object({
 
 		for (let key of order) {
 			let current = XKit.storage.get("timestamps", `extension__setting__${key}`, "");
+			XKit.storage.remove("timestamps", `extension__setting__${key}`);
 			if (current !== "true") {
 				continue;
 			}

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -26,15 +26,16 @@ XKit.extensions.timestamps = new Object({
 			default: true,
 			value: true
 		},
-		op: {
-			text: "On reblogs, show the timestamp of the original post",
-			default: true,
-			value: true
-		},
 		reblogs: {
-			text: "Show timestamps on reblog comments",
-			default: false,
-			value: false
+			text: "Reblog timestamps",
+			type: "combo",
+			values: [
+				"Don't display any", "off",
+				"Display only on the original post", "op",
+				"Display on all comments", "all"
+			],
+			default: "op",
+			value: "op"
 		},
 
 		display_title: {
@@ -76,8 +77,8 @@ XKit.extensions.timestamps = new Object({
 	convert_preferences: function() {
 		[
 			["only_inbox", "false", {inbox: true, posts: false}],
-			["do_reblogs", "true", {op: true, reblogs: true}],
-			["only_original", "true", {reblogs: false}]
+			["do_reblogs", "true", {reblogs: "all"}],
+			["only_original", "true", {reblogs: "op"}]
 		]
 		.filter(([preference, isDefault]) => XKit.storage.get("timestamps", `extension__setting__${preference}`, isDefault) === "true")
 		.forEach(([preference, isDefault, conversion]) => {
@@ -129,7 +130,7 @@ XKit.extensions.timestamps = new Object({
 					this.add_timestamps();
 				}
 
-				if (this.preferences.op.value || this.preferences.reblogs.value) {
+				if (this.preferences.reblogs.value !== "off") {
 					XKit.post_listener.add("timestamps", this.add_reblog_timestamps);
 					this.add_reblog_timestamps();
 				}
@@ -192,13 +193,9 @@ XKit.extensions.timestamps = new Object({
 	},
 
 	add_reblog_timestamps: function() {
-		var preferences = XKit.extensions.timestamps.preferences;
 		var selector = ".reblog-list-item";
-
-		if (!preferences.reblogs.value) {
+		if (XKit.extensions.timestamps.preferences.reblogs.value === "op") {
 			selector += ".original-reblog-content";
-		} else if (!preferences.op.value) {
-			selector += ":not(.original-reblog-content)";
 		}
 
 		$(selector).not(".xkit_timestamps")

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -41,11 +41,6 @@ XKit.extensions.timestamps = new Object({
 			text: "Display options",
 			type: "separator"
 		},
-		show_absolute: {
-			text: "Display the absolute time",
-			default: true,
-			value: true
-		},
 		format: {
 			text: 'Timestamp format (<span id="xkit-timestamps-format-help" style="text-decoration: underline; cursor: pointer;">what is this?</span>)',
 			type: "text",
@@ -54,6 +49,11 @@ XKit.extensions.timestamps = new Object({
 		},
 		only_on_hover: {
 			text: "Hide timestamps until I hover over a post",
+			default: false,
+			value: false
+		},
+		only_relative: {
+			text: "Display timestamps in relative form",
 			default: false,
 			value: false
 		}
@@ -289,10 +289,10 @@ XKit.extensions.timestamps = new Object({
 
 	format_date: function(date) {
 		var relative = date.from(moment());
-		if (this.preferences.show_absolute.value) {
-			return date.format(this.preferences.format.value) + " &middot; " + relative;
-		} else {
+		if (this.preferences.only_relative.value) {
 			return relative;
+		} else {
+			return date.format(this.preferences.format.value) + " &middot; " + relative;
 		}
 	},
 

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -80,8 +80,8 @@ XKit.extensions.timestamps = new Object({
 			["do_reblogs", "true", {reblogs: "all"}],
 			["only_original", "true", {reblogs: "op"}]
 		]
-		.filter(([preference, isDefault]) => XKit.storage.get("timestamps", `extension__setting__${preference}`, isDefault) === "true")
-		.forEach(([preference, isDefault, conversion]) => {
+		.filter(([preference, defaultValue]) => XKit.storage.get("timestamps", `extension__setting__${preference}`, defaultValue) === "true")
+		.forEach(([preference, _, conversion]) => {
 			Object.entries(conversion).forEach(([key, value]) => {
 				XKit.storage.set("timestamps", `extension__setting__${key}`, value.toString());
 				this.preferences[key].value = value;

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -74,31 +74,18 @@ XKit.extensions.timestamps = new Object({
 	},
 
 	convert_preferences: function() {
-		const conversion = {
-			only_relative: {show_absolute: false},
-			only_inbox: {inbox: true, posts: false},
-			do_reblogs: {op: true, reblogs: true},
-			only_original: {reblogs: false}
-		};
-		const order = [
-			"only_relative",
-			"only_inbox",
-			"do_reblogs",
-			"only_original"
-		];
-
-		for (let key of order) {
-			let current = XKit.storage.get("timestamps", `extension__setting__${key}`, "");
-			XKit.storage.remove("timestamps", `extension__setting__${key}`);
-			if (current !== "true") {
-				continue;
-			}
-
-			for (let x of Object.keys(conversion[key])) {
-				XKit.storage.set("timestamps", `extension__setting__${x}`, conversion[key][x].toString());
-				this.preferences[x].value = conversion[key][x];
-			}
-		}
+		[
+			["only_inbox", "false", {inbox: true, posts: false}],
+			["do_reblogs", "true", {op: true, reblogs: true}],
+			["only_original", "true", {reblogs: false}]
+		]
+		.filter(([preference, isDefault]) => XKit.storage.get("timestamps", `extension__setting__${preference}`, isDefault) === "true")
+		.forEach(([preference, isDefault, conversion]) => {
+			Object.entries(conversion).forEach(([key, value]) => {
+				XKit.storage.set("timestamps", `extension__setting__${key}`, value.toString());
+				this.preferences[key].value = value;
+			});
+		});
 
 		XKit.storage.set("timestamps", "preference_conversion", "done");
 	},


### PR DESCRIPTION
Rethinks or rewords preferences to make them more positive-action than dont-do-something as requested/conceptualised by nightpool via Discord, including a preference converter so that current users' configs carry over without behavioural differences.

As a result of redoing the preferences, new features that come with this include:
 - Being able to turn off post timestamps while retaining other timestamps
   - Inbox timestamps can still be shown
   - OP/reblog timestamps can still be shown
 - ~~Being able to turn off OP timestamps while retaining reblog timestamps~~
   - ~~I have no idea why anyone would want this, but I also couldn't think of a way to concisely explain reblog timestamps requiring OP timestamps and it wasn't too hard to do, so here we are.~~