### PR TITLE
[XKit Preferences] Evade Tumblr keyboard shortcuts

### DIFF
--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 7.6.2 **//
+//* VERSION 7.6.3 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER new-xkit **//
 
@@ -606,6 +606,7 @@ XKit.extensions.xkit_preferences = new Object({
 
 		$("body").css("overflow", "hidden");
 		$("#xkit-control-panel").animate({ marginTop: '-200px', opacity: 1}, 500);
+		$("#xkit-control-panel").keydown(event => event.stopPropagation());
 		$("#xkit-control-panel-shadow").fadeIn('slow');
 		$("#xkit-control-panel-shadow").click(XKit.extensions.xkit_preferences.close);
 


### PR DESCRIPTION
prevents keydown events being caught by Tumblr when typing into the XKit Control Panel, which made typing certain letters impossible