### PR TITLE
Autotagger: fix issue where source tag wasn't added

### DIFF
--- a/Extensions/auto_tagger.js
+++ b/Extensions/auto_tagger.js
@@ -301,8 +301,7 @@ XKit.extensions.auto_tagger = new Object({
 			var source;
 			if (obj.source_owner !== undefined) {
 				source = obj.source_owner;
-			}
-			else {
+			} else {
 				source = obj.owner;
 			}
 

--- a/Extensions/auto_tagger.js
+++ b/Extensions/auto_tagger.js
@@ -1,5 +1,5 @@
 //* TITLE Auto Tagger **//
-//* VERSION 0.7.4 **//
+//* VERSION 0.7.5 **//
 //* DESCRIPTION Tags posts automatically. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS This extension allows you to automatically add tags to posts based on state (reblogged, original, queued) or post type (audio, video, etc) and keeping original tags while reblogging a post. **//
@@ -297,16 +297,26 @@ XKit.extensions.auto_tagger = new Object({
 		}
 
 
-		if (XKit.extensions.auto_tagger.preferences.tag_source.value && obj.source_owner) {
-			var sourceTag;
-
-			if (XKit.extensions.auto_tagger.preferences.tag_person_replace_hyphens.value) {
-				sourceTag = XKit.extensions.auto_tagger.preferences.tag_source_prefix.value + obj.source_owner.replace(/-/g, ' ');
-			} else {
-				sourceTag = XKit.extensions.auto_tagger.preferences.tag_source_prefix.value + obj.source_owner;
+		if (XKit.extensions.auto_tagger.preferences.tag_source.value) {
+			var source;
+			if (obj.source_owner !== undefined) {
+				source = obj.source_owner;
+			}
+			else {
+				source = obj.owner;
 			}
 
-			to_return = this.mreturn_add(to_return, sourceTag);
+			if (source !== undefined && source !== "") {
+				var sourceTag;
+
+				if (XKit.extensions.auto_tagger.preferences.tag_person_replace_hyphens.value) {
+					sourceTag = XKit.extensions.auto_tagger.preferences.tag_source_prefix.value + source.replace(/-/g, ' ');
+				} else {
+					sourceTag = XKit.extensions.auto_tagger.preferences.tag_source_prefix.value + source;
+				}
+
+				to_return = this.mreturn_add(to_return, sourceTag);
+			}
 		}
 
 		if (XKit.extensions.auto_tagger.preferences.tag_date.value) {


### PR DESCRIPTION
obj.source_owner is only defined for reblogged posts, causing the source tag not to be added for original posts. For original posts, we can fall back to using the obj.owner in order to add the source tag.