### PR TITLE
[Blacklist] Fix ask posts being ignored; don't use 100% cpu

### DIFF
--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1,5 +1,5 @@
 //* TITLE Blacklist **//
-//* VERSION 3.1.2 **//
+//* VERSION 3.1.3 **//
 //* DESCRIPTION Clean your dash **//
 //* DETAILS This extension allows you to block posts based on the words you specify. If a post has the text you've written in the post itself or it's tags, it will be replaced by a warning, or won't be shown on your dashboard, depending on your settings. **//
 //* DEVELOPER new-xkit **//
@@ -628,10 +628,11 @@ XKit.extensions.blacklist = new Object({
 					}).get().join(" ");
 				}
 
-				// New method for finding content
-				const rowsSel = XKit.css_map.keyToCss('rows');
-				if (rowsSel && $(this).find(rowsSel).length > 0) {
-					m_content = $(this).find(rowsSel).map(function() {
+				// New method for finding content on react. "link" finds the content of link posts
+				const contentSel = XKit.css_map.keyToCss('textBlock') + "," + XKit.css_map.keyToCss('link');
+				var content = $(this).find(contentSel);
+				if (content.length) {
+					m_content += content.map(function() {
 					    return $(this).html();
 					}).get().join(" ");
 				}
@@ -650,7 +651,7 @@ XKit.extensions.blacklist = new Object({
 				// Strip HTML tags.
 				m_content = m_content.replace(/<(?:.|\n)*?>/gm, ' ');
 
-				console.log('all the content is', m_content);
+				//console.log('all the content is', m_content);
 
 				var m_result = XKit.extensions.blacklist.do_post($(this), m_content, tag_array);
 				if (m_result !== "") {

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -696,12 +696,7 @@ XKit.extensions.blacklist = new Object({
 
 			}, 300);
 		}
-
-		//XKit.extensions.blacklist.check_interval = setTimeout(function() { XKit.extensions.blacklist.check(); }, 2000);
-
 	},
-
-	//check_interval: 0,
 
 	hide_post: function($post, word) {
 		const {

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -697,11 +697,11 @@ XKit.extensions.blacklist = new Object({
 			}, 300);
 		}
 
-		XKit.extensions.blacklist.check_interval = setTimeout(function() { XKit.extensions.blacklist.check(); }, 2000);
+		//XKit.extensions.blacklist.check_interval = setTimeout(function() { XKit.extensions.blacklist.check(); }, 2000);
 
 	},
 
-	check_interval: 0,
+	//check_interval: 0,
 
 	hide_post: function($post, word) {
 		const {


### PR DESCRIPTION
This fixes an issue where blacklist doesn't see and block content in ask posts and prevents it from calling check() an exponentially increasing number of times as you scroll.

Asks:

> Blacklist currently uses a `rows` css selector, which surrounds the majority of post contents but for some reason isn't used in asks. I switched it to use `textBlock` (plus `link`, to grab the contents of link posts). 
> 
> I scrolled through a few hours worth of my dash looking at the debug output, and I didn't see any post content that wasn't picked up by `textBlock`, but I don't have any non-NPF posts/posts edited with editable reblogs/etc to test on.
> 
> Performance-wise, this significantly increases `find` calls but reduces regex'ing. Dunno what net effect that has but it's a slow extension already.
> 
> resolves #1931 

Performance:

> Ever since [this commit from September 2013](https://github.com/new-xkit/XKit/commit/81c57507a4762d23bf0cd259b1465306c5ec2401#diff-e4f15bc0f67b8e407e7dc3e45b3a5f1d), blacklist has called check() a number of times every 2 seconds that could reach into the hundreds if you scroll enough. This is due to:
> 
> ```js
> run: async function() {
> 	/* etc */
> 	XKit.post_listener.add("blacklist", XKit.extensions.blacklist.check);
> },
> 
> check: function() {
> 	/* etc */
> 	setTimeout(function() { XKit.extensions.blacklist.check(); }, 2000);
> },
> 
> ```
> I haven't figured out what the last line is actually supposed to be for, but as far as I can tell the extension works perfectly without it. This may be one of the primary causes of slowdown people experience from xkit, at least as far as I can tell with a rudimentary understanding of chrome's dev tools.

Aside: Do we want to consider adding a onetime popup message telling people that Tumblr has native blacklisting now?