### PR TITLE
Add Tweak for making the Follow button more subtle

### DIFF
--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -817,7 +817,6 @@ XKit.extensions.tweaks = new Object({
 
 		if (XKit.extensions.tweaks.preferences.subtle_follow_button.value) {
 			let followButtonSelector = XKit.css_map.keyToClasses('followButton').map(cssClass => `.${cssClass}`).join(',');
-			console.log('follow button selector: ', followButtonSelector);
 			XKit.extensions.tweaks.add_css(`${followButtonSelector} {
 				color: var(--gray-40) !important;
 			}`, 'xkit_tweaks_subtle_follow_button');

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -816,7 +816,7 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.subtle_follow_button.value) {
-			let followButtonSelector = XKit.css_map.keyToClasses('followButton').map(cssClass => `.${cssClass}`).join(',');
+			let followButtonSelector = XKit.css_map.keyToCss('followButton');
 			XKit.extensions.tweaks.add_css(`${followButtonSelector} {
 				color: var(--gray-40) !important;
 			}`, 'xkit_tweaks_subtle_follow_button');

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -329,7 +329,7 @@ XKit.extensions.tweaks = new Object({
 			desktop_only: true
 		},
 		subtle_follow_button: {
-			text: "Make the Follow button more subtle",
+			text: "Make the Follow button more subtle inside posts",
 			default: false,
 			value: false,
 			desktop_only: true

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Tweaks **//
-//* VERSION 6.0.1 **/
+//* VERSION 6.0.3 **/
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -324,6 +324,12 @@ XKit.extensions.tweaks = new Object({
 		},
 		grayscale_new_post_button: {
 			text: "Turn the New Post button gray",
+			default: false,
+			value: false,
+			desktop_only: true
+		},
+		subtle_follow_button: {
+			text: "Make the Follow button more subtle",
 			default: false,
 			value: false,
 			desktop_only: true
@@ -801,14 +807,22 @@ XKit.extensions.tweaks = new Object({
 				box-shadow: none !important;
 			}`, 'xkit_tweaks_hide_post_highlight');
 		}
-		
+
 		if (XKit.extensions.tweaks.preferences.grayscale_new_post_button.value) {
 			let postIconButtonSel = XKit.css_map.keyToCss('postIconButton').map(cssClass => `${cssClass} span`).join(',');
 			XKit.extensions.tweaks.add_css(`${postIconButtonSel} {
 				filter: grayscale(100%);
 			}`, 'xkit_tweaks_grayscale_new_post_button');
 		}
-		
+
+		if (XKit.extensions.tweaks.preferences.subtle_follow_button.value) {
+			let followButtonSelector = XKit.css_map.keyToClasses('followButton').map(cssClass => `.${cssClass}`).join(',');
+			console.log('follow button selector: ', followButtonSelector);
+			XKit.extensions.tweaks.add_css(`${followButtonSelector} {
+				color: var(--gray-40) !important;
+			}`, 'xkit_tweaks_subtle_follow_button');
+		}
+
 		XKit.tools.add_css(XKit.extensions.tweaks.css_to_add, "xkit_tweaks");
 	},
 

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -816,8 +816,12 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.subtle_follow_button.value) {
-			let followButtonSelector = XKit.css_map.keyToCss('followButton');
-			XKit.extensions.tweaks.add_css(`${followButtonSelector} {
+			let followButtonSelectors = XKit.css_map.keyToClasses('followButton');
+			let postSelectors = XKit.css_map.keyToClasses('post');
+			let postFollowButtonSelectors = postSelectors.map(postCssClass => {
+				return followButtonSelectors.map(followCssClass => `.${postCssClass} .${followCssClass}`).join(', ');
+			}).join(', ');
+			XKit.extensions.tweaks.add_css(`${postFollowButtonSelectors} {
 				color: var(--gray-40) !important;
 			}`, 'xkit_tweaks_subtle_follow_button');
 		}


### PR DESCRIPTION
This adds a new Tweak to make the Follow button more subtle.

The existing design:

<img width="378" alt="Screen Shot 2020-07-03 at 3 07 13 PM" src="https://user-images.githubusercontent.com/770158/86493570-05bc3b00-bd40-11ea-975d-095ac15544f6.png">

With this tweak, I just reset it to the `--gray-40` Tumblr official palette variable, which looks great (to me) across palettes:

<img width="390" alt="Screen Shot 2020-07-03 at 3 12 30 PM" src="https://user-images.githubusercontent.com/770158/86493597-18367480-bd40-11ea-955f-a5a4d6b08662.png">

<img width="356" alt="Screen Shot 2020-07-03 at 3 12 38 PM" src="https://user-images.githubusercontent.com/770158/86493602-1bc9fb80-bd40-11ea-9cfc-9ed7ddad4308.png">

<img width="372" alt="Screen Shot 2020-07-03 at 3 12 44 PM" src="https://user-images.githubusercontent.com/770158/86493604-1e2c5580-bd40-11ea-9d51-4b94d14ca478.png">

hello again @AprilSylph @nightpool @invalidCards  😄 

