### PR TITLE
[One-Click Postage] Make reblog button greenness more persistent

### DIFF
--- a/Extensions/one_click_postage.css
+++ b/Extensions/one_click_postage.css
@@ -396,6 +396,9 @@
 	display: none;
 }
 
+.xkit--react .reblogged svg[fill="var(--gray-65)"] {
+	fill: var(--green);
+}
 
 /* in-frame styles */
 

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.4.15 **//
+//* VERSION 4.4.16 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -842,12 +842,8 @@ XKit.extensions.one_click_postage = new Object({
 		});
 	},
 
-	make_button_reblogged: function(m_button) {
-		if (XKit.page.react) {
-			m_button.find("svg").attr("fill", "var(--green)");
-		} else {
-			m_button.addClass("reblogged");
-		}
+	make_button_reblogged: function($button) {
+		$button.addClass("reblogged");
 	},
 
 	destroy: function() {


### PR DESCRIPTION
fixes AlreadyReblogged to not be easily destroyed by pressing ALT or W
pressing/holding ALT or W will still turn all reblog buttons blue or pink, but previously-green reblog buttons will now stay green after the key is released