### PR TITLE
[Blacklist] Fix soft refresh inconsistency and j/k

### DIFF
--- a/Extensions/blacklist.css
+++ b/Extensions/blacklist.css
@@ -116,12 +116,6 @@
 	right: 5px !important;
 }
 
-.xblacklist_hidden_post {
-	display: none !important;
-	height: 0px !important; width: 0px !important;
-	overflow: hidden !important;
-}
-
 .xkit-blacklist-add-margins-to-ul {
 	margin: 0; padding: 0px 20px;
 }

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -132,6 +132,7 @@ XKit.extensions.blacklist = new Object({
 		}
 
 		XKit.tools.init_css("blacklist");
+		XKit.interface.hide(".xblacklist_hidden_post", "blacklist");
 
 		var m_blacklist = XKit.storage.get("blacklist", "words", "").split(",");
 		var m_whitelist = XKit.storage.get("blacklist", "words_whitelisted", "").split(",");

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1,5 +1,5 @@
 //* TITLE Blacklist **//
-//* VERSION 3.1.3 **//
+//* VERSION 3.1.4 **//
 //* DESCRIPTION Clean your dash **//
 //* DETAILS This extension allows you to block posts based on the words you specify. If a post has the text you've written in the post itself or it's tags, it will be replaced by a warning, or won't be shown on your dashboard, depending on your settings. **//
 //* DEVELOPER new-xkit **//

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -210,7 +210,6 @@ XKit.extensions.blacklist = new Object({
 
 		}
 
-		//running on every react page until xkit handles tumblr's soft refresh
 		if (XKit.page.react || $(postSel).length > 0) {
 			XKit.post_listener.add("blacklist", XKit.extensions.blacklist.check);
 			XKit.extensions.blacklist.check();

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -209,7 +209,8 @@ XKit.extensions.blacklist = new Object({
 
 		}
 
-		if ($(postSel).length > 0) {
+		//running on every react page until xkit handles tumblr's soft refresh
+		if (XKit.page.react || $(postSel).length > 0) {
 			XKit.post_listener.add("blacklist", XKit.extensions.blacklist.check);
 			XKit.extensions.blacklist.check();
 


### PR DESCRIPTION
This fixes a bug where loading a react tumblr page without any posts on it, then navigating to another page via soft refresh would cause blacklist to break. Thanks to Panur on discord for helping identify the issue.

It also fixes j/k when using the completely hide posts option.