### PR TITLE
One-Click Postage: suggest clearing cookies on error

### DIFF
--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.4.18 **//
+//* VERSION 4.4.19 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -1441,8 +1441,7 @@ XKit.extensions.one_click_postage = new Object({
 					message += "However, Tumblr has indicated that something is wrong.";
 					break;
 				case 401:
-					message += "This usually means your browser is not sending Referer headers.<br>";
-					message += "Please contact support if you don't know what this means.";
+					message += 'This may mean that your login session is broken, or that your browser is not sending Referer headers.';
 					break;
 				case 403:
 					message += `This usually means you've been blocked by the owner of the post.`;
@@ -1464,7 +1463,7 @@ XKit.extensions.one_click_postage = new Object({
 					message += `<p>${data.error}</p>`;
 				}
 			} catch (e) {
-				message += "Tumblr returned a generic HTTP error page. Please refresh the page and try again.";
+				message += "Tumblr returned a generic HTTP error page. Please try clearing your Tumblr cookies, then try again.";
 			}
 		} else {
 			console.error(error);


### PR DESCRIPTION
updates the error window to reflect the possibility of the user's legacy login session being broken for HTTP 401 responses, and changes the non-JSON error message to instruct the user to clear their cookies, rather than simply refresh the page

https://discord.com/channels/104051306309644288/317335902810537985/753102482573361203
> yeah, the "Error loading forms" bug is when the bridge between the legacy authentication and new authentication fails for some reason. easiest way to fix it is to log out and back in. :sob: