### PR TITLE
[AccessKit] toggle to disable (some?) XKit animations

### DIFF
--- a/Extensions/accesskit.js
+++ b/Extensions/accesskit.js
@@ -1,5 +1,5 @@
 //* TITLE AccessKit **//
-//* VERSION 2.0.0 **//
+//* VERSION 2.0.1 **//
 //* DESCRIPTION Accessibility tools for Tumblr **//
 //* DETAILS Provides accessibility tools for XKit and your dashboard, such as increased font sizes, more contrast on icons and more. **//
 //* DEVELOPER new-xkit **//

--- a/Extensions/accesskit.js
+++ b/Extensions/accesskit.js
@@ -136,7 +136,7 @@ XKit.extensions.accesskit = new Object({
 
 		XKit.tools.init_css('accesskit');
 
-		$.fx.off = this.preferences.xkit_disable_animation.value ? true : false;
+		$.fx.off = this.preferences.xkit_disable_animation.value;
 
 		if (XKit.page.react) {
 			const {font, make_links_blue, no_npf_colors, increase_post_margins, xkit_contrast_icons} = this.preferences;

--- a/Extensions/accesskit.js
+++ b/Extensions/accesskit.js
@@ -84,6 +84,11 @@ XKit.extensions.accesskit = new Object({
 			default: false,
 			value: false
 		},
+		xkit_disable_animation: {
+			text: "Disable some XKit animations",
+			default: false,
+			value: false
+		},
 		"sep-1": {
 			text: "Color Adjustments",
 			type: "separator"
@@ -130,6 +135,8 @@ XKit.extensions.accesskit = new Object({
 		this.running = true;
 
 		XKit.tools.init_css('accesskit');
+
+		$.fx.off = this.preferences.xkit_disable_animation.value ? true : false;
 
 		if (XKit.page.react) {
 			const {font, make_links_blue, no_npf_colors, increase_post_margins, xkit_contrast_icons} = this.preferences;


### PR DESCRIPTION
This adds an AccessKit toggle to disable the slide-up animation on the XKit preferences window, and anything else using jQuery's `.animate`. I'm sure that's not the only way to animate things, but it's something.

Resolves #1954