### PR TITLE
use post.id_string

### DIFF
--- a/Extensions/mass_plus.js
+++ b/Extensions/mass_plus.js
@@ -1,5 +1,5 @@
 //* TITLE Mass+ **//
-//* VERSION 0.4.6 **//
+//* VERSION 0.4.7 **//
 //* DESCRIPTION Enhancements for the Mass Editor **//
 //* DETAILS This extension allows you to select multiple posts by once, by type or month. It also comes with visual enhancements for the mass post editor, such as selected post count and more! **//
 //* DEVELOPER STUDIOXENIX **//
@@ -178,7 +178,6 @@ XKit.extensions.mass_plus = new Object({
 		this.search_found_posts = [];
 		this.search_url = `https://api.tumblr.com/v2/blog/${blog_shortname}/posts?` + $.param({
 			"api_key": XKit.api_key,
-			"post_id_strings": true,
 			"tag": tag.toLowerCase()
 		});
 		this.search_next_page(tag.toLowerCase());
@@ -200,7 +199,7 @@ XKit.extensions.mass_plus = new Object({
 					return;
 				}
 				posts_array.forEach(function(post) {
-					XKit.extensions.mass_plus.search_found_posts.push(post.id);
+					XKit.extensions.mass_plus.search_found_posts.push(post.id_string);
 					XKit.extensions.mass_plus.search_found_count++;
 				});
 				if (XKit.extensions.mass_plus.search_found_count < 100 && XKit.extensions.mass_plus.search_page <= 5) {

--- a/Extensions/tag_replacer.js
+++ b/Extensions/tag_replacer.js
@@ -1,5 +1,5 @@
 //* TITLE Tag Replacer **//
-//* VERSION 1.0.2 **//
+//* VERSION 1.0.3 **//
 //* DESCRIPTION Replace old tags! **//
 //* DETAILS Allows you to bulk replace tags of posts. Go to your Posts page on your dashboard and click on the button on the sidebar and enter the tag you want replaced, and the new tag, and Tag Replacer will take care of the rest. **//
 //* DEVELOPER new-xkit **//
@@ -177,7 +177,6 @@ XKit.extensions.tag_replacer = new Object({
 			method: "GET",
 			url: `https://api.tumblr.com/v2/blog/${this.url}/posts?` + $.param({
 				"api_key": XKit.api_key,
-				"post_id_strings": true,
 				"tag": this.replace,
 				"limit": 50,
 				"offset": page * 50
@@ -190,7 +189,7 @@ XKit.extensions.tag_replacer = new Object({
 					return;
 				}
 
-				data.response.posts.forEach(post => this.post_ids.push(post.id));
+				data.response.posts.forEach(post => this.post_ids.push(post.id_string));
 				$("#xkit-tag-replacer-loaded").html(`Loaded ${this.post_ids.length} tagged posts...`);
 
 				this.fetch_posts(page + 1);


### PR DESCRIPTION
stop using the unofficial `post_id_strings` request parameter and start using the official [`id_string`](https://engineering.tumblr.com/post/612771063988879360/new-bigger-post-ids) field