### PR TITLE
[Timestamps] Visual improvements

### DIFF
--- a/Extensions/timestamps.css
+++ b/Extensions/timestamps.css
@@ -63,11 +63,21 @@
 }
 
 .xkit--react .xtimestamp.xtimestamp-bottom {
-	margin: 0 auto 0 0;
+	margin: 0;
 	padding: 0;
+	display: inline-block;
 }
 
-:not(:empty) + .xtimestamp.xtimestamp-bottom {
+.xkit--react .xtimestamp-bottom-container {
+	flex-grow: 1;
+	flex-basis: 0;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	font-size: 1rem; /* fixes buggy behavior with old blue enabled */
+}
+
+:not(:empty) + .xtimestamp-bottom-container {
 	margin-left: var(--post-padding);
 }
 

--- a/Extensions/timestamps.css
+++ b/Extensions/timestamps.css
@@ -65,7 +65,6 @@
 .xkit--react .xtimestamp.xtimestamp-bottom {
 	margin: 0;
 	padding: 0;
-	display: inline-block;
 }
 
 .xkit--react .xtimestamp-bottom-container {

--- a/Extensions/timestamps.css
+++ b/Extensions/timestamps.css
@@ -39,7 +39,7 @@
 	margin-left: 20px;
 }
 
-.xkit--react .xtimestamp, 
+.xkit--react .xtimestamp,
 .xkit--react .xtimestamp-in-search {
 	position: static;
 	color: var(--gray-65);
@@ -61,6 +61,16 @@
 	margin: 0;
 	margin-left: auto;
 }
+
+.xkit--react .xtimestamp.xtimestamp-bottom {
+	margin: 0 auto 0 0;
+	padding: 0;
+}
+
+:not(:empty) + .xtimestamp.xtimestamp-bottom {
+	margin-left: var(--post-padding);
+}
+
 
 .xtimestamp.xtimestamp-loading {
 	background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Cpath d='M.9.5a.4.4 2 0 1-.247.37.4.4 0 0 1-.436-.087A.4.4 0 0 1 .13.347.4.4 0 0 1 .5.1' fill='none' stroke='%23888' stroke-width='.12' stroke-linecap='round' stroke-linejoin='round'%3E%3CanimateTransform attributeName='transform' attributeType='XML' type='rotate' from='0 .5 .5' to='360 .5 .5' dur='1s' repeatCount='indefinite'/%3E%3C/path%3E%3C/svg%3E") center no-repeat;

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -296,6 +296,7 @@ XKit.extensions.timestamps = new Object({
 			if (preferences.display_on_top.value) {
 				$(xtimestamp_html).insertAfter($post.find("header"));
 			} else {
+				xtimestamp_html = `<span class="xtimestamp-bottom-container">${xtimestamp_html}</span>`;
 				$(xtimestamp_html).insertAfter($post.find(note_count_class));
 			}
 

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -451,6 +451,7 @@ XKit.extensions.timestamps = new Object({
 
 	destroy: function() {
 		$(".xtimestamp").remove();
+		$(".xtimestamp-bottom-container").remove();
 		$(".xkit-fan-timestamp").remove();
 		$(".with-xkit-timestamp").removeClass("with-xkit-timestamp");
 		$(".xkit_timestamps").removeClass("xkit_timestamps");

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -42,19 +42,35 @@ XKit.extensions.timestamps = new Object({
 			text: "Display options",
 			type: "separator"
 		},
-		no_xkit_rewritten_format: {
-			text: "Select your own timestamp format",
-			default: false,
-			value: false
+		format_type_absolute: {
+			text: "Absolute timestamps",
+			type: "combo",
+			values: [
+				'None', "none",
+				'Minimal: 9:30PM / June 12', "xkit_rewritten",
+				'Custom (see below)', "custom"
+			],
+			default: "xkit_rewritten",
+			value: "xkit_rewritten"
 		},
 		format: {
-			text: 'Manual timestamp format (<span id="xkit-timestamps-format-help" style="text-decoration: underline; cursor: pointer;">what is this?</span>)',
+			text: 'Custom format, if selected (<span id="xkit-timestamps-format-help" style="text-decoration: underline; cursor: pointer;">what is this?</span>)',
 			type: "text",
 			default: "MMMM Do YYYY, h:mm:ss a",
 			value: "MMMM Do YYYY, h:mm:ss a"
 		},
+		format_type_relative: {
+			text: "Relative timestamps",
+			type: "combo",
+			values: [
+				'None', "none",
+				'Auto: 2 hours ago / 3 days ago', "auto",
+			],
+			default: "auto",
+			value: "auto"
+		},
 		no_xkit_rewritten_location: {
-			text: "Display timestamps on the top of posts instead of the bottom",
+			text: "Display timestamps on the top of posts",
 			default: false,
 			value: false
 		},
@@ -63,11 +79,7 @@ XKit.extensions.timestamps = new Object({
 			default: false,
 			value: false
 		},
-		only_relative: {
-			text: "Display timestamps in relative form",
-			default: false,
-			value: false
-		}
+
 	},
 
 	check_quota: function() {
@@ -405,20 +417,33 @@ XKit.extensions.timestamps = new Object({
 		}
 	  },
 
-	  format_date: function(timestamp) {
-		if (!this.preferences.no_xkit_rewritten_format.value) {
-			return this.constructMinimalTimeString(timestamp);
-		}
+	format_date: function(timestamp) {
+		var absoluteText = '';
+		var relativeText = '';
+		var tooltip = '';
 
 		const date = moment(new Date(timestamp * 1000));
 
-		const absolute = date.format(this.preferences.format.value);
-		const relative = date.from(moment());
-
-		if (this.preferences.only_relative.value) {
-			return `<span title="${absolute}">${relative}</span>`;
+		if (this.preferences.format_type_absolute.value == "xkit_rewritten") {
+			absoluteText = this.constructMinimalTimeString(timestamp);
+		} else if (this.preferences.format_type_absolute.value == "custom") {
+			absoluteText = date.format(this.preferences.format.value);
 		} else {
-			return `${absolute} &middot; ${relative}`;
+			tooltip = date.format(this.preferences.format.value);
+		}
+
+		if (this.preferences.format_type_relative.value == "auto") {
+			relativeText = date.from(moment());
+		} else {
+			tooltip = date.from(moment());
+		}
+
+		if (absoluteText && relativeText) {
+			return `${absoluteText} &middot; ${relativeText}`;
+		} else if (relativeText) {
+			return `<span title="${tooltip}">${relativeText}</span>`;
+		} else {
+			return `<span title="${tooltip}">${absoluteText}</span>`;
 		}
 	},
 

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -69,7 +69,7 @@ XKit.extensions.timestamps = new Object({
 			default: "auto",
 			value: "auto"
 		},
-		no_xkit_rewritten_location: {
+		display_on_top: {
 			text: "Display timestamps on the top of posts",
 			default: false,
 			value: false
@@ -274,7 +274,7 @@ XKit.extensions.timestamps = new Object({
 	},
 
 	react_add_timestamps: function() {
-		const {note_count_class, preferences} = XKit.extensions.timestamps;
+		const {note_count_class, preferences, in_search} = XKit.extensions.timestamps;
 		var $posts = $("[data-id]:not(.xkit_timestamps)");
 		$posts.addClass("xkit_timestamps");
 
@@ -284,16 +284,16 @@ XKit.extensions.timestamps = new Object({
 			var post_id = $post.attr("data-id");
 
 			var xtimestamp_class = "xtimestamp";
-			if (XKit.extensions.timestamps.in_search) {
+			if (in_search) {
 				xtimestamp_class = "xtimestamp-in-search";
 			}
-			if (!preferences.no_xkit_rewritten_location.value) {
+			if (!preferences.display_on_top.value) {
 				xtimestamp_class += " xtimestamp-bottom";
 			}
 
 			var xtimestamp_html = `<div class="xkit_timestamp_${post_id} ${xtimestamp_class} xtimestamp-loading">&nbsp;</div>`;
 
-			if (preferences.no_xkit_rewritten_location.value) {
+			if (preferences.display_on_top.value) {
 				$(xtimestamp_html).insertAfter($post.find("header"));
 			} else {
 				$(xtimestamp_html).insertAfter($post.find(note_count_class));
@@ -418,21 +418,24 @@ XKit.extensions.timestamps = new Object({
 	  },
 
 	format_date: function(timestamp) {
+		const absolute_type = this.preferences.format_type_absolute.value;
+		const relative_type = this.preferences.format_type_relative.value;
+
 		var absoluteText = '';
 		var relativeText = '';
 		var tooltip = '';
 
 		const date = moment(new Date(timestamp * 1000));
 
-		if (this.preferences.format_type_absolute.value == "xkit_rewritten") {
+		if (absolute_type == "xkit_rewritten") {
 			absoluteText = this.constructMinimalTimeString(timestamp);
-		} else if (this.preferences.format_type_absolute.value == "custom") {
+		} else if (absolute_type == "custom") {
 			absoluteText = date.format(this.preferences.format.value);
 		} else {
 			tooltip = date.format(this.preferences.format.value);
 		}
 
-		if (this.preferences.format_type_relative.value == "auto") {
+		if (relative_type == "auto") {
 			relativeText = date.from(moment());
 		} else {
 			tooltip = date.from(moment());
@@ -440,10 +443,8 @@ XKit.extensions.timestamps = new Object({
 
 		if (absoluteText && relativeText) {
 			return `${absoluteText} &middot; ${relativeText}`;
-		} else if (relativeText) {
-			return `<span title="${tooltip}">${relativeText}</span>`;
 		} else {
-			return `<span title="${tooltip}">${absoluteText}</span>`;
+			return `<span title="${tooltip}">${relativeText}${absoluteText}</span>`;
 		}
 	},
 

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -1,5 +1,5 @@
 //* TITLE Timestamps **//
-//* VERSION 2.11.2 **//
+//* VERSION 2.11.3 **//
 //* DESCRIPTION See when a post has been made. **//
 //* DETAILS This extension lets you see when a post was made, in full date or relative time (eg: 5 minutes ago). It also works on asks, and you can format your timestamps. **//
 //* DEVELOPER New-XKit **//
@@ -243,7 +243,7 @@ XKit.extensions.timestamps = new Object({
 			}
 
 			var timestamp = responseData.posts[0].timestamp;
-			date_element.html(this.format_date(moment(new Date(timestamp * 1000))));
+			date_element.html(this.format_date(timestamp));
 			date_element.removeClass("xtimestamp-loading");
 			XKit.storage.set("timestamps", "xkit_timestamp_cache_" + post_id, timestamp);
 		})
@@ -311,7 +311,7 @@ XKit.extensions.timestamps = new Object({
 				}, {uuid, id}).then(timestamp => {
 					$xtimestamp
 					.removeClass("xtimestamp-loading")
-					.html(XKit.extensions.timestamps.format_date(moment(new Date(timestamp * 1000))));
+					.html(XKit.extensions.timestamps.format_date(timestamp));
 
 					XKit.storage.set("timestamps", `xkit_timestamp_cache_${id}`, timestamp);
 				}).catch(() => {
@@ -325,7 +325,7 @@ XKit.extensions.timestamps = new Object({
 		var {timestamp} = await XKit.interface.react.post_props(post_id);
 
 		if (timestamp) {
-			date_element.html(this.format_date(moment(new Date(timestamp * 1000))));
+			date_element.html(this.format_date(timestamp));
 			date_element.removeClass("xtimestamp-loading");
 			XKit.storage.set("timestamps", "xkit_timestamp_cache_" + post_id, timestamp);
 		} else {
@@ -349,7 +349,7 @@ XKit.extensions.timestamps = new Object({
 			return false;
 		}
 
-		date_element.html(this.format_date(cached_date));
+		date_element.html(this.format_date(cached_utc_seconds));
 		date_element.removeClass("xtimestamp-loading");
 		return true;
 	},
@@ -363,7 +363,9 @@ XKit.extensions.timestamps = new Object({
 		$("#xkit-timestamps-format-help").click(XKit.tools.show_timestamps_help);
 	},
 
-	format_date: function(date) {
+	format_date: function(timestamp) {
+		const date = moment(new Date(timestamp * 1000));
+
 		const absolute = date.format(this.preferences.format.value);
 		const relative = date.from(moment());
 

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -42,8 +42,13 @@ XKit.extensions.timestamps = new Object({
 			text: "Display options",
 			type: "separator"
 		},
+		no_xkit_rewritten_format: {
+			text: "Select your own timestamp format",
+			default: false,
+			value: false
+		},
 		format: {
-			text: 'Timestamp format (<span id="xkit-timestamps-format-help" style="text-decoration: underline; cursor: pointer;">what is this?</span>)',
+			text: 'Manual timestamp format (<span id="xkit-timestamps-format-help" style="text-decoration: underline; cursor: pointer;">what is this?</span>)',
 			type: "text",
 			default: "MMMM Do YYYY, h:mm:ss a",
 			value: "MMMM Do YYYY, h:mm:ss a"
@@ -378,7 +383,33 @@ XKit.extensions.timestamps = new Object({
 		$("#xkit-timestamps-format-help").click(XKit.tools.show_timestamps_help);
 	},
 
-	format_date: function(timestamp) {
+	constructMinimalTimeString: function(unixTime) {
+		const locale = document.documentElement.lang;
+		const date = new Date(unixTime * 1000);
+		const now = new Date();
+
+		const sameDate = date.toDateString() === now.toDateString();
+		const sameYear = date.getFullYear() === now.getFullYear();
+
+		if (sameDate) {
+		  return date.toLocaleTimeString(locale, {
+			hour: 'numeric',
+			minute: 'numeric',
+		  });
+		} else {
+		  return date.toLocaleDateString(locale, {
+			day: 'numeric',
+			month: 'short',
+			year: sameYear ? undefined : 'numeric',
+		  });
+		}
+	  },
+
+	  format_date: function(timestamp) {
+		if (!this.preferences.no_xkit_rewritten_format.value) {
+			return this.constructMinimalTimeString(timestamp);
+		}
+
 		const date = moment(new Date(timestamp * 1000));
 
 		const absolute = date.format(this.preferences.format.value);

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -160,7 +160,9 @@ XKit.extensions.timestamps = new Object({
 				}
 
 				if (this.preferences.only_on_hover.value) {
-					XKit.tools.add_css(`.xtimestamp { display: none; } ${this.posts_class.split(", ").map(x => x + ":hover .xtimestamp").join(", ")} { display: block; }`, "timestamps_on_hover");
+					XKit.tools.add_css(`.xtimestamp { display: none; } ${this.posts_class.split(", ").map(x => x + ":hover .xtimestamp").join(", ")} { display: inline-block; }`, "timestamps_on_hover");
+				} else {
+					XKit.tools.add_css(".xtimestamp { display: inline-block; }", "timestamps_on_hover");
 				}
 			});
 

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -48,6 +48,11 @@ XKit.extensions.timestamps = new Object({
 			default: "MMMM Do YYYY, h:mm:ss a",
 			value: "MMMM Do YYYY, h:mm:ss a"
 		},
+		no_xkit_rewritten_location: {
+			text: "Display timestamps on the top of posts instead of the bottom",
+			default: false,
+			value: false
+		},
 		only_on_hover: {
 			text: "Hide timestamps until I hover over a post",
 			default: false,
@@ -125,6 +130,7 @@ XKit.extensions.timestamps = new Object({
 				this.reblogs_class = XKit.css_map.keyToCss("reblog");
 				this.reblog_headers_class = XKit.css_map.keyToCss("reblogHeader");
 				this.blog_link_class = XKit.css_map.keyToCss("blogLink");
+				this.note_count_class = XKit.css_map.keyToCss('noteCount');
 
 				if (this.preferences.posts.value || (this.preferences.inbox.value && XKit.interface.where().inbox)) {
 					this.react_add_timestamps();
@@ -251,6 +257,7 @@ XKit.extensions.timestamps = new Object({
 	},
 
 	react_add_timestamps: function() {
+		const {note_count_class, preferences} = XKit.extensions.timestamps;
 		var $posts = $("[data-id]:not(.xkit_timestamps)");
 		$posts.addClass("xkit_timestamps");
 
@@ -263,9 +270,17 @@ XKit.extensions.timestamps = new Object({
 			if (XKit.extensions.timestamps.in_search) {
 				xtimestamp_class = "xtimestamp-in-search";
 			}
+			if (!preferences.no_xkit_rewritten_location.value) {
+				xtimestamp_class += " xtimestamp-bottom";
+			}
 
 			var xtimestamp_html = `<div class="xkit_timestamp_${post_id} ${xtimestamp_class} xtimestamp-loading">&nbsp;</div>`;
-			$(xtimestamp_html).insertAfter($post.find("header"));
+
+			if (preferences.no_xkit_rewritten_location.value) {
+				$(xtimestamp_html).insertAfter($post.find("header"));
+			} else {
+				$(xtimestamp_html).insertAfter($post.find(note_count_class));
+			}
 
 			var note = $(".xkit_timestamp_" + post_id);
 			XKit.extensions.timestamps.react_fetch_timestamp(post_id, note);

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -362,7 +362,9 @@ XKit.extensions.timestamps = new Object({
 		if (timestamp) {
 			date_element.html(this.format_date(timestamp));
 			date_element.removeClass("xtimestamp-loading");
-			XKit.storage.set("timestamps", "xkit_timestamp_cache_" + post_id, timestamp);
+			if (XKit.extensions.timestamps.preferences.reblogs.value !== "off") {
+				XKit.storage.set("timestamps", "xkit_timestamp_cache_" + post_id, timestamp);
+			}
 		} else {
 			this.show_failed(date_element);
 		}

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -321,7 +321,7 @@ XKit.extensions.timestamps = new Object({
 			}
 
 			$reblogs.each(function(i) {
-				if (trail[i].blog === undefined || trail[i].blog.active === false) {
+				if (trail[i] === undefined || trail[i].blog === undefined || trail[i].blog.active === false) {
 					return;
 				}
 


### PR DESCRIPTION
This adds options to put timestamps on the bottom of posts near the note count, and to use clean/minimal absolute timestamp labels, both of which are just directly ported from April's [XKit Rewritten](https://github.com/AprilSylph/XKit-Rewritten).

It also splits the options up to let you use any combination of formats. Want your timestamps to say "7:12 PM · 6 minutes ago" or just "August 14th"? Go for it.

Not sure what defaults to set for the new preference values; one way many people won't discover the new options and the other way some will be upset by the unexpected change.