### PR TITLE
[Retags] Hide rollup notes when only viewing retags+responses

### DIFF
--- a/Extensions/retags.js
+++ b/Extensions/retags.js
@@ -1,6 +1,6 @@
 //* TITLE       Retags **//
 //* DEVELOPER   new-xkit **//
-//* VERSION     1.2.6 **//
+//* VERSION     1.2.7 **//
 //* DESCRIPTION Adds tags to reblog notes **//
 //* FRAME       false **//
 //* SLOW        false **//
@@ -265,7 +265,7 @@ XKit.extensions.retags = {
 	$('<style class="retags"> ' +
 		'.ui_note, .ui_notes .activity-notification { display: none; } ' +
 		'.ui_note.is_retags, .ui_note.is_reply, .ui_note.is_response, .ui_note.is_user_mention { display: block; } ' +
-		'.activity-notification.is_retags, .activity-notification.is_reply, .activity-notification.is_reblog:not(.naked), .activity-notification.user_mention, .activity-notification.note_mention { display: flex; }' +
+		'.activity-notification.is_retags, .activity-notification.is_reply, .activity-notification.is_reblog:not(.naked):not(.rollup), .activity-notification.user_mention, .activity-notification.note_mention { display: flex; }' +
 	'</style>'),
 
 	mobile_toggle:


### PR DESCRIPTION
Only `.is_reblog` notes that aren't either `.naked` or `.rollup` should be displayed with the "Show only retags / responses" option.