### PR TITLE
[Activity+] Use .is_reblog_naked correctly

### DIFF
--- a/Extensions/activity_plus.js
+++ b/Extensions/activity_plus.js
@@ -192,11 +192,7 @@ XKit.extensions.activity_plus = new Object({
 			notification.classList.add('activity-notification');
 			notification.dataset.timestamp = Math.round(reblog.timestamp);
 			notification.dataset.tumblelogName = reblog.blog_name;
-
-			notification.classList.add('is_reblog');
-			if (!reblog.added_text) {
-				notification.classList.add('is_reblog_naked');
-			}
+			notification.classList.add('is_reblog_naked');
 
 			var reblogUrl = reblog.blog_url + 'post/' + reblog.post_id;
 			var avatarUrl64 = reblog.avatar_url['64'];

--- a/Extensions/activity_plus.js
+++ b/Extensions/activity_plus.js
@@ -128,6 +128,9 @@ XKit.extensions.activity_plus = new Object({
 					if (m_type === "is_user_mention") {
 						m_type = "is_user_mention, .ui_notes .activity-notification.user_mention, .ui_notes .activity-notification.note_mention";
 					}
+					if (m_type === "is_reblog") {
+						m_type += ", .ui_notes .activity-notification.is_reblog_naked";
+					}
 
 					var m_filter_css = ".ui_notes .activity-notification { display: none; }";
 					m_filter_css += ".ui_notes .activity-notification." + m_type + " { display: flex }";

--- a/Extensions/activity_plus.js
+++ b/Extensions/activity_plus.js
@@ -1,5 +1,5 @@
 //* TITLE Activity+ **//
-//* VERSION 0.4.4 **//
+//* VERSION 0.4.5 **//
 //* DESCRIPTION Tweaks for the Activity page **//
 //* DETAILS This extension brings a couple of tweaks for the Activity page, such as the ability to filter notes by type and showing timestamps. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -68,7 +68,7 @@ XKit.extensions.activity_plus = new Object({
 				m_css = m_css + " #user_graphs, .ui_stats { display: none; }";
 			}
 
-			if (this.preferences.show_timestamps.value === true || this.preferences.condensed_notes.value === true) {
+			if (this.preferences.show_timestamps.value === true || this.preferences.condensed_notes.value === true || this.preferences.unfold_rollups.value) {
 				// m_css = m_css + " .part_activity { left: 95px !important; } .activity-notification .part_avatar { left: 57px !important; } .part_response { padding-left: 95px !important; }";
 				setInterval(XKit.extensions.activity_plus.do_on_new, 3000);
 			}
@@ -439,8 +439,8 @@ XKit.extensions.activity_plus = new Object({
 			}
 		}
 
-		if (this.preferences.unfold_rollups.value) {
-			this.do_unfold();
+		if (XKit.extensions.activity_plus.preferences.unfold_rollups.value) {
+			XKit.extensions.activity_plus.do_unfold();
 		}
 	},
 


### PR DESCRIPTION
- Filter by note type updated to show `.is_reblog_naked` as well as `.is_reblog` (was previously `.is_reblog.naked`)
- Unrolling now always adds `.is_reblog_naked` and never `.is_reblog` since text additions would never be rolled up anyway; Retags already behaves with the proper classes and thus this resolves #1567 
- Unroll can now activate upon a new page of notes loading (unrelated, but partially tackles #1566)