### PR TITLE
[Anti-Capitalism] Prevent hiding content on grid view tagged pages + refinements

### DIFF
--- a/Extensions/anti_capitalism.js
+++ b/Extensions/anti_capitalism.js
@@ -70,7 +70,8 @@ XKit.extensions.anti_capitalism = new Object({
 			}
 
 			if (this.preferences.sidebar_ad.value) {
-				XKit.tools.add_css(`${XKit.css_map.keyToCss('mrecContainer')} { display: none !important; }`, "anti_capitalism");
+				const selector = XKit.css_map.keyToClasses("mrecContainer").map(css => `.${css}`).join(",");
+				XKit.tools.add_css(`${selector} {height: 0; margin: 0; overflow: hidden;}`, "anti_capitalism");
 			}
 
 			return;

--- a/Extensions/anti_capitalism.js
+++ b/Extensions/anti_capitalism.js
@@ -61,11 +61,15 @@ XKit.extensions.anti_capitalism = new Object({
 		if (XKit.page.react) {
 			await XKit.css_map.getCssMap();
 
-			//exit if we're on a grid page to avoid breaking anything
-			if ($(XKit.css_map.keyToCss("masonry")).length) { return; }
-
 			if (this.preferences.sponsored_posts.value) {
-				const selector = XKit.css_map.keyToClasses("listTimelineObject").map(css => `.${css}:not([data-id])`).join(",");
+				const listTimelineObject = XKit.css_map.keyToClasses("listTimelineObject");
+				const masonryTimelineObject = XKit.css_map.keyToClasses("masonryTimelineObject");
+
+				// pattern created:
+				// listTimelineObject:not([data-id]):not(masonryTimelineObject)
+				const selector = XKit.tools.cartesian_product([listTimelineObject, masonryTimelineObject])
+					.map(i => `.${i[0]}:not([data-id]):not(.${i[1]})`)
+					.join(", ");
 				XKit.interface.hide(selector, "anti_capitalism");
 			}
 

--- a/Extensions/anti_capitalism.js
+++ b/Extensions/anti_capitalism.js
@@ -66,12 +66,12 @@ XKit.extensions.anti_capitalism = new Object({
 
 			if (this.preferences.sponsored_posts.value) {
 				const selector = XKit.css_map.keyToClasses("listTimelineObject").map(css => `.${css}:not([data-id])`).join(",");
-				XKit.tools.add_css(`${selector} {height: 0; margin: 0; overflow: hidden;}`, "anti_capitalism");
+				XKit.interface.hide(selector, "anti_capitalism");
 			}
 
 			if (this.preferences.sidebar_ad.value) {
 				const selector = XKit.css_map.keyToClasses("mrecContainer").map(css => `.${css}`).join(",");
-				XKit.tools.add_css(`${selector} {height: 0; margin: 0; overflow: hidden;}`, "anti_capitalism");
+				XKit.interface.hide(selector, "anti_capitalism");
 			}
 
 			return;

--- a/Extensions/anti_capitalism.js
+++ b/Extensions/anti_capitalism.js
@@ -1,5 +1,5 @@
 //* TITLE Anti-Capitalism **//
-//* VERSION 1.6.2 **//
+//* VERSION 1.6.3 **//
 //* DESCRIPTION Removes sponsored posts, vendor buttons, and other nonsense that wants your money. **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -61,9 +61,12 @@ XKit.extensions.anti_capitalism = new Object({
 		if (XKit.page.react) {
 			await XKit.css_map.getCssMap();
 
+			//exit if we're on a grid page to avoid breaking anything
+			if ($(XKit.css_map.keyToCss("masonry")).length) { return; }
+
 			if (this.preferences.sponsored_posts.value) {
 				const selector = XKit.css_map.keyToClasses("listTimelineObject").map(css => `.${css}:not([data-id])`).join(",");
-				XKit.tools.add_css(`${selector} {height: 0; margin: 0; overflow: hidden;}", "anti_capitalism`);
+				XKit.tools.add_css(`${selector} {height: 0; margin: 0; overflow: hidden;}`, "anti_capitalism");
 			}
 
 			if (this.preferences.sidebar_ad.value) {

--- a/Extensions/anti_capitalism.js
+++ b/Extensions/anti_capitalism.js
@@ -70,7 +70,7 @@ XKit.extensions.anti_capitalism = new Object({
 			}
 
 			if (this.preferences.sidebar_ad.value) {
-				const selector = XKit.css_map.keyToClasses("mrecContainer").map(css => `.${css}`).join(",");
+				const selector = XKit.css_map.keyToCss("mrecContainer");
 				XKit.interface.hide(selector, "anti_capitalism");
 			}
 


### PR DESCRIPTION
Right now, the changes in #1945 also hide a little "top Tumblrs" element on tagged pages if Tumblr serves your account the new(?) grid view. This fixes that by doing nothing on those pages.

It also includes a fix to the sidebar-hiding code in #1938 in case Tumblr assigns multiple CSS classes to `mrecContainer`, and fixes a typo that breaks `destroy()`.