### PR TITLE
Fix tweaks to hide radar and recommended blogs

### DIFF
--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -558,7 +558,7 @@ XKit.extensions.tweaks = new Object({
 
 		if (XKit.extensions.tweaks.preferences.hide_radar.value) {
 			if (XKit.page.react) {
-				$(`${XKit.css_map.keyToCss('radar')}`).parent().css("display", "none");
+				$(`${XKit.css_map.keyToCss('radar')}`).parent().hide();
 			} else {
 				$("#tumblr_radar").css("display", "none");
 				$(".radar_header").parent().css("display", "none");
@@ -666,7 +666,7 @@ XKit.extensions.tweaks = new Object({
 
 		if (XKit.extensions.tweaks.preferences.hide_recommended.value) {
 			if (XKit.page.react) {
-				$(`${XKit.css_map.keyToCss('recommendedBlogs')}`).parent().css("display", "none");
+				$(`${XKit.css_map.keyToCss('recommendedBlogs')}`).parent().hide();
 			} else {
 				XKit.extensions.tweaks.add_css(".controls_section.recommended_tumblelogs { display: none !important; }", "xkit_tweaks_hide_recommended");
 			}
@@ -1030,6 +1030,10 @@ XKit.extensions.tweaks = new Object({
 		$(".customize").parent().css("display", "block");
 		$("xkit_post_tags_inner_add_back").addClass("post_tags_inner");
 		$("xkit_post_tags_inner_add_back").removeClass("xkit_post_tags_inner_add_back");
+		if (XKit.page.react) {
+			$(`${XKit.css_map.keyToCss('radar')}`).parent().show();
+			$(`${XKit.css_map.keyToCss('recommendedBlogs')}`).parent().show();
+		}
 
 		XKit.tools.remove_css("tweaks_grey_urls");
 	}

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Tweaks **//
-//* VERSION 6.0.6 **/
+//* VERSION 6.0.7 **/
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//
@@ -557,8 +557,12 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_radar.value) {
-			$("#tumblr_radar").css("display", "none");
-			$(".radar_header").parent().css("display", "none");
+			if (XKit.page.react) {
+				$(`${XKit.css_map.keyToCss('radar')}`).parent().css("display", "none");
+			} else {
+				$("#tumblr_radar").css("display", "none");
+				$(".radar_header").parent().css("display", "none");
+			}
 		}
 
 		if (XKit.extensions.tweaks.preferences.real_red.value) {
@@ -661,7 +665,11 @@ XKit.extensions.tweaks = new Object({
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_recommended.value) {
-			XKit.extensions.tweaks.add_css(".controls_section.recommended_tumblelogs { display: none !important; }", "xkit_tweaks_hide_recommended");
+			if (XKit.page.react) {
+				$(`${XKit.css_map.keyToCss('recommendedBlogs')}`).parent().css("display", "none");
+			} else {
+				XKit.extensions.tweaks.add_css(".controls_section.recommended_tumblelogs { display: none !important; }", "xkit_tweaks_hide_recommended");
+			}
 		}
 
 		if (XKit.extensions.tweaks.preferences.hide_share_menu.value) {


### PR DESCRIPTION
Due to the nature of the new sidebar, only some inner containers have specific classes, so this is not something that can be easily solved without CSS. Luckily we still have jQuery available and it's a one-liner for both cases.