### PR TITLE
Modularize "run on every post"

### DIFF
--- a/Extensions/postblock.js
+++ b/Extensions/postblock.js
@@ -1,5 +1,5 @@
 //* TITLE PostBlock **//
-//* VERSION 1.0.1 **//
+//* VERSION 1.0.2 **//
 //* DESCRIPTION Block the posts you don't like **//
 //* DETAILS This extension lets you blocks posts you don't like on your dashboard. When you block a post, it will be hidden completely, including reblogs of it.<br><br>Tip: hold down ALT to skip the blocking confirmation! **//
 //* DEVELOPER new-xkit **//

--- a/Extensions/postblock.js
+++ b/Extensions/postblock.js
@@ -22,8 +22,7 @@ XKit.extensions.postblock = new Object({
 		this.blacklisted = XKit.storage.get("postblock", "posts", "").split(",");
 
 		XKit.interface.react.create_control_button("xpostblockbutton", this.button_icon, "PostBlock", XKit.extensions.postblock.block).then(() => {
-			XKit.post_listener.add("postblock", XKit.extensions.postblock.process_posts);
-			XKit.extensions.postblock.process_posts();
+			XKit.interface.react.post_iterator.add("postblock", this.process_post);
 		});
 	},
 
@@ -82,21 +81,16 @@ XKit.extensions.postblock = new Object({
 		}
 	},
 
-	process_posts: async function() {
+	process_post: async function() {
 		let blacklist = XKit.extensions.postblock.blacklisted;
+		const $post = $(this);
+		const post = await XKit.interface.react.post($post);
 
-		XKit.interface.react.get_posts("xpostblock-done").then(($posts) => {
-			$posts.each(async function() {
-				const $post = $(this);
-				const post = await XKit.interface.react.post($post);
-
-				if (blacklist.includes(post.root_id)) {
-					XKit.extensions.postblock.remove(post.root_id);
-				} else {
-					await XKit.interface.react.add_control_button($post, "xpostblockbutton");
-				}
-			});
-		});
+		if (blacklist.includes(post.root_id)) {
+			$post.addClass("xpostblock-hidden");
+		} else {
+			await XKit.interface.react.add_control_button($post, "xpostblockbutton");
+		}
 	},
 
 	cpanel: function(m_div) {
@@ -127,7 +121,7 @@ XKit.extensions.postblock = new Object({
 
 	destroy: function() {
 		this.running = false;
-		XKit.post_listener.remove("postblock");
+		XKit.interface.react.post_iterator.remove("postblock");
 		XKit.tools.remove_css("postblock");
 		$(".xpostblock-done").removeClass("xpostblock-done");
 		$(".xpostblockbutton").remove();

--- a/Extensions/postblock.js
+++ b/Extensions/postblock.js
@@ -13,7 +13,7 @@ XKit.extensions.postblock = new Object({
 	slow: true,
 	blacklisted: [],
 	button_icon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAYAAAByUDbMAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6Q0U0NTdGNzMwMjA1MTFFM0IwRTREQUE2OUI0ODg5QzAiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6Q0U0NTdGNzQwMjA1MTFFM0IwRTREQUE2OUI0ODg5QzAiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDpDRTQ1N0Y3MTAyMDUxMUUzQjBFNERBQTY5QjQ4ODlDMCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDpDRTQ1N0Y3MjAyMDUxMUUzQjBFNERBQTY5QjQ4ODlDMCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PumfPHEAAACvSURBVHjaYmDAD44C8Q4GCoAlEFtA2f+hmGzwFYg/YTFsNRAvINUwZAPQ2f/waWQi0SJGahoGAw1AXECJNwkCFhLDEq+3Qd50B+IWIOZDU6hDpCXzkTkfobYuQPPafxxexiYON/AsUrRbkGkY3MBSJIEzZBiGAkSA+BsOxYQMQ8GgCHhDTjbBB1SA+DelLkM2cAI1DeMF4rvUMgwEdIH4ObUMAwEJaNn1lVTDAAIMAPLOnUicW2nyAAAAAElFTkSuQmCC",
-	processing: false,
+
 
 	run: function() {
 		this.running = true;
@@ -83,17 +83,10 @@ XKit.extensions.postblock = new Object({
 	},
 
 	process_posts: async function() {
-		if (XKit.extensions.postblock.processing === true) {
-			return;
-		}
-		XKit.extensions.postblock.processing = true;
-
 		let blacklist = XKit.extensions.postblock.blacklisted;
 
-		const $posts = await XKit.interface.react.get_posts("xpostblock-done");
-		$posts
-			.addClass("xpostblock-done")
-			.each(async function() {
+		XKit.interface.react.get_posts("xpostblock-done").then(($posts) => {
+			$posts.each(async function() {
 				const $post = $(this);
 				const post = await XKit.interface.react.post($post);
 
@@ -103,7 +96,7 @@ XKit.extensions.postblock = new Object({
 					await XKit.interface.react.add_control_button($post, "xpostblockbutton");
 				}
 			});
-		XKit.extensions.postblock.processing = false;
+		});
 	},
 
 	cpanel: function(m_div) {

--- a/Extensions/quick_tags.js
+++ b/Extensions/quick_tags.js
@@ -50,8 +50,6 @@ XKit.extensions.quick_tags = new Object({
 
 	tag_array: [],
 
-	processing: false,
-
 	cancel_menu_close: function() {
 		clearTimeout(XKit.extensions.quick_tags.menu_closer_int);
 		XKit.extensions.quick_tags.user_on_box = true;
@@ -400,24 +398,15 @@ XKit.extensions.quick_tags = new Object({
 	},
 
 	do_posts: async function() {
-		if (XKit.extensions.quick_tags.processing === true) {
-			return;
-		}
-
 		if (XKit.interface.where().inbox) {
 			return;
 		}
 
-		XKit.extensions.quick_tags.processing = true;
-		var $posts = await XKit.interface.react.get_posts("xkit-quick-tags-done", true);
-
-		$posts
-			.addClass("xkit-quick-tags-done")
-			.each(function() {
+		XKit.interface.react.get_posts("xkit-quick-tags-done", true).then(($posts) => {
+			$posts.each(async function() {
 				XKit.interface.react.add_control_button($(this), "xkit-quick-tags", "");
 			});
-
-		XKit.extensions.quick_tags.processing = false;
+		});
 	},
 
 	destroy: function() {

--- a/Extensions/quick_tags.js
+++ b/Extensions/quick_tags.js
@@ -84,9 +84,8 @@ XKit.extensions.quick_tags = new Object({
 
 		if (XKit.page.react) {
 			XKit.interface.react.create_control_button("xkit-quick-tags", this.button_icon, "Quick Tags!", "", this.button_ok_icon).then(() => {
-				XKit.post_listener.add("quick_tags", XKit.extensions.quick_tags.do_posts);
 
-				this.do_posts();
+				XKit.interface.react.post_iterator.add("quick_tags", this.add_tags_button, true);
 			});
 		}
 	},
@@ -397,16 +396,11 @@ XKit.extensions.quick_tags = new Object({
 
 	},
 
-	do_posts: async function() {
+	add_tags_button: async function() {
 		if (XKit.interface.where().inbox) {
 			return;
 		}
-
-		XKit.interface.react.get_posts("xkit-quick-tags-done", true).then(($posts) => {
-			$posts.each(async function() {
-				XKit.interface.react.add_control_button($(this), "xkit-quick-tags", "");
-			});
-		});
+		XKit.interface.react.add_control_button($(this), "xkit-quick-tags", "");
 	},
 
 	destroy: function() {
@@ -414,7 +408,7 @@ XKit.extensions.quick_tags = new Object({
 		this.running = false;
 
 		XKit.interface.post_window_listener.remove("quick_tags");
-		XKit.post_listener.remove("quick_tags");
+		XKit.interface.react.post_iterator.remove("quick_tags");
 
 		$(document).off("mouseover", "#xkit-quick-tags-window", XKit.extensions.quick_tags.cancel_menu_close);
 		$(document).off("mouseout", "#xkit-quick-tags-window", XKit.extensions.quick_tags.menu_close);

--- a/Extensions/quick_tags.js
+++ b/Extensions/quick_tags.js
@@ -1,5 +1,5 @@
 //* TITLE Quick Tags **//
-//* VERSION 0.6.8 **//
+//* VERSION 0.6.9 **//
 //* DESCRIPTION Quickly add tags to posts **//
 //* DETAILS Allows you to create tag bundles and add tags to posts without leaving the dashboard. **//
 //* DEVELOPER New-XKit **//

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1110,7 +1110,7 @@ XKit.extensions.xkit_patches = new Object({
 					 * @param {string} id - Unique id for this function; will be added to processed
 					 *     posts as an ."id"-done class
 					 * @param {post_iterator_func} func - The function to run.
-					 * @param {boolean} can_edit -
+					 * @param {boolean} can_edit - If true, only run on posts the user can edit.
 					 */
 					add: function(id, func, can_edit) {
 

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.11 **//
+//* VERSION 7.4.12 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -927,7 +927,7 @@ XKit.extensions.xkit_patches = new Object({
 						selector += `:not(.${without_tag})`;
 					}
 
-					var $posts = $(selector);
+					var $posts = $(selector).addClass(without_tag);
 
 					if (can_edit) {
 						const edit_label = await XKit.interface.translate("Edit");

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1102,6 +1102,43 @@ XKit.extensions.xkit_patches = new Object({
 						}
 					},
 				},
+
+				post_iterator: {
+
+					/**
+					 * Runs a function on every post exactly once.
+					 * @param {string} id - Unique id for this function; will be added to processed
+					 *     posts as an ."id"-done class
+					 * @param {post_iterator_func} func - The function to run.
+					 * @param {boolean} can_edit -
+					 */
+					add: function(id, func, can_edit) {
+
+						const do_posts = async function iterator() {
+							XKit.interface.react.get_posts(`${id}-done`, can_edit).then(($posts) => {
+								$posts.each(function() {
+									(func.bind(this))().catch((e) => {
+										console.error(`error in ${id}'s post iterator: ${e}`);
+									});
+								});
+							});
+						};
+
+						XKit.post_listener.add(id, do_posts);
+						do_posts();
+					},
+
+					/**
+					 * Callback to be run on every post. No parameters right now, but could have
+					 * post_props caching added in the future if desired.
+					 * @callback post_iterator_func
+					 */
+
+					remove: function(id) {
+						XKit.post_listener.remove(id);
+						$(`${id}-done`).removeClass(`${id}-done`);
+					}
+				}
 			};
 
 			XKit.interface.async_form_key = async function() {

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.9 **//
+//* VERSION 7.4.10 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.10 **//
+//* VERSION 7.4.11 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 


### PR DESCRIPTION
This is a proposal to create an interface function for running the same code on every post. Ideally, it should enable fixes for or optimizations to this behavior in the future without having to push updates to multiple extensions. For now, it changes the implementation as little as possible compared to the current code, _besides_:

This also moves the addition of the html class into interface.react.get_posts, which removes the need for processing status variables (pointed out by April). (They could be added back globally for a minor performance improvement on async callbacks by just updating this code, which is the whole point!) While developers should be aware of this change going forward, it doesn't break anything if you add a class twice.