### PR TITLE
update Editable Reblogs for new dashboard

### DIFF
--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -1,5 +1,5 @@
 //* TITLE Editable Reblogs **//
-//* VERSION 3.3.11 **//
+//* VERSION 3.3.12 **//
 //* DESCRIPTION Restores ability to edit previous reblogs of a post **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -88,6 +88,11 @@ XKit.extensions.editable_reblogs = new Object({
 		var location_path = window.location.pathname;
 		var location_items = location_path.split("/");
 		location_items.shift();
+
+		if (XKit.page.form_frame) {
+			location_items = location_items.slice(2);
+		}
+
 		if (location_items[0] != "reblog" && location_items[0] != "edit") {
 			return;
 		}
@@ -169,6 +174,11 @@ XKit.extensions.editable_reblogs = new Object({
 		var location_path = window.location.pathname;
 		var location_items = location_path.split("/");
 		location_items.shift();
+
+		if (XKit.page.form_frame) {
+			location_items = location_items.slice(2);
+		}
+
 		if (location_items[0] != "edit") {
 			return;
 		}
@@ -462,6 +472,10 @@ XKit.extensions.editable_reblogs = new Object({
 		var location_path = window.location.pathname;
 		var location_items = location_path.split("/");
 		location_items.shift();
+
+		if (XKit.page.form_frame) {
+			location_items = location_items.slice(2);
+		}
 
 		request.form_key = XKit.interface.form_key();
 		request.channel_id = $('.post-form--header .tumblelog-select .caption').text();

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.3.4 **//
+//* VERSION 7.3.5 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -180,10 +180,10 @@ XKit.extensions.xkit_patches = new Object({
 		}, 1000);
 	},
 
-	run_order: ["7.8.1", "7.8.2", "7.9.0", "7.9.1"],
+	run_order: ["7.8.1", "7.8.2", "7.9.0", "7.9.1", "7.9.2"],
 
 	patches: {
-		"7.9.1": function() {
+		"7.9.2": function() {
 			/**
 			 * Show an XKit alert window
 			 * @param {String} title - Text for alert window's title bar
@@ -852,6 +852,8 @@ XKit.extensions.xkit_patches = new Object({
 				});
 			};
 		},
+
+		"7.9.1": function() {},
 
 		"7.9.0": function() {},
 

--- a/WebExtension/manifest.json
+++ b/WebExtension/manifest.json
@@ -24,7 +24,7 @@
   "name": "New XKit",
   "author": "New XKit Team",
   "permissions": ["storage", "unlimitedStorage", "*://*.tumblr.com/*", "https://new-xkit.github.io/XKit/*", "https://cloud.new-xkit.com/*" ],
-  "version": "7.9.1",
+  "version": "7.9.2",
   "web_accessible_resources": [ "manifest.json", "editor.js" ],
   "applications": {
     "gecko": {

--- a/xkit.js
+++ b/xkit.js
@@ -12,6 +12,8 @@ var xkit_global_start = Date.now();  // log start timestamp
 			standard:
 				window.window === window.top &&
 				document.location.href.indexOf("://www.tumblr.com/dashboard/iframe?") === -1,
+			form_frame:
+				document.location.href.indexOf("://www.tumblr.com/neue_web/iframe/") !== -1,
 			ask_frame:
 				document.location.href.indexOf("://www.tumblr.com/ask_form/") !== -1,
 			blog_frame:
@@ -34,7 +36,7 @@ var xkit_global_start = Date.now();  // log start timestamp
 				return;
 			}
 
-			if (XKit.page.standard) {
+			if (XKit.page.standard || XKit.page.form_frame) {
 				XKit.init_normal();
 				return;
 			}


### PR DESCRIPTION
relies on the changes to `xkit.js`. Editable Reblogs will not be fixed on the new dashboard until 7.9.2 is released.

allows XKit to run in the post forms frames completely normally, where the post window listener works exactly as intended and activates Editable Reblogs (and presumably other extensions; untested). the only adjustment ER itself actually needs is to correctly identify the new pathname parts.

doesn't shuffle the 7.9.0/7.9.1 patches into `xkit.js` because we don't need to deal with that right now.