### PR TITLE
[Search Likes] Rewrite for React

### DIFF
--- a/Extensions/search_likes.css
+++ b/Extensions/search_likes.css
@@ -1,45 +1,49 @@
-#xkit-search-likes-box { display: none; padding-top: 6px; }
-
-#xkit-search-likes-button:after {
-
-	background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6MDRBQkU4RjMzNkU2MTFFM0E0MTFDNDE2OTFDMzA4QzciIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6MDRBQkU4RjQzNkU2MTFFM0E0MTFDNDE2OTFDMzA4QzciPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDowNEFCRThGMTM2RTYxMUUzQTQxMUM0MTY5MUMzMDhDNyIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDowNEFCRThGMjM2RTYxMUUzQTQxMUM0MTY5MUMzMDhDNyIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PuSNlSQAAAEbSURBVHjaYvz//z8DNQETDvEcIL4PxK+B+D0Q3wJiL2IMZERzoSYQX8Oj/hsQ8wDxf2IM1AbiK0hyZ4B4GRCzQF0sh6wPp5UgA6EYGQgjicOwFZL8OyzyYAxj5CMpFsGlGIhDkNS54DPwIVTRGTyGwfBzqNq52ORhscwFpZcSEZEXoDQPvmTDQjCwMQEzPgPfQulCIgxygtIf8MWyB1JgW+IJvxIkddL4IgU92QRjUVyMJP8Fl6XoOQWZ8xSIrwLxPyC2B2JONM+dBmIzfAkbhJmA+PV/3ABd7hwhF8KAOxAHATEfELMB8XMgboXSJ4DYHKdLiUjI2PAZNJdeR0/YpAITaOEBA/dwFV+kgttQ7EUtA4kusckGAAEGAGOJAD0xp7muAAAAAElFTkSuQmCC');
-	content: "A";
-	font-size: 0;
-	width: 24px;
-	background-repeat: no-repeat;
-	background-position: 3px 7px;
-	opacity: 0.42;
-
+#search-likes-box {
+	padding: 10px 10px 28px 10px;
 }
 
-#xkit-search-likes-input {
+#search-likes-input {
 	width: 100%;
 	border-radius: 3px;
 	border: 0px;
-	padding: 5px 10px 5px 30px;
-	margin-top: 0px;
-	margin-right: 5px;
-	margin-bottom: 0;
-	margin-left: 0px;
-	font-size: 15px;
+	padding: 10px 10px 10px 30px;
+	font-size: 1rem;
 	box-sizing: border-box;
