### PR TITLE
[PostBlock] Properly handle post variants

### DIFF
--- a/Extensions/postblock.css
+++ b/Extensions/postblock.css
@@ -1,0 +1,8 @@
+.postblock-cp {
+    text-align: center;
+    padding-top: 48px;
+}
+.postblock-cp small {
+    color: rgb(128,128,128);
+    font-size: small;
+}


### PR DESCRIPTION
slight rewrite of PostBlock to make it 
1. ensure `data-root_id` exists and 
2. only removes the actual posts (and their `.post_container`s if they have them)

resolves #619 

new feature: blocking a post now also removes all reblogs immediately!