### PR TITLE
Debounce post listener

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -220,15 +220,22 @@ XKit.extensions.xkit_patches = new Object({
 				});
 
 				if (new_posts) {
-					Object.values(XKit.post_listener.callbacks).forEach(list => list.forEach(callback => {
-						try {
-							callback();
-						} catch (e) {
-							console.error(e);
-						}
-					}));
+					XKit.post_listener.run_callbacks_debounced();
 				}
 			});
+
+			XKit.post_listener.run_callbacks = function() {
+				Object.values(XKit.post_listener.callbacks).forEach(list => list.forEach(callback => {
+					try {
+						callback();
+					} catch (e) {
+						console.error(e);
+					}
+				}));
+			};
+
+			XKit.post_listener.run_callbacks_debounced =
+				XKit.tools.debounce(XKit.post_listener.run_callbacks, 0);
 
 			/**
 			 * Show an XKit alert window

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -209,9 +209,8 @@ XKit.extensions.xkit_patches = new Object({
 			XKit.post_listener.debounce_timer = null;
 
 			XKit.post_listener.observer = new MutationObserver(mutations => {
-				const self = XKit.post_listener;
 				const criteria = XKit.page.react ? "[data-id]" : ".post_container, .post";
-				var new_posts = false;
+				let new_posts = false;
 				const observed = mutations.some(({addedNodes, target}) => {
 					for (let i = 0; i < addedNodes.length; i++) {
 						const $addedNode = $(addedNodes[i]);
@@ -225,6 +224,7 @@ XKit.extensions.xkit_patches = new Object({
 				});
 
 				if (observed) {
+					const self = XKit.post_listener;
 					clearTimeout(self.debounce_timer);
 					if (new_posts) {
 						self.run_callbacks();

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -227,17 +227,14 @@ XKit.extensions.xkit_patches = new Object({
 				if (observed) {
 					clearTimeout(self.debounce_timer);
 					if (new_posts) {
-						console.warn("post listener: new posts, running immediately");
 						self.run_callbacks();
 					} else {
-						console.log("post listener: delayed");
 						self.debounce_timer = setTimeout(self.run_callbacks, 60);
 					}
 				}
 			});
 
 			XKit.post_listener.run_callbacks = function() {
-				console.log("post listener: running");
 				Object.values(XKit.post_listener.callbacks).forEach(list => list.forEach(callback => {
 					try {
 						callback();

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.9 **//
+//* VERSION 7.4.10 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 


### PR DESCRIPTION
Debouncing the post listener's callbacks reduces XKit's CPU load contribution when getting new posts by, when I tested, about 60%. There doesn't have to be any actual delay set; all we need to do is fire the post listener once instead of many times after a bulk mutation (i.e. adding a button or timestamp to every post).

Using setTimeout(0) and requestAnimationFrame() gave identical results, so I used the interface function we already have.

I don't think this deserves to get merged by itself, but if people can test it that'd be great and maybe we can piggyback it on another xkit_patches change? Haven't seen any issues so far, but anything with timing is hard to be sure of.