### PR TITLE
Remove integer post IDs from bookmarker, go-to-dash, retags, and xinbox (again)

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -42,6 +42,7 @@
       - before: true
         after: true
   globals:
+    BigInt: false,
     _: true
     XKit: true
     XBridge: true

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -42,7 +42,7 @@
       - before: true
         after: true
   globals:
-    BigInt: false,
+    BigInt: false
     _: true
     XKit: true
     XBridge: true

--- a/Extensions/bookmarker.js
+++ b/Extensions/bookmarker.js
@@ -1,5 +1,5 @@
 //* TITLE Bookmarker **//
-//* VERSION 2.3.8 **//
+//* VERSION 2.3.9 **//
 //* DESCRIPTION Dashboard Time Machine **//
 //* DEVELOPER new-xkit **//
 //* DETAILS The Bookmarker extension allows you to bookmark posts and get back to them whenever you want to. Just click on the Bookmark icon on posts and the post will be added to your Bookmark List on your sidebar. **//

--- a/Extensions/bookmarker.js
+++ b/Extensions/bookmarker.js
@@ -72,7 +72,7 @@ XKit.extensions.bookmarker = new Object({
 		var post_id = BigInt(str[5]);
 		if (isNaN(post_id) || post_id === 0) { return; }
 
-		post_id = post_id - 1;
+		post_id = post_id - 1n;
 
 		if ($("#xkit_bookmark_" + post_id).length <= 0) { return; }
 
@@ -212,11 +212,11 @@ XKit.extensions.bookmarker = new Object({
 
 			} else {
 				// Go to the post!
-				post_id = BigInt(post_id);
+				const dashboard_page = BigInt(post_id) + 1n;
 				if (XKit.extensions.bookmarker.preferences.new_tab.value === true) {
-					window.open("/dashboard/100/" + (post_id + 1) + "/?bookmark=true");
+					window.open("/dashboard/100/" + dashboard_page + "/?bookmark=true");
 				} else {
-					document.location.href = "/dashboard/100/" + (post_id + 1) + "/?bookmark=true";
+					document.location.href = "/dashboard/100/" + dashboard_page + "/?bookmark=true";
 				}
 			}
 

--- a/Extensions/bookmarker.js
+++ b/Extensions/bookmarker.js
@@ -69,7 +69,7 @@ XKit.extensions.bookmarker = new Object({
 
 		if (str[3] !== "dashboard") { return; }
 
-		var post_id = parseInt(str[5]);
+		var post_id = BigInt(str[5]);
 		if (isNaN(post_id) || post_id === 0) { return; }
 
 		post_id = post_id - 1;
@@ -212,7 +212,7 @@ XKit.extensions.bookmarker = new Object({
 
 			} else {
 				// Go to the post!
-				post_id = parseInt(post_id);
+				post_id = BigInt(post_id);
 				if (XKit.extensions.bookmarker.preferences.new_tab.value === true) {
 					window.open("/dashboard/100/" + (post_id + 1) + "/?bookmark=true");
 				} else {

--- a/Extensions/bookmarker.js
+++ b/Extensions/bookmarker.js
@@ -66,13 +66,10 @@ XKit.extensions.bookmarker = new Object({
 
 		var str = document.location.href.toLowerCase().split("/");
 		if (str.length < 5) { return; }
-
 		if (str[3] !== "dashboard") { return; }
+		if (!str[5]) { return; }
 
-		var post_id = BigInt(str[5]);
-		if (isNaN(post_id) || post_id === 0) { return; }
-
-		post_id = post_id - BigInt(1);
+		var post_id = BigInt(str[5]) - BigInt(1);
 
 		if ($("#xkit_bookmark_" + post_id).length <= 0) { return; }
 

--- a/Extensions/bookmarker.js
+++ b/Extensions/bookmarker.js
@@ -72,7 +72,7 @@ XKit.extensions.bookmarker = new Object({
 		var post_id = BigInt(str[5]);
 		if (isNaN(post_id) || post_id === 0) { return; }
 
-		post_id = post_id - 1n;
+		post_id = post_id - BigInt(1);
 
 		if ($("#xkit_bookmark_" + post_id).length <= 0) { return; }
 
@@ -212,7 +212,7 @@ XKit.extensions.bookmarker = new Object({
 
 			} else {
 				// Go to the post!
-				const dashboard_page = BigInt(post_id) + 1n;
+				const dashboard_page = BigInt(post_id) + BigInt(1);
 				if (XKit.extensions.bookmarker.preferences.new_tab.value === true) {
 					window.open("/dashboard/100/" + dashboard_page + "/?bookmark=true");
 				} else {

--- a/Extensions/go_to_dash.js
+++ b/Extensions/go_to_dash.js
@@ -48,7 +48,7 @@ XKit.extensions.go_to_dash = new Object({
 			var blog = XKit.iframe.get_tumblelog();
 			go_back_html = html_pieces.join('dashboard/blog/' + blog + '/' + post_id);
 		} else {
-			var next_post_id = BigInt(post_id) + 1;
+			var next_post_id = BigInt(post_id) + 1n;
 			go_back_html = html_pieces.join('dashboard/2/' + next_post_id);
 		}
 		// Remove the text from the dashboard button because otherwise the iframe

--- a/Extensions/go_to_dash.js
+++ b/Extensions/go_to_dash.js
@@ -48,7 +48,7 @@ XKit.extensions.go_to_dash = new Object({
 			var blog = XKit.iframe.get_tumblelog();
 			go_back_html = html_pieces.join('dashboard/blog/' + blog + '/' + post_id);
 		} else {
-			var next_post_id = parseInt(post_id) + 1;
+			var next_post_id = BigInt(post_id) + 1;
 			go_back_html = html_pieces.join('dashboard/2/' + next_post_id);
 		}
 		// Remove the text from the dashboard button because otherwise the iframe

--- a/Extensions/go_to_dash.js
+++ b/Extensions/go_to_dash.js
@@ -48,7 +48,7 @@ XKit.extensions.go_to_dash = new Object({
 			var blog = XKit.iframe.get_tumblelog();
 			go_back_html = html_pieces.join('dashboard/blog/' + blog + '/' + post_id);
 		} else {
-			var next_post_id = BigInt(post_id) + 1n;
+			var next_post_id = BigInt(post_id) + BigInt(1);
 			go_back_html = html_pieces.join('dashboard/2/' + next_post_id);
 		}
 		// Remove the text from the dashboard button because otherwise the iframe

--- a/Extensions/go_to_dash.js
+++ b/Extensions/go_to_dash.js
@@ -1,5 +1,5 @@
 //* TITLE Go-To-Dash **//
-//* VERSION 1.3.0 **//
+//* VERSION 1.3.1 **//
 //* DESCRIPTION View a post from a blog on your dashboard or sidebar. **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS This extension adds a 'view' button on people's blogs that allows you to go back to that post on your dashboard or sidebar. Viewing on dashboard only works on the blogs you follow, and may fail if the post dates to before you followed them. **//

--- a/Extensions/retags.js
+++ b/Extensions/retags.js
@@ -200,6 +200,14 @@ XKit.extensions.retags = {
 		return XKit.extensions.retags.count_cached_posts() > XKit.extensions.retags.POST_CACHE_CLEAR_THRESHOLD || XKit.storage.quota('retags') < 100;
 	},
 
+	sortable_key: function(id) {
+		if (typeof(BigInt) !== 'undefined') {
+			return BigInt(id);
+		} else {
+			return id.padStart(20, '0');
+		}
+	},
+
 	clear_old_posts: function() {
 		// There's no API call to delete specific keys from the storage, so we'll
 		// clear all of them and then restore the ones we want to keep.
@@ -212,18 +220,14 @@ XKit.extensions.retags = {
 		Object.keys(cache).forEach(function(key) {
 			var id_match;
 			if ((id_match = key.match(/^post_([0-9]+)$/))) {
-				postIds.push(parseInt(id_match[1], 10));
+				postIds.push(this.sortable_key(id_match[1]));
 			} else {
 				settingKeys.push(key);
 			}
 		});
 
-		// Now sort the post IDs in descending order and take only the first
-		// few, so we only keep the newest posts.
-		postIds.sort(function(id_one, id_two) { return id_two - id_one; });
-		if (postIds.length > XKit.extensions.retags.POST_CACHE_CLEAR_PRESERVED) {
-			postIds.length = XKit.extensions.retags.POST_CACHE_CLEAR_PRESERVED;
-		}
+		postIds.sort();
+		postIds = postIds.slice(-this.POST_CACHE_CLEAR_PRESERVED);
 		postIds.forEach(function(id) {
 			settingKeys.push('post_' + id);
 		});

--- a/Extensions/retags.js
+++ b/Extensions/retags.js
@@ -1,6 +1,6 @@
 //* TITLE       Retags **//
 //* DEVELOPER   new-xkit **//
-//* VERSION     1.2.7 **//
+//* VERSION     1.2.8 **//
 //* DESCRIPTION Adds tags to reblog notes **//
 //* FRAME       false **//
 //* SLOW        false **//

--- a/Extensions/retags.js
+++ b/Extensions/retags.js
@@ -200,14 +200,6 @@ XKit.extensions.retags = {
 		return XKit.extensions.retags.count_cached_posts() > XKit.extensions.retags.POST_CACHE_CLEAR_THRESHOLD || XKit.storage.quota('retags') < 100;
 	},
 
-	sortable_key: function(id) {
-		if (typeof(BigInt) !== 'undefined') {
-			return BigInt(id);
-		} else {
-			return id.padStart(20, '0');
-		}
-	},
-
 	clear_old_posts: function() {
 		// There's no API call to delete specific keys from the storage, so we'll
 		// clear all of them and then restore the ones we want to keep.
@@ -220,16 +212,17 @@ XKit.extensions.retags = {
 		Object.keys(cache).forEach(function(key) {
 			var id_match;
 			if ((id_match = key.match(/^post_([0-9]+)$/))) {
-				postIds.push(this.sortable_key(id_match[1]));
+				postIds.push(id_match[1]);
 			} else {
 				settingKeys.push(key);
 			}
 		});
 
-		postIds.sort();
+		postIds.map(id => id.padStart(20, '0')).sort();
 		postIds = postIds.slice(-this.POST_CACHE_CLEAR_PRESERVED);
 		postIds.forEach(function(id) {
-			settingKeys.push('post_' + id);
+			const idWithoutPadding = id.match(/^0*(\d+)/)[1];
+			settingKeys.push('post_' + idWithoutPadding);
 		});
 
 		// And finally write back to storage!

--- a/Extensions/xinbox.js
+++ b/Extensions/xinbox.js
@@ -683,9 +683,9 @@ XKit.extensions.xinbox = new Object({
 
 	resize_text_area: function(post_id) {
 
-		if ($("#ask_answer_field_" + (+post_id) + "_tbl").length > 0) {
+		if ($("#ask_answer_field_" + post_id + "_tbl").length > 0) {
 
-			$("#ask_answer_field_" + (+post_id) + "_tbl, #ask_answer_field_" + post_id + "_ifr").css("height", "220px");
+			$("#ask_answer_field_" + post_id + "_tbl, #ask_answer_field_" + post_id + "_ifr").css("height", "220px");
 
 		} else {
 

--- a/Extensions/xinbox.js
+++ b/Extensions/xinbox.js
@@ -1,5 +1,5 @@
 //* TITLE XInbox **//
-//* VERSION 1.9.16 **//
+//* VERSION 1.9.17 **//
 //* DESCRIPTION Enhances your Inbox experience **//
 //* DEVELOPER new-xkit **//
 //* DETAILS XInbox allows you to tag posts before posting them, and see all your messages at once, and lets you delete multiple messages at once using the Mass Editor mode. To use this mode, go to your Inbox and click on the Mass Editor Mode button on your sidebar, click on the messages you want to delete then click the Delete Messages button.  **//


### PR DESCRIPTION
- In bookmarker & go to dash, just try to use BigInt and fail if it doesn't exist
 - For retags, we can be smarter--all we need to do is sort, so padLeft works just as well
 - for xinbox, we're just doing string interpolation, so no integers are needed