### PR TITLE
[No Recommended] Fix J/K scrolling by not completely hiding posts

### DIFF
--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -1,5 +1,5 @@
 //* TITLE No Recommended **//
-//* VERSION 2.3.2 **//
+//* VERSION 2.3.3 **//
 //* DESCRIPTION Removes recommended posts **//
 //* DETAILS This extension removes recommended posts from your dashboard. To remove Recommended Blogs on the sidebar, please use Tweaks extension. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -25,16 +25,6 @@ XKit.extensions.norecommended = new Object({
 			default: false,
 			value: false
 		},
-		"no_liked": {
-			text: "Get rid of recommended likes",
-			default: false,
-			value: false
-		},
-		"no_mini_recs": {
-			text: "Get rid of two-column recommended blogs",
-			default: true,
-			value: true
-		},
 		"hide_recommended_on_blogs": {
 			text: "Hide recommended posts under permalinked posts on user blogs",
 			default: false,
@@ -46,13 +36,25 @@ XKit.extensions.norecommended = new Object({
 		this.running = true;
 
 		if (XKit.page.react) {
+			XKit.tools.add_css(`
+				.norecommended-note {
+					height: 1em;
+					color: var(--white-on-dark);
+					opacity: 0.4;
+					padding: var(--post-header-vertical-padding) var(--post-padding);
+				}
+				.norecommended-note ~ * {
+					display: none;
+				}
+			`, 'norecommended');
 			XKit.post_listener.add('norecommended', this.react_do);
 			this.react_do();
 			return;
 		}
 
-		XKit.post_listener.add("norecommended", XKit.extensions.norecommended.do);
-		XKit.extensions.norecommended.do();
+		if (this.preferences.hide_recommended_on_blogs.value) {
+			this.hide_recommended_on_blogs();
+		}
 	},
 
 	react_do: function() {
@@ -67,68 +69,25 @@ XKit.extensions.norecommended = new Object({
 				const is_pinned = loggingReason.startsWith('pin:');
 
 				if ((no_search.value && is_search) || (no_pinned.value && is_pinned) || (!is_search && !is_pinned)) {
-					$this.addClass('norecommended-hidden');
-					$this.hide();
+					$this.prepend('<div class="norecommended-note">Hidden by No Recommended</div>');
 				}
 			}
 		});
 	},
 
-	do: function() {
-
-		if (XKit.extensions.norecommended.preferences.no_mini_recs.value) {
-			XKit.tools.add_css(" .recommended-unit-container.blog-card-compact {display: none;}", "norecommended_no_mini_recs");
-		}
-
-		if (XKit.extensions.norecommended.preferences.no_liked.value) {
-			XKit.tools.add_css(" .rapid-recs {display: none;}", "norecommended_no_liked");
-		}
-
-		var doResize = false;
-
-		$(".posts .post").not(".norecommended-done").each(function() {
-
-			$(this).addClass("norecommended-done");
-
-			if ($(this).hasClass("is_recommended") || $(this).find(".post_info_recommended").length > 0) {
-				$(this).remove();
-				doResize = true;
-			}
-
-		});
-
-		if (doResize) {
-			XKit.extensions.norecommended.call_tumblr_resize();
-		}
-
-		if (XKit.extensions.norecommended.preferences.hide_recommended_on_blogs.value) {
-			XKit.extensions.norecommended.hide_recommended_on_blogs();
-		}
-
-	},
-
-	call_tumblr_resize: function() {
-
-		XKit.tools.add_function(function() {
-			Tumblr.Events.trigger("DOMEventor:updateRect");
-		}, true, "");
-
-	},
-
 	hide_recommended_on_blogs: function() {
 		if (!XKit.interface.is_tumblr_page()) {
 			//We're not going to expect other themes have this class as well.
-			XKit.tools.add_css(".related-posts-wrapper, .recommended-posts-wrapper {display:none;}", "norecommended_hide_recommended_on_blogs");
+			XKit.tools.add_css(".related-posts-wrapper, .recommended-posts-wrapper {display:none;}", "norecommended");
 		}
 	},
 
 	destroy: function() {
 		this.running = false;
 		$('.norecommended-done').removeClass('norecommended-done');
-		$('.norecommended-hidden').show();
-		XKit.tools.remove_css("norecommended_no_mini_recs");
-		XKit.tools.remove_css("norecommended_no_liked");
-		XKit.tools.remove_css("norecommended_hide_recommended_on_blogs");
+		$('.norecommended-note').remove();
+		XKit.post_listener.remove('norecommended');
+		XKit.tools.remove_css("norecommended");
 	}
 
 });


### PR DESCRIPTION
adds a notification in place of hiding posts
since technically part of the post HTML, this notification can be scrolled to successfully with J/K scrolling, preventing No Recommended from activating the K-takes-you-to-top bug.

![image](https://user-images.githubusercontent.com/28949509/87232502-70601d00-c3b7-11ea-9bc8-6f6794c99770.png)

fixes #1863 

also removes all old-dash code since no other pages have recommended posts