### PR TITLE
[Timestamps] Check for blog existence in trail

### DIFF
--- a/Extensions/timestamps.css
+++ b/Extensions/timestamps.css
@@ -57,7 +57,7 @@
 .xkit--react .xtimestamp.xtimestamp-reblog {
 	align-self: center;
 	flex-shrink: 9999;
-	padding: 0;
+	padding-right: 0;
 	margin: 0;
 	margin-left: auto;
 }

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -1,5 +1,5 @@
 //* TITLE Timestamps **//
-//* VERSION 2.11.0 **//
+//* VERSION 2.11.1 **//
 //* DESCRIPTION See when a post has been made. **//
 //* DETAILS This extension lets you see when a post was made, in full date or relative time (eg: 5 minutes ago). It also works on asks, and you can format your timestamps. **//
 //* DEVELOPER New-XKit **//
@@ -290,7 +290,7 @@ XKit.extensions.timestamps = new Object({
 			}
 
 			$reblogs.each(function(i) {
-				if (trail[i].blog.active === false) {
+				if (trail[i].blog === undefined || trail[i].blog.active === false) {
 					return;
 				}
 


### PR DESCRIPTION
handles reblog comments from broken blogs correctly, and fixes reblog timestamps not being added on further comments

(broken blogs do not have a `blog` object in their trail, but a `brokenBlog` instead, so the current logic throws when processing a broken blog comment)