### PR TITLE
rewrite Tag Replacer

### DIFF
--- a/Extensions/tag_replacer.js
+++ b/Extensions/tag_replacer.js
@@ -182,9 +182,9 @@ XKit.extensions.tag_replacer = new Object({
 			XKit.window.show(
 				"Nothing for me to do.",
 
-				"Tag Replacer could not find any posts containing the tag you were searching for.",
+				`Tag Replacer could not find any posts tagged <br><b>#${this.replace}</b>.`,
 
-				"error",
+				"info",
 
 				'<div id="xkit-close-message" class="xkit-button default">OK</div>'
 			);
@@ -194,9 +194,9 @@ XKit.extensions.tag_replacer = new Object({
 		XKit.window.show(
 			"Working...",
 
-			"Tag Replacer is replacing tags." +
-			XKit.progress.add("tag-replacer-progress") +
-			"This might take a long, long, long time.",
+			`Tag Replacer is ${this.append_mode ? "appending" : "replacing"} tags.
+			${XKit.progress.add("tag-replacer-progress")}
+			This might take a long, long, long time.`,
 
 			"info"
 		);

--- a/Extensions/tag_replacer.js
+++ b/Extensions/tag_replacer.js
@@ -43,7 +43,7 @@ XKit.extensions.tag_replacer = new Object({
 	show: function(url) {
 
 		XKit.window.show(
-			"Tag Replacer",
+			'Tag Replacer',
 
 			'<b>Replace this tag:</b>' +
 			'<input type="text" maxlength="150" placeholder="Enter a tag (example: &quot;I like pandas&quot;)" class="xkit-textbox" id="xkit-tag-replacer-replace">' +
@@ -54,9 +54,9 @@ XKit.extensions.tag_replacer = new Object({
 			'<div class="xkit-checkbox" id="xkit-tag-replacer-append"><b>&nbsp;</b>Don\'t replace the tag but append the tag above</div>' +
 			'<div class="xkit-tag-replacer-separator">&nbsp;</div>' +
 			'<small>You can replace only one tag at a time.<br/>' +
-			"Due to technical reasons, you can't edit tags containing dashes or slashes.</small>",
+			'Due to technical reasons, you can\'t edit tags containing dashes or slashes.</small>',
 
-			"question",
+			'question',
 
 			'<div class="xkit-button default" id="xkit-tag-replacer-ok">Go!</div>' +
 			'<div class="xkit-button" id="xkit-close-message">Cancel</div>'
@@ -133,12 +133,12 @@ XKit.extensions.tag_replacer = new Object({
 		});
 
 		XKit.window.show(
-			"Working...",
+			'Working...',
 
-			"Tag Replacer is trying to find posts with the tag you've entered, please wait. This might take a while." +
+			'Tag Replacer is trying to find posts with the tag you\'ve entered, please wait. This might take a while.' +
 			'<div id="xkit-tag-replacer-loaded">Initializing...</div>',
 
-			"info"
+			'info'
 		);
 
 		this.fetch_posts();
@@ -180,11 +180,11 @@ XKit.extensions.tag_replacer = new Object({
 
 		if (this.post_count === 0) {
 			XKit.window.show(
-				"Nothing for me to do.",
+				'Nothing for me to do.',
 
 				`Tag Replacer could not find any posts tagged <br><b>#${this.replace}</b>.`,
 
-				"info",
+				'info',
 
 				'<div id="xkit-close-message" class="xkit-button default">OK</div>'
 			);
@@ -192,13 +192,13 @@ XKit.extensions.tag_replacer = new Object({
 		}
 
 		XKit.window.show(
-			"Working...",
+			'Working...',
 
 			`Tag Replacer is ${this.append_mode ? "appending" : "replacing"} tags.
 			${XKit.progress.add("tag-replacer-progress")}
 			This might take a long, long, long time.`,
 
-			"info"
+			'info'
 		);
 
 		this.replace_tag();
@@ -282,12 +282,12 @@ XKit.extensions.tag_replacer = new Object({
 		}
 
 		XKit.window.show(
-			"All done!",
+			'All done!',
 
 			`Tag Replacer successfully ${this.append_mode ? "appended" : "replaced"} tags on <b>${this.success_count}</b> posts.<br>
 			(Failed: ${this.fail_count})`,
 
-			"info",
+			'info',
 
 			'<div id="xkit-close-message" class="xkit-button default">Yay!</div>'
 		);
@@ -296,7 +296,7 @@ XKit.extensions.tag_replacer = new Object({
 	show_error: (title, message) => XKit.window.show(
 		title, message,
 
-		"error",
+		'error',
 
 		'<div class="xkit-button default" id="xkit-close-message">OK</div>' +
 		'<a href="https://new-xkit-support.tumblr.com/" target="_blank" class="xkit-button">New XKit support</a>'

--- a/Extensions/tag_replacer.js
+++ b/Extensions/tag_replacer.js
@@ -30,14 +30,42 @@ XKit.extensions.tag_replacer = new Object({
 			}]
 		});
 
-		$("#tag_replacer_button").click(function() {
-			var m_url = $(".open_blog_link").attr('href').replace(/https?:\/\//gi, "");
-			if (m_url.substring(m_url.length - 1) === "/") { m_url = m_url.substring(0, m_url.length - 1); }
-			XKit.extensions.tag_replacer.show(m_url);
+		$("#tag_replacer_button").click(() => {
+			const url = XKit.interface.where().user_url;
+			const shown_warning = XKit.storage.get("tag_replacer", "shown_warning", "false");
 
-			return false;
+			if (shown_warning !== "true") {
+				this.warning(url);
+			} else {
+				this.show(url);
+			}
 		});
 
+	},
+
+	warning: function(url) {
+		XKit.window.show(
+			"Important Notice",
+
+			"Usage of Tag Replacer has reportedly caused some accounts to be temporarily terminated. " +
+			"We aren't sure exactly why this is or what we can do to fix it, but using special characters in your tags might be a factor.<br><br>" +
+			"<b>Please only use this tool if you understand that, in the event that your usage of it triggers Tumblr's spam detector, " +
+			"you will have to contact Tumblr support to restore your account.</b><br><br>" +
+			"We have provided a link below to Tumblr's support form for you to bookmark. " +
+			"(The link opens in a new tab.)<br><br>" +
+			"If you accept this risk, this warning will not be shown again.",
+
+			"warning",
+
+			'<div id="xkit-tag-replacer-accept-risk" class="xkit-button default">I understand</div>' +
+			'<div id="xkit-close-message" class="xkit-button">Cancel</div>' +
+			'<a href="https://www.tumblr.com/support" target="_blank" class="xkit-button">Tumblr support &rarr;</a>'
+		);
+
+		$("#xkit-tag-replacer-accept-risk").click(() => {
+			XKit.storage.set("tag_replacer", "shown_warning", "true");
+			this.show(url);
+		});
 	},
 
 	show: function(url) {

--- a/Extensions/tag_replacer.js
+++ b/Extensions/tag_replacer.js
@@ -1,5 +1,5 @@
 //* TITLE Tag Replacer **//
-//* VERSION 0.4.9 **//
+//* VERSION 1.0.0 **//
 //* DESCRIPTION Replace old tags! **//
 //* DETAILS Allows you to bulk replace tags of posts. Go to your Posts page on your dashboard and click on the button on the sidebar and enter the tag you want replaced, and the new tag, and Tag Replacer will take care of the rest. **//
 //* DEVELOPER new-xkit **//
@@ -9,16 +9,14 @@
 XKit.extensions.tag_replacer = new Object({
 
 	running: false,
-	apiKey: XKit.api_key,
 
 	run: function() {
 
 		this.running = true;
 
-		if (!XKit.interface.where().channel) {
+		if (!XKit.interface.where().channel || !XKit.interface.where().user_url) {
 			return;
 		}
-		if (typeof XKit.interface.where().user_url === "undefined" || XKit.interface.where().user_url === "") {return; }
 
 		XKit.tools.init_css("tag_replacer");
 
@@ -44,268 +42,272 @@ XKit.extensions.tag_replacer = new Object({
 
 	show: function(url) {
 
-		XKit.window.show("Tag Replacer", "<b>Replace this tag:</b><input type=\"text\" maxlength=\"150\" placeholder=\"Enter a tag (example: 'I like pandas')\" class=\"xkit-textbox\" id=\"xkit-tag-replacer-replace\"><div class=\"xkit-checkbox\" id=\"xkit-tag-replacer-case-sensitive\"><b>&nbsp;</b>Case Sensitive Mode</div><div class=\"xkit-tag-replacer-separator\">&nbsp;</div><b>With this tag:</b> (leave blank to delete the tag)<input type=\"text\" maxlength=\"150\" placeholder=\"Enter a tag (example: 'I still like pandas')\" class=\"xkit-textbox\" id=\"xkit-tag-replacer-with\"><div class=\"xkit-checkbox\" id=\"xkit-tag-replacer-append\"><b>&nbsp;</b>Don't replace the tag but append the tag above</div><div class=\"xkit-tag-replacer-separator\">&nbsp;</div><small>You can replace only one tag at a time.<br/>Due to technical reasons, you can't edit tags containing dashes.</small>", "question", "<div class=\"xkit-button default\" id=\"xkit-tag-replacer-ok\">Go!</div><div class=\"xkit-button\" id=\"xkit-close-message\">Cancel</div>");
+		XKit.window.show(
+			"Tag Replacer",
+
+			'<b>Replace this tag:</b>' +
+			'<input type="text" maxlength="150" placeholder="Enter a tag (example: &quot;I like pandas&quot;)" class="xkit-textbox" id="xkit-tag-replacer-replace">' +
+			'<div class="xkit-checkbox" id="xkit-tag-replacer-case-sensitive"><b>&nbsp;</b>Case Sensitive Mode</div>' +
+			'<div class="xkit-tag-replacer-separator">&nbsp;</div>' +
+			'<b>With this tag:</b> (leave blank to delete the tag)' +
+			'<input type="text" maxlength="150" placeholder="Enter a new tag (example: &quot;I still like pandas&quot;)" class="xkit-textbox" id="xkit-tag-replacer-with">' +
+			'<div class="xkit-checkbox" id="xkit-tag-replacer-append"><b>&nbsp;</b>Don\'t replace the tag but append the tag above</div>' +
+			'<div class="xkit-tag-replacer-separator">&nbsp;</div>' +
+			'<small>You can replace only one tag at a time.<br/>' +
+			"Due to technical reasons, you can't edit tags containing dashes or slashes.</small>",
+
+			"question",
+
+			'<div class="xkit-button default" id="xkit-tag-replacer-ok">Go!</div>' +
+			'<div class="xkit-button" id="xkit-close-message">Cancel</div>'
+		);
 
 		$("#xkit-tag-replacer-case-sensitive").click(function() { $(this).toggleClass("selected"); });
 		$("#xkit-tag-replacer-append").click(function() { $(this).toggleClass("selected"); });
 
 		$("#xkit-tag-replacer-ok").click(function() {
-			var quit = false;
+			var $replace = $("#xkit-tag-replacer-replace");
+			var replace = $replace.val().trim();
 
-			var $t_replace = $("#xkit-tag-replacer-replace");
-			var t_replace = "";
-
-			if (XKit.extensions.tag_replacer.case_sensitive) {
-				t_replace = $.trim($t_replace.val());
-			} else {
-				t_replace = $.trim($t_replace.val().toLowerCase());
+			if (!$("#xkit-tag-replacer-case-sensitive").hasClass("selected")) {
+				replace = replace.toLowerCase();
 			}
 
-			var $t_with = $("#xkit-tag-replacer-with");
-			var t_with = $.trim($t_with.val());
+			var $replace_with = $("#xkit-tag-replacer-with");
+			var replace_with = $replace_with.val().trim();
 
-			if (t_replace.indexOf(",") !== -1) {
-				$t_replace
+			function complain($target, message, original) {
+				$target
 					.css("border-color", "red")
-					.attr("placeholder", "Tag to search for can not contain commas.")
+					.attr("placeholder", message)
 					.val("")
-					.click(function() {
-						$t_replace
-							.removeAttr("style")
-							.attr("placeholder", "Enter a tag (example: 'I like pandas')")
-							.off("click");
-					});
-				quit = true;
-			} else if (t_replace === "") {
-				$t_replace
-					.css("border-color", "red")
-					.attr("placeholder", "Enter the tag you want replaced.")
-					.click(function() {
-						$t_replace
-							.removeAttr("style")
-							.attr("placeholder", "Enter a tag (example: 'I like pandas')")
-							.off("click");
-					});
-				quit = true;
+					.click(() => $target
+						.removeAttr("style")
+						.attr("placeholder", original)
+						.off("click"));
 			}
 
-			if (t_with === "" && $("#xkit-tag-replacer-append").hasClass("selected")) {
-				$t_with
-					.css("border-color", "red")
-					.attr("placeholder", "Enter the tag you want to append.")
-					.val("")
-					.click(function() {
-						$t_with
-							.removeAttr("style")
-							.attr("placeholder", "Enter a tag (example: 'I still like pandas')")
-							.off("click");
-					});
-				quit = true;
+			if (replace.includes(",")) {
+				complain($replace, "Tag to search for can not contain commas.", 'Enter a tag (example: "I like pandas")');
+				return;
 			}
 
-			if (!quit) {
-				XKit.extensions.tag_replacer.start(url, encodeURIComponent(t_replace), t_with, $("#xkit-tag-replacer-append").hasClass("selected"));
+			if (replace === "") {
+				complain($replace, "Enter the tag you want replaced.", 'Enter a tag (example: "I like pandas")');
+				return;
 			}
+
+			if ($("#xkit-tag-replacer-append").hasClass("selected") && replace_with === "") {
+				complain($replace_with, "Enter the tag(s) you want to append.", 'Enter a new tag (example: "I still like pandas")');
+				return;
+			}
+
+			XKit.extensions.tag_replacer.start(url, replace, replace_with);
 
 		});
 
 	},
 
-	page: 0,
 	url: "",
-	t_replace: "",
-	t_with: "",
-	p_array: [],
-	p_array_index: 0,
+	replace: "",
+	replace_with: "",
+	post_ids: [],
+	post_count: 0,
 	append_mode: false,
 	case_sensitive: false,
 	success_count: 0,
 	fail_count: 0,
 
-	start: function(url, t_replace, t_with, append_mode) {
+	start: function(url, replace, replace_with) {
 
-		console.log("replace " + t_replace + " with " + t_with + " on " + url);
-
-		XKit.extensions.tag_replacer.page = 0;
-		XKit.extensions.tag_replacer.url = url;
-		XKit.extensions.tag_replacer.t_replace = t_replace;
-		XKit.extensions.tag_replacer.t_with = t_with;
-		XKit.extensions.tag_replacer.p_array = [];
-		XKit.extensions.tag_replacer.p_array_index = 0;
-		XKit.extensions.tag_replacer.success_count = 0;
-		XKit.extensions.tag_replacer.fail_count = 0;
-		XKit.extensions.tag_replacer.append_mode = append_mode;
-		XKit.extensions.tag_replacer.case_sensitive = $("#xkit-tag-replacer-case-sensitive").hasClass("selected");
-
-		XKit.extensions.tag_replacer.next();
-
-		XKit.window.show("Working...", "Tag Replacer is trying to find posts with the tag you've entered, please wait. This might take a while.<div id=\"xkit-tag-replacer-progress\">Initializing...</div>", "info");
-
-	},
-
-	show_error: function(message) {
-
-		XKit.window.show("Tag Replacer encountered an error", message, "error", "<div class=\"xkit-button default\" id=\"xkit-close-message\">OK</div>");
-
-	},
-
-	start_replacing: function() {
-
-		if (XKit.extensions.tag_replacer.p_array.length === 0) {
-
-			XKit.window.show("Nothing for me to do.", "Tag Replacer could not find any posts containing the tag you were searching for.", "error", "<div class=\"xkit-button default\" id=\"xkit-close-message\">OK</div>");
-			return;
-
-		}
-
-		XKit.window.show("Working...", "Tag Replacer is replacing tags." + XKit.progress.add("tag-replacer-pb") +  "<div id=\"xkit-tag-replacer-progress\">This might take a long, long, long time.</div>", "info");
-		XKit.extensions.tag_replacer.replace_next();
-
-	},
-
-	replace_next: function() {
-
-		var m_post = XKit.extensions.tag_replacer.p_array[XKit.extensions.tag_replacer.p_array_index];
-
-		var m_post_obj = {};
-
-		m_post_obj.id = m_post;
-		m_post_obj.owner = XKit.interface.where().user_url;
-
-		if (XKit.extensions.tag_replacer.p_array_index >= XKit.extensions.tag_replacer.p_array.length) {
-			if (XKit.extensions.tag_replacer.success_count === 0) {
-				XKit.window.show("Thank you, come again!", "Tag Replacer could not find any posts with the tag you've specified. Make sure you turn off Case Sensitive mode if you can't find the posts.", "info", "<div class=\"xkit-button default\" id=\"xkit-close-message\">OK</div>");
-			} else {
-				XKit.window.show("Thank you, come again!", "Tag Replacer replaced tags of " + XKit.extensions.tag_replacer.success_count + " posts. (Failed: " + XKit.extensions.tag_replacer.fail_count + " posts)", "info", "<div class=\"xkit-button default\" id=\"xkit-close-message\">OK</div>");
-			}
-			return;
-		}
-
-		console.log("Fetching post with ID " + m_post);
-
-		XKit.interface.fetch(m_post_obj, function(data) {
-
-			console.log(data);
-
-			if (data.error === true) {
-				XKit.extensions.tag_replacer.show_error("<b>Unable to fetch post object.</b><br/>Please try again later.<br/><br/>Error Code: TGR-935");
-				return;
-			}
-
-			var m_tags = data.data.post.tags.split(",");
-			if (!XKit.extensions.tag_replacer.case_sensitive) {
-				m_tags = m_tags.map(function(tag) {
-					return tag.toLowerCase();
-				});
-			}
-
-			var found_tag = false;
-
-			if (XKit.extensions.tag_replacer.append_mode === false) {
-
-				for (var i = 0; i < m_tags.length; i++) {
-					if (encodeURIComponent(m_tags[i]) === XKit.extensions.tag_replacer.t_replace) {
-						found_tag = true;
-						m_tags[i] = XKit.extensions.tag_replacer.t_with;
-						break;
-					}
-				}
-
-			} else {
-
-				found_tag = true;
-				console.log("append mode, appending " + XKit.extensions.tag_replacer.t_with);
-				m_tags.push(XKit.extensions.tag_replacer.t_with);
-
-			}
-
-			if (found_tag === false) {
-				var perc = Math.round((XKit.extensions.tag_replacer.p_array_index * 100) / XKit.extensions.tag_replacer.p_array.length);
-				XKit.progress.value("tag-replacer-pb", perc);
-				XKit.extensions.tag_replacer.p_array_index++;
-				setTimeout(function() { XKit.extensions.tag_replacer.replace_next(); }, 500);
-				return;
-			}
-
-			XKit.extensions.tag_replacer.success_count++;
-
-			var tags_to_post = m_tags.join(",");
-
-			var m_post_object = XKit.interface.edit_post_object(data.data, { tags: tags_to_post });
-
-			XKit.interface.edit(m_post_object, function(edit_data) {
-
-				var progress_perc = Math.round((XKit.extensions.tag_replacer.p_array_index * 100) / XKit.extensions.tag_replacer.p_array.length);
-				XKit.progress.value("tag-replacer-pb", progress_perc);
-
-				if (edit_data.error === false && edit_data.data.errors === false) {
-
-					console.log("Post " + m_post + " updated successfully.");
-
-					XKit.extensions.tag_replacer.p_array_index++;
-					setTimeout(function() { XKit.extensions.tag_replacer.replace_next(); }, 1000);
-
-				} else {
-
-					XKit.extensions.tag_replacer.fail_count++;
-
-					XKit.extensions.tag_replacer.p_array_index++;
-					setTimeout(function() { XKit.extensions.tag_replacer.replace_next(); }, 2000);
-
-				}
-
-			});
-
+		Object.assign(this, {
+			url: url,
+			replace: replace,
+			replace_with: replace_with,
+			post_ids: [],
+			post_count: 0,
+			success_count: 0,
+			fail_count: 0,
+			append_mode: $("#xkit-tag-replacer-append").hasClass("selected"),
+			case_sensitive: $("#xkit-tag-replacer-case-sensitive").hasClass("selected")
 		});
 
+		XKit.window.show(
+			"Working...",
+
+			"Tag Replacer is trying to find posts with the tag you've entered, please wait. This might take a while." +
+			'<div id="xkit-tag-replacer-loaded">Initializing...</div>',
+
+			"info"
+		);
+
+		this.fetch_posts();
 	},
 
-	next: function(retry_mode) {
-
-		var api_url = "https://api.tumblr.com/v2/blog/" +  XKit.extensions.tag_replacer.url + "/posts" + "?api_key=" + XKit.extensions.tag_replacer.apiKey + "&tag=" + XKit.extensions.tag_replacer.t_replace + "&limit=50" + "&offset=" + XKit.extensions.tag_replacer.page * 50;
-
+	fetch_posts: function(page = 0) {
 		GM_xmlhttpRequest({
 			method: "GET",
-			url: api_url,
-			json: true,
-			onerror: function(response) {
-				if (response.status === 404) {
-					XKit.window.show("Nothing for me to do.", "Tag Replacer could not find any posts containing the tag you were searching for.", "error", "<div class=\"xkit-button default\" id=\"xkit-close-message\">OK</div>");
-				} else {
-					XKit.extensions.tag_replacer.show_error("<b>Unable to get the blog information.</b><br/>Please try again later.<br/><br/>Error Code: TGR-230");
-				}
-				return;
-			},
-			onload: function(response) {
-				try {
+			url: `https://api.tumblr.com/v2/blog/${this.url}/posts?` + $.param({
+				"api_key": XKit.api_key,
+				"tag": this.replace,
+				"limit": 50,
+				"offset": page * 50
+			}),
+			onload: response => {
+				let data = JSON.parse(response.responseText);
 
-					var data = JSON.parse(response.responseText);
-					var posts = data.response.posts;
-
-					if (posts.length === 0) {
-						XKit.extensions.tag_replacer.start_replacing();
-						return;
-					}
-
-					for (var i = 0; i < posts.length; i++) {
-						XKit.extensions.tag_replacer.p_array.push(posts[i].id);
-					}
-
-					$("#xkit-tag-replacer-progress").html("Loaded " + XKit.extensions.tag_replacer.p_array.length + " tagged posts..");
-
-					XKit.extensions.tag_replacer.page++;
-					setTimeout(function() { XKit.extensions.tag_replacer.next(); }, 1500);
-
-				} catch (e) {
-					// Could this be a custom URL and Tumblr's stupidity on stripping the JSON part of the URL requested?
-					XKit.extensions.tag_replacer.show_error("<b>Unable to read JSON received from API calls.</b><br/>Please try again later.<br/><br/>Error Code: TGR-235");
+				if (data.response.posts.length === 0) {
+					this.start_replace();
 					return;
 				}
 
+				data.response.posts.forEach(post => this.post_ids.push(post.id));
+				$("#xkit-tag-replacer-loaded").html(`Loaded ${this.post_ids.length} tagged posts...`);
+
+				this.fetch_posts(++page);
+			},
+			onerror: response => {
+				XKit.window.show(
+					"Can't fetch posts.",
+
+					"Tag Replacer could not fetch a list of tagged posts. This is usually due to your blog being private.<br>" +
+					"Please check your blog settings and try again.",
+
+					"error",
+
+					'<div id="xkit-close-message" class="xkit-button default">OK</div>' +
+					'<a href="https://new-xkit-support.tumblr.com/" target="_blank" class="xkit-button">New XKit support</a>'
+				);
 			}
 		});
-
 	},
+
+	start_replace: function() {
+		this.post_count = this.post_ids.length;
+
+		if (this.post_count === 0) {
+			XKit.window.show(
+				"Nothing for me to do.",
+
+				"Tag Replacer could not find any posts containing the tag you were searching for.",
+
+				"error",
+
+				'<div id="xkit-close-message" class="xkit-button default">OK</div>'
+			);
+			return;
+		}
+
+		XKit.window.show(
+			"Working...",
+
+			"Tag Replacer is replacing tags." +
+			XKit.progress.add("tag-replacer-progress") +
+			"This might take a long, long, long time.",
+
+			"info"
+		);
+
+		this.replace_tag();
+	},
+
+	replace_tag: function() {
+		const post_id = this.post_ids.shift();
+
+		if (post_id === undefined) {
+			this.done_replacing();
+			return;
+		}
+
+		XKit.interface.fetch({"id": post_id}, response => {
+			if (response.error) {
+				this.show_error(
+					"Can't fetch post.",
+					"Try again later."
+				);
+				return;
+			}
+
+			let tags = response.data.post.tags.split(",");
+			let edited = false;
+
+			if (this.append_mode) {
+				tags.push(this.replace_with);
+				edited = true;
+			} else {
+				for (let tag of tags) {
+					let i = tags.indexOf(tag);
+
+					if (!this.case_sensitive) {
+						tag = tag.toLowerCase();
+					}
+
+					if (tag === this.replace) {
+						tags[i] = this.replace_with;
+						edited = true;
+						break;
+					}
+				}
+			}
+
+			if (!edited) {
+				this.update_progress();
+				this.replace_tag();
+				return;
+			}
+
+			let edited_post = XKit.interface.edit_post_object(response.data, {
+				tags: tags.join(",")
+			});
+
+			XKit.interface.edit(edited_post, edit_response => {
+				if (edit_response.error) {
+					this.fail_count++;
+				} else {
+					this.success_count++;
+				}
+
+				this.update_progress();
+				this.replace_tag();
+			});
+		});
+	},
+
+	update_progress: function() {
+		let done = this.post_count - this.post_ids.length;
+		let percentage = Math.round((done * 100) / this.post_count);
+		XKit.progress.value("tag-replacer-progress", percentage);
+	},
+
+	done_replacing: function() {
+		if (this.fail_count == this.post_count) {
+			this.show_error(
+				"Oh dear...",
+				"I was unable to replace tags on any of the posts.<br>Try again later?"
+			);
+			return;
+		}
+
+		XKit.window.show(
+			"All done!",
+
+			`Tag Replacer successfully ${this.append_mode ? "appended" : "replaced"} tags on <b>${this.success_count}</b> posts.<br>
+			(Failed: ${this.fail_count})`,
+
+			"info",
+
+			'<div id="xkit-close-message" class="xkit-button default">Yay!</div>'
+		);
+	},
+
+	show_error: (title, message) => XKit.window.show(
+		title, message,
+
+		"error",
+
+		'<div class="xkit-button default" id="xkit-close-message">OK</div>' +
+		'<a href="https://new-xkit-support.tumblr.com/" target="_blank" class="xkit-button">New XKit support</a>'
+	),
 
 	destroy: function() {
 		this.running = false;

--- a/Extensions/tag_replacer.js
+++ b/Extensions/tag_replacer.js
@@ -166,19 +166,12 @@ XKit.extensions.tag_replacer = new Object({
 
 				this.fetch_posts(++page);
 			},
-			onerror: response => {
-				XKit.window.show(
-					"Can't fetch posts.",
+			onerror: () => this.show_error(
+				"Can't fetch posts",
 
-					"Tag Replacer could not fetch a list of tagged posts. This is usually due to your blog being private.<br>" +
-					"Please check your blog settings and try again.",
-
-					"error",
-
-					'<div id="xkit-close-message" class="xkit-button default">OK</div>' +
-					'<a href="https://new-xkit-support.tumblr.com/" target="_blank" class="xkit-button">New XKit support</a>'
-				);
-			}
+				"Tag Replacer could not fetch a list of tagged posts. This is usually due to your blog being private.<br>" +
+				"Please check your blog settings and try again."
+			)
 		});
 	},
 

--- a/Extensions/tag_replacer.js
+++ b/Extensions/tag_replacer.js
@@ -164,7 +164,7 @@ XKit.extensions.tag_replacer = new Object({
 				data.response.posts.forEach(post => this.post_ids.push(post.id));
 				$("#xkit-tag-replacer-loaded").html(`Loaded ${this.post_ids.length} tagged posts...`);
 
-				this.fetch_posts(++page);
+				this.fetch_posts(page + 1);
 			},
 			onerror: () => this.show_error(
 				"Can't fetch posts",


### PR DESCRIPTION
makes Tag Replacer's code make sense

- resolves #1289 
- removes a ton of single-line XKit.window calls
- puts the functions in the order that theyre used
- did i mention i fixed case sensitive mode
- (and that tags we're not replacing are left completely untouched now)
- (as they should be)