### PR TITLE
[Enhanced Queue] Update for react

### DIFF
--- a/Extensions/shuffle_queue.js
+++ b/Extensions/shuffle_queue.js
@@ -10,6 +10,8 @@ XKit.extensions.shuffle_queue = new Object({
 
 	running: false,
 
+	queueoptions_selector: ".dashboard_options_form",
+
 	run: async function() {
 
 		if (!XKit.interface.where().queue) {
@@ -26,9 +28,11 @@ XKit.extensions.shuffle_queue = new Object({
 					{ id: "xshufflequeue_button", text: "Shuffle Queue" },
 					{ id: "xdeletequeue_button", text: "Clear Queue" },
 					{ id: "xshrinkposts_button", text: "Shrink Posts", count: "off" },
-					{ id: "xqueueoptions_button", text: "Queue Options", count: "on" }
+					{ id: "xqueueoptions_button", text: "Show Queue Options", count: "on" }
 				]
 			});
+			await XKit.css_map.getCssMap();
+			this.queueoptions_selector = XKit.css_map.keyToCss('queueSettings');
 		} else {
 			XKit.interface.sidebar.add({
 				id: "queue_plus_sidebar",
@@ -80,7 +84,7 @@ XKit.extensions.shuffle_queue = new Object({
 			if ($button.hasClass("xkit-queue-option-button-on")) {
 				$button.find(".count").html("off");
 				XKit.storage.set("shuffle_queue", "hide_options", "true");
-				XKit.tools.add_css(" .dashboard_options_form { display: none; }", "shuffle_queue_hide_options");
+				XKit.tools.add_css(`${XKit.extensions.shuffle_queue.queueoptions_selector} { display: none; }`, "shuffle_queue_hide_options");
 			} else {
 				$button.find(".count").html("on");
 				XKit.storage.set("shuffle_queue", "hide_options", "false");

--- a/Extensions/shuffle_queue.js
+++ b/Extensions/shuffle_queue.js
@@ -259,8 +259,7 @@ XKit.extensions.shuffle_queue = new Object({
 						.text(`Mass-deleting ${shuffle_queue.posts_to_delete.length} posts...`);
 					shuffle_queue.posts_to_delete_count = shuffle_queue.posts_to_delete.length;
 
-					//this.clear_delete_next();
-					await new Promise(r => setTimeout(r, 2000));
+					this.clear_delete_next();
 
 					this.clear_done();
 				}

--- a/Extensions/shuffle_queue.js
+++ b/Extensions/shuffle_queue.js
@@ -10,7 +10,7 @@ XKit.extensions.shuffle_queue = new Object({
 
 	running: false,
 
-	run: function() {
+	run: async function() {
 
 		if (!XKit.interface.where().queue) {
 			return;
@@ -18,16 +18,29 @@ XKit.extensions.shuffle_queue = new Object({
 
 		this.running = true;
 
-		XKit.interface.sidebar.add({
-			id: "queue_plus_sidebar",
-			title: "Queue+",
-			items: [
-				{ id: "xshufflequeue_button", text: "Shuffle Queue" },
-				{ id: "xdeletequeue_button", text: "Clear Queue" },
-				{ id: "xshrinkposts_button", text: "Shrink Posts", count: "off" },
-				{ id: "xqueueoptions_button", text: "Queue Options", count: "on" }
-			]
-		});
+		if (XKit.page.react) {
+			await XKit.interface.react.sidebar.add({
+				id: "queue_plus_sidebar",
+				title: "Queue+",
+				items: [
+					{ id: "xshufflequeue_button", text: "Shuffle Queue" },
+					{ id: "xdeletequeue_button", text: "Clear Queue" },
+					{ id: "xshrinkposts_button", text: "Shrink Posts", count: "off" },
+					{ id: "xqueueoptions_button", text: "Queue Options", count: "on" }
+				]
+			});
+		} else {
+			XKit.interface.sidebar.add({
+				id: "queue_plus_sidebar",
+				title: "Queue+",
+				items: [
+					{ id: "xshufflequeue_button", text: "Shuffle Queue" },
+					{ id: "xdeletequeue_button", text: "Clear Queue" },
+					{ id: "xshrinkposts_button", text: "Shrink Posts", count: "off" },
+					{ id: "xqueueoptions_button", text: "Queue Options", count: "on" }
+				]
+			});
+		}
 
 		$("#xshufflequeue_button").click(() => this.shuffle());
 		$("#xdeletequeue_button").click(() => this.clear());

--- a/Extensions/shuffle_queue.js
+++ b/Extensions/shuffle_queue.js
@@ -124,10 +124,18 @@ XKit.extensions.shuffle_queue = new Object({
 				.text("Shuffling...");
 
 			let postIDs = [];
-			$("#posts [data-pageable]").each(function() {
-				let [ /* "post" */, postID] = $(this).attr("data-pageable").split("_");
-				postIDs.push(postID);
-			});
+
+			if (XKit.page.react) {
+				$("[data-id]").each(function() {
+					let postID = $(this).attr("data-id");
+					postIDs.push(postID);
+				});
+			} else {
+				$("#posts [data-pageable]").each(function() {
+					let [ /* "post" */, postID] = $(this).attr("data-pageable").split("_");
+					postIDs.push(postID);
+				});
+			}
 
 			if (postIDs.length === 0) {
 				XKit.window.close();
@@ -152,9 +160,7 @@ XKit.extensions.shuffle_queue = new Object({
 					"post_ids": postIDs.join(",")
 				}),
 				onload: response => {
-					postIDs.reverse().forEach(postID => {
-						$("#new_post_buttons").after($(`[data-pageable="post_${postID}"]`));
-					});
+					this.update_shuffled_order(postIDs);
 					XKit.window.close();
 					XKit.notifications.add(`Shuffled ${postIDs.length} posts!`, "ok");
 				},
@@ -170,6 +176,18 @@ XKit.extensions.shuffle_queue = new Object({
 				}
 			});
 		});
+	},
+
+	update_shuffled_order: function(postIDs) {
+		if (XKit.page.react) {
+			postIDs.reverse().forEach(postID => {
+				$(".sortableContainer").prepend($(`[data-id="${postID}"]`));
+			});
+		} else {
+			postIDs.reverse().forEach(postID => {
+				$("#new_post_buttons").after($(`[data-pageable="post_${postID}"]`));
+			});
+		}
 	},
 
 	posts_to_delete: [],

--- a/Extensions/shuffle_queue.js
+++ b/Extensions/shuffle_queue.js
@@ -1,5 +1,5 @@
 //* TITLE Enhanced Queue **//
-//* VERSION 2.2.1 **//
+//* VERSION 2.2.2 **//
 //* DESCRIPTION Additions to the Queue page. **//
 //* DEVELOPER STUDIOXENIX **//
 //* DETAILS Go to your queue and click on the Shuffle button on the sidebar to shuffle the posts. Note that only the posts you see will be shuffled. If you have more than 15 posts on your queue, scroll down and load more posts in order to shuffle them too. Or click on Shrink Posts button to quickly rearrange them. **//

--- a/Extensions/shuffle_queue.js
+++ b/Extensions/shuffle_queue.js
@@ -11,6 +11,7 @@ XKit.extensions.shuffle_queue = new Object({
 	running: false,
 
 	queueoptions_selector: ".dashboard_options_form",
+	footer_selector: "",
 	shrinkPostsCss: "",
 
 	preferences: {
@@ -47,6 +48,7 @@ XKit.extensions.shuffle_queue = new Object({
 			});
 			await XKit.css_map.getCssMap();
 			this.queueoptions_selector = XKit.css_map.keyToCss('queueSettings');
+			this.footer_selector = XKit.css_map.keyToCss('footerWrapper');
 
 			if (this.preferences.shrink_height.value == "") {
 				this.preferences.shrink_height.value = "200px";
@@ -377,7 +379,7 @@ XKit.extensions.shuffle_queue = new Object({
 
 			$header.next().css("margin", 0);
 
-			$header.nextUntil("footer")
+			$header.nextUntil(XKit.extensions.shuffle_queue.footer_selector)
 			.wrapAll(
 				`<div class="queue_plus_shrink_container">
 					<div class="queue_plus_shrink_container_inner"></div>

--- a/Extensions/shuffle_queue.js
+++ b/Extensions/shuffle_queue.js
@@ -13,6 +13,19 @@ XKit.extensions.shuffle_queue = new Object({
 	queueoptions_selector: ".dashboard_options_form",
 	shrinkPostsCss: "",
 
+	preferences: {
+		"sep0": {
+			text: "Shrink Posts",
+			type: "separator"
+		},
+		"shrink_height": {
+			text: "Maximum height for shrunk posts",
+			type: "text",
+			default: "200px",
+			value: "200px"
+		},
+	},
+
 	run: async function() {
 
 		if (!XKit.interface.where().queue) {
@@ -35,6 +48,10 @@ XKit.extensions.shuffle_queue = new Object({
 			await XKit.css_map.getCssMap();
 			this.queueoptions_selector = XKit.css_map.keyToCss('queueSettings');
 
+			if (this.preferences.shrink_height.value == "") {
+				this.preferences.shrink_height.value = "200px";
+			}
+
 			this.shrinkPostsCss = `
 				.sortableContainer header {
 					padding-top: 10px;
@@ -44,7 +61,7 @@ XKit.extensions.shuffle_queue = new Object({
 				.sortableContainer a[title=${XKit.interface.where().user_url}] {
 					display: none; /* hide the header avatar */
 				}
-				footer[role=contentinfo] {
+				.sortableContainer footer {
 					margin-top: 5px;
     				padding-bottom: 5px;
 				}
@@ -52,11 +69,11 @@ XKit.extensions.shuffle_queue = new Object({
 					position: relative;
 				}
 				.queue_plus_shrink_container_inner {
-					max-height: 200px !important;
+					max-height: ${this.preferences.shrink_height.value} !important;
 					overflow-y: scroll;
 				}
 				.queue_plus_shrink_container_shadow {
-					box-shadow: inset 0 -20px 20px -26px black, inset 0 20px 20px -26px black;
+					box-shadow: inset 0 -18px 18px -24px black, inset 0 18px 18px -24px black;
 					position: absolute;
 					width: 100%;
 					height: 100%;

--- a/Extensions/shuffle_queue.js
+++ b/Extensions/shuffle_queue.js
@@ -375,16 +375,14 @@ XKit.extensions.shuffle_queue = new Object({
 			const $post = $(this).addClass('queue_plus_shrink-done').find("article").first();
 			const $header = $post.find("header").first();
 
-			const outerHtml = `<div class="queue_plus_shrink_container"><div class="queue_plus_shrink_container_shadow"></div></div>.`;
-			const innerHtml = `<div class="queue_plus_shrink_container_inner"></div>`;
+			$header.next().css("margin", 0);
 
-			const $shrinkContainer = $(outerHtml).insertAfter($header);
-			const $shrinkContainerInner = $(innerHtml).appendTo($shrinkContainer);
-
-			$shrinkContainer.next().css("margin", 0);
-
-			//move everything between the header and footer into the shrink container
-			$shrinkContainer.nextUntil("footer").appendTo($shrinkContainerInner);
+			$header.nextUntil("footer")
+			.wrapAll(
+				`<div class="queue_plus_shrink_container">
+					<div class="queue_plus_shrink_container_inner"></div>
+				</div>`)
+			.parent().before('<div class="queue_plus_shrink_container_shadow"></div>');
 		});
 	},
 


### PR DESCRIPTION
This updates Enhanced Queue / Queue+ / Shuffle Queue / whatever-you-call-it for the new dashboard. It requires #1957 and #1903.

- The shuffle queue button and show queue options toggle just needed fairly minor react-specific fixes.
- The clear queue button is rewritten to get posts using the Tumblr API instead of downloading and scraping queue pages(??) It really, really doesn't need to be recursive, but I started with the old code that was, and it works this way, sooo... 😬
- The shrink posts button is rewritten to stuff everything between the header and footer of a post into a `<div>` using jquery, since there's no `post_content` element containing everything we want to shrink anymore.
 


