### PR TITLE
update Open In Tabs for new dashboard

### DIFF
--- a/Extensions/open_in_new_tabs.js
+++ b/Extensions/open_in_new_tabs.js
@@ -1,5 +1,5 @@
 //* TITLE Open In Tabs **//
-//* VERSION 1.1.7 **//
+//* VERSION 1.1.8 **//
 //* DESCRIPTION Changes links to open in new tabs **//
 //* DETAILS Open In Tabs allows you to open links on new tabs, useful if you don't like being confined to one tab. Since some links, if opened in new tabs, can break functionality, they are not effected by this extension. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -11,7 +11,7 @@ XKit.extensions.open_in_new_tabs = new Object({
 
 	running: false,
 	slow: true,
-	
+
 	preferences: {
 		"sep-0": {
 			text: "Options",
@@ -32,13 +32,27 @@ XKit.extensions.open_in_new_tabs = new Object({
 	run: function() {
 		this.running = true;
 
+		if (document.location.href.indexOf('/mega-editor/') != -1) {
+			return;
+		}
+
+		if (XKit.page.react) {
+			$(document.body).on('click', 'a[role="link"][target="_blank"]', e => e.stopPropagation());
+
+			XKit.tools.add_css(`
+				.xkit--react [data-extension-id="open_in_new_tabs"][data-setting-id="button_tabs"],
+				.xkit--react [data-extension-id="open_in_new_tabs"][data-setting-id="no_sidebar"] {
+					display: none;
+				}
+			`, 'open_in_new_tabs');
+
+			return;
+		}
+
 		if (XKit.extensions.open_in_new_tabs.preferences.button_tabs.value) {
 			$("#content area").attr('target', '_blank');
 			$(document).on("click", XKit.extensions.open_in_new_tabs.do_open);
 		}
-		
-		if (document.location.href.indexOf('/mega-editor/') != -1)
-			return;
 
 		if (XKit.extensions.open_in_new_tabs.preferences.no_sidebar.value === true) {
 			XKit.post_listener.add("open_in_new_tabs", XKit.extensions.open_in_new_tabs.do);
@@ -48,17 +62,17 @@ XKit.extensions.open_in_new_tabs = new Object({
 	},
 
 	do_open: function(e) {
-		
+
 		//XKit.window.show("do_open!", JSON.stringify(e.target), "info", "<div class=\"xkit-button default\" id=\"xkit-close-message\">OK</div>");
 		//return;
 
 		var m_box = e.target;
 
 		var m_url = $(m_box).attr('href');
-		
+
 		if ($(m_box).closest('.fan_mail').length && $(m_box).hasClass('reply'))
 			return;
-		
+
 		if (typeof m_url === "undefined") {
 			m_url = $(m_box).parent().attr('href');
 		}
@@ -75,17 +89,17 @@ XKit.extensions.open_in_new_tabs = new Object({
 			} else {
 				if ($(m_box).attr('target').toLowerCase() !== "_blank") {
 					open_new_tab = true;
-					
+
 				}
 			}
 			if ($(m_box).attr('title').toLowerCase() == "dashboard" && XKit.interface.where().dashboard === true) {
 				open_new_tab = false;
 			}
-			
+
 			if ($(m_box).attr('title').toLowerCase() == "inbox" && XKit.interface.where().inbox === true) {
 				open_new_tab = false;
 			}
-			
+
 			if ($(m_box).attr('title').toLowerCase() == "activity" || $(m_box).attr('title').toLowerCase() == "edit" ) {
 				open_new_tab = false;
 			}
@@ -102,7 +116,7 @@ XKit.extensions.open_in_new_tabs = new Object({
 		}
 
 	},
-	
+
 	do: function() {
 
 		$("a").off("click", XKit.extensions.open_in_new_tabs.click);
@@ -158,6 +172,8 @@ XKit.extensions.open_in_new_tabs = new Object({
 
 	destroy: function() {
 		this.running = false;
+		$(document.body).off('click', 'a[role="link"][target="_blank"]');
+		XKit.tools.remove_css('open_in_new_tabs');
 		$(document).off("click", "#right_column a", XKit.extensions.open_in_new_tabs.do_open);
 		$(".note_link_current").off("click", XKit.extensions.open_in_new_tabs.click_notes);
 		$("a").off("click", XKit.extensions.open_in_new_tabs.click);


### PR DESCRIPTION
retires both extension options; only opens links marked as links by tumblr (`role="link"`) in new tabs