### PR TITLE
Revert "Include XKit version as a header in requests to Tumblr"

### DIFF
--- a/Extensions/replyviewer.js
+++ b/Extensions/replyviewer.js
@@ -1,5 +1,5 @@
 //* TITLE ReplyViewer **//
-//* VERSION 0.3.5 **//
+//* VERSION 0.3.4 **//
 //* DESCRIPTION View post replies easily **//
 //* DETAILS The close relative of TagViewer, this extension allows you to see what replies, answers and additional content added to it while reblogging on any post. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -82,10 +82,7 @@ XKit.extensions.replyviewer = new Object({
 
 		$.ajax({
 			url: m_url,
-			dataType: 'json',
-			headers: {
-				"X-XKit-Version": XKit.version,
-			},
+			dataType: 'json'
 		}).fail(function() {
 
 			XKit.window.close();

--- a/Extensions/replyviewer.js
+++ b/Extensions/replyviewer.js
@@ -1,5 +1,5 @@
 //* TITLE ReplyViewer **//
-//* VERSION 0.3.4 **//
+//* VERSION 0.3.6 **//
 //* DESCRIPTION View post replies easily **//
 //* DETAILS The close relative of TagViewer, this extension allows you to see what replies, answers and additional content added to it while reblogging on any post. **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/tagviewer.js
+++ b/Extensions/tagviewer.js
@@ -1,5 +1,5 @@
 //* TITLE TagViewer **//
-//* VERSION 0.5.2 **//
+//* VERSION 0.5.1 **//
 //* DESCRIPTION View post tags easily **//
 //* DEVELOPER new-xkit **//
 //* DETAILS This extension allows you to see what tags people added to a post while they reblogged it. It also provides access to the post, and to Tumblr search pages to find similar posts.<br><br>Based on the work of <a href='http://inklesspen.tumblr.com'>inklesspen</a> **//
@@ -114,10 +114,7 @@ XKit.extensions.tagviewer = new Object({
 
 		$.ajax({
 			url: m_url,
-			dataType: "json",
-			headers: {
-				"X-XKit-Version": XKit.version,
-			},
+			dataType: "json"
 		}).fail(function() {
 
 			XKit.window.close();

--- a/Extensions/tagviewer.js
+++ b/Extensions/tagviewer.js
@@ -1,5 +1,5 @@
 //* TITLE TagViewer **//
-//* VERSION 0.5.1 **//
+//* VERSION 0.5.3 **//
 //* DESCRIPTION View post tags easily **//
 //* DEVELOPER new-xkit **//
 //* DETAILS This extension allows you to see what tags people added to a post while they reblogged it. It also provides access to the post, and to Tumblr search pages to find similar posts.<br><br>Based on the work of <a href='http://inklesspen.tumblr.com'>inklesspen</a> **//

--- a/Extensions/view_on_dash.js
+++ b/Extensions/view_on_dash.js
@@ -1,5 +1,5 @@
 //* TITLE View On Dash **//
-//* VERSION 0.8.0 **//
+//* VERSION 0.8.2 **//
 //* DESCRIPTION View blogs on your dash **//
 //* DEVELOPER new-xkit **//
 //* DETAILS A shortcut to viewing any blog on your dashboard! Uses the blog sidebar (Peepr) by default, but can be configured differently. **//

--- a/Extensions/view_on_dash.js
+++ b/Extensions/view_on_dash.js
@@ -1,5 +1,5 @@
 //* TITLE View On Dash **//
-//* VERSION 0.8.1 **//
+//* VERSION 0.8.0 **//
 //* DESCRIPTION View blogs on your dash **//
 //* DEVELOPER new-xkit **//
 //* DETAILS A shortcut to viewing any blog on your dashboard! Uses the blog sidebar (Peepr) by default, but can be configured differently. **//
@@ -601,10 +601,7 @@ XKit.extensions.view_on_dash = new Object({
 			success: function(data) {
 				tumblelog_key = data.response.posts[0].tumblelog_key;
 			},
-			datatype: "json",
-			headers: {
-				"X-XKit-Version": XKit.version,
-			},
+			datatype: "json"
 		});
 
 		//$("#view-on-dash-background,#view-on-dash-content").remove();

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.2.7 **//
+//* VERSION 7.2.9 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -161,10 +161,10 @@ XKit.extensions.xkit_patches = new Object({
 		}, 1000);
 	},
 
-	run_order: ["7.8.1", "7.8.2", "7.9.0"],
+	run_order: ["7.8.1", "7.8.2", "7.9.1"],
 
 	patches: {
-		"7.9.0": function() {
+		"7.9.1": function() {
 
 			// Override "Search Page Brick Post Fix" from xkit.css
 			XKit.tools.add_css(

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.2.8 **//
+//* VERSION 7.2.7 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -165,13 +165,6 @@ XKit.extensions.xkit_patches = new Object({
 
 	patches: {
 		"7.9.0": function() {
-
-			GM_xmlhttpRequest = _.wrap(GM_xmlhttpRequest,
-				(original, settings) => original(_.merge({}, settings, {
-					headers: {
-						"X-XKit-Version": XKit.version,
-					}
-				})));
 
 			// Override "Search Page Brick Post Fix" from xkit.css
 			XKit.tools.add_css(
@@ -396,8 +389,7 @@ XKit.extensions.xkit_patches = new Object({
 
 				const standard_headers = {
 					"X-Requested-With": "XMLHttpRequest",
-					"X-Tumblr-Form-Key": XKit.interface.form_key(),
-					"X-XKit-Version": XKit.version
+					"X-Tumblr-Form-Key": XKit.interface.form_key()
 				};
 
 				if (details.headers === undefined) {

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -161,7 +161,7 @@ XKit.extensions.xkit_patches = new Object({
 		}, 1000);
 	},
 
-	run_order: ["7.8.1", "7.8.2", "7.9.1"],
+	run_order: ["7.8.1", "7.8.2", "7.9.0", "7.9.1"],
 
 	patches: {
 		"7.9.1": function() {
@@ -512,6 +512,9 @@ XKit.extensions.xkit_patches = new Object({
 			XKit.interface.post_window.reblogging_from =
 				() => $(".post-form--header .reblog_source .reblog_name").text();
 		},
+
+		"7.9.0": function() {},
+
 		"7.8.2": function() {
 			XKit.api_key = "kZSI0VnPBJom8cpIeTFw4huEh9gGbq4KfWKY7z5QECutAAki6D";
 

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -389,7 +389,8 @@ XKit.extensions.xkit_patches = new Object({
 
 				const standard_headers = {
 					"X-Requested-With": "XMLHttpRequest",
-					"X-Tumblr-Form-Key": XKit.interface.form_key()
+					"X-Tumblr-Form-Key": XKit.interface.form_key(),
+					"X-XKit-Version": XKit.version,
 				};
 
 				if (details.headers === undefined) {

--- a/Safari/Info.plist
+++ b/Safari/Info.plist
@@ -13,9 +13,9 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>7.9.0</string>
+	<string>7.9.1</string>
 	<key>CFBundleVersion</key>
-	<string>7.9.0</string>
+	<string>7.9.1</string>
 	<key>Chrome</key>
 	<dict>
 		<key>Database Quota</key>

--- a/Safari/bridge.js
+++ b/Safari/bridge.js
@@ -213,7 +213,6 @@ if (!String.prototype.startsWith) {
 				// Safari does not like us passing functions.
 				delete toSend.settings.onload;
 				delete toSend.settings.onerror;
-
 				toSend.settings.headers = JSON.stringify(toSend.settings.headers);
 
 				XBridge.dispatchMessage("http_request", toSend);

--- a/WebExtension/manifest.json
+++ b/WebExtension/manifest.json
@@ -24,7 +24,7 @@
   "name": "New XKit",
   "author": "New XKit Team",
   "permissions": ["storage", "unlimitedStorage", "*://*.tumblr.com/*", "https://new-xkit.github.io/XKit/*", "https://cloud.new-xkit.com/*" ],
-  "version": "7.9.0",
+  "version": "7.9.1",
   "web_accessible_resources": [ "manifest.json", "editor.js" ],
   "applications": {
     "gecko": {

--- a/xkit.js
+++ b/xkit.js
@@ -96,6 +96,12 @@ var xkit_global_start = Date.now();  // log start timestamp
 					return;
 				}
 
+				// Before we run main--if patches is a broken version,
+				// we need to force an update.
+				if (XKit.installed.version('xkit_patches') === '7.2.8') {
+					XKit.special.force_update();
+				}
+
 				// It exists! Great.
 				var xkit_main = XKit.installed.get("xkit_main");
 				if (!xkit_main.errors && xkit_main.script) {

--- a/xkit.js
+++ b/xkit.js
@@ -1322,8 +1322,6 @@ var xkit_global_start = Date.now();  // log start timestamp
 						xhr.setRequestHeader(header, add_tag.headers[header]);
 					}
 
-					xhr.setRequestHeader('X-XKit-Version', XKit.version);
-
 					function callback(result) {
 						var bare_headers = xhr.getAllResponseHeaders().split("\r\n");
 						var cur_headers = {}, splitter;
@@ -3147,9 +3145,6 @@ var xkit_global_start = Date.now();  // log start timestamp
 					url: "https://www.tumblr.com/svc/blog/followed_by",
 					data: "tumblelog=" + blog + "&query=" + username,
 					dataType: "json",
-					headers: {
-						"X-XKit-Version": XKit.version,
-					},
 				}).then(function(msg) {
 					return msg.response.is_friend == 1;
 				});


### PR DESCRIPTION
Reverts new-xkit/XKit#1744

On some chrome installs (but not others?) this triggers a CORS preflight check. This didn't show up in testing, and it's really grinding my gears. Sorry @cyle 
