### PR TITLE
[Tweaks] Remove Split Gear Tweak

### DIFF
--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -1,5 +1,5 @@
 //* TITLE Tweaks **//
-//* VERSION 6.0.11 **/
+//* VERSION 6.0.12 **/
 //* DESCRIPTION Various little tweaks for your dashboard. **//
 //* DEVELOPER new-xkit **//
 //* DETAILS These are small little tweaks that allows you customize your dashboard. If you have used XKit 6, you will notice that some of the extensions have been moved here as options you can toggle. Keep in mind that some of the tweaks (the ones marked with a '*') can slow down your computer. **//

--- a/Extensions/tweaks.js
+++ b/Extensions/tweaks.js
@@ -147,13 +147,6 @@ XKit.extensions.tweaks = new Object({
 			default: true,
 			value: true
 		},
-		"split_gear": {
-			text: "Move the edit/remove buttons out of the gear menu",
-			default: false,
-			value: false,
-			experimental: true,
-			desktop_only: true
-		},
 		"border_asks": {
 			text: "Show border around ask posts and answers",
 			default: false,
@@ -541,12 +534,6 @@ XKit.extensions.tweaks = new Object({
 
 			}
 
-		}
-
-		if (XKit.extensions.tweaks.preferences.split_gear.value) {
-			XKit.tools.add_css(".post_controls .post_control.queue::after { background: none !important; }", "tweaks_split_gear");
-			XKit.post_listener.add("tweaks", XKit.extensions.tweaks.split_gear);
-			XKit.extensions.tweaks.split_gear();
 		}
 
 		if (XKit.extensions.tweaks.preferences.border_asks.value) {
@@ -956,28 +943,6 @@ XKit.extensions.tweaks = new Object({
 	add_css: function(css, name) {
 
 		XKit.extensions.tweaks.css_to_add += " \n " + css;
-
-	},
-
-	split_gear: function() {
-		if (!XKit.browser().mobile) { // mobile stuff
-			$(".post_control.post_control_menu.creator").not(".xkit-tweaks-split-gear-done").each(function() {
-				var $gear = $(this).addClass("xkit-tweaks-split-gear-done");
-
-				// Remove captions
-				$gear.find(".post_control.edit").html("<span class=\"offscreen\">Edit</span>");
-				$gear.find(".post_control.queue").html("<span class=\"offscreen\">Queue</span>");
-				$gear.find(".post_control.delete").html("<span class=\"offscreen\">Delete</span>");
-
-				// Remove their menu-specific classes
-				$gear.find(".post_control.edit, .post_control.queue, .post_control.delete").removeClass("show_label");
-
-				$gear.find(".post_control.edit").appendTo($gear.parent());
-				$gear.find(".post_control.queue").addClass("icon_queue_small").appendTo($gear.parent());
-				$gear.find(".post_control.delete").appendTo($gear.parent());
-				$gear.css("display", "none");
-			});
-		}
 
 	},
 


### PR DESCRIPTION
The "Split Gear" tweak is now obsolete in the React site (#1794).

The edit and remove buttons are now not under a gear icon.