### PR TITLE
[Anti-Capitalism] Prevent hiding content on grid view tagged pages

### DIFF
--- a/Extensions/anti_capitalism.js
+++ b/Extensions/anti_capitalism.js
@@ -62,10 +62,11 @@ XKit.extensions.anti_capitalism = new Object({
 			await XKit.css_map.getCssMap();
 
 			if (this.preferences.sponsored_posts.value) {
-				//const selector = `${XKit.css_map.keyToCss("listTimelineObject")}:not([data-id]):not(${XKit.css_map.keyToCss("masonryTimelineObject")})`;
-
 				const listTimelineObject = XKit.css_map.keyToClasses("listTimelineObject");
 				const masonryTimelineObject = XKit.css_map.keyToClasses("masonryTimelineObject");
+
+				//find every combination of css selectors that follow the pattern --> listTimelineObject:not([data-id]):not(masonryTimelineObject)
+				//masonryTimelineObject is excluded to not hide part of the /tagged/ page
 				const selector = XKit.tools.cartesian_product([listTimelineObject, masonryTimelineObject]).map(i => `.${i[0]}:not([data-id]):not(.${i[1]})`).join(", ");
 
 				XKit.tools.add_css(`${selector} {height: 0; margin: 0; overflow: hidden;}`, "anti_capitalism");

--- a/Extensions/anti_capitalism.js
+++ b/Extensions/anti_capitalism.js
@@ -1,5 +1,5 @@
 //* TITLE Anti-Capitalism **//
-//* VERSION 1.6.2 **//
+//* VERSION 1.6.3 **//
 //* DESCRIPTION Removes sponsored posts, vendor buttons, and other nonsense that wants your money. **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -62,12 +62,20 @@ XKit.extensions.anti_capitalism = new Object({
 			await XKit.css_map.getCssMap();
 
 			if (this.preferences.sponsored_posts.value) {
-				const selector = XKit.css_map.keyToClasses("listTimelineObject").map(css => `.${css}:not([data-id])`).join(",");
-				XKit.tools.add_css(`${selector} {height: 0; margin: 0; overflow: hidden;}", "anti_capitalism`);
+				//const selector = `${XKit.css_map.keyToCss("listTimelineObject")}:not([data-id]):not(${XKit.css_map.keyToCss("masonryTimelineObject")})`;
+
+				const listTimelineObject = XKit.css_map.keyToClasses("listTimelineObject");
+				const masonryTimelineObject = XKit.css_map.keyToClasses("masonryTimelineObject");
+				const selector = XKit.tools.cartesian_product([listTimelineObject, masonryTimelineObject]).map(i => `.${i[0]}:not([data-id]):not(.${i[1]})`).join(", ");
+
+				XKit.tools.add_css(`${selector} {height: 0; margin: 0; overflow: hidden;}`, "anti_capitalism");
 			}
 
 			if (this.preferences.sidebar_ad.value) {
-				XKit.tools.add_css(`${XKit.css_map.keyToCss('mrecContainer')} { display: none !important; }`, "anti_capitalism");
+				//XKit.tools.add_css(`${XKit.css_map.keyToCss('mrecContainer')} { display: none !important; }`, "anti_capitalism");
+
+				const selector = XKit.css_map.keyToClasses("mrecContainer").map(css => `.${css}`).join(",");
+				XKit.tools.add_css(`${selector} {height: 0; margin: 0; overflow: hidden;}`, "anti_capitalism");
 			}
 
 			return;

--- a/Extensions/anti_capitalism.js
+++ b/Extensions/anti_capitalism.js
@@ -73,8 +73,6 @@ XKit.extensions.anti_capitalism = new Object({
 			}
 
 			if (this.preferences.sidebar_ad.value) {
-				//XKit.tools.add_css(`${XKit.css_map.keyToCss('mrecContainer')} { display: none !important; }`, "anti_capitalism");
-
 				const selector = XKit.css_map.keyToClasses("mrecContainer").map(css => `.${css}`).join(",");
 				XKit.tools.add_css(`${selector} {height: 0; margin: 0; overflow: hidden;}`, "anti_capitalism");
 			}


### PR DESCRIPTION
Right now, the changes in #1945 also hide a little "top Tumblrs" element on tagged pages if Tumblr serves your account the new(?) grid view. This prevents that by excluding the `masonryTimelineObject` class.

It also includes a fix to the sidebar-hiding code in #1938 in case Tumblr assigns multiple CSS classes to `mrecContainer`. Thanks to @beccasafan for both.