-	-webkit-box-sizing: border-box;
-	-o-box-sizing: border-box;
-	-moz-box-sizing: border-box;
-	background: white 10px 50% no-repeat url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAANCAYAAABy6+R8AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QjMxRTZFMEZBODY4MTFFMkFDMDJFMzk3N0RDMDc2NDQiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QjMxRTZFMTBBODY4MTFFMkFDMDJFMzk3N0RDMDc2NDQiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDpCMzFFNkUwREE4NjgxMUUyQUMwMkUzOTc3REMwNzY0NCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDpCMzFFNkUwRUE4NjgxMUUyQUMwMkUzOTc3REMwNzY0NCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pnjwe50AAADhSURBVHjalJExEoIwEEVDvAAdpUeQhhk7OQKeAO2k4wh6AztK4w04AvYUUNp5BDwB/sz8MGsGh/HP/MmyyctulmAcR2VVVdUOSwnHcAg38LUoiofyFFgIQI7YqHkZgEeZWEVRZCvU8ACfcGCfJMmlbVtbKYO3iDvkng7SbMmqBHB3G2wr4+dZVtJ8g5KAB3bujIRC9ac0p+Sm9yXkNqzy8iE3tVqCiNdiz8yN/Ib4wFzHVb7DTjbFG/sJ4s25+LmKLRnmQglO0C/xXY0AY700KbaUErDVh8VK3mAGXPL+CDAAWp9eZGKACQQAAAAASUVORK5CYII=') !important;
+	color: var(--black);
+	background: var(--white) 10px 50% no-repeat url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAANCAYAAABy6+R8AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QjMxRTZFMEZBODY4MTFFMkFDMDJFMzk3N0RDMDc2NDQiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QjMxRTZFMTBBODY4MTFFMkFDMDJFMzk3N0RDMDc2NDQiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDpCMzFFNkUwREE4NjgxMUUyQUMwMkUzOTc3REMwNzY0NCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDpCMzFFNkUwRUE4NjgxMUUyQUMwMkUzOTc3REMwNzY0NCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pnjwe50AAADhSURBVHjalJExEoIwEEVDvAAdpUeQhhk7OQKeAO2k4wh6AztK4w04AvYUUNp5BDwB/sz8MGsGh/HP/MmyyctulmAcR2VVVdUOSwnHcAg38LUoiofyFFgIQI7YqHkZgEeZWEVRZCvU8ACfcGCfJMmlbVtbKYO3iDvkng7SbMmqBHB3G2wr4+dZVtJ8g5KAB3bujIRC9ac0p+Sm9yXkNqzy8iE3tVqCiNdiz8yN/Ib4wFzHVb7DTjbFG/sJ4s25+LmKLRnmQglO0C/xXY0AY700KbaUErDVh8VK3mAGXPL+CDAAWp9eZGKACQQAAAAASUVORK5CYII=') !important;
 }
 
-#xkit-search-likes-input::-webkit-input-placeholder { color: #999; }
-#xkit-search-likes-input:-moz-placeholder { color: #999; }
-#xkit-search-likes-input:placeholder { color: #999; }
+#search-likes-input::placeholder { color: var(--gray-40); }
 
-.xkit-search-likes-force-found, .xkit-search-likes-found { display: block !important; }
-
-#xkit-search-likes-status-bar {
+.search-likes-status-bar {
+	font-size: 1rem;
 	background: rgba(0,0,0,0.12);
 	border: 1px solid rgba(0,0,0,0.22);
-	color: rgba(255,255,255,0.53);
+    color: var(--transparent-white-65);
 	padding: 10px 14px;
 	border-radius: 6px;
-	margin-bottom: 15px;
+	line-height: 1.3;
+	text-align: center;
+}
+
+.search-likes-status-bar a {
+	cursor: pointer;
+    color: var(--transparent-white-65);
+}
+
+#search-likes-status-bar-bottom {
+	margin-top: -20px;
+}
+
+#search-likes-status-bar-top {
+	margin-bottom: 20px;
+}
+
+.xkit--react #search-likes-status-bar-bottom ~ div {
+	display: none;
+}
+
+#prevent-load {
+	height: 1600px;
+	border-top: 2px solid var(--transparent-white-13);
 }

--- a/Extensions/search_likes.css
+++ b/Extensions/search_likes.css
@@ -9,8 +9,8 @@
 	padding: 10px 10px 10px 30px;
 	font-size: 1rem;
 	box-sizing: border-box;
