### PR TITLE
rewrite Post Limit Checker

### DIFF
--- a/Extensions/post_limit_checker.css
+++ b/Extensions/post_limit_checker.css
@@ -22,24 +22,3 @@
 .xkit-plc-division:first-child {
 	margin-top: 10px;
 }
-
-.xkit-plc-division {
-	border-top: 1px dotted rgb(200,200,200);
-	height: 40px;
-	position: relative;
-}
-
-.xkit-plc-title {
-	position: absolute;
-	top: 0px;
-	left: 0px;
-	line-height: 40px;
-	font-weight: bold;
-}
-
-.xkit-plc-value {
-	position: absolute;
-	top: 0px;
-	right: 0px;
-	line-height: 40px;
-}

--- a/Extensions/post_limit_checker.js
+++ b/Extensions/post_limit_checker.js
@@ -109,9 +109,9 @@ XKit.extensions.post_limit_checker = new Object({
 	next: function(blog, page = 0) {
 
 		XKit.svc.indash_blog({
-			"tumblelog_name_or_id": blog,
-			"limit": 50,
-			"offset": page * 50
+			tumblelog_name_or_id: blog,
+			limit: 50,
+			offset: page * 50
 		}).then(response => {
 			const posts = response.json().response.posts;
 

--- a/Extensions/post_limit_checker.js
+++ b/Extensions/post_limit_checker.js
@@ -1,7 +1,7 @@
 //* TITLE Post Limit Checker **//
-//* VERSION 0.3.4 **//
+//* VERSION 1.0.0 **//
 //* DESCRIPTION Are you close to the limit? **//
-//* DETAILS Shows you how many posts you can reblog today. **//
+//* DETAILS Shows you how many posts you can make or reblog today. **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
 //* BETA false **//
@@ -16,7 +16,9 @@ XKit.extensions.post_limit_checker = new Object({
 
 		XKit.tools.init_css("post_limit_checker");
 
-		if (XKit.interface.where().dashboard !== true && XKit.interface.where().channel !== true) { return; }
+		if (!XKit.interface.where().dashboard && !XKit.interface.where().channel) {
+			return;
+		}
 
 		XKit.interface.sidebar.add({
 			id: "post_limit_checker_sidebar",
@@ -27,203 +29,150 @@ XKit.extensions.post_limit_checker = new Object({
 			}]
 		});
 
-		$("#post_limit_checker_view").click(function() {
-
-			XKit.extensions.post_limit_checker.start();
-
-			return false;
-		});
+		$("#post_limit_checker_view").click(() => this.start());
 	},
 
-	window_id: 0,
+	staticBlogs: [],
+
+	blogs: [],
+	posts: {},
+	cutoff: 0,
 
 	start: function() {
 
-		var m_html = "<div id=\"xkit-plc-list\" class=\"nano\"><div id=\"xkit-plc-list-content\" class=\"content\">" +
-					"<div class=\"xkit-warning-plc-text\"><b>Deleted posts</b><br/>Deleted posts are counted by Tumblr, but this tool can't count them. For example, if you've made 250 posts since the last reset but then deleted 50 of them, this tool will tell you that you have 50 more posts to go, but in reality you've already hit your post limit.</div>" +
-					"<div class=\"xkit-warning-plc-text\"><b>Original photo posts</b><br/>There is a separate, 75 uploads per day limit for photo posts. This extension does not check for that.</div>" +
-					"<div class=\"xkit-warning-plc-text\"><b>No Guarantee</b><br/>The New XKit Team is not making any guarantees about the reliability of this tool.</div>" +
-				"</div></div>";
+		XKit.window.show(
+			'Important!',
 
-		XKit.window.show("Important!", "Before beginning, please read the following carefully." + m_html, "warning", "<div class=\"xkit-button default\" id=\"xkit-plc-continue\">Continue</div><div class=\"xkit-button default\" id=\"xkit-close-message\">Cancel</div>");
+			'Before beginning, please read the following carefully.' +
+			'<div id="xkit-plc-list" class="nano">' +
+				'<div id="xkit-plc-list-content" class="content">' +
+					'<div class="xkit-warning-plc-text"><b>Deleted posts</b><br>Deleted posts are counted by Tumblr, but this tool can\'t count them. For example, if you\'ve made 250 posts since the last reset but then deleted 50 of them, this tool will tell you that you have 50 more posts to go, but in reality you\'ve already hit your post limit.</div>' +
+					'<div class="xkit-warning-plc-text"><b>Original photo posts</b><br>There is a separate limit for media uploads of 150. This extension does not check for that.</div>' +
+					'<div class="xkit-warning-plc-text"><b>Edited timestamps</b><br>This tool relies on the time and date on posts being accurate. If you have set a custom post date on any recent posts, inaccurate data will be shown.</div>' +
+					'<div class="xkit-warning-plc-text"><b>Group blogs</b><br>If you are a member of a group blog that has posted today, this tool cannot tell if those posts were made by your account or not.</div>' +
+					'<div class="xkit-warning-plc-text"><b>No Guarantee</b><br>The New XKit Team is not making any guarantees about the reliability of this tool.</div>' +
+				'</div>' +
+			'</div>',
+
+			'warning',
+
+			'<div class="xkit-button default" id="xkit-plc-continue">Continue</div>' +
+			'<div class="xkit-button default" id="xkit-close-message">Cancel</div>'
+		);
 
 		$("#xkit-plc-list").nanoScroller();
 		$("#xkit-plc-list").nanoScroller({ scroll: 'top' });
 
-		$("#xkit-plc-continue").click(function() {
+		$("#xkit-plc-continue").click(() => {
+			XKit.window.show(
+				'Please wait',
 
-			XKit.extensions.post_limit_checker.window_id = XKit.tools.random_string();
+				'Gathering the information I need:<br>' +
+				'<span id="xkit-plc-progress">Initialising...</span>',
 
-			XKit.window.show("Please wait", "Gathering the information I need..." + XKit.progress.add("post-limit-checker-progress"), "info");
-			var posts = [];
-			for (var i = 0; i < XKit.tools.get_blogs().length; i++) {posts.push([]);}
-			XKit.extensions.post_limit_checker.next(0, posts, XKit.extensions.post_limit_checker.window_id, XKit.tools.get_blogs(), 0);
+				'info'
+			);
 
+			this.staticBlogs = XKit.tools.get_blogs();
+
+			this.blogs = [...this.staticBlogs];
+			this.posts = {};
+			this.cutoff = Math.floor(this.get_cutoff());
+
+			this.scan_next_blog();
 		});
 
 	},
 
-	get_time: function(m_window_id, posts) {
+	get_cutoff: function() {
+		let now = new Date();
 
-		// Calculate the date according to NY time.
-		// To-do: DST calculations?
-		var date = XKit.extensions.post_limit_checker.convert_timezone(Math.round(+new Date() / 1000) * 1000, - 4);
+		if (now.getUTCHours() >= 5) {
+			return now.setUTCHours(5, 0, 0) / 1000;
+		} else {
+			return now.setUTCHours(5 - 24, 0, 0) / 1000;
+		}
+	},
 
-		// Now we need to figure out when the next reset is.
-		var next_reset = new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1, 0, 0, 0);
+	scan_next_blog: function() {
+		const blog = this.blogs.shift();
+		if (blog === undefined) {
+			this.done();
+			return;
+		}
 
-		var difference = (next_reset - date);
-		var hours = Math.floor((difference % 86400000) / 3600000);
-		var minutes = Math.floor(((difference % 86400000) % 3600000) / 60000);
+		$('#xkit-plc-progress').html(`Checking posts on <b>${blog}</b>...`);
+		this.posts[blog] = 0;
+		this.next(blog);
+	},
 
-		// Now get when the last reset was. Lazy coding.
-		var last_reset = new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0);
+	next: function(blog, page = 0) {
 
-		var posts_since_reset = 0;
+		XKit.svc.indash_blog({
+			"tumblelog_name_or_id": blog,
+			"limit": 50,
+			"offset": page * 50
+		}).then(response => {
+			const posts = response.json().response.posts;
 
-		for (var i = 0; i < posts.length; i++) {
-
-			var m_timestamp = XKit.extensions.post_limit_checker.convert_timezone(posts[i].timestamp * 1000, - 4);
-
-			if ((m_timestamp.getTime() <= next_reset.getTime() && m_timestamp.getTime() >= last_reset.getTime())) {
-				posts_since_reset++;
+			if (!posts.length) {
+				this.scan_next_blog();
+				return;
 			}
 
-		}
-
-		var remaining = 250 - posts_since_reset;
-
-		var remaining_color = "#298a51";
-		if (remaining <= 60) { remaining_color = "#de8c00"; }
-		if (remaining <= 30) { remaining_color = "#ec0000"; }
-
-		if (remaining === 0) { remaining = "None"; }
-
-		var reset_str = hours + " hours and " + minutes + " minutes";
-		if (hours === 0) {
-			reset_str = minutes + " minutes";
-		}
-		if (minutes <= 1) {
-			reset_str = "a few seconds";
-		}
-		if (hours >= 1 && minutes === 0) {
-			reset_str = hours + " hours";
-		}
-		if (hours == 1) {
-			reset_str = reset_str.replace("hours", "hour");
-		}
-		if (minutes == 1) {
-			reset_str = reset_str.replace("minutes", "minute");
-		}
-
-		var m_html = "<div class=\"xkit-plc-division\">" +
-					"<div class=\"xkit-plc-title\">Posts Made</div>" +
-					"<div class=\"xkit-plc-value\">" + posts_since_reset + "</div>" +
-				"</div>" +
-				"<div class=\"xkit-plc-division\">" +
-					"<div class=\"xkit-plc-title\">Posts Remaining</div>" +
-					"<div class=\"xkit-plc-value\" style=\"font-weight: bold; color: " + remaining_color + "\">" + remaining + "</div>" +
-				"</div>" +
-				"<div class=\"xkit-plc-division\">" +
-					"<div class=\"xkit-plc-title\">Next reset in</div>" +
-					"<div class=\"xkit-plc-value\">" + reset_str + "</div>" +
-				"</div>";
-
-		XKit.window.show("Results", "Here is what I could gather:" + m_html, "info", "<div class=\"xkit-button default\" id=\"xkit-close-message\">OK</div>");
-
-	},
-
-	convert_timezone: function(time, offset) {
-
-		// From:
-		// http://www.techrepublic.com/article/convert-the-local-time-to-another-time-zone-with-this-javascript/
-
-		// create Date object for current location
-		var date = new Date(time);
-
-		// convert to msec
-		// add local time zone offset
-		// get UTC time in msec
-		var utc = date.getTime() + (date.getTimezoneOffset() * 60000);
-
-		// create new Date object for different city
-		// using supplied offset
-		var nd = new Date(utc + (3600000 * offset));
-
-		// return time as a string
-		return nd;
-
-	},
-
-	next: function(page, posts, m_window_id, blogs, index) {
-
-		if (m_window_id !== XKit.extensions.post_limit_checker.window_id) { console.log("wrong window id. 01"); return; }
-
-		var offset = page * 20;
-		var api_url = "https://api.tumblr.com/v2/blog/" + blogs[index] + ".tumblr.com/posts/?api_key=" + XKit.extensions.post_limit_checker.apiKey + "&offset=" + offset;
-		GM_xmlhttpRequest({
-			method: "GET",
-			url: api_url,
-			json: true,
-			onerror: function(response) {
-				if (this.status === 404) {
-					console.log("Probably tried to query a private blog");
-					if (index < blogs.length - 1) {
-						index++;
-						setTimeout(function() { XKit.extensions.post_limit_checker.next(0, posts, m_window_id, blogs, index);}, 400);
-					}
+			for (let post of posts) {
+				if (post.timestamp > this.cutoff) {
+					this.posts[blog]++;
 				} else {
-					console.log("Error getting page.");
-					XKit.extensions.post_limit_checker.display_error(m_window_id, "501");
-				}
-				return;
-			},
-			onload: function(response) {
-
-				if (XKit.extensions.post_limit_checker.window_id !== m_window_id) { console.log("wrong window id. 02"); return; }
-
-				try {
-
-					var data = JSON.parse(response.responseText);
-
-					for (var i = 0; i < data.response.posts.length; i++) {
-
-						// I would check the date here but I'm a lazy man.
-						posts[index].push(data.response.posts[i]);
-
-					}
-
-					XKit.progress.value("post-limit-checker-progress", (posts[index].length / 2.5) - 10);
-
-					if (posts[index].length >= 250 || data.response.posts.length === 0) {
-						if (index < blogs.length - 1) {
-							index++;
-							setTimeout(function() { XKit.extensions.post_limit_checker.next(0, posts, m_window_id, blogs, index);}, 400);
-						} else {
-							var all_posts = [];
-							all_posts = all_posts.concat.apply(all_posts, posts);
-							XKit.extensions.post_limit_checker.get_time(m_window_id, all_posts);
-						}
-					} else {
-						setTimeout(function() { XKit.extensions.post_limit_checker.next((page + 1), posts, m_window_id, blogs, index); }, 400);
-					}
-
-				} catch (e) {
-					console.log("Error parsing page, " + e.message);
-					XKit.extensions.post_limit_checker.display_error(m_window_id, "551");
+					this.scan_next_blog();
 					return;
 				}
-
 			}
-		});
 
+			this.next(blog, page + 1);
+		}).catch(this.show_error);
 	},
 
-	display_error: function(m_window_id, err_code) {
+	done: function() {
+		const remaining = 250 - Object.values(this.posts).reduce((total, x) => total + x);
+		const nextReset = new Date((this.cutoff + 86400) * 1000);
 
-		if (XKit.extensions.post_limit_checker.window_id !== m_window_id) { return; }
-		XKit.window.show("Oops.", "An error prevented me from gathering the information needed.<br/>Please try again later.<br/>Code: \"XPLC" + err_code + "\"", "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
+		XKit.window.show(
+			'Results',
 
+			`You have <b>${remaining}</b> posts remaining today.<br>
+			In your timezone, the limit resets each day at ${nextReset.toLocaleTimeString()}.<br><br>` +
+			'<table style="width:100%">' +
+				'<tr>' +
+					'<th><b>Blog</b></th>' +
+					'<th><b>Posts made today</b></th>' +
+				'</tr>' + this.staticBlogs.map(blog => `
+				<tr>
+					<td>${blog}</td>
+					<td>${this.posts[blog]}</td>
+				</tr>`).join("") +
+			'</table>',
+
+			'info',
+
+			'<div id="xkit-close-message" class="xkit-button default">OK</div>'
+		);
+	},
+
+	show_error: function(error) {
+		XKit.window.show(
+			'Something went wrong.',
+
+			'I was unable to process a blog.<br>Please refresh the page and try again.<br><br>' +
+			`Here's what I know about this error: <p style="overflow-x:scroll">${error.message || error.responseText || error}</p>`,
+
+			'error',
+
+			'<div id="xkit-close-message" class="xkit-button default">OK</div>' +
+			'<div id="xkit-plc-refresh" class="xkit-button">Refresh now</div>'
+		);
+
+		$("#xkit-plc-refresh").click(() => location.reload(true));
 	},
 
 	destroy: function() {


### PR DESCRIPTION
rewrites the extension to use `XKit.svc.indash_blog`, so that it can check dashboard-only blogs. the information/warning window has also been updated to reflect the new media upload limit, which was recently publically confirmed by Tumblr to be [150](https://tumblr.zendesk.com/hc/en-us/articles/360040699294-December-20th-2019-Troubleshooting-queued-posts).

resolves #1071, resolves #1630

other improvements include providing an exact limit reset time, displayed in the user's timezone (e.g. it tells me that it resets at 05:00:00, while it tells @invalidCards that it resets at 6:00:00 AM, since we are in UTC+0 and UTC+1 respectively), and a complete rundown of how many posts were counted on each blog. the progress window now also states which blog it's checking, instead of a progress bar with loose meaning. the extension should also now be faster, as it checks 50 posts at a time instead of 20.

![image](https://user-images.githubusercontent.com/28949509/71927431-5ede5400-318d-11ea-8bc9-7107c9bed6b9.png)
