### PR TITLE
[Disable Gifs] Minor refinements

### DIFF
--- a/Extensions/disable_gifs.js
+++ b/Extensions/disable_gifs.js
@@ -341,6 +341,7 @@ XKit.extensions.disable_gifs = new Object({
 	},
 
 	destroy: function() {
+		XKit.post_listener.remove('disable_gifs', this.react_do);
 		$('.xkit-paused-gif, .xkit-gif-label').remove();
 		$('.xkit-disabled-gif').removeClass('xkit-disabled-gif');
 		XKit.tools.remove_css("disable_gifs");

--- a/Extensions/disable_gifs.js
+++ b/Extensions/disable_gifs.js
@@ -1,5 +1,5 @@
 //* TITLE Disable Gifs **//
-//* VERSION 1.0.0 **//
+//* VERSION 1.0.1 **//
 //* DESCRIPTION Stops GIFs on dashboard **//
 //* DETAILS This is a very early preview version of an extension that allows you to stop the GIFs from playing on your dashboard. If you still would like to view them, you can click on the Play button on the post. Please note that for now, this extension can't stop GIFs added to text posts. **//
 //* DEVELOPER new-xkit **//

--- a/Extensions/disable_gifs.js
+++ b/Extensions/disable_gifs.js
@@ -15,6 +15,11 @@ XKit.extensions.disable_gifs = new Object({
 	slow: true,
 
 	preferences: {
+		"hover": {
+			text: "Animate gifs when you mouse over them",
+			default: true,
+			value: true
+		},
 		"hide_completely": {
 			text: "Completely hide posts with GIFs.",
 			default: false,
@@ -32,10 +37,6 @@ XKit.extensions.disable_gifs = new Object({
 			await XKit.css_map.getCssMap();
 
 			XKit.tools.add_css(`
-				figure:hover .xkit-paused-gif,
-				figure:hover .xkit-gif-label {
-					display: none;
-				}
 				.xkit-gif-label {
 					color: white;
 					background-color: black;
@@ -51,7 +52,19 @@ XKit.extensions.disable_gifs = new Object({
 				${XKit.css_map.keyToCss("baseContainer")} {
 					z-index: 3;
 				}
+				.xkit--react .xkit-extension-setting[data-extension-id="disable_gifs"][data-setting-id="hide_completely"] {
+					display: none;
+				}
 			`, 'disable_gifs');
+
+			if (this.preferences.hover.value) {
+				XKit.tools.add_css(`
+					figure:hover .xkit-paused-gif,
+					figure:hover .xkit-gif-label {
+						display: none;
+					}
+				`, 'disable_gifs');
+			}
 
 			return;
 		}

--- a/Extensions/disable_gifs.js
+++ b/Extensions/disable_gifs.js
@@ -50,7 +50,7 @@ XKit.extensions.disable_gifs = new Object({
 					z-index: 2;
 				}
 				${XKit.css_map.keyToCss("baseContainer")} {
-					z-index: 80;
+					z-index: 99;
 				}
 				.xkit--react .xkit-extension-setting[data-extension-id="disable_gifs"][data-setting-id="hide_completely"] {
 					display: none;

--- a/Extensions/disable_gifs.js
+++ b/Extensions/disable_gifs.js
@@ -22,12 +22,14 @@ XKit.extensions.disable_gifs = new Object({
 		}
 	},
 
-	run: function() {
+	run: async function() {
 		this.running = true;
 
 		if (XKit.page.react) {
 			XKit.post_listener.add('disable_gifs', this.react_do);
 			this.react_do();
+
+			await XKit.css_map.getCssMap();
 
 			XKit.tools.add_css(`
 				figure:hover .xkit-paused-gif,
@@ -45,6 +47,9 @@ XKit.extensions.disable_gifs = new Object({
 					top: 5px;
 					left: 5px;
 					z-index: 2;
+				}
+				${XKit.css_map.keyToCss("baseContainer")} {
+					z-index: 3;
 				}
 			`, 'disable_gifs');
 

--- a/Extensions/disable_gifs.js
+++ b/Extensions/disable_gifs.js
@@ -50,7 +50,7 @@ XKit.extensions.disable_gifs = new Object({
 					z-index: 2;
 				}
 				${XKit.css_map.keyToCss("baseContainer")} {
-					z-index: 3;
+					z-index: 80;
 				}
 				.xkit--react .xkit-extension-setting[data-extension-id="disable_gifs"][data-setting-id="hide_completely"] {
 					display: none;

--- a/Extensions/disable_gifs.js
+++ b/Extensions/disable_gifs.js
@@ -1,7 +1,7 @@
 //* TITLE Disable Gifs **//
 //* VERSION 1.0.1 **//
 //* DESCRIPTION Stops GIFs on dashboard **//
-//* DETAILS This is a very early preview version of an extension that allows you to stop the GIFs from playing on your dashboard. If you still would like to view them, you can click on the Play button on the post. Please note that for now, this extension can't stop GIFs added to text posts. **//
+//* DETAILS This extension allows you to stop the GIFs from playing on your dashboard until you place your mouse on them. **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
 //* BETA false **//


### PR DESCRIPTION
This fixes the issue reported by Purple Hinagiku on the Discord where disabled gifs were overlaid on top of the notes window of a previous post. This is because they shared a z-index value of 1; this simply adjusts `baseContainer` to ~~3~~ 80, which... hopefully doesn't break anything. (The header's at 100, so at least thats not an issue.)

Also fixed a broken `destroy` and ~~added back~~ **removed** the "hide posts with gifs" function since I was here anyway.