### PR TITLE
retire jQuery.parseJSON

### DIFF
--- a/Extensions/one_click_reply.js
+++ b/Extensions/one_click_reply.js
@@ -269,7 +269,7 @@ XKit.extensions.one_click_reply = new Object({
 					XKit.interface.kitty.set(response.getResponseHeader("X-Tumblr-Kittens"));
 					var mdata = null;
 					try {
-						mdata = jQuery.parseJSON(response.responseText);
+						mdata = JSON.parse(response.responseText);
 					} catch (e) {
 						XKit.extensions.one_click_reply.quick_reply_error("106");
 					}

--- a/Extensions/post_crushes.js
+++ b/Extensions/post_crushes.js
@@ -234,7 +234,7 @@ XKit.extensions.post_crushes = new Object({
 				},
 				onload: function(response) {
 					XKit.interface.kitty.set(response.getResponseHeader("X-Tumblr-Kittens"));
-					var m_obj = jQuery.parseJSON(response.responseText);
+					var m_obj = JSON.parse(response.responseText);
 					if (m_obj.errors === false) {
 						$("#xkit_post_crushes").html("Posted!");
 						XKit.window.close();

--- a/Extensions/stats.js
+++ b/Extensions/stats.js
@@ -550,7 +550,7 @@ XKit.extensions.stats = new Object({
 					XKit.extensions.stats.post_error("Can't post stats", "Server returned invalid/blank page or could not be reached. Maybe you hit your post limit for today, or your account has been suspended. Please check your internet connection and try again later.");
 				},
 				onload: function(response) {
-					var m_obj = jQuery.parseJSON(response.responseText);
+					var m_obj = JSON.parse(response.responseText);
 					XKit.interface.kitty.set(response.getResponseHeader("X-Tumblr-Kittens"));
 					XKit.window.close();
 					if (m_obj.errors === false) {

--- a/Extensions/xcloud.js
+++ b/Extensions/xcloud.js
@@ -225,7 +225,7 @@ XKit.extensions.xcloud = new Object({
 
 					var mdata = null;
 					try {
-						mdata = jQuery.parseJSON(response.responseText);
+						mdata = JSON.parse(response.responseText);
 					} catch (e) {
 						XKit.extensions.xcloud.hide_overlay();
 						XKit.window.show("Can't connect to server", "XKit was unable to contact XCloud servers.<br/>Error code: 1001<br/>Please try again or <a href=\"http://new-xkit-support.tumblr.com/ask\">send a bug report</a>.", "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
@@ -320,7 +320,7 @@ XKit.extensions.xcloud = new Object({
 
 					var mdata = null;
 					try {
-						mdata = jQuery.parseJSON(response.responseText);
+						mdata = JSON.parse(response.responseText);
 					} catch (e) {
 						XKit.extensions.xcloud.hide_overlay();
 						XKit.window.show("Can't connect to server", "XKit was unable to contact XCloud servers.<br/>Error code: 1001<br/>Please try again or <a href=\"http://new-xkit-support.tumblr.com/ask\">send a bug report</a>.", "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
@@ -539,7 +539,7 @@ XKit.extensions.xcloud = new Object({
 			},
 			onload: function(response) {
 
-				var data = jQuery.parseJSON(response.responseText);
+				var data = JSON.parse(response.responseText);
 				if (data.server_down) {
 					XKit.extensions.xcloud.hide_overlay();
 					XKit.window.show("Can't connect to server", "XKit was unable to contact XCloud servers.<br/>Please try again or <a href=\"http://new-xkit-support.tumblr.com/ask\">send a bug report</a>.", "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
@@ -877,7 +877,7 @@ XKit.extensions.xcloud = new Object({
 
 				var mdata = null;
 				try {
-					mdata = jQuery.parseJSON(response.responseText);
+					mdata = JSON.parse(response.responseText);
 				} catch (e) {
 					XKit.extensions.xcloud.hide_overlay();
 					XKit.window.show("Can't connect to server", "XKit was unable to contact XCloud servers.<br/>Error code: 1001<br/>Please try again or <a href=\"http://new-xkit-support.tumblr.com/ask\">send a bug report</a>.", "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");

--- a/Extensions/xinbox.js
+++ b/Extensions/xinbox.js
@@ -898,7 +898,7 @@ XKit.extensions.xinbox = new Object({
 				// We are done!
 				var mdata = null;
 				try {
-					mdata = $.parseJSON(response.responseText);
+					mdata = JSON.parse(response.responseText);
 				} catch (e) {
 					XKit.extensions.xinbox.show_error("Server returned a non-JSON object. Maybe server overloaded, try again later. Error: " + e.message);
 					return;
@@ -978,7 +978,7 @@ XKit.extensions.xinbox = new Object({
 				},
 				onload: function(response) {
 					try {
-						var responseData = $.parseJSON(response.responseText);
+						var responseData = JSON.parse(response.responseText);
 					} catch (e) {
 						XKit.extensions.xinbox.show_error("Server returned a non-JSON object. Maybe server overloaded, try again later. Error: " + e.message);
 						return;

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1809,7 +1809,7 @@ XKit.extensions.xkit_patches = new Object({
 								XKit.interface.kitty.set(response.getResponseHeader("X-Tumblr-Kittens"));
 
 								try {
-									to_return.data = jQuery.parseJSON(response.responseText);
+									to_return.data = JSON.parse(response.responseText);
 									func(to_return);
 								} catch (e) {
 									to_return.error = true;
@@ -1884,7 +1884,7 @@ XKit.extensions.xkit_patches = new Object({
 						onload: function(response) {
 
 							try {
-								to_return.data = jQuery.parseJSON(response.responseText);
+								to_return.data = JSON.parse(response.responseText);
 								func(to_return);
 							} catch (e) {
 								to_return.error = true;
@@ -2929,7 +2929,7 @@ XKit.extensions.xkit_patches = new Object({
 						// We are done!
 						var mdata = {};
 						try {
-							mdata = jQuery.parseJSON(response.responseText);
+							mdata = JSON.parse(response.responseText);
 						} catch (e) {
 							// Server returned bad thingy.
 							console.log("Unable to download '" + path +

--- a/xkit.js
+++ b/xkit.js
@@ -196,7 +196,7 @@ var xkit_global_start = Date.now();  // log start timestamp
 						// We are done!
 						var mdata = {};
 						try {
-							mdata = jQuery.parseJSON(response.responseText);
+							mdata = JSON.parse(response.responseText);
 						} catch (e) {
 							// Server returned bad thingy.
 							console.error("Unable to download '" + path +
@@ -2421,7 +2421,7 @@ var xkit_global_start = Date.now();  // log start timestamp
 							XKit.interface.kitty.set(response.getResponseHeader("X-Tumblr-Kittens"));
 
 							try {
-								to_return.data = jQuery.parseJSON(response.responseText);
+								to_return.data = JSON.parse(response.responseText);
 								func(to_return);
 							} catch (e) {
 								to_return.error = true;
@@ -2496,7 +2496,7 @@ var xkit_global_start = Date.now();  // log start timestamp
 					onload: function(response) {
 
 						try {
-							to_return.data = jQuery.parseJSON(response.responseText);
+							to_return.data = JSON.parse(response.responseText);
 							func(to_return);
 						} catch (e) {
 							to_return.error = true;


### PR DESCRIPTION
replace all instances of the deprecated `jQuery.parseJSON` with `JSON.parse`

conflict-free/no version bumps; no changes to logic, codebase cleanup only