### PR TITLE
Add async_form_key for kitty requests on redpop

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -742,7 +742,67 @@ XKit.extensions.xkit_patches = new Object({
 						avatar: post.blog.avatar[post.blog.avatar.length - 1].url,
 						tags: post.tags.join(","),
 					};
+				},
+			};
+
+			XKit.interface.async_form_key = async function() {
+				const request = await fetch('https://www.tumblr.com/settings/dashboard');
+				const meta_tag = (await request.text()).match(
+					/tumblr-form-key[^<]*content=["']?(\w+)["']?/
+				);
+
+				const form_key = meta_tag && meta_tag[1];
+				XKit.storage.set('xkit_patches', 'last_stored_form_key', window.btoa(form_key));
+				return form_key;
+			};
+
+			/**
+			 * Get the secure_form_key through a request using the current form_key
+			 * @param {Function} callback invoked with `{errors: boolean, kitten: String}`
+			 */
+			XKit.interface.kitty.get = async function(callback) {
+
+				var m_object = {
+					errors: false,
+					kitten: ''
+				};
+
+				var kitty_diff = (new Date()) - XKit.interface.kitty.store_time;
+
+				if (XKit.interface.kitty.stored !== "") {
+					if (kitty_diff <= XKit.interface.kitty.expire_time && kitty_diff > 0) {
+						m_object.kitten = XKit.interface.kitty.stored;
+						callback(m_object);
+						return;
+					}
 				}
+
+				if (!XKit.interface.form_key()) {
+					await XKit.interface.async_form_key();
+				}
+
+				XKit.tools.Nx_XHR({
+					method: "POST",
+					url: "https://www.tumblr.com/svc/secure_form_key",
+					headers: {
+						"X-tumblr-form-key": XKit.interface.form_key(),
+					},
+					onload: function(response) {
+						XKit.interface.kitty.store_time = new Date().getTime();
+						var kitty_text = response.headers["x-tumblr-secure-form-key"];
+						XKit.interface.kitty.stored = kitty_text;
+						m_object.kitten = XKit.interface.kitty.stored;
+						m_object.response = response;
+						callback(m_object);
+					},
+					onerror: function(response) {
+						m_object.errors = true;
+						m_object.kitten = "";
+						m_object.response = response;
+						XKit.interface.kitty.stored = "";
+						callback(m_object);
+					}
+				});
 			};
 		},
 
@@ -1297,61 +1357,6 @@ XKit.extensions.xkit_patches = new Object({
 						XKit.interface.kitty.stored = kitty;
 
 					},
-
-					/**
-					 * Get the secure_form_key through a request using the current form_key
-					 * @param {Function} callback invoked with `{errors: boolean, kitten: String}`
-					 */
-					get: function(callback) {
-
-						var m_object = {};
-						m_object.errors = false;
-						m_object.kitten = "";
-
-						var current_ms = new Date().getTime();
-						var kitty_diff = current_ms - XKit.interface.kitty.store_time;
-
-						if (XKit.interface.kitty.stored !== "") {
-							if (kitty_diff >= XKit.interface.kitty.expire_time || kitty_diff < 0) {
-								//// console.log("XKitty: Kitty expired? Let's try again.");
-							} else {
-								//// console.log("XKitty: Kitty already received, passing: " + XKit.interface.kitty.stored);
-								m_object.kitten = XKit.interface.kitty.stored;
-								callback(m_object);
-								return;
-							}
-						}
-
-						//// console.log("XKitty: Kitty blank / expired, requesting new feline.");
-
-						XKit.tools.Nx_XHR({
-							method: "POST",
-							url: "https://www.tumblr.com/svc/secure_form_key",
-							headers: {
-								"X-tumblr-form-key": XKit.interface.form_key(),
-							},
-							onload: function(response) {
-								//// console.log("XKitty: YAY! Kitty request complete!");
-								XKit.interface.kitty.store_time = new Date().getTime();
-								var kitty_text = response.headers["x-tumblr-secure-form-key"];
-								XKit.interface.kitty.stored = kitty_text;
-								m_object.kitten = XKit.interface.kitty.stored;
-								m_object.response = response;
-								callback(m_object);
-							},
-							onerror: function(response) {
-								//// console.log("XKitty: DAMN IT! Kitty request FAILED!");
-								m_object.errors = true;
-								m_object.kitten = "";
-								m_object.response = response;
-								XKit.interface.kitty.stored = "";
-								callback(m_object);
-							}
-						});
-
-					},
-
-
 				},
 
 				post_window: {

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -748,7 +748,7 @@ XKit.extensions.xkit_patches = new Object({
 			XKit.interface.async_form_key = async function() {
 				const request = await fetch('https://www.tumblr.com/settings/dashboard');
 				const meta_tag = (await request.text()).match(
-					/tumblr-form-key[^<]*content=["']?(\w+)["']?/
+					/tumblr-form-key[^>]*content=("[^"]+"|'[^']+')/
 				);
 
 				if (meta_tag) {

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -761,7 +761,6 @@ XKit.extensions.xkit_patches = new Object({
 			 * @param {Function} callback invoked with `{errors: boolean, kitten: String}`
 			 */
 			XKit.interface.kitty.get = async function(callback) {
-
 				var m_object = {
 					errors: false,
 					kitten: ''

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -748,11 +748,11 @@ XKit.extensions.xkit_patches = new Object({
 			XKit.interface.async_form_key = async function() {
 				const request = await fetch('https://www.tumblr.com/settings/dashboard');
 				const meta_tag = (await request.text()).match(
-					/tumblr-form-key[^>]*content=("[^"]+"|'[^']+')/
+					/tumblr-form-key[^>]*content=("([^"]+)"|'([^']+)')/
 				);
 
 				if (meta_tag) {
-					const form_key = meta_tag[1];
+					const form_key = meta_tag[2] || meta_tag[3];
 					XKit.storage.set('xkit_patches', 'last_stored_form_key', window.btoa(form_key));
 					return form_key;
 				}

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.3.1 **//
+//* VERSION 7.3.2 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -751,9 +751,11 @@ XKit.extensions.xkit_patches = new Object({
 					/tumblr-form-key[^<]*content=["']?(\w+)["']?/
 				);
 
-				const form_key = meta_tag && meta_tag[1];
-				XKit.storage.set('xkit_patches', 'last_stored_form_key', window.btoa(form_key));
-				return form_key;
+				if (meta_tag) {
+					const form_key = meta_tag[1];
+					XKit.storage.set('xkit_patches', 'last_stored_form_key', window.btoa(form_key));
+					return form_key;
+				}
 			};
 
 			/**


### PR DESCRIPTION
Redpop doesn't have a tumblr-form-key meta tag, so we're going to grab one from the settings page if we need it. This is on the theory that the settings page is probably going to be the last non-redpop page due to priority, but i could also see an argument that it's simple enough that there might be a redpop version coming down the pipe soon. in that case we should switch to blog settings or the theme editor or something equally complicated + neglected