### PR TITLE
[Quick Tags] Always activate on redpop

### DIFF
--- a/Extensions/quick_tags.js
+++ b/Extensions/quick_tags.js
@@ -1,5 +1,5 @@
 //* TITLE Quick Tags **//
-//* VERSION 0.6.5 **//
+//* VERSION 0.6.6 **//
 //* DESCRIPTION Quickly add tags to posts **//
 //* DETAILS Allows you to create tag bundles and add tags to posts without leaving the dashboard. **//
 //* DEVELOPER New-XKit **//
@@ -69,7 +69,9 @@ XKit.extensions.quick_tags = new Object({
 
 		XKit.tools.init_css("quick_tags");
 
-		if (!$(".post.post_full, .post.post_brick, [data-id]").length) { return; }
+		if (!$(".post.post_full, .post.post_brick, [data-id]").length && !XKit.page.react) {
+			return;
+		}
 
 		XKit.interface.post_window.create_control_button("xkit-quick-tags-window", this.button_icon, "Quick Tags in a window!");
 		XKit.interface.create_control_button("xkit-quick-tags", this.button_icon, "Quick Tags!", "", this.button_ok_icon);


### PR DESCRIPTION
fixes Quick Tags sometimes not working in the One-Click Postage box, which happens if XKit runs before any posts load.