### PR TITLE
[Tweaks] Slim appeal notification icons

### DIFF
--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Tweaks **//
-//* VERSION 5.7.2 **/
+//* VERSION 5.7.3 **/
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -358,7 +358,8 @@ XKit.extensions.tweaks = new Object({
 				"{ padding: 0; min-width: 25px; }" +
 
 			// Allow user avatars to use the padding too
-			".ui_notes .activity-notification .activity-notification__avatar .ui_avatar" +
+			".ui_notes .activity-notification .activity-notification__avatar .ui_avatar," +
+			".ui_notes .activity-notification .activity-notification__avatar .flagged-post" +
 				"{ margin: 0; }" +
 
 			// Shrink post type icons


### PR DESCRIPTION
apparently content appeals have notifications now, but their icon (in the place of a user avatar) wasn't being slimmed by the slim-activity tweak

**Before:**
![image](https://user-images.githubusercontent.com/28949509/60388593-f874cc80-9aab-11e9-9d98-47b93ac4f850.png)
**After:**
![image](https://user-images.githubusercontent.com/28949509/60388613-29550180-9aac-11e9-9b1d-55e99058c1cc.png)

