### PR TITLE
package.json: remove unnecessary fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,6 @@
 {
-  "name": "XKit",
-  "version": "2.0.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.10.1",

--- a/package.json
+++ b/package.json
@@ -1,34 +1,10 @@
 {
-  "name": "XKit",
-  "description": "The extension framework for Tumblr.",
-  "version": "2.0.1",
-  "main": "xkit.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/new-xkit/XKit.git"
-  },
-  "author": {
-    "name": "STUDIOENIX",
-    "email": "xkit@studioxenix.com",
-    "url": "http://www.studioxenix.com/"
-  },
+  "repository": "github:new-xkit/XKit",
   "license": "GPL-3.0",
-  "bugs": {
-    "url": "https://github.com/new-xkit/XKit/issues"
-  },
-  "homepage": "https://new-xkit-extension.tumblr.com",
   "engines": {
     "node": ">= 8.11.2",
     "npm": ">= 5.6.0"
   },
-  "keywords": [
-    "framework",
-    "Tumblr",
-    "accessibility",
-    "extension",
-    "interface",
-    "tweaks"
-  ],
   "scripts": {
     "dev": "gulp server",
     "test": "gulp lint:scripts",


### PR DESCRIPTION
removes all fields from `package.json` that have no bearing on unpublished packages. `"repository"` and `"license"` are retained purely because npm warns about them being missing upon package install

why? because i like when things are tidy, and i have to admit the inclusion of these fields led me to believe that setting them were necessary, or at the very least best-practice, when they all either have no use at all or simply repeat information easily found elsewhere in this repository. (real answer: mainly to get rid of the nonsensical non-matching package version)

also how did i only just notice that "STUDIOXENIX" is misspelt here? that's hilarious