### PR TITLE
[Timestamps] Clarify UI and convert "only relative" preference

### DIFF
--- a/Extensions/timestamps.css
+++ b/Extensions/timestamps.css
@@ -107,7 +107,7 @@
 	color: rgb(80,80,80);
 }
 
-.timestamps-cpanel-squished-preference {
+.xkit--react .timestamps-cpanel-squished-preference {
 	border: none;
 	margin: -15px 0;
 }

--- a/Extensions/timestamps.css
+++ b/Extensions/timestamps.css
@@ -99,3 +99,15 @@
     top: 0;
     margin: 0;
 }
+
+.timestamps-cpanel-notice {
+	padding: 15px;
+	font-size: 14px;
+	line-height: 1.3em;
+	color: rgb(80,80,80);
+}
+
+.timestamps-cpanel-squished-preference {
+	border: none;
+	margin: -15px 0;
+}

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -1,5 +1,5 @@
 //* TITLE Timestamps **//
-//* VERSION 2.11.4 **//
+//* VERSION 2.11.5 **//
 //* DESCRIPTION See when a post has been made. **//
 //* DETAILS This extension lets you see when a post was made, in full date or relative time (eg: 5 minutes ago). It also works on asks, and you can format your timestamps. **//
 //* DEVELOPER New-XKit **//
@@ -420,7 +420,7 @@ XKit.extensions.timestamps = new Object({
 			year: sameYear ? undefined : 'numeric',
 		  });
 		}
-	  },
+	},
 
 	format_date: function(timestamp) {
 		const absolute_type = this.preferences.format_type_absolute.value;

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -180,9 +180,23 @@ XKit.extensions.timestamps = new Object({
 				}
 
 				if (this.preferences.only_on_hover.value) {
-					XKit.tools.add_css(`.xtimestamp { display: none; } ${this.posts_class.split(", ").map(x => x + ":hover .xtimestamp").join(", ")} { display: inline-block; }`, "timestamps_on_hover");
+					XKit.tools.add_css(`
+						.xtimestamp {
+							display: none;
+						}
+						${this.posts_class.split(", ").map(x => x + ":hover .xtimestamp").join(", ")} {
+							display: block;
+						}
+						${this.posts_class.split(", ").map(x => x + ":hover .xtimestamp.xtimestamp-bottom").join(", ")} {
+							display: inline-block;
+						}
+					`, "timestamps_on_hover");
 				} else {
-					XKit.tools.add_css(".xtimestamp { display: inline-block; }", "timestamps_on_hover");
+					XKit.tools.add_css(`
+						.xtimestamp {
+							display: block;
+						}
+					`, "timestamps_on_hover");
 				}
 			});
 

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -409,16 +409,16 @@ XKit.extensions.timestamps = new Object({
 		const sameYear = date.getFullYear() === now.getFullYear();
 
 		if (sameDate) {
-		  return date.toLocaleTimeString(locale, {
-			hour: 'numeric',
-			minute: 'numeric',
-		  });
+			return date.toLocaleTimeString(locale, {
+				hour: 'numeric',
+				minute: 'numeric',
+			});
 		} else {
-		  return date.toLocaleDateString(locale, {
-			day: 'numeric',
-			month: 'short',
-			year: sameYear ? undefined : 'numeric',
-		  });
+			return date.toLocaleDateString(locale, {
+				day: 'numeric',
+				month: 'short',
+				year: sameYear ? undefined : 'numeric',
+			});
 		}
 	},
 


### PR DESCRIPTION
This adds explanatory text to the customizable-but-extremely-unclear changes in #1963 and correctly imports the "only relative" preference.

If it breaks the extension I will cry in real life.

Edit: It also fixes a vertical space after timestamps when they're in the top position that I apparently added because CSS makes no sense.