-	color: var(--black);
-	background: var(--white) 10px 50% no-repeat url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAANCAYAAABy6+R8AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QjMxRTZFMEZBODY4MTFFMkFDMDJFMzk3N0RDMDc2NDQiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QjMxRTZFMTBBODY4MTFFMkFDMDJFMzk3N0RDMDc2NDQiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDpCMzFFNkUwREE4NjgxMUUyQUMwMkUzOTc3REMwNzY0NCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDpCMzFFNkUwRUE4NjgxMUUyQUMwMkUzOTc3REMwNzY0NCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pnjwe50AAADhSURBVHjalJExEoIwEEVDvAAdpUeQhhk7OQKeAO2k4wh6AztK4w04AvYUUNp5BDwB/sz8MGsGh/HP/MmyyctulmAcR2VVVdUOSwnHcAg38LUoiofyFFgIQI7YqHkZgEeZWEVRZCvU8ACfcGCfJMmlbVtbKYO3iDvkng7SbMmqBHB3G2wr4+dZVtJ8g5KAB3bujIRC9ac0p+Sm9yXkNqzy8iE3tVqCiNdiz8yN/Ib4wFzHVb7DTjbFG/sJ4s25+LmKLRnmQglO0C/xXY0AY700KbaUErDVh8VK3mAGXPL+CDAAWp9eZGKACQQAAAAASUVORK5CYII=') !important;
+	color: rgba(var(--black));
+	background: rgba(var(--white)) 10px 50% no-repeat url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAANCAYAAABy6+R8AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QjMxRTZFMEZBODY4MTFFMkFDMDJFMzk3N0RDMDc2NDQiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QjMxRTZFMTBBODY4MTFFMkFDMDJFMzk3N0RDMDc2NDQiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDpCMzFFNkUwREE4NjgxMUUyQUMwMkUzOTc3REMwNzY0NCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDpCMzFFNkUwRUE4NjgxMUUyQUMwMkUzOTc3REMwNzY0NCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pnjwe50AAADhSURBVHjalJExEoIwEEVDvAAdpUeQhhk7OQKeAO2k4wh6AztK4w04AvYUUNp5BDwB/sz8MGsGh/HP/MmyyctulmAcR2VVVdUOSwnHcAg38LUoiofyFFgIQI7YqHkZgEeZWEVRZCvU8ACfcGCfJMmlbVtbKYO3iDvkng7SbMmqBHB3G2wr4+dZVtJ8g5KAB3bujIRC9ac0p+Sm9yXkNqzy8iE3tVqCiNdiz8yN/Ib4wFzHVb7DTjbFG/sJ4s25+LmKLRnmQglO0C/xXY0AY700KbaUErDVh8VK3mAGXPL+CDAAWp9eZGKACQQAAAAASUVORK5CYII=') !important;
 }
 
 #search-likes-input::placeholder { color: var(--gray-40); }
@@ -19,7 +19,7 @@
 	font-size: 1rem;
 	background: rgba(0,0,0,0.12);
 	border: 1px solid rgba(0,0,0,0.22);
-    color: var(--transparent-white-65);
+    color: rgba(var(--white-on-dark), 0.65);
 	padding: 10px 14px;
 	border-radius: 6px;
 	line-height: 1.3;
@@ -28,7 +28,7 @@
 
 .search-likes-status-bar a {
 	cursor: pointer;
-    color: var(--transparent-white-65);
+    color: rgba(var(--white-on-dark), 0.65);
 }
 
 #search-likes-status-bar-bottom {
@@ -45,5 +45,5 @@
 
 #prevent-load {
 	height: 1600px;
-	border-top: 2px solid var(--transparent-white-13);
+	border-top: 2px solid rgba(var(--white-on-dark), 0.13);
 }

--- a/Extensions/search_likes.js
+++ b/Extensions/search_likes.js
@@ -48,7 +48,8 @@ XKit.extensions.search_likes = new Object({
 		this.max_results = !isNaN(max_results) && max_results > 0 ? max_results : 200;
 
 		await XKit.css_map.getCssMap();
-		this.highlight_selector = 'p, ' +
+		this.highlight_selector =
+			XKit.css_map.keyToCss('textBlock') + ', ' +
 			XKit.css_map.keyToCss('tag') + ', ' +
 			XKit.css_map.keyToCss('attribution') + ', ' +
 			XKit.css_map.keyToCss('contentSource');
@@ -154,7 +155,6 @@ XKit.extensions.search_likes = new Object({
 			return;
 		}
 
-		//search_likes.update_status_bar(`Searching for <b>"${search_likes.term}"</b>`);
 		search_likes.wait_for_render().then(() => {
 			XKit.extensions.search_likes.filter_posts(search_likes.term);
 		});

--- a/Extensions/search_likes.js
+++ b/Extensions/search_likes.js
@@ -156,7 +156,7 @@ XKit.extensions.search_likes = new Object({
 
 		//search_likes.update_status_bar(`Searching for <b>"${search_likes.term}"</b>`);
 		search_likes.wait_for_render().then(() => {
-			XKit.extensions.search_likes.filter_posts();
+			XKit.extensions.search_likes.filter_posts(search_likes.term);
 		});
 	},
 

--- a/Extensions/search_likes.js
+++ b/Extensions/search_likes.js
@@ -71,7 +71,7 @@ XKit.extensions.search_likes = new Object({
 		$('#search-likes-input').keyup(new_search_debounced);
 	},
 
-	new_search_term: function() {
+	new_search_term: async function() {
 		const {search_likes} = XKit.extensions;
 		var term = $(this).val().toLowerCase().trim();
 		if (term.length < 2) {
@@ -79,7 +79,7 @@ XKit.extensions.search_likes = new Object({
 		}
 		if (search_likes.term != term) {
 			if (!search_likes.searching) {
-				search_likes.init_search();
+				await search_likes.init_search();
 			}
 			search_likes.term = term;
 			search_likes.results = 0;
@@ -316,7 +316,8 @@ XKit.extensions.search_likes = new Object({
 				<a class='destroy-button'>Exit search and show all posts</a>`;
 
 		} else if (endless_scrolling_disabled) {
-			`<br/>${results} results on this page.<br/>
+			status_html = status +
+				`<br/>${results} results on this page.<br/>
 				Enabling endless scrolling is recommended with the Search Likes extension.<br/>
 				<a class='destroy-button'>Exit search and show all posts</a>`;
 		} else {
@@ -326,7 +327,7 @@ XKit.extensions.search_likes = new Object({
 				<a class='destroy-button'>Exit search and show all posts</a>`;
 		}
 
-		if (results > 0) {
+		if (results > 0 || endless_scrolling_disabled) {
 			if ($('#search-likes-status-bar-top').length > 0) {
 				$('#search-likes-status-bar-top').html(status_html);
 			 } else {

--- a/Extensions/search_likes.js
+++ b/Extensions/search_likes.js
@@ -229,6 +229,24 @@ XKit.extensions.search_likes = new Object({
 
 		const process_content = function(input) {
 			for (let block of input) {
+				if (block.attribution) {
+					text.push(block.attribution.appName, block.attribution.displayText, block.attribution.url);
+				}
+				if (block.description) {
+					text.push(block.description);
+				}
+				if (block.displayUrl) {
+					text.push(block.displayUrl);
+				}
+				if (block.title) {
+					text.push(block.title);
+				}
+				if (block.artist) {
+					text.push(block.artist);
+				}
+				if (block.artist) {
+					text.push(block.album);
+				}
 				if (block.text) {
 					text.push(block.text);
 				}
@@ -243,9 +261,6 @@ XKit.extensions.search_likes = new Object({
 							}
 						}
 					}
-				}
-				if (block.embedUrl) {
-					text.push(block.embedUrl);
 				}
 			}
 		};

--- a/Extensions/search_likes.js
+++ b/Extensions/search_likes.js
@@ -111,12 +111,8 @@ XKit.extensions.search_likes = new Object({
 				#search-likes-timeline {
 					min-height: calc(100vh - ${$('#search-likes-timeline').offset().top - 10}px);
 				}
-				#search-likes-timeline article {
-					display: none;
-				}
-				#search-likes-timeline .search-likes-shown article {
-					display: block;
-			}`, 'search-likes-searching');
+			`, 'search-likes-searching');
+			XKit.interface.hide('[data-id]:not(.search-likes-shown)', 'search-likes-searching');
 		});
 	},
 

--- a/Extensions/search_likes.js
+++ b/Extensions/search_likes.js
@@ -210,7 +210,14 @@ XKit.extensions.search_likes = new Object({
 		search_likes.update_status_bar(`Searching for <b>"${term}"</b>`);
 	},
 
+	post_text_cache: {},
 	get_post_text: async function(post) {
+		const {post_text_cache} = XKit.extensions.search_likes;
+		const id = post.getAttribute('data-id');
+		if (Object.prototype.hasOwnProperty.call(post_text_cache, id)) {
+			return post_text_cache[id];
+		}
+
 		var text = [];
 		const {blogName, rebloggedFromName, rebloggedRootname, sourceTitle, askingName, content, trail, postAuthor, tags} =
 			await XKit.interface.react.post_props(post.getAttribute('data-id'));
@@ -285,7 +292,8 @@ XKit.extensions.search_likes = new Object({
 				text.push('#' + tag);
 			}
 		}
-		return text.join('\n');
+		post_text_cache[id] = text.join('\n');
+		return post_text_cache[id];
 	},
 
 	simple_get_post_text: function(post) {

--- a/Extensions/search_likes.js
+++ b/Extensions/search_likes.js
@@ -61,7 +61,7 @@ XKit.extensions.search_likes = new Object({
 		}
 		const search_box_html =
 			`<div id='search-likes-box'>
-				<input type='text' placeholder='Search Likes' id='search-likes-input'>
+				<input type='text' placeholder='Search Likes' autocomplete="off" id='search-likes-input'>
 			</div>`;
 		$('#xkit_react_sidebar').prepend(search_box_html);
 		$('#search-likes-input').keydown(event => event.stopPropagation());

--- a/Extensions/search_likes.js
+++ b/Extensions/search_likes.js
@@ -80,7 +80,6 @@ XKit.extensions.search_likes = new Object({
 			if (!search_likes.searching) {
 				search_likes.init_search();
 			}
-			console.log(`search term: ${term}`);
 			search_likes.term = term;
 			search_likes.results = 0;
 			const $allPosts = $('#search-likes-timeline [data-id]');
@@ -194,10 +193,7 @@ XKit.extensions.search_likes = new Object({
 				search_likes.update_status_bar(`Searching for <b>"${term}"</b>`);
 				break;
 			}
-			let text;
-
-			text = await search_likes.get_post_text(post);
-			console.log(text);
+			let text = await search_likes.get_post_text(post);
 
 			if (text.toLowerCase().indexOf(term) > -1) {
 				posts_to_show.push(post);

--- a/Extensions/search_likes.js
+++ b/Extensions/search_likes.js
@@ -141,6 +141,7 @@ XKit.extensions.search_likes = new Object({
 		if (!search_likes.searching) { return; }
 		if (!XKit.interface.where().likes) {
 			XKit.post_listener.remove('search_likes');
+			search_likes.destroy_search();
 			return;
 		}
 		const $allPosts = $('#search-likes-timeline [data-id]');


### PR DESCRIPTION
~~Totally functional draft of search likes. I will un-refactor this (is that a word?) to make an easier-to-review PR.~~ Actually, upon attempting to do that, never mind. Let's start over.

This rewrites Search Likes for the React likes page. Because it is no longer feasible to append posts to the page dynamically, this loads posts via endless scrolling and hides all but the desired results. Because this can quickly result in unreasonably large amounts of loaded content (and because I wanted to learn this kind of thing anyway), I made an effort to rewrite things taking performance and responsiveness into account, hence things like rendering posts to the dom in chunks. Yes, this makes the code huge. Sorry :P If this winds up being looked at before we move to XKit 8, let me know if you'd like a simple version. It would be fairly easy.

Requires #1957.

Not-fixed bug from previous version: search term highlighting breaks hyperlinks. If you have any ideas how to fix this without another 300 lines of code, please let me know.