### PR TITLE
[Blacklist] Fix mentions not being blacklisted + ZWSPs + "don't block me"

### DIFF
--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -463,7 +463,7 @@ XKit.extensions.blacklist = new Object({
 		$("#xkit-blacklist-add-word").click(function() {
 
 			var $m_to_add = $("#xkit-blacklist-word");
-			var m_to_add = $m_to_add.val();
+			var m_to_add = $m_to_add.val().replace(/\u200B/g, '');
 			function complain(problem) {
 				$m_to_add
 					.css("border-color", "red")
@@ -787,7 +787,7 @@ XKit.extensions.blacklist = new Object({
 	do_post: function(obj, post_content, tags) {
 
 		// if ($.trim(post_content) === "") { return ""; }
-		post_content = post_content.replace(/\n/g, ' ');
+		post_content = post_content.replace(/\n/g, ' ').replace(/\u200B/g, '');
 		var p_words = post_content.split(" ");
 
 		var new_array = [];

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1,5 +1,5 @@
 //* TITLE Blacklist **//
-//* VERSION 3.1.4 **//
+//* VERSION 3.1.5 **//
 //* DESCRIPTION Clean your dash **//
 //* DETAILS This extension allows you to block posts based on the words you specify. If a post has the text you've written in the post itself or it's tags, it will be replaced by a warning, or won't be shown on your dashboard, depending on your settings. **//
 //* DEVELOPER new-xkit **//
@@ -896,7 +896,7 @@ XKit.extensions.blacklist = new Object({
 									var mp_word = m_p_words[j].replace(/\./g, '');
 									mp_word = mp_word.replace(/,/g, '');
 									mp_word = mp_word.replace(/\u2026/g, '');
-									mp_word = mp_word.replace(/[.,-/#!$%^&*;:{}=\-_`~()]/g, "").replace(/\s{2,}/g, " ");
+									mp_word = mp_word.replace(/[.,-/#!$%^&*;:{}=\-_`~()@]/g, "").replace(/\s{2,}/g, " ");
 									//// console.log('%c  mp_word = ' + mp_word, 'background: #a5edae; color: black');
 									if (m_word === mp_word) {
 										if (tag_search_mode) {

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -116,6 +116,8 @@ XKit.extensions.blacklist = new Object({
 	blacklisted: [],
 	whitelisted: [],
 
+	edit_label: "",
+
 	run: async function() {
 		this.running = true;
 
@@ -124,6 +126,9 @@ XKit.extensions.blacklist = new Object({
 		}
 
 		await XKit.css_map.getCssMap();
+		if (XKit.page.react) {
+			this.edit_label = await XKit.interface.translate("Edit");
+		}
 
 		if ($("body").hasClass("dashboard_messages_inbox") === true || $("body").hasClass("dashboard_messages_submissions") === true) {
 			if (this.preferences.dont_on_inbox.value) {
@@ -560,6 +565,10 @@ XKit.extensions.blacklist = new Object({
 				// Add class to not do this twice.
 				$(this).addClass("xblacklist-done");
 
+				if (XKit.extensions.blacklist.preferences.dont_block_me.value && $(this).find(`[aria-label='${XKit.extensions.blacklist.edit_label}']`).length) {
+					return;
+				}
+
 				// Collect the tags
 				var tag_array = [];
 				const tagSel = XKit.css_map.keyToCss('tag') || '.post_tag';
@@ -665,7 +674,7 @@ XKit.extensions.blacklist = new Object({
 
 			} catch (e) {
 
-				// console.error("Can't parse post: " + e.message);
+				console.error("Blacklist can't parse post: " + e.message);
 				// $(this).css("background","red");
 
 			}


### PR DESCRIPTION
This PR fixes a bug where blacklist would miss posts `@mention`ing a user whose name is blacklisted. It is 277 times smaller than this description text (ignoring the version bump) and it took me 44 minutes to understand Blacklist's code enough to find where to make the change.

**Edit:** It also handles zero-width spaces that may be accidentally inserted into the blacklisted term or in the post text. This ruins my funny description, unfortunately.

**Edit 2:** Now it also fixes "don't block my own posts" on react. Dunno if this makes it less likely to get reviewed but ¯\\\_(ツ)\_/¯