### PR TITLE
[Read More Now] Don't activate on themes

### DIFF
--- a/Extensions/read_more_now.js
+++ b/Extensions/read_more_now.js
@@ -1,5 +1,5 @@
 //* TITLE Read More Now **//
-//* VERSION 2.0.1 **//
+//* VERSION 2.0.2 **//
 //* DESCRIPTION Read Mores in your dash **//
 //* DETAILS This extension allows you to read &quot;Keep Reading&quot; posts without leaving your dash. Just click on the &quot;Read More Now!&quot; button on posts and XKit will automatically load and display the post on your dashboard. **//
 //* DEVELOPER New-XKit **//
@@ -13,6 +13,11 @@ XKit.extensions.read_more_now = new Object({
 
 	run: function() {
 		this.running = true;
+
+		if (!XKit.interface.is_tumblr_page()) {
+			return;
+		}
+
 		XKit.post_listener.add("read_more_now", this.find_links);
 		this.find_links();
 


### PR DESCRIPTION
check `is_tumblr_page` before actually running the extension, since it will always fail to get the required peepr data if it activates on a blog theme