### PR TITLE
README: update CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# XKit
-
-[![Build Status](https://travis-ci.org/new-xkit/XKit.svg?branch=master)](https://travis-ci.org/new-xkit/XKit)
+# XKit [![CI](https://github.com/new-xkit/XKit/workflows/CI/badge.svg)](https://github.com/new-xkit/XKit/actions?query=workflow%3ACI)
 
 XKit is a small extension framework that powers tweaks for Tumblr.
 


### PR DESCRIPTION
updates the build/CI badge in the README to use the GitHub Action badge now that we've ~~killed~~ *abandoned* travis