### PR TITLE
Update maximum TS blacklist version

### DIFF
--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1,5 +1,5 @@
 //* TITLE Blacklist **//
-//* VERSION 3.1.5 **//
+//* VERSION 3.1.6 **//
 //* DESCRIPTION Clean your dash **//
 //* DETAILS This extension allows you to block posts based on the words you specify. If a post has the text you've written in the post itself or it's tags, it will be replaced by a warning, or won't be shown on your dashboard, depending on your settings. **//
 //* DEVELOPER new-xkit **//

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -343,7 +343,7 @@ XKit.extensions.blacklist = new Object({
 			var to_check_blacklist = "listBlack";
 			var to_check_whitelist = "listWhite";
 
-			var supported_ver = "1.2.0";
+			var supported_ver = "1.7.0";
 
 			if (m_obj.creator === "XKIT") {
 

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -343,7 +343,7 @@ XKit.extensions.blacklist = new Object({
 			var to_check_blacklist = "listBlack";
 			var to_check_whitelist = "listWhite";
 
-			var supported_ver = "1.7.0";
+			var supported_ver = "1.8.0";
 
 			if (m_obj.creator === "XKIT") {
 


### PR DESCRIPTION
Importing a current export (ver. 1.7.0) and changing the version in the JSON to 1.2.0 works just fine, so there's no reason to not crank up the supported version. (Also apparently people still use this, hooda thunk)