### PR TITLE
Fix react control button issues affecting the QuickTags and PostBlock extensions

### DIFF
--- a/Extensions/quick_tags.js
+++ b/Extensions/quick_tags.js
@@ -413,8 +413,8 @@ XKit.extensions.quick_tags = new Object({
 
 		$posts
 			.addClass("xkit-quick-tags-done")
-			.each(async function() {
-				await XKit.interface.react.add_control_button($(this), "xkit-quick-tags", "");
+			.each(function() {
+				XKit.interface.react.add_control_button($(this), "xkit-quick-tags", "");
 			});
 
 		XKit.extensions.quick_tags.processing = false;

--- a/Extensions/quick_tags.js
+++ b/Extensions/quick_tags.js
@@ -1,5 +1,5 @@
 //* TITLE Quick Tags **//
-//* VERSION 0.6.7 **//
+//* VERSION 0.6.8 **//
 //* DESCRIPTION Quickly add tags to posts **//
 //* DETAILS Allows you to create tag bundles and add tags to posts without leaving the dashboard. **//
 //* DEVELOPER New-XKit **//
@@ -85,10 +85,11 @@ XKit.extensions.quick_tags = new Object({
 		XKit.interface.post_window_listener.add("quick_tags", XKit.extensions.quick_tags.post_window);
 
 		if (XKit.page.react) {
-			XKit.interface.react.create_control_button("xkit-quick-tags", this.button_icon, "Quick Tags!", "", this.button_ok_icon);
-			XKit.post_listener.add("quick_tags", XKit.extensions.quick_tags.do_posts);
+			XKit.interface.react.create_control_button("xkit-quick-tags", this.button_icon, "Quick Tags!", "", this.button_ok_icon).then(() => {
+				XKit.post_listener.add("quick_tags", XKit.extensions.quick_tags.do_posts);
 
-			this.do_posts();
+				this.do_posts();
+			});
 		}
 	},
 
@@ -412,8 +413,8 @@ XKit.extensions.quick_tags = new Object({
 
 		$posts
 			.addClass("xkit-quick-tags-done")
-			.each(function() {
-				XKit.interface.react.add_control_button($(this), "xkit-quick-tags", "");
+			.each(async function() {
+				await XKit.interface.react.add_control_button($(this), "xkit-quick-tags", "");
 			});
 
 		XKit.extensions.quick_tags.processing = false;

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.7 **//
+//* VERSION 7.4.8 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -956,6 +956,8 @@ XKit.extensions.xkit_patches = new Object({
 				},
 
 				control_button_template: null,
+				added_func: {},
+
 				get_control_button_template: async function() {
 					await XKit.css_map.getCssMap();
 
@@ -996,15 +998,13 @@ XKit.extensions.xkit_patches = new Object({
 				 */
 				create_control_button: async function(class_name, icon, text, func, ok_icon) {
 					if (this.control_button_template == null) {
-						this.control_button_template = {
-							template: await this.get_control_button_template(),
-							func: func
-						};
+						this.control_button_template = await this.get_control_button_template();
 					}
 
 					XKit.interface.added_icon.push(class_name);
 					XKit.interface.added_icon_icon.push(icon);
 					XKit.interface.added_icon_text.push(text);
+					XKit.interface.react.added_func[class_name] = func;
 
 					XKit.tools.add_css(`.${class_name} .xkit-interface-icon {
 						background-image: url('${icon}');
@@ -1035,7 +1035,9 @@ XKit.extensions.xkit_patches = new Object({
 
 					var m_data = `data-post-id = "${post_id}" data-post-type="${post_type}" data-permalink="${post_permalink}"`;
 
-					var { template, func } = this.control_button_template;
+					var template = this.control_button_template;
+					var func = XKit.interface.react.added_func[class_name];
+
 					var m_html = template
 						.replace(/{{className}}/g, class_name)
 						.replace(/{{text}}/g, m_text)


### PR DESCRIPTION
- Don't ignore async handling
- React control buttons need to store the click function separately, so those need an object for storage