### PR TITLE
update Disable GIFs for new dashboard

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.2 **//
+//* VERSION 7.4.3 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -186,13 +186,15 @@ XKit.extensions.xkit_patches = new Object({
 		"7.9.2": function() {
 			XKit.post_listener.observer = new MutationObserver(mutations => {
 				const criteria = XKit.page.react ? "[data-id]" : ".post_container, .post";
-				const new_posts = mutations.some(({addedNodes}) => {
+				const new_posts = mutations.some(({addedNodes, target}) => {
 					for (let i = 0; i < addedNodes.length; i++) {
 						const $addedNode = $(addedNodes[i]);
 						if ($addedNode.is(criteria) || $addedNode.find(criteria).length) {
 							return true;
 						}
 					}
+
+					return $(target).parents(criteria).length !== 0;
 				});
 
 				if (new_posts) {


### PR DESCRIPTION
updates the extension to look for, pause, and label GIFs on the react dashboard. GIF unpausing behaviour is shifted to play-on-hover, to match Discord and Mastodon (also because it's easy to do with just CSS).

![image](https://user-images.githubusercontent.com/28949509/82263371-a4403880-995a-11ea-9f53-477abca0bc39.png)

unfortunately with the way React loads posts, this change to the post listener is necessary; when a post is initially loaded (in most manners), image elements don't exist at all, and furthermore are taken out of the DOM (along with their siblings) and reinserted when scrolling, losing any changes made to them and discarding any inserted siblings entirely.

our existing repetition prevention should mean that the post listener activating more often won't cause any issues, while allowing extensions that target such existence-challenged elements to be written more simply. (this new post listener should also remove the need for a custom observer in react!vanilla_video / #1786)