### PR TITLE
[Read More Now] Don't activate in the rich text editor

### DIFF
--- a/Extensions/read_more_now.js
+++ b/Extensions/read_more_now.js
@@ -28,11 +28,9 @@ XKit.extensions.read_more_now = new Object({
 
 	find_links: function() {
 		$("a.tmblr-truncated-link:not(.xreadmore-done)")
+			.not("[contenteditable] a")
 			.addClass("xreadmore-done")
 			.each(function() {
-				if ($(this).parents("[contenteditable]").length) {
-					return;
-				}
 				XKit.extensions.read_more_now.add_button($(this));
 			});
 	},

--- a/Extensions/read_more_now.js
+++ b/Extensions/read_more_now.js
@@ -1,5 +1,5 @@
 //* TITLE Read More Now **//
-//* VERSION 2.0.2 **//
+//* VERSION 2.0.3 **//
 //* DESCRIPTION Read Mores in your dash **//
 //* DETAILS This extension allows you to read &quot;Keep Reading&quot; posts without leaving your dash. Just click on the &quot;Read More Now!&quot; button on posts and XKit will automatically load and display the post on your dashboard. **//
 //* DEVELOPER New-XKit **//
@@ -30,6 +30,9 @@ XKit.extensions.read_more_now = new Object({
 		$("a.tmblr-truncated-link:not(.xreadmore-done)")
 			.addClass("xreadmore-done")
 			.each(function() {
+				if ($(this).parents("[contenteditable]").length) {
+					return;
+				}
 				XKit.extensions.read_more_now.add_button($(this));
 			});
 	},


### PR DESCRIPTION
prevents Read More Now from inserting buttons when editing posts. this fixes an issue where, if reblogging a legacy Quote post with a read more link, Read More Now would insert a button after the link in the reblog window, which would then be posted to tumblr and show up on themes as part of the post, regardless of whether Read More Now, or even XKit, is installed or activated.