### PR TITLE
[Reblog Display Options] Bail early if not on dashboard

### DIFF
--- a/Extensions/better_reblogs.js
+++ b/Extensions/better_reblogs.js
@@ -1,5 +1,5 @@
 //* TITLE Reblog Display Options **//
-//* VERSION 1.3.5 **//
+//* VERSION 1.3.6 **//
 //* DESCRIPTION Adds different styles to the new reblog layout, including the "classic" nested look. **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -141,6 +141,10 @@ XKit.extensions.better_reblogs = new Object({
 	run: function() {
 		this.running = true;
 
+		if (!XKit.interface.where().dashboard) {
+			return;	
+		}
+		
 		if (this.preferences.type.value === "nested") {
 			this.run_nested();
 		} else {

--- a/Extensions/better_reblogs.js
+++ b/Extensions/better_reblogs.js
@@ -141,7 +141,7 @@ XKit.extensions.better_reblogs = new Object({
 	run: function() {
 		this.running = true;
 
-		if (!XKit.interface.where().dashboard) {
+		if (!XKit.interface.is_tumblr_page()) {
 			return;	
 		}
 		


### PR DESCRIPTION
Apparently there have been select cases of posts disappearing from blog themes with RDO on nested mode. I fail to see why RDO should run on blog pages in the first place, so bailing early if we're not on the dashboard should solve this issue.