### PR TITLE
[Anti-Capitalism] Hide... less ads?

### DIFF
--- a/Extensions/anti_capitalism.js
+++ b/Extensions/anti_capitalism.js
@@ -19,6 +19,11 @@ XKit.extensions.anti_capitalism = new Object({
 			default: true,
 			value: true
 		},
+		"sponsored_sidebar": {
+			text: "Move them to the sidebar instead",
+			default: false,
+			value: false
+		},
 		"sidebar_ad": {
 			text: "Hide the Sidebar Ads",
 			default: true,
@@ -70,7 +75,44 @@ XKit.extensions.anti_capitalism = new Object({
 				const selector = XKit.tools.cartesian_product([listTimelineObject, masonryTimelineObject])
 					.map(i => `.${i[0]}:not([data-id]):not(.${i[1]})`)
 					.join(", ");
-				XKit.interface.hide(selector, "anti_capitalism");
+
+				if (!this.preferences.sponsored_sidebar.value) {
+					XKit.interface.hide(selector, "anti_capitalism");
+				} else {
+					$(selector).addClass("anti-capitalism-hidden-first-page");
+					XKit.interface.hide(".anti-capitalism-hidden-first-page", "anti_capitalism");
+
+					XKit.tools.add_css(`
+						${selector} {
+							height: 0;
+							margin: 0;
+							width: 300px;
+						}
+					`, 'anti_capitalism');
+					for (const instreamAd of await XKit.css_map.keyToClasses("instreamAd")) {
+						XKit.tools.add_css(`
+							.${instreamAd} {
+								background-color: transparent;
+								height: 0;
+								position: relative;
+								left: 580px;
+							}
+							.${instreamAd} header {
+								display: none;
+							}
+						`, 'anti_capitalism');
+					}
+					for (const adTimelineObject of await XKit.css_map.keyToClasses("adTimelineObject")) {
+						XKit.tools.add_css(`
+							.${adTimelineObject}, .${adTimelineObject} iframe {
+								width: 300px !important;
+								max-height: 300px !important;
+								margin: 0;
+								overflow: hidden;
+							}
+						`, 'anti_capitalism');
+					}
+				}
 			}
 
 			if (this.preferences.sidebar_ad.value) {

--- a/Extensions/anti_capitalism.js
+++ b/Extensions/anti_capitalism.js
@@ -23,7 +23,8 @@ XKit.extensions.anti_capitalism = new Object({
 		"sponsored_sidebar": {
 			text: "Move them to the sidebar instead",
 			default: false,
-			value: false
+			value: false,
+			experimental: true
 		},
 		"sidebar_ad": {
 			text: "Hide the Sidebar Ads",
@@ -88,7 +89,7 @@ XKit.extensions.anti_capitalism = new Object({
 						.map(cls => `.${cls}:not(.anti-capitalism-done)`)
 						.join(', ');
 					XKit.interface.hide(".anti-capitalism-hidden", "anti_capitalism");
-					XKit.post_listener.add("mutualchecker", this.process_posts);
+					XKit.post_listener.add("anti_capitalism", this.process_posts);
 					this.process_posts();
 				} else {
 					$(no_id_selector).addClass("anti-capitalism-hidden-first-page");
@@ -188,7 +189,11 @@ XKit.extensions.anti_capitalism = new Object({
 		$('anti-capitalism-done').removeClass('anti-capitalism-done');
 		$('anti-capitalism-hidden').removeClass('anti-capitalism-hidden');
 		XKit.tools.remove_css("anti_capitalism");
-		XKit.post_listener.remove("mutualchecker", this.process_posts);
+		try {
+			XKit.post_listener.remove("anti_capitalism", this.process_posts);
+		} catch (e) {
+			//no listener to remove
+		}
 		clearInterval(this.interval_id);
 	}
 


### PR DESCRIPTION
This adds an option to anti-capitalism to move ads into the sidebar instead of hiding them completely, for people who want to support the site but don't like the dash getting interrupted.
![sidebar ad thingy](https://user-images.githubusercontent.com/8336245/93247415-20992b80-f743-11ea-9242-66f26ba95a25.png)
It's a huge pain to test since Tumblr just stops giving me ads sometimes, so I have no idea if its broken after I merged my other anti-cap PR into it 😬

If anyone wants to take this off my hands, for the love of god, please do.