### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ In your clone of this repository run:
 npm install
 ```
 
+Use Node 8 for best compatibility. Some commands, such as `npm test`, will fail on Node 10+.
+
 To build XKit from source, run:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 XKit is a small extension framework that powers tweaks for Tumblr.
 
 ## Get a release build
-Currently we support [Firefox](https://new-xkit-extension.tumblr.com/firefox), [Chrome](https://new-xkit-extension.tumblr.com/chrome), and [Safari](https://new-xkit-extension.tumblr.com/safari) officially. 
-We support Opera unofficially using the same file as the Chrome extension, [which you can download here](https://github.com/new-xkit/XKit/releases).
+Currently we support [Firefox](https://new-xkit-extension.tumblr.com/firefox) and [Chrome](https://new-xkit-extension.tumblr.com/chrome) officially.  
+We support Opera and Edge unofficially using the same file as the Chrome extension.
 
 ## Support [![Discord](https://img.shields.io/badge/discord-join_support_chat-7289DA.svg)](https://new-xkit-extension.tumblr.com/discord-support)
 
@@ -15,8 +15,7 @@ First, [check the list of issues](https://github.com/new-xkit/XKit/issues), and 
 ## Contribute [![Discord](https://img.shields.io/badge/discord-join_developer_chat-7289DA.svg)](https://new-xkit-extension.tumblr.com/discord)
 XKit needs all the help it can get! If you want to help out, the first step is
 finding something going wrong. There's a long list of known issues
-[on our issues page](https://github.com/new-xkit/XKit/issues) and
-[on the original issues page](https://github.com/atesh/XKit/issues). The next step is to
+[on our issues page](https://github.com/new-xkit/XKit/issues). The next step is to
 [fix the bug](https://github.com/new-xkit/XKit/wiki/Fixing-a-bug).
 
 Come join us in [the XKit Discord](https://new-xkit-extension.tumblr.com/discord) if you get stuck, or want some advice! There's normally a few people lurking in there any time of day.


### PR DESCRIPTION
- remove mention of official Safari support
- add mention of unofficial Edge support
- remove dead link to original issues page

~~todo: test which highest version of node can be used to install/test/build XKit, it definitely fails on the latest version~~

- add note about how it's best to use Node 8 (since that's what we use for travis) and that using Node 10+ will fuck things up

