### PR TITLE
[One-Click Postage] Fix reblog button selector again

### DIFF
--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.4.11 **//
+//* VERSION 4.4.12 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -661,7 +661,7 @@ XKit.extensions.one_click_postage = new Object({
 			'.reblog_button',
 			'.post_control.reblog',
 			'button[aria-label="Reblog"]',
-			'a[role="button"][href^="/reblog/"]'
+			'a[role="button"][href*="/reblog/"]'
 		].join(',');
 
 		$(document).on("mouseover", reblog_buttons, function(event) {
@@ -1173,7 +1173,7 @@ XKit.extensions.one_click_postage = new Object({
 			$(XKit.extensions.one_click_postage.last_object).find(".reblog_button, .post_control.reblog").addClass("xkit-one-click-reblog-working");
 		}
 
-		var m_button = $(XKit.extensions.one_click_postage.last_object).find('.reblog_button, .post_control.reblog, button[aria-label="Reblog"], a[role="button"][href^="/reblog/"]');
+		var m_button = $(XKit.extensions.one_click_postage.last_object).find('.reblog_button, .post_control.reblog, button[aria-label="Reblog"], a[role="button"][href*="/reblog/"]');
 
 		if (quick_queue_mode) {
 			m_button = $(XKit.extensions.one_click_postage.last_object).find(".xkit-one-click-postage-quickqueue");


### PR DESCRIPTION
reblog buttons updated again, but now have full paths instead of relative paths, so the selector broke again