### PR TITLE
[No Recommended] Improvements to hidden post indicators

### DIFF
--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -59,6 +59,31 @@ XKit.extensions.norecommended = new Object({
 					margin:0;
 					padding-left: 15px;
 				}
+				.norecommended-hidden-button {
+				    position: absolute !important;
+					height: 30px;
+					line-height: 30px;
+					right: 5px;
+					display: none !important;
+				}
+				.norecommended-hidden:hover .norecommended-hidden-button {
+					display: inline-block !important;
+					height: unset;
+					line-height: initial;
+					top: 50% !important;
+					transform: translateY(-50%);
+					margin: 0;
+				}
+				.norecommended-hidden-button {
+					color: rgba(var(--rgb-white-on-dark), 0.8);
+					background: rgba(var(--rgb-white-on-dark), 0.05);
+					border-color: rgba(var(--rgb-white-on-dark), 0.3);
+				}
+				.norecommended-hidden-button:hover {
+					color: rgba(var(--rgb-white-on-dark));
+					background: rgba(var(--rgb-white-on-dark), 0.1);
+					border-color: rgba(var(--rgb-white-on-dark), 0.5);
+				}
 				.norecommended-note ~ * {
 					display: none;
 				}
@@ -83,7 +108,7 @@ XKit.extensions.norecommended = new Object({
 		$('[data-id]:not(.norecommended-done)').each(async function() {
 			const $this = $(this).addClass('norecommended-done');
 			const {no_search, no_pinned, hide_posts_completely} = XKit.extensions.norecommended.preferences;
-			const {recommendationReason} = await XKit.interface.react.post_props($this.attr('data-id'));
+			const {recommendationReason, blogName} = await XKit.interface.react.post_props($this.attr('data-id'));
 
 			if (recommendationReason && recommendationReason.hasOwnProperty('loggingReason')) {
 				const {loggingReason} = recommendationReason;
@@ -95,11 +120,25 @@ XKit.extensions.norecommended = new Object({
 						$this.addClass('norecommended-hidden-completely');
 					} else {
 						$this.addClass('norecommended-hidden');
-						$this.prepend('<div class="norecommended-note">Hidden by No Recommended</div>');
+
+						const button = '<div class="xkit-button norecommended-hidden-button">show post</div>';
+						$this.prepend(`<div class="norecommended-note">recommended post by ${blogName}${button}</div>`);
+
+						// add listener to unhide the post on button click
+						$this.on('click', '.norecommended-hidden-button', XKit.extensions.norecommended.unhide_post);
 					}
 				}
 			}
 		});
+	},
+
+	unhide_post: function(e) {
+		const $button = $(e.target);
+		const $post = $button.parents('.norecommended-hidden');
+		const $note = $button.parents('.norecommended-note');
+
+		$post.removeClass('norecommended-hidden');
+		$note.remove();
 	},
 
 	hide_recommended_on_blogs: function() {

--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -52,7 +52,7 @@ XKit.extensions.norecommended = new Object({
 
 			XKit.tools.add_css(`
 				.norecommended-hidden {
-					opacity: 0.65;
+					opacity: 0.75;
 					margin-bottom: calc(20px - ${shrink_post_amount});
 					transform: translateY(calc(-${shrink_post_amount}/2));
 				}

--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -1,5 +1,5 @@
 //* TITLE No Recommended **//
-//* VERSION 2.3.3 **//
+//* VERSION 2.3.4 **//
 //* DESCRIPTION Removes recommended posts **//
 //* DETAILS This extension removes recommended posts from your dashboard. To remove Recommended Blogs on the sidebar, please use Tweaks extension. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -37,14 +37,11 @@ XKit.extensions.norecommended = new Object({
 
 		if (XKit.page.react) {
 			XKit.tools.add_css(`
-				.norecommended-note {
-					height: 1em;
-					color: var(--white-on-dark);
-					opacity: 0.4;
-					padding: var(--post-header-vertical-padding) var(--post-padding);
-				}
-				.norecommended-note ~ * {
-					display: none;
+				.norecommended-hidden,
+ 				.norecommended-hidden + :not(.norecommended-done) {
+					height: 0;
+					margin: 0;
+					overflow: hidden;
 				}
 			`, 'norecommended');
 			XKit.post_listener.add('norecommended', this.react_do);
@@ -69,7 +66,7 @@ XKit.extensions.norecommended = new Object({
 				const is_pinned = loggingReason.startsWith('pin:');
 
 				if ((no_search.value && is_search) || (no_pinned.value && is_pinned) || (!is_search && !is_pinned)) {
-					$this.prepend('<div class="norecommended-note">Hidden by No Recommended</div>');
+					$this.addClass('norecommended-hidden');
 				}
 			}
 		});
@@ -85,7 +82,7 @@ XKit.extensions.norecommended = new Object({
 	destroy: function() {
 		this.running = false;
 		$('.norecommended-done').removeClass('norecommended-done');
-		$('.norecommended-note').remove();
+		$('.norecommended-hidden').removeClass('norecommended-hidden');
 		XKit.post_listener.remove('norecommended');
 		XKit.tools.remove_css("norecommended");
 	}

--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -31,7 +31,7 @@ XKit.extensions.norecommended = new Object({
 			value: false
 		},
 		"hide_posts_completely": {
-			text: "Hide posts completely",
+			text: "Hide posts completely (may break post loading if it hides your entire dash)",
 			default: false,
 			value: false,
 			experimental: true
@@ -42,18 +42,28 @@ XKit.extensions.norecommended = new Object({
 		this.running = true;
 
 		if (XKit.page.react) {
+			//symmetrically reduce the "top and bottom" margins of a hidden post by this amount
+			const shrink_post_amount = '12px';
+
 			XKit.tools.add_css(`
+				.norecommended-hidden {
+					opacity: 0.65;
+					margin-bottom: calc(20px - ${shrink_post_amount});
+					transform: translateY(calc(-${shrink_post_amount}/2));
+				}
 				.norecommended-note {
-					height: 1em;
-					color: var(--white-on-dark);
-					opacity: 0.4;
-					padding: var(--post-header-vertical-padding) var(--post-padding);
+					height: 30px !important;
+					line-height: 30px !important;
+					color: var(--transparent-white-65);
+					padding: 0;
+					margin:0;
+					padding-left: 15px;
 				}
 				.norecommended-note ~ * {
 					display: none;
 				}
-				.norecommended-hidden,
- 				.norecommended-hidden + :not([data-id]) {
+				.norecommended-hidden-completely,
+ 				.norecommended-hidden-completely + :not([data-id]) {
 					height: 0;
 					margin: 0;
 					overflow: hidden;
@@ -82,8 +92,9 @@ XKit.extensions.norecommended = new Object({
 
 				if ((no_search.value && is_search) || (no_pinned.value && is_pinned) || (!is_search && !is_pinned)) {
 					if (hide_posts_completely.value) {
-						$this.addClass('norecommended-hidden');
+						$this.addClass('norecommended-hidden-completely');
 					} else {
+						$this.addClass('norecommended-hidden');
 						$this.prepend('<div class="norecommended-note">Hidden by No Recommended</div>');
 					}
 				}
@@ -102,6 +113,7 @@ XKit.extensions.norecommended = new Object({
 		this.running = false;
 		$('.norecommended-done').removeClass('norecommended-done');
 		$('.norecommended-hidden').removeClass('norecommended-hidden');
+		$('.norecommended-hidden-completely').removeClass('norecommended-hidden-completely');
 		$('.norecommended-note').remove();
 		XKit.post_listener.remove('norecommended');
 		XKit.tools.remove_css("norecommended");

--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -31,11 +31,17 @@ XKit.extensions.norecommended = new Object({
 			value: false
 		},
 		"hide_posts_completely": {
-			text: "Hide posts completely (may break post loading if it hides your entire dash)",
+			text: "Hide posts completely (<a id=\"norecommended-completely-hide-help\" href=\"#\" onclick=\"return false\">may break endless scrolling</a>)",
 			default: false,
 			value: false,
-			experimental: true
+			slow: true
 		}
+	},
+
+	cpanel: function(div) {
+		$("#norecommended-completely-hide-help").click(function() {
+			XKit.window.show("Completely hiding posts", 'If you have endless scrolling enabled and XKit completely hides every single post on the first "page" of your dashboard, you may become unable to scroll down to load more posts. Disable this option if you experience an empty dashboard with the loading icon appearing forever.', "info", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
+		});
 	},
 
 	run: function() {

--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -1,5 +1,5 @@
 //* TITLE No Recommended **//
-//* VERSION 2.3.4 **//
+//* VERSION 2.3.5 **//
 //* DESCRIPTION Removes recommended posts **//
 //* DETAILS This extension removes recommended posts from your dashboard. To remove Recommended Blogs on the sidebar, please use Tweaks extension. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -29,6 +29,12 @@ XKit.extensions.norecommended = new Object({
 			text: "Hide recommended posts under permalinked posts on user blogs",
 			default: false,
 			value: false
+		},
+		"hide_posts_completely": {
+			text: "Hide posts completely",
+			default: false,
+			value: false,
+			experimental: true
 		}
 	},
 
@@ -37,6 +43,15 @@ XKit.extensions.norecommended = new Object({
 
 		if (XKit.page.react) {
 			XKit.tools.add_css(`
+				.norecommended-note {
+					height: 1em;
+					color: var(--white-on-dark);
+					opacity: 0.4;
+					padding: var(--post-header-vertical-padding) var(--post-padding);
+				}
+				.norecommended-note ~ * {
+					display: none;
+				}
 				.norecommended-hidden,
  				.norecommended-hidden + :not([data-id]) {
 					height: 0;
@@ -57,7 +72,7 @@ XKit.extensions.norecommended = new Object({
 	react_do: function() {
 		$('[data-id]:not(.norecommended-done)').each(async function() {
 			const $this = $(this).addClass('norecommended-done');
-			const {no_search, no_pinned} = XKit.extensions.norecommended.preferences;
+			const {no_search, no_pinned, hide_posts_completely} = XKit.extensions.norecommended.preferences;
 			const {recommendationReason} = await XKit.interface.react.post_props($this.attr('data-id'));
 
 			if (recommendationReason && recommendationReason.hasOwnProperty('loggingReason')) {
@@ -66,7 +81,11 @@ XKit.extensions.norecommended = new Object({
 				const is_pinned = loggingReason.startsWith('pin:');
 
 				if ((no_search.value && is_search) || (no_pinned.value && is_pinned) || (!is_search && !is_pinned)) {
-					$this.addClass('norecommended-hidden');
+					if (hide_posts_completely.value) {
+						$this.addClass('norecommended-hidden');
+					} else {
+						$this.prepend('<div class="norecommended-note">Hidden by No Recommended</div>');
+					}
 				}
 			}
 		});
@@ -83,6 +102,7 @@ XKit.extensions.norecommended = new Object({
 		this.running = false;
 		$('.norecommended-done').removeClass('norecommended-done');
 		$('.norecommended-hidden').removeClass('norecommended-hidden');
+		$('.norecommended-note').remove();
 		XKit.post_listener.remove('norecommended');
 		XKit.tools.remove_css("norecommended");
 	}

--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -38,7 +38,7 @@ XKit.extensions.norecommended = new Object({
 		if (XKit.page.react) {
 			XKit.tools.add_css(`
 				.norecommended-hidden,
- 				.norecommended-hidden + :not(.norecommended-done) {
+ 				.norecommended-hidden + :not([data-id]) {
 					height: 0;
 					margin: 0;
 					overflow: hidden;

--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -42,6 +42,11 @@ XKit.extensions.norecommended = new Object({
 		this.running = true;
 
 		if (XKit.page.react) {
+
+			//adjust colors to look good on the sidebar if we're there
+			const automatic_color = 'var(--blog-contrasting-title-color,var(--transparent-white-65))';
+			const automatic_button_color = 'var(--blog-contrasting-title-color,var(--rgb-white-on-dark))';
+
 			//symmetrically reduce the "top and bottom" margins of a hidden post by this amount
 			const shrink_post_amount = '12px';
 
@@ -54,7 +59,7 @@ XKit.extensions.norecommended = new Object({
 				.norecommended-note {
 					height: 30px !important;
 					line-height: 30px !important;
-					color: var(--transparent-white-65);
+					color: ${automatic_color};
 					padding: 0;
 					margin:0;
 					padding-left: 15px;
@@ -75,14 +80,14 @@ XKit.extensions.norecommended = new Object({
 					margin: 0;
 				}
 				.norecommended-hidden-button {
-					color: rgba(var(--rgb-white-on-dark), 0.8);
-					background: rgba(var(--rgb-white-on-dark), 0.05);
-					border-color: rgba(var(--rgb-white-on-dark), 0.3);
+					color: rgba(${automatic_button_color}, 0.8);
+					background: rgba(${automatic_button_color}, 0.05);
+					border-color: rgba(${automatic_button_color}, 0.3);
 				}
 				.norecommended-hidden-button:hover {
-					color: rgba(var(--rgb-white-on-dark));
-					background: rgba(var(--rgb-white-on-dark), 0.1);
-					border-color: rgba(var(--rgb-white-on-dark), 0.5);
+					color: rgba(${automatic_button_color});
+					background: rgba(${automatic_button_color}, 0.1);
+					border-color: rgba(${automatic_button_color}, 0.5);
 				}
 				.norecommended-note ~ * {
 					display: none;

--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -65,27 +65,21 @@ XKit.extensions.norecommended = new Object({
 					transform: translateY(calc(-${shrink_post_amount}/2));
 				}
 				.norecommended-note {
-					height: 30px !important;
-					line-height: 30px !important;
+					height: 30px;
 					color: ${automatic_color};
-					padding: 0;
-					margin:0;
 					padding-left: 15px;
+					display: flex;
+					align-items: center;
 				}
 				.norecommended-hidden-button {
-				    position: absolute !important;
-					height: 30px;
-					line-height: 30px;
+					line-height: initial;
+					margin: 0;
+					position: absolute !important;
 					right: 5px;
 					display: none !important;
 				}
 				.norecommended-hidden:hover .norecommended-hidden-button {
 					display: inline-block !important;
-					height: unset;
-					line-height: initial;
-					top: 50% !important;
-					transform: translateY(-50%);
-					margin: 0;
 				}
 				.norecommended-hidden-button {
 					color: rgba(${automatic_button_color}, 0.8);

--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -126,8 +126,9 @@ XKit.extensions.norecommended = new Object({
 					} else {
 						$this.addClass('norecommended-hidden');
 
+						var note_text = loggingReason.startsWith('pin:') ? `pinned post by ${blogName}` : `recommended post by ${blogName}`;
 						const button = '<div class="xkit-button norecommended-hidden-button">show post</div>';
-						$this.prepend(`<div class="norecommended-note">recommended post by ${blogName}${button}</div>`);
+						$this.prepend(`<div class="norecommended-note">${note_text}${button}</div>`);
 
 						// add listener to unhide the post on button click
 						$this.on('click', '.norecommended-hidden-button', XKit.extensions.norecommended.unhide_post);

--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -53,7 +53,7 @@ XKit.extensions.norecommended = new Object({
 			if (this.preferences.hide_posts_completely.value) {
 				XKit.interface.hide(".norecommended-hidden, .norecommended-hidden + :not([data-id])", "norecommended");
 			} else {
-				this.add_css();
+				XKit.interface.react.init_collapsed('norecommended');
 			}
 			XKit.post_listener.add('norecommended', this.react_do);
 			this.react_do();
@@ -63,53 +63,6 @@ XKit.extensions.norecommended = new Object({
 		if (this.preferences.hide_recommended_on_blogs.value) {
 			this.hide_recommended_on_blogs();
 		}
-	},
-
-	add_css: function() {
-		//adjust colors to look good on the sidebar if we're there
-		const automatic_color = 'var(--blog-contrasting-title-color,var(--transparent-white-65))';
-		const automatic_button_color = 'var(--blog-contrasting-title-color,var(--rgb-white-on-dark))';
-
-		//symmetrically reduce the "top and bottom" margins of a hidden post by this amount
-		const shrink_post_amount = '12px';
-
-		XKit.tools.add_css(`
-			.norecommended-hidden {
-				opacity: 0.75;
-				margin-bottom: calc(20px - ${shrink_post_amount});
-				transform: translateY(calc(-${shrink_post_amount}/2));
-			}
-			.norecommended-note {
-				height: 30px;
-				color: ${automatic_color};
-				padding-left: 15px;
-				display: flex;
-				align-items: center;
-			}
-			.norecommended-hidden-button {
-				line-height: initial;
-				margin: 0;
-				position: absolute !important;
-				right: 5px;
-				display: none !important;
-			}
-			.norecommended-hidden:hover .norecommended-hidden-button {
-				display: inline-block !important;
-			}
-			.norecommended-hidden-button {
-				color: rgba(${automatic_button_color}, 0.8);
-				background: rgba(${automatic_button_color}, 0.05);
-				border-color: rgba(${automatic_button_color}, 0.3);
-			}
-			.norecommended-hidden-button:hover {
-				color: rgba(${automatic_button_color});
-				background: rgba(${automatic_button_color}, 0.1);
-				border-color: rgba(${automatic_button_color}, 0.5);
-			}
-			.norecommended-note ~ * {
-				display: none;
-			}
-		`, 'norecommended');
 	},
 
 	react_do: function() {
@@ -129,23 +82,13 @@ XKit.extensions.norecommended = new Object({
 					$this.addClass('norecommended-hidden');
 
 					if (!hide_posts_completely.value) {
-						let note_text = loggingReason.startsWith('pin:') ? `pinned post by ${blogName}` : `recommended post by ${blogName}`;
-						const button = '<div class="xkit-button norecommended-hidden-button">show post</div>';
-						$this.prepend(`<div class="norecommended-note">${note_text}${button}</div>`);
-						$this.on('click', '.norecommended-hidden-button', XKit.extensions.norecommended.unhide_post);
+						let note_text = loggingReason.startsWith('pin:') ?
+							`pinned post by ${blogName}` : `recommended post by ${blogName}`;
+						XKit.interface.react.collapse($this, note_text, 'norecommended');
 					}
 				}
 			}
 		});
-	},
-
-	unhide_post: function(e) {
-		const $button = $(e.target);
-		const $post = $button.parents('.norecommended-hidden');
-		const $note = $button.parents('.norecommended-note');
-
-		$post.removeClass('norecommended-hidden');
-		$note.remove();
 	},
 
 	hide_recommended_on_blogs: function() {
@@ -159,7 +102,7 @@ XKit.extensions.norecommended = new Object({
 		this.running = false;
 		$('.norecommended-done').removeClass('norecommended-done');
 		$('.norecommended-hidden').removeClass('norecommended-hidden');
-		$('.norecommended-note').remove();
+		XKit.interface.react.destroy_collapsed('norecommended');
 		XKit.post_listener.remove('norecommended');
 		XKit.tools.remove_css("norecommended");
 	}

--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -41,6 +41,8 @@ XKit.extensions.norecommended = new Object({
 	run: function() {
 		this.running = true;
 
+		if (XKit.interface.where().explore) { return; }
+
 		if (XKit.page.react) {
 
 			//adjust colors to look good on the sidebar if we're there

--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -100,13 +100,10 @@ XKit.extensions.norecommended = new Object({
 				.norecommended-note ~ * {
 					display: none;
 				}
-				.norecommended-hidden-completely,
- 				.norecommended-hidden-completely + :not([data-id]) {
-					height: 0;
-					margin: 0;
-					overflow: hidden;
-				}
 			`, 'norecommended');
+
+			XKit.interface.hide(".norecommended-hidden-completely, .norecommended-hidden-completely + :not([data-id])", "norecommended");
+
 			XKit.post_listener.add('norecommended', this.react_do);
 			this.react_do();
 			return;

--- a/Extensions/norecommended.js
+++ b/Extensions/norecommended.js
@@ -129,7 +129,7 @@ XKit.extensions.norecommended = new Object({
 					$this.addClass('norecommended-hidden');
 
 					if (!hide_posts_completely.value) {
-						var note_text = loggingReason.startsWith('pin:') ? `pinned post by ${blogName}` : `recommended post by ${blogName}`;
+						let note_text = loggingReason.startsWith('pin:') ? `pinned post by ${blogName}` : `recommended post by ${blogName}`;
 						const button = '<div class="xkit-button norecommended-hidden-button">show post</div>';
 						$this.prepend(`<div class="norecommended-note">${note_text}${button}</div>`);
 						$this.on('click', '.norecommended-hidden-button', XKit.extensions.norecommended.unhide_post);

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.9 **//
+//* VERSION 7.4.10 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -1102,6 +1102,72 @@ XKit.extensions.xkit_patches = new Object({
 						}
 					},
 				},
+
+				init_collapsed: function(id) {
+					//adjust colors to look good on the sidebar if we're there
+					const automatic_color = 'var(--blog-contrasting-title-color,var(--transparent-white-65))';
+					const automatic_button_color = 'var(--blog-contrasting-title-color,var(--rgb-white-on-dark))';
+
+					//symmetrically reduce the "top and bottom" margins of a hidden post by this amount
+					const shrink_post_amount = '12px';
+
+					XKit.tools.add_css(`
+						.xkit--react .${id}-collapsed {
+							opacity: 0.75;
+							margin-bottom: calc(20px - ${shrink_post_amount});
+							transform: translateY(calc(-${shrink_post_amount}/2));
+						}
+						.xkit--react .${id}-collapsed-note {
+							height: 30px;
+							color: ${automatic_color};
+							padding-left: 15px;
+							display: flex;
+							align-items: center;
+						}
+						.xkit--react .${id}-collapsed-button {
+							line-height: initial;
+							margin: 0;
+							position: absolute !important;
+							right: 5px;
+							display: none !important;
+						}
+						.xkit--react .${id}-collapsed:hover .${id}-collapsed-button {
+							display: inline-block !important;
+						}
+						.xkit--react .${id}-collapsed-button {
+							color: rgba(${automatic_button_color}, 0.8);
+							background: rgba(${automatic_button_color}, 0.05);
+							border-color: rgba(${automatic_button_color}, 0.3);
+						}
+						.xkit--react .${id}-collapsed-button:hover {
+							color: rgba(${automatic_button_color});
+							background: rgba(${automatic_button_color}, 0.1);
+							border-color: rgba(${automatic_button_color}, 0.5);
+						}
+						.xkit--react .${id}-collapsed-note ~ div {
+							display: none;
+						}
+					`, id);
+				},
+
+				collapse: function($post, note_text, id) {
+					$post.addClass(`${id}-collapsed`);
+					const button = `<div class="xkit-button ${id}-collapsed-button">show post</div>`;
+					$post.prepend(`<div class="${id}-collapsed-note">${note_text}${button}</div>`);
+					$post.on('click', `.${id}-collapsed-button`, (e) => {
+						const $clickedbutton = $(e.target);
+						const $clickedpost = $clickedbutton.parents(`.${id}-collapsed`);
+						const $note = $clickedbutton.parents(`.${id}-collapsed-note`);
+
+						$clickedpost.removeClass(`${id}-collapsed`);
+						$note.remove();
+					});
+				},
+
+				destroy_collapsed: function(id) {
+					$(`.${id}-collapsed`).removeClass(`${id}-collapsed`);
+					$(`.${id}-collapsed-note`).remove();
+				}
 			};
 
 			XKit.interface.async_form_key = async function() {


### PR DESCRIPTION
This PR improves No Recommended in three ways:

- Implements the "fully hide posts" functionality from #1929, but as a toggleable option with a warning so no one runs into the nothing-is-on-my-dash problem without it being their own fault
- Shrinks the hidden post indicators vertically to take up less space
- Makes the hidden post indicators more informative and show-able, drawing heavily from the UI code/styling from Blacklist
<img width="400" src="https://user-images.githubusercontent.com/8336245/89755049-e5944000-da92-11ea-8de6-f30ada6ce23d.png">

- [x] Use XKit.interface.hide when it becomes available
- [x] Abstract this UI to (an) interface function(s) so I can reuse it in Show Originals? Maybe?

I made sure to do the refactor in its own commit, so it can be reverted if desired. I can always move that commit to the Show Originals PR.

Resolves #1924
