### PR TITLE
[Mass+] Fix search by tag

### DIFF
--- a/Extensions/mass_plus.js
+++ b/Extensions/mass_plus.js
@@ -171,10 +171,7 @@ XKit.extensions.mass_plus = new Object({
 		if (last_timestamp.indexOf(" ") !== -1) {
 			last_timestamp = last_timestamp.substring(0, last_timestamp.indexOf(" "));
 		}
-		var blog_shortname = location.pathname.split("/")[3];
-		if (blog_shortname .indexOf("/") !== -1) { blog_shortname = blog_shortname.substring(0, blog_shortname.indexOf("/")); }
-		if (blog_shortname .indexOf("?") !== -1) { blog_shortname = blog_shortname.substring(0, blog_shortname.indexOf("?")); }
-		if (blog_shortname .indexOf("#") !== -1) { blog_shortname = blog_shortname.substring(0, blog_shortname.indexOf("#")); }
+		var [/* root */, /* page */, /* state */, blog_shortname] = location.pathname.split("/");
 		this.search_found_count = 0;
 		this.search_last_timestamp = last_timestamp;
 		this.search_page = 0;

--- a/Extensions/mass_plus.js
+++ b/Extensions/mass_plus.js
@@ -171,7 +171,7 @@ XKit.extensions.mass_plus = new Object({
 		if (last_timestamp.indexOf(" ") !== -1) {
 			last_timestamp = last_timestamp.substring(0, last_timestamp.indexOf(" "));
 		}
-		var blog_shortname = location.pathname.split("/").slice(-1)[0];
+		var blog_shortname = location.pathname.split("/")[3];
 		if (blog_shortname .indexOf("/") !== -1) { blog_shortname = blog_shortname.substring(0, blog_shortname.indexOf("/")); }
 		if (blog_shortname .indexOf("?") !== -1) { blog_shortname = blog_shortname.substring(0, blog_shortname.indexOf("?")); }
 		if (blog_shortname .indexOf("#") !== -1) { blog_shortname = blog_shortname.substring(0, blog_shortname.indexOf("#")); }

--- a/Extensions/mass_plus.js
+++ b/Extensions/mass_plus.js
@@ -1,5 +1,5 @@
 //* TITLE Mass+ **//
-//* VERSION 0.4.4 **//
+//* VERSION 0.4.5 **//
 //* DESCRIPTION Enhancements for the Mass Editor **//
 //* DETAILS This extension allows you to select multiple posts by once, by type or month. It also comes with visual enhancements for the mass post editor, such as selected post count and more! **//
 //* DEVELOPER STUDIOXENIX **//
@@ -33,8 +33,8 @@ XKit.extensions.mass_plus = new Object({
 	},
 	do_headings: function() {
 		$(".heading").each(function() {
-			if ($(this).find(".xkit-mass-plus-buttons-month-inside").length > 0) { 
-				return; 
+			if ($(this).find(".xkit-mass-plus-buttons-month-inside").length > 0) {
+				return;
 			}
 			$(this).append( "<div class=\"xkit-mass-plus-buttons-month-inside\">" +
 				"<div data-type=\"month-select\" class=\"xkit-mass-link xkit-selector\">first 100 in this month</div>" +
@@ -171,7 +171,7 @@ XKit.extensions.mass_plus = new Object({
 		if (last_timestamp.indexOf(" ") !== -1) {
 			last_timestamp = last_timestamp.substring(0, last_timestamp.indexOf(" "));
 		}
-		var blog_shortname = document.location.href.substring(document.location.href.indexOf('mega-editor/') + 12);
+		var blog_shortname = location.pathname.split("/").slice(-1)[0];
 		if (blog_shortname .indexOf("/") !== -1) { blog_shortname = blog_shortname.substring(0, blog_shortname.indexOf("/")); }
 		if (blog_shortname .indexOf("?") !== -1) { blog_shortname = blog_shortname.substring(0, blog_shortname.indexOf("?")); }
 		if (blog_shortname .indexOf("#") !== -1) { blog_shortname = blog_shortname.substring(0, blog_shortname.indexOf("#")); }


### PR DESCRIPTION
now that the Mass Post Editor can also work with your drafts and queue, assuming the blogname comes after `/mega-editor/` in the URL is incorrect - changed this logic to pluck out the last part of the pathname every time