### PR TITLE
[One-Click Postage] Make AlreadyReblogged work on new dash

### DIFF
--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.4.13 **//
+//* VERSION 4.4.14 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -829,16 +829,21 @@ XKit.extensions.one_click_postage = new Object({
 	},
 
 	check_if_alreadyreblogged: function() {
-		$(".post").not(".xkit_already_reblogged_check").each(function() {
+		$(".post, [data-id]").not(".xkit_already_reblogged_check").each(async function() {
 			var post_id = $(this).attr('data-root_id');
 			$(this).addClass("xkit_already_reblogged_check");
+
+			if (!post_id && XKit.page.react) {
+				const {root_id} = await XKit.interface.async_post($(this));
+				post_id = root_id;
+			}
 
 			if (XKit.extensions.one_click_postage.is_alreadyreblogged(post_id)) {
 				if (XKit.extensions.one_click_postage.preferences.enable_hide_alreadyreblogged.value) {
 					if (XKit.interface.where().dashboard === true) { $(this).remove(); }
 				}
 
-				XKit.extensions.one_click_postage.make_button_reblogged($(this).find(".post_control.reblog"));
+				XKit.extensions.one_click_postage.make_button_reblogged($(this).find('.post_control.reblog, a[role="button"][href*="/reblog/"]'));
 			}
 		});
 	},


### PR DESCRIPTION
fixes `check_if_alreadyreblogged()` to process posts on the react dash correctly and display green reblog buttons where appropriate

made incredibly easy by `XKit.interface.async_post()` being amazing and already saving posts' root IDs to alreadyreblogged (<3 @nightpool) and `make_button_reblogged()` already being fixed by @invalidCards 

doesn't fix the `enable_hide_alreadyreblogged` preference since `XKit.interface.where()` still doesn't understand the new dash yet