### PR TITLE
[Classic Search] Retain tracked tags dropdown

### DIFF
--- a/Extensions/disable_search.js
+++ b/Extensions/disable_search.js
@@ -1,5 +1,5 @@
 //* TITLE Classic Search **//
-//* VERSION 2.0.0 **//
+//* VERSION 2.0.1 **//
 //* DESCRIPTION Get the old search back **//
 //* DETAILS This is a very simple extension that simply redirects your search requests to the old Tumblr tag search pages. Note that features of the new search page, such as multiple tag search will not work when this extension is enabled. **//
 //* DEVELOPER new-xkit **//
@@ -33,12 +33,16 @@ XKit.extensions.disable_search = {
 
 		if (XKit.page.react) {
 			const $search = $('form[role="search"][action="//www.tumblr.com/search"]');
+			const $input = $search.find('input');
 			const $tagged = $search.clone();
 
 			$search.hide();
 			$search.after($tagged);
 
+			$input.before($input.clone());
+
 			$tagged.addClass("xkit-classic-search");
+			$tagged.find('input').replaceWith($input);
 			$tagged.on("keydown", event => event.stopPropagation());
 			$tagged.on("submit", event => {
 				event.preventDefault();


### PR DESCRIPTION
fixes Classic Search removing the tracked tags from the search bar; fixes #1874 

unfortunately `.clone(true)` doesn't retain events as intended (probably because of xray vision) but not cloning the `input` at all and instead simply moving it *does* work, so this easy solution clones the search `input` in-place and then moves the original to the classic search `form`. this breaks tracked tags when the extension is disabled by the user, but i'm going to bet nobody will mind