### PR TITLE
[Tag Tracking+] Fix tag icons not changing colors with tumblr palettes

### DIFF
--- a/Extensions/classic_tags.css
+++ b/Extensions/classic_tags.css
@@ -1,7 +1,4 @@
 .xtag {
-	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' width='18' height='18' fill='rgba(255,255,255,0.5)'%3E%3Cpath d='M 0 0 L 0 8 L 11 18 L 18 10 L 8 0 L 0 0 z M 3.5 2 A 1.5 1.5 0 0 1 5 3.5 A 1.5 1.5 0 0 1 3.5 5 A 1.5 1.5 0 0 1 2 3.5 A 1.5 1.5 0 0 1 3.5 2 z '%3E%3C/path%3E%3C/svg%3E");
-	background-repeat: no-repeat;
-	background-position: 13px 50%;
 	border-top: 1px solid var(--transparent-white-7);
 	position: relative;
 	padding: 0;
@@ -28,11 +25,17 @@
 
 .xtag .result_title {
 	width: 88% !important;
-	display: block;
 	color: var(--transparent-white-65);
-	padding: 8px 0 8px 40px;
+	padding-left: 3px;
 	font-weight: 700;
-	position: relative;
+	position: absolute;
+	line-height: 30px;
+}
+
+.xtag .result_icon {
+	display: inline-block;
+	height: 18px;
+	padding: 6px 6px 6px 13px;
 }
 
 .xtag a .count {

--- a/Extensions/classic_tags.js
+++ b/Extensions/classic_tags.js
@@ -1,5 +1,5 @@
 //* TITLE Tag Tracking+ **//
-//* VERSION 1.6.8 **//
+//* VERSION 1.6.9 **//
 //* DESCRIPTION Shows your tracked tags on your sidebar **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -322,13 +322,16 @@ XKit.extensions.classic_tags = new Object({
 				extra_classes += " hidden";
 			}
 
+			const svg = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' width='18' height='18' fill='var(--transparent-white-65)'><path d='M 0 0 L 0 8 L 11 18 L 18 10 L 8 0 L 0 0 z M 3.5 2 A 1.5 1.5 0 0 1 5 3.5 A 1.5 1.5 0 0 1 3.5 5 A 1.5 1.5 0 0 1 2 3.5 A 1.5 1.5 0 0 1 3.5 2 z '></path></svg>`;
+
 			m_html += `
 				<div class="xtag ${extra_classes}">
-					<div class="hide_overflow">
-						<a class="result_link" href="${tag.link}" data-tag-result="${tag.name}" ${(this.preferences.open_in_new_tab.value ? "target='_blank'" : "")}>
+					<a class="result_link" href="${tag.link}" data-tag-result="${tag.name}" ${(this.preferences.open_in_new_tab.value ? "target='_blank'" : "")}>
+						<div class="hide_overflow">
+							<span class="result_icon">${svg}</span>
 							<span class="result_title">${tag.name}</span>
-						</a>
-					</div>
+						</div>
+					</a>
 				</div>
 			`;
 


### PR DESCRIPTION
My changes in #1942 used css variable colors for the "tracked tags" sidebar, which made them change along with the tumblr "change palette" button. The vector icon didn't, though, since it was implemented as an HTML background image, which can't use css variables (I guess?)

This fixes that by implementing the icon as its own element and hopefully doesn't change any other styling, fingers crossed. Don't ask me about that `position:absolute`; I have no idea why everything breaks without it.

This extension still has the #1948 problem and I dunno how best to fix that; if someone wants to look at it you can probably just tack this on to avoid version number conflict and close this (or vice versa).