### PR TITLE
[Tweaks] Fix activation on non-react pages

### DIFF
--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Tweaks **//
-//* VERSION 6.0.4 **/
+//* VERSION 6.0.5 **/
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -773,7 +773,7 @@ XKit.extensions.tweaks = new Object({
 			}
 		}
 
-		if (XKit.extensions.tweaks.preferences.notification_badge_style.value != "default") {
+		if (XKit.extensions.tweaks.preferences.notification_badge_style.value !== "default" && XKit.page.react) {
 			let notificationBadgeSel = XKit.css_map.keyToCss('notificationBadge');
 			let notificationBadgeStyle = '';
 			switch (XKit.extensions.tweaks.preferences.notification_badge_style.value) {
@@ -793,7 +793,7 @@ XKit.extensions.tweaks = new Object({
 			}`, 'xkit_tweaks_notification_badge_style');
 		}
 
-		if (XKit.extensions.tweaks.preferences.hide_activity_notification_badge.value) {
+		if (XKit.extensions.tweaks.preferences.hide_activity_notification_badge.value && XKit.page.react) {
 			let notificationBadgeSel = XKit.css_map.keyToCss('notificationBadge');
 			let activityAriaLabel = await XKit.interface.translate('Activity');
 			XKit.extensions.tweaks.add_css(`button[aria-label="${activityAriaLabel}"] + ${notificationBadgeSel} {
@@ -801,21 +801,21 @@ XKit.extensions.tweaks = new Object({
 			}`, 'xkit_tweaks_hide_activity_notification_badge');
 		}
 
-		if (XKit.extensions.tweaks.preferences.hide_post_highlight.value) {
+		if (XKit.extensions.tweaks.preferences.hide_post_highlight.value && XKit.page.react) {
 			const ltoSel = XKit.css_map.keyToCss('listTimelineObjectInner');
 			XKit.extensions.tweaks.add_css(`${ltoSel} {
 				box-shadow: none !important;
 			}`, 'xkit_tweaks_hide_post_highlight');
 		}
 
-		if (XKit.extensions.tweaks.preferences.grayscale_new_post_button.value) {
+		if (XKit.extensions.tweaks.preferences.grayscale_new_post_button.value && XKit.page.react) {
 			let postIconButtonSel = XKit.css_map.keyToClasses('postIconButton').map(cssClass => `.${cssClass} span`).join(',');
 			XKit.extensions.tweaks.add_css(`${postIconButtonSel} {
 				filter: grayscale(100%);
 			}`, 'xkit_tweaks_grayscale_new_post_button');
 		}
 
-		if (XKit.extensions.tweaks.preferences.subtle_follow_button.value) {
+		if (XKit.extensions.tweaks.preferences.subtle_follow_button.value && XKit.page.react) {
 			let followButtonSelectors = XKit.css_map.keyToClasses('followButton');
 			let postSelectors = XKit.css_map.keyToClasses('post');
 			let postFollowButtonSelectors = postSelectors.map(postCssClass => {


### PR DESCRIPTION
the new react-specific options don't currently check for `XKit.page.react`, breaking most tweaks on non-react pages if you have any of them enabled