### PR TITLE
Remove tinyMCE poking attempts

### DIFF
--- a/Extensions/outbox.js
+++ b/Extensions/outbox.js
@@ -236,7 +236,6 @@ XKit.extensions.outbox = new Object({
 		var m_to = $(m_parent).attr('data-tumblelog-name');
 
 		var post_id = $(m_parent).attr('data-post-id');
-		XKit.extensions.outbox.poke_tinymce(post_id);
 
 		if (m_message.indexOf("<div id=\"ask_answer_") !== -1) {
 
@@ -287,21 +286,6 @@ XKit.extensions.outbox = new Object({
 
 		}, 1);
 
-	},
-
-	poke_tinymce: function(post_id) {
-		var source = " if (tinyMCE && tinyMCE.get('ask_answer_field_" + post_id + "')) {  " +
-						" document.getElementById('ask_answer_field_" + post_id + "').value = (tinyMCE.get('ask_answer_field_" + post_id + "').getContent()); " +
-				 " } ";
-
-		if ('function' == typeof source) {
-			source = '(' + source + ')();';
-		}
-
-		var script = document.createElement('script');
-		script.setAttribute("type", "application/javascript");
-		script.textContent = source;
-		document.body.appendChild(script);
 	},
 
 	start: function() {

--- a/Extensions/outbox.js
+++ b/Extensions/outbox.js
@@ -1,5 +1,5 @@
 //* TITLE Outbox **//
-//* VERSION 0.11.2 **//
+//* VERSION 0.11.3 **//
 //* DESCRIPTION Saves your sent replies and asks. **//
 //* DETAILS This extension stores and lets you view the last 50 asks you've answered privately. Please keep in mind that this is a highly experimental extension, so if you hit a bug, please send the XKit blog an ask with the problem you've found. **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/xinbox.js
+++ b/Extensions/xinbox.js
@@ -1,5 +1,5 @@
 //* TITLE XInbox **//
-//* VERSION 1.9.14 **//
+//* VERSION 1.9.15 **//
 //* DESCRIPTION Enhances your Inbox experience **//
 //* DEVELOPER new-xkit **//
 //* DETAILS XInbox allows you to tag posts before posting them, and see all your messages at once, and lets you delete multiple messages at once using the Mass Editor mode. To use this mode, go to your Inbox and click on the Mass Editor Mode button on your sidebar, click on the messages you want to delete then click the Delete Messages button.  **//
@@ -810,7 +810,6 @@ XKit.extensions.xinbox = new Object({
 						m_state = "0";
 					}
 
-					XKit.extensions.xinbox.poke_tinymce(post_id);
 					setTimeout(function() {
 						XKit.extensions.xinbox.publish_ask(this_obj, post_id, m_tags, m_state);
 					}, 200);
@@ -847,8 +846,6 @@ XKit.extensions.xinbox = new Object({
 	},
 
 	publish_ask: function(post_div, post_id, tags, state) {
-
-		XKit.extensions.xinbox.poke_tinymce(post_id);
 
 		var answer = $('#ask_answer_field_' + post_id).val();
 
@@ -984,21 +981,6 @@ XKit.extensions.xinbox = new Object({
 
 		XKit.window.show("Can't publish ask", "Something went wrong and prevented XKit from publishing this ask. You might want to disable XInbox (or at least the tagging options of XInbox) if this is related to a recent Tumblr change.<br/><p>" + msg + "</p>Try refreshing the page and trying again, or disable XInbox extension and file a bug report.", "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
 
-	},
-
-	poke_tinymce: function(post_id) {
-		var source = " if (tinyMCE && tinyMCE.get('ask_answer_field_" + post_id + "')) {  " +
-						" document.getElementById('ask_answer_field_" + post_id + "').value = (tinyMCE.get('ask_answer_field_" + post_id + "').getContent()); " +
-						" } ";
-
-		if ('function' == typeof source) {
-			source = '(' + source + ')();';
-		}
-
-		var script = document.createElement('script');
-		script.setAttribute("type", "application/javascript");
-		script.textContent = source;
-		document.body.appendChild(script);
 	},
 
 	destroy: function() {


### PR DESCRIPTION
removes the `poke_tinymce` function from XInbox and Outbox. this function has not worked in over 3 years (at least on Firefox), and upon further investigation, doesn't even do anything if fixed - `tinyMCE` is always `undefined`.

resolves #995 