### PR TITLE
fix async_add_function exception handling

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.1 **//
+//* VERSION 7.4.2 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -372,11 +372,11 @@ XKit.extensions.xkit_patches = new Object({
 						} catch (exception) {
 							window.postMessage({
 								xkit_callback_nonce: callback_nonce,
-								exception: {
+								exception: JSON.stringify({
 									...exception,
 									message: exception.message,
 									stack: exception.stack,
-								},
+								}),
 							})
 						}
 					})(add_tag)`;
@@ -388,7 +388,7 @@ XKit.extensions.xkit_patches = new Object({
 							const original_exception = data.exception && JSON.parse(data.exception);
 							const error = new Error(`Error in injected function (${original_exception.message})`);
 							error.cause = original_exception;
-							reject();
+							reject(error);
 						}
 					};
 


### PR DESCRIPTION
`async_add_function` currently never rejects (instead just fails to resolve) on caught exceptions since it doesn't stringify the exception, which leads to a `DataCloneError`. it already gets `JSON.parse`d later so i assume it was always supposed to be stringified

also feeds `reject()` the error instead of doing nothing with it

allows my [`react_add_reblog_timestamps`](https://github.com/new-xkit/XKit/pull/1844#issuecomment-642126308) function in #1844 to work properly