### PR TITLE
[One-Click Postage] fix on non-react pages (e.g. /liked/by)

### DIFF
--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -650,14 +650,18 @@ XKit.extensions.one_click_postage = new Object({
 			if ($(this).hasClass("selected") === true) { m_value = "true"; }
 			XKit.storage.set("one_click_postage", "share_on_" + $(this).attr('data-site'), m_value);
 		});
-		
-		const reblogAriaLabel = await XKit.interface.translate('Reblog');
-		const reblog_buttons = [
+
+		var reblog_buttons = [
 			'.reblog_button',
 			'.post_control.reblog',
 			'button[aria-label="Reblog"]',
-			`a[aria-label="${reblogAriaLabel}"][href*="/reblog/"]`
+			'a[role="button"][href*="/reblog/"]'
 		].join(',');
+
+		if (XKit.page.react) {
+			const reblogAriaLabel = await XKit.interface.translate('Reblog');
+			reblog_buttons += `, a[aria-label="${reblogAriaLabel}"][href*="/reblog/"]`;
+		}
 
 		$(document).on("mouseover", reblog_buttons, function(event) {
 			if ($(this).hasClass("radar_button") === true) {return; }

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.4.17 **//
+//* VERSION 4.4.18 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -655,7 +655,6 @@ XKit.extensions.one_click_postage = new Object({
 			'.reblog_button',
 			'.post_control.reblog',
 			'button[aria-label="Reblog"]',
-			'a[role="button"][href*="/reblog/"]'
 		].join(',');
 
 		if (XKit.page.react) {


### PR DESCRIPTION
The changes in #1958 broke OCP on non-react pages because the interface.translate call doesn't work (or stalls or something idk). This fixes that by putting the new code behind an `if (XKit.page.react)`.