### PR TITLE
[Old Blue] Update for react site

### DIFF
--- a/Extensions/old_blue.js
+++ b/Extensions/old_blue.js
@@ -1,7 +1,7 @@
 //* TITLE Old Blue **//
-//* VERSION 1.0.3 **//
+//* VERSION 2.0.0 **//
 //* DESCRIPTION No more dark blue background! **//
-//* DETAILS Reverses the so-called accessibility update that causes so many headaches. **//
+//* DETAILS Reverts the colour scheme and font to that of 2018 Tumblr. Overrides any Tumblr-provided color palettes. **//
 //* DEVELOPER New-XKit **//
 //* FRAME false **//
 //* BETA false **//
@@ -10,19 +10,51 @@ XKit.extensions.old_blue = new Object({
 
 	running: false,
 
-	preferences: {
-		"note": {
-			text: `If you would like to use this as a userstyle in a faster-loading add-on, the CSS this extension uses can be found <a href="https://raw.githubusercontent.com/new-xkit/XKit/master/Extensions/old_blue.css" target="_blank">here</a>.`,
-			type: "separator"
-		}
-	},
-
-	cpanel: () => $(".xkit-extension-setting-separator").css("margin", 0).css("text-transform", "none"),
-
 	run: function() {
 		this.running = true;
-		if (XKit.interface.is_tumblr_page() && $('link[href*="/pop/"]').length === 0) {
-			XKit.tools.init_css("old_blue");
+		if (XKit.interface.is_tumblr_page()) {
+			if (!XKit.page.react) {
+				XKit.tools.init_css("old_blue");
+			} else {
+				XKit.tools.add_css(`
+					.xkit--react {
+						--rgb-white: 255, 255, 255;
+						--rgb-white-on-dark: 191, 191, 191;
+						--rgb-black: 68, 68, 68;
+
+						--navy: #36465d;
+						--red: #d95e40;
+						--orange: #f2992e;
+						--yellow: #e8d738;
+						--green: #56bc8a;
+						--blue: #529ecc;
+						--purple: #a77dc2;
+						--pink: #748089;
+
+						--accent: #529ecc;
+						--secondary-accent: #e5e7ea;
+						--follow: #f3f8fb;
+
+						--white: rgb(var(--rgb-white));
+						--white-on-dark: rgb(var(--rgb-white-on-dark));
+						--black: rgb(var(--rgb-black));
+
+						--transparent-white-65: rgba(var(--rgb-white-on-dark), 0.65);
+						--transparent-white-40: rgba(var(--rgb-white-on-dark), 0.4);
+						--transparent-white-25: rgba(var(--rgb-white-on-dark), 0.25);
+						--transparent-white-13: rgba(var(--rgb-white-on-dark), 0.13);
+						--transparent-white-7: rgba(var(--rgb-white-on-dark), 0.07);
+
+						--gray-65: rgba(var(--rgb-black), 0.65);
+						--gray-40: rgba(var(--rgb-black), 0.4);
+						--gray-25: rgba(var(--rgb-black), 0.25);
+						--gray-13: rgba(var(--rgb-black), 0.13);
+						--gray-7: rgba(var(--rgb-black), 0.07);
+
+						--font-family: "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, "AppleGothic", "Malgun Gothic", "Dotum", "Gulim", sans-serif;
+					}
+				`, "old_blue");
+			}
 		}
 	},
 


### PR DESCRIPTION
1. take "Low-Contrast Classic" variables
2. make rule more specific
3. transplant the colour values for the actual old colours
4. remove Favorit from the font-family list
5. profit

i didn't touch the `rgb-white-on-dark` variable since its old blue equivalent is an hsla colour and it looks good/accurate enough as is, nor the `yellow` variable since it doesn't have an old blue equivalent

also removes the userstyle addon link/notice since the redpop code can't be linked to easily (yet)