### PR TITLE
[Alternative Timestamps] Hide alt. timestamps when Timestamps is active

### DIFF
--- a/Extensions/alternative_timestamps.css
+++ b/Extensions/alternative_timestamps.css
@@ -14,3 +14,7 @@
 .alternative_timestamps_preview {
 	font-style: italic;
 }
+
+.xkit_timestamps .alternative_timestamp {
+    display: none;
+}

--- a/Extensions/alternative_timestamps.js
+++ b/Extensions/alternative_timestamps.js
@@ -1,5 +1,5 @@
 //* TITLE Alternative Timestamps **//
-//* VERSION 1.1.2 **//
+//* VERSION 1.1.3 **//
 //* DESCRIPTION Adds timestamps to dashboard posts using a parsing method **//
 //* DETAILS This version of Timestamps uses parsing methods to display the timestamp instead of AJAX calls. Currently only in English. **//
 //* DEVELOPER jesskay **//


### PR DESCRIPTION
motivated purely by the fact i hate seeing screenshots with both timestamps extensions active and visible.

now that we're using `XKit.svc` to get times with Timestamps, there will be no posts where Alternative Timestamps successfully parses a timestamp where Timestamps will fail to fetch one. for people that purely use Alternative Timestamps to save on requests, there will be no change.

my reasoning for hiding alternative timestamps and not actually deactivating the extension is to make switching between the two timestamps methods more seamless; if Timestamps deactivated Alternative Timestamps, deactivating Timestamps (or simply turning off post timestamps) in order to see parsed timestamps would require the user to then reactivate Alternative Timestamps themselves.

something something #800 