### PR TITLE
[One-Click Postage] Update reblog button selector

### DIFF
--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -660,7 +660,7 @@ XKit.extensions.one_click_postage = new Object({
 		const reblog_buttons = [
 			'.reblog_button',
 			'.post_control.reblog',
-			'a[role="button"][aria-label="Reblog"]'
+			'a[role="button"][href^="/reblog/"]'
 		].join(',');
 
 		$(document).on("mouseover", reblog_buttons, function(event) {
@@ -1172,7 +1172,7 @@ XKit.extensions.one_click_postage = new Object({
 			$(XKit.extensions.one_click_postage.last_object).find(".reblog_button, .post_control.reblog").addClass("xkit-one-click-reblog-working");
 		}
 
-		var m_button = $(XKit.extensions.one_click_postage.last_object).find('.reblog_button, .post_control.reblog, a[role="button"][aria-label="Reblog"]');
+		var m_button = $(XKit.extensions.one_click_postage.last_object).find('.reblog_button, .post_control.reblog, a[role="button"][href^="/reblog/"]');
 
 		if (quick_queue_mode) {
 			m_button = $(XKit.extensions.one_click_postage.last_object).find(".xkit-one-click-postage-quickqueue");

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.4.9 **//
+//* VERSION 4.4.10 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -660,7 +660,7 @@ XKit.extensions.one_click_postage = new Object({
 		const reblog_buttons = [
 			'.reblog_button',
 			'.post_control.reblog',
-			'button[aria-label="Reblog"]'
+			'a[role="button"][aria-label="Reblog"]'
 		].join(',');
 
 		$(document).on("mouseover", reblog_buttons, function(event) {
@@ -1172,7 +1172,7 @@ XKit.extensions.one_click_postage = new Object({
 			$(XKit.extensions.one_click_postage.last_object).find(".reblog_button, .post_control.reblog").addClass("xkit-one-click-reblog-working");
 		}
 
-		var m_button = $(XKit.extensions.one_click_postage.last_object).find('.reblog_button, .post_control.reblog, button[aria-label="Reblog"]');
+		var m_button = $(XKit.extensions.one_click_postage.last_object).find('.reblog_button, .post_control.reblog, a[role="button"][aria-label="Reblog"]');
 
 		if (quick_queue_mode) {
 			m_button = $(XKit.extensions.one_click_postage.last_object).find(".xkit-one-click-postage-quickqueue");


### PR DESCRIPTION
reblog buttons are no longer `button`s but `a[role="button"]` instead