### PR TITLE
remove gulp-eslint

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,35 +11,46 @@ on:
 jobs:
   build:
     name: Autobuild extensions
-    if: github.repository == 'new-xkit/XKit'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Use Node.js 12
-        uses: actions/setup-node@v1
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.1.2
         with:
-          node-version: 12
+          node-version: 14
+
       - name: Configure git
         run: |
           git config --global user.name "github-actions"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Fetch and reset gh-pages
         run: |
           git remote set-branches --add origin gh-pages
           git fetch
           git checkout -f -t -b gh-pages origin/gh-pages
           git reset --hard master
+
       - name: Install dependencies
         run: npm ci
+
+      - name: Run tests
+        run: npm test
+
       - name: Install gulp-cli
         run: npm install gulp-cli
+
       - name: Build distribution
         run: gulp build
+
       - name: Commit changes
         run: |
           git add --force Extensions/
           git commit -m 'Rebuild Distribution'
+
       - name: Force-push to gh-pages
         run: git push -f

--- a/docs/contributing/Build-XKit.md
+++ b/docs/contributing/Build-XKit.md
@@ -26,7 +26,7 @@ Serving extensions and themes locally is useful for rapid development without re
 
 #### `npm test`
 
-Shortcut for [`gulp lint:scripts`](#gulp-lintscripts).
+Shortcut for `eslint .`.
 
 #### `npm run dev`
 
@@ -42,17 +42,7 @@ Uses `web-ext build` with the necessary file exclusions to build and pack the We
 
 The default task.
 
-See also: [`gulp lint`](#gulp-lint).
-
-#### `gulp lint`
-
-Top-level linting task.
-
-See also [`gulp lint:scripts`](#gulp-lintscripts).
-
-#### `gulp lint:scripts`
-
-Lints JavaScript files using ESLint, and reports the output.
+See also: [`gulp build`](#gulp-build).
 
 #### `gulp build`
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,12 +1,10 @@
 /* eslint-env node */
 'use strict';
 
-var cache = require('gulp-cached'),
-	connect = require('connect'),
+var connect = require('connect'),
 	connectLogger = require('morgan'),
 	connectStatic = require('serve-static'),
 	del = require('del'),
-	eslint = require('gulp-eslint'),
 	fs = require('fs'),
 	gulp = require('gulp'),
 	gutil = require('gulp-util'),
@@ -40,23 +38,7 @@ gulp.task('clean:themes', function(cb) {
 
 gulp.task('clean', gulp.series('clean:extensions', 'clean:themes'));
 
-gulp.task('lint:scripts', function() {
-	var src = [].concat(
-		paths.scripts.dev,
-		paths.scripts.core,
-		paths.scripts.extensions
-	);
-
-	return gulp.src(src)
-		.pipe(cache('lint:scripts'))
-		.pipe(eslint())
-		.pipe(eslint.format())
-		.pipe(eslint.failAfterError());
-});
-
-gulp.task('lint', gulp.series('lint:scripts'));
-
-gulp.task('build:extensions', gulp.series('lint:scripts', 'clean:extensions', function() {
+gulp.task('build:extensions', gulp.series('clean:extensions', function() {
 	var extensionBuilder = require('./dev/builders/extension');
 	return gulp.src(paths.scripts.extensions)
 		.pipe(extensionBuilder())
@@ -125,4 +107,4 @@ gulp.task('server', gulp.series('build', function(callback) {
 	});
 }));
 
-gulp.task('default', gulp.series('lint'));
+gulp.task('default', gulp.series('build'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1975,47 +1975,6 @@
       "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
       "dev": true
     },
-    "bufferstreams": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-1.1.3.tgz",
-      "integrity": "sha512-HaJnVuslRF4g2kSDeyl++AaVizoitCpL9PglzCYwy0uHHyvWerfvEb8jWmYbF1z4kiVFolGomnxSGl+GUQp2jg==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
     "bunyan": {
       "version": "1.8.12",
       "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
@@ -4678,27 +4637,6 @@
         }
       }
     },
-    "gulp-cached": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/gulp-cached/-/gulp-cached-1.1.1.tgz",
-      "integrity": "sha1-/nzU+H83YB5gc8/t7lwr2vi2rM4=",
-      "dev": true,
-      "requires": {
-        "lodash.defaults": "^4.2.0",
-        "through2": "^2.0.1"
-      }
-    },
-    "gulp-eslint": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/gulp-eslint/-/gulp-eslint-3.0.1.tgz",
-      "integrity": "sha1-BOV+PhjGl0JnwSz2hV3HF9SjE70=",
-      "dev": true,
-      "requires": {
-        "bufferstreams": "^1.1.1",
-        "eslint": "^3.0.0",
-        "gulp-util": "^3.0.6"
-      }
-    },
     "gulp-util": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
@@ -5840,12 +5778,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
       "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
-      "dev": true
-    },
-    "lodash.defaults": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
       "dev": true
     },
     "lodash.escape": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
     "del": "^1.2.1",
     "eslint": "^3.19.0",
     "gulp": "^4.0.2",
-    "gulp-cached": "^1.1.1",
-    "gulp-eslint": "^3.0.1",
     "gulp-util": "^3.0.8",
     "merge-stream": "^0.1.8",
     "morgan": "^1.10.0",


### PR DESCRIPTION
removes the `gulp-eslint` devDependency, removes the linting task in the gulpfile, and adds a step to the Rebuild Distribution workflow to run **`npm test`** before building extensions+themes. this allows us to focus on using (and upgrading) the real `eslint` without having to worry about the `gulp build` task.

other changes to the Rebuild Distribution workflow:
- upgrade to node 14 (latest LTS)
- allow forks to build their own distributions (may be a useful alternative to the local dev server)