### PR TITLE
[Read More Now] Remove erroneous init_css

### DIFF
--- a/Extensions/read_more_now.js
+++ b/Extensions/read_more_now.js
@@ -1,5 +1,5 @@
 //* TITLE Read More Now **//
-//* VERSION 2.0.0 **//
+//* VERSION 2.0.1 **//
 //* DESCRIPTION Read Mores in your dash **//
 //* DETAILS This extension allows you to read &quot;Keep Reading&quot; posts without leaving your dash. Just click on the &quot;Read More Now!&quot; button on posts and XKit will automatically load and display the post on your dashboard. **//
 //* DEVELOPER New-XKit **//
@@ -13,7 +13,6 @@ XKit.extensions.read_more_now = new Object({
 
 	run: function() {
 		this.running = true;
-		XKit.tools.init_css("read_more_now");
 		XKit.post_listener.add("read_more_now", this.find_links);
 		this.find_links();
 


### PR DESCRIPTION
#1680's initial changes added a CSS file but when it was removed I didn't notice `XKit.tools.init_css` was still being called, so this is the shameful followup PR that removes it

motivated by a report that Read More Now has to be restarted to actually activate; I'm unable to reproduce the issue but this is the one thing I can see that looks off