### PR TITLE
end the nightmare: part 2

### DIFF
--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -1,5 +1,5 @@
 //* TITLE Editable Reblogs **//
-//* VERSION 3.3.10 **//
+//* VERSION 3.3.11 **//
 //* DESCRIPTION Restores ability to edit previous reblogs of a post **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -174,7 +174,7 @@ XKit.extensions.editable_reblogs = new Object({
 		}
 
 		var post_fetch_request = {
-			id: parseInt(location_items[1]),
+			id: location_items[1],
 			form_key: XKit.interface.form_key(),
 			post_type: false
 		};
@@ -469,10 +469,10 @@ XKit.extensions.editable_reblogs = new Object({
 		request.reblog = location_items[0] === "reblog";
 
 		if (location_items[0] === "reblog") {
-			request.reblog_id = parseInt(location_items[1]);
+			request.reblog_id = location_items[1];
 		}
 		if (location_items[0] === "edit") {
-			request.post_id = parseInt(location_items[1]);
+			request.post_id = location_items[1];
 		}
 
 		request.reblog_key = location_items[2];

--- a/Extensions/people_notifier.js
+++ b/Extensions/people_notifier.js
@@ -1,5 +1,5 @@
 //* TITLE Blog Tracker **//
-//* VERSION 0.6.5 **//
+//* VERSION 0.6.6 **//
 //* DESCRIPTION Track people like tags **//
 //* DEVELOPER new-xkit **//
 //* DETAILS Blog Tracker lets you track blogs like you can track tags. Add them on your dashboard, and it will let you know how many new posts they've made the last time you've checked their blogs, or if they've changed their URLs.<br><br>Please be aware that the more blogs you add, the longer it will take to track them all. **//
@@ -146,9 +146,9 @@ XKit.extensions.people_notifier = new Object({
 					XKit.extensions.people_notifier.blogs[i].last_20_posts.pop();
 				}
 
-				if (XKit.extensions.people_notifier.blogs[i].last_20_posts.indexOf(parseInt(post_id)) === -1) {
-					console.log("Adding " + parseInt(post_id) + " to list.");
-					XKit.extensions.people_notifier.blogs[i].last_20_posts.unshift(parseInt(post_id));
+				if (XKit.extensions.people_notifier.blogs[i].last_20_posts.indexOf(post_id) === -1) {
+					console.log("Adding " + post_id + " to list.");
+					XKit.extensions.people_notifier.blogs[i].last_20_posts.unshift(post_id);
 				}
 
 			}

--- a/Extensions/quick_tags.js
+++ b/Extensions/quick_tags.js
@@ -1,5 +1,5 @@
 //* TITLE Quick Tags **//
-//* VERSION 0.6.3 **//
+//* VERSION 0.6.4 **//
 //* DESCRIPTION Quickly add tags to posts **//
 //* DETAILS Allows you to create tag bundles and add tags to posts without leaving the dashboard. **//
 //* DEVELOPER New-XKit **//
@@ -553,7 +553,7 @@ XKit.extensions.quick_tags = new Object({
 
 			if ($(event.target).hasClass("xkit-quick-tags-cp-up") || $(event.target).hasClass("xkit-quick-tags-cp-down")) { return; }
 
-			var m_id = parseInt($(this).attr('data-id'));
+			var m_id = $(this).attr('data-id');
 
 			var m_tags = XKit.extensions.quick_tags.tag_array[m_id].tags;
 			var m_title = XKit.extensions.quick_tags.tag_array[m_id].title;
@@ -625,7 +625,7 @@ XKit.extensions.quick_tags = new Object({
 
 			try {
 
-				var m_id = parseInt($(this).attr('data-id'));
+				var m_id = $(this).attr('data-id');
 
 				XKit.extensions.quick_tags.tag_array.splice(m_id, 1);
 

--- a/Extensions/shuffle_queue.js
+++ b/Extensions/shuffle_queue.js
@@ -1,5 +1,5 @@
 //* TITLE Enhanced Queue **//
-//* VERSION 2.2.0 **//
+//* VERSION 2.2.1 **//
 //* DESCRIPTION Additions to the Queue page. **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS Go to your queue and click on the Shuffle button on the sidebar to shuffle the posts. Note that only the posts you see will be shuffled. If you have more than 15 posts on your queue, scroll down and load more posts in order to shuffle them too. Or click on Shrink Posts button to quickly rearrange them. **//
@@ -209,7 +209,7 @@ XKit.extensions.shuffle_queue = new Object({
 
 			$("#posts .post", response.responseText).each((i, post) => {
 				const $post = $(post);
-				const post_id = parseInt($post.attr("data-post-id"));
+				const post_id = $post.attr("data-post-id");
 				this.posts_to_delete.push(post_id);
 			});
 


### PR DESCRIPTION
fixes editable reblogs (resolves #1760), blog tracker, quick tags, and shuffle queue... hopefully! all untested

extensions afflicted by the nightmare that are definitely still broken:
- go to dash
- bookmarker
- retags (cache logic only)

go-to-dash and bookmarker now have a very specific problem where we need to add 1 to the post id in order to get to the right part of the dashboard, but we can't parse any post IDs as integers easily, so if there's anything that can be done about them it's gonna be real nasty. luckily existing bookmarks are not affected, and go-to-dash still works with the peepr option