### PR TITLE
stop keydown events propagating above XKit windows

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -46,6 +46,7 @@
     _: true
     XKit: true
     XBridge: true
+    centerIt: true
     Tumblr: true
     add_tag: true
 

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -190,49 +190,35 @@ XKit.extensions.xkit_patches = new Object({
 			 * @param {String} msg - Text for body of window, can be HTML
 			 * @param {"error"|"warning"|"question"|"info"} icon - Window's
 			 *   icon type, determined by CSS class `icon`.
-			 *   See also xkit_patches.css.
 			 * @param {String} buttons - The HTML to be used in the button area of the window.
 			 *                           Usually divs with class "xkit-button".
 			 * @param {boolean} wide - Whether the XKit window should be wide.
 			 */
-			XKit.window.show = function(title, msg, icon, buttons, wide) {
+			XKit.window.show = function(title, msg, icon = "", buttons = "", wide) {
+				const wide_class = wide ? "xkit-wide-window" : "";
 
-				if (typeof icon === "undefined") {
-					icon = "";
-				}
+				$("#xkit-window").fadeOut('fast', function() {
+					$(this).remove();
+				});
 
-				var additional_classes = "";
-
-				if (wide) {
-					additional_classes = "xkit-wide-window";
-				}
-
-				if ($("#xkit-window").length > 0) {
-					$("#xkit-window").attr('id', "xkit-window-old");
-					$("#xkit-window-old").fadeOut('fast', function() {
-						$(this).remove();
-					});
-				}
-
-				var m_html = "<div id=\"xkit-window\" class=\"" + icon + " " + additional_classes + "\" style=\"display: none;\">" +
-									"<div class=\"xkit-window-title\">" + title + "</div>" +
-									"<div class=\"xkit-window-msg\">" + msg + "</div>";
-
-				if (typeof buttons !== "undefined") {
-					m_html = m_html + "<div class=\"xkit-window-buttons\">" + buttons + "</div>";
-				}
+				let window_html = `
+					<div id="xkit-window" class="${icon} ${wide_class}" style="display:none">
+						<div class="xkit-window-title">${title}</div>
+						<div class="xkit-window-msg">"${msg}</div>
+						<div class="xkit-window-buttons">${buttons}</div>
+					</div>`;
 
 				if ($("#xkit-window-shadow").length === 0) {
-					m_html = m_html + "</div><div id=\"xkit-window-shadow\"></div>";
+					window_html += '<div id="xkit-window-shadow"></div>';
 				}
 
-				$("body").prepend(m_html);
-
+				$("body").prepend(window_html);
 				$("#tiptip_holder").css("z-index", "99000000");
-
 				centerIt($("#xkit-window"));
-				$("#xkit-window").fadeIn('fast');
-				$("#xkit-window").keydown(event => event.stopPropagation());
+
+				$("#xkit-window")
+					.fadeIn('fast')
+					.keydown(event => event.stopPropagation());
 
 				$("#xkit-close-message").click(function() {
 					$("#xkit-window-shadow").fadeOut('fast', function() {
@@ -242,7 +228,6 @@ XKit.extensions.xkit_patches = new Object({
 						$(this).remove();
 					});
 				});
-
 			};
 
 			XKit.tools.normalize_indentation = (level, string) => {

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.3.2 **//
+//* VERSION 7.3.3 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -184,6 +184,67 @@ XKit.extensions.xkit_patches = new Object({
 
 	patches: {
 		"7.9.1": function() {
+			/**
+			 * Show an XKit alert window
+			 * @param {String} title - Text for alert window's title bar
+			 * @param {String} msg - Text for body of window, can be HTML
+			 * @param {"error"|"warning"|"question"|"info"} icon - Window's
+			 *   icon type, determined by CSS class `icon`.
+			 *   See also xkit_patches.css.
+			 * @param {String} buttons - The HTML to be used in the button area of the window.
+			 *                           Usually divs with class "xkit-button".
+			 * @param {boolean} wide - Whether the XKit window should be wide.
+			 */
+			XKit.window.show = function(title, msg, icon, buttons, wide) {
+
+				if (typeof icon === "undefined") {
+					icon = "";
+				}
+
+				var additional_classes = "";
+
+				if (wide) {
+					additional_classes = "xkit-wide-window";
+				}
+
+				if ($("#xkit-window").length > 0) {
+					$("#xkit-window").attr('id', "xkit-window-old");
+					$("#xkit-window-old").fadeOut('fast', function() {
+						$(this).remove();
+					});
+				}
+
+				var m_html = "<div id=\"xkit-window\" class=\"" + icon + " " + additional_classes + "\" style=\"display: none;\">" +
+									"<div class=\"xkit-window-title\">" + title + "</div>" +
+									"<div class=\"xkit-window-msg\">" + msg + "</div>";
+
+				if (typeof buttons !== "undefined") {
+					m_html = m_html + "<div class=\"xkit-window-buttons\">" + buttons + "</div>";
+				}
+
+				if ($("#xkit-window-shadow").length === 0) {
+					m_html = m_html + "</div><div id=\"xkit-window-shadow\"></div>";
+				}
+
+				$("body").prepend(m_html);
+
+				$("#tiptip_holder").css("z-index", "99000000");
+
+				centerIt($("#xkit-window"));
+				$("#xkit-window").fadeIn('fast');
+				$("#xkit-window").keydown(event => event.stopPropagation());
+
+				$("#xkit-close-message").click(function() {
+					$("#xkit-window-shadow").fadeOut('fast', function() {
+						$(this).remove();
+					});
+					$("#xkit-window").fadeOut('fast', function() {
+						$(this).remove();
+					});
+				});
+
+			};
+
 			XKit.tools.normalize_indentation = (level, string) => {
 				const lines = string.split("\n");
 				const indentation_level = _.minBy(
@@ -1259,67 +1320,6 @@ XKit.extensions.xkit_patches = new Object({
 					$(this).remove();
 					$("#xkit-window-shadow").remove();
 					$("#xkit-window-old").remove();
-				});
-
-			};
-
-			/**
-			 * Show an XKit alert window
-			 * @param {String} title - Text for alert window's title bar
-			 * @param {String} msg - Text for body of window, can be HTML
-			 * @param {"error"|"warning"|"question"|"info"} icon - Window's
-			 *   icon type, determined by CSS class `icon`.
-			 *   See also xkit_patches.css.
-			 * @param {String} buttons - The HTML to be used in the button area of the window.
-			 *                           Usually divs with class "xkit-button".
-			 * @param {boolean} wide - Whether the XKit window should be wide.
-			 */
-			XKit.window.show = function(title, msg, icon, buttons, wide) {
-
-				if (typeof icon === "undefined") {
-					icon = "";
-				}
-
-				var additional_classes = "";
-
-				if (wide) {
-					additional_classes = "xkit-wide-window";
-				}
-
-				if ($("#xkit-window").length > 0) {
-					$("#xkit-window").attr('id', "xkit-window-old");
-					$("#xkit-window-old").fadeOut('fast', function() {
-						$(this).remove();
-					});
-				}
-
-				var m_html = "<div id=\"xkit-window\" class=\"" + icon + " " + additional_classes + "\" style=\"display: none;\">" +
-									"<div class=\"xkit-window-title\">" + title + "</div>" +
-									"<div class=\"xkit-window-msg\">" + msg + "</div>";
-
-				if (typeof buttons !== "undefined") {
-					m_html = m_html + "<div class=\"xkit-window-buttons\">" + buttons + "</div>";
-				}
-
-				if ($("#xkit-window-shadow").length === 0) {
-					m_html = m_html + "</div><div id=\"xkit-window-shadow\"></div>";
-				}
-
-				$("body").prepend(m_html);
-
-				$("#tiptip_holder").css("z-index", "99000000");
-
-				centerIt($("#xkit-window"));
-				$("#xkit-window").fadeIn('fast');
-				$("#xkit-window").keydown(event => event.stopPropagation());
-
-				$("#xkit-close-message").click(function() {
-					$("#xkit-window-shadow").fadeOut('fast', function() {
-						$(this).remove();
-					});
-					$("#xkit-window").fadeOut('fast', function() {
-						$(this).remove();
-					});
 				});
 
 			};

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1309,10 +1309,9 @@ XKit.extensions.xkit_patches = new Object({
 
 				$("#tiptip_holder").css("z-index", "99000000");
 
-				// from xkit.js
-				/* globals centerIt */
 				centerIt($("#xkit-window"));
 				$("#xkit-window").fadeIn('fast');
+				$("#xkit-window").keydown(event => event.stopPropagation());
 
 				$("#xkit-close-message").click(function() {
 					$("#xkit-window-shadow").fadeOut('fast', function() {


### PR DESCRIPTION
also simplified `XKit.window.show` because i couldnt help myself

prevents Tumblr keyboard shortcuts from eating input a la #1792 
(i dont have a right alt key on this keyboard so i cant type the accent. sorry.)

> there are probably some things that will break if we make every xkit window stop propagation.
> places where we do `$(document.body).on(` or similar
> like $`("body").on("#xkit-button", "click", function() {`

since we're specifically preventing the `keydown` event from propagating and no other events, nothing is broken by this. while a few extensions do attach a listener for `keydown` on the `document`, none of them are listening for keydown events in XKit windows. most of them are listening for keyboard shortcuts (such as Blacklist's ALT+B) that you would expect to be suspended when an XKit window is open.