### PR TITLE
OCP: Fix reblogging from blog themes

### DIFF
--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.4.20 **//
+//* VERSION 4.4.21 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -223,7 +223,7 @@ XKit.extensions.one_click_postage = new Object({
 
 		var post_id = XKit.iframe.single_post_id();
 		var form_key = XKit.iframe.form_key();
-		var reblog_key = XKit.iframe.reblog_button()[0].pathname.split('/')[3];
+		var reblog_key = XKit.iframe.reblog_button()[0].pathname.split('/')[4];
 
 		var m_blogs = XKit.tools.get_blogs();
 		var blog_id = "";


### PR DESCRIPTION
One-Click Postage currently fails on blog themes and claims the post has been deleted, because the form of reblog URLs has changed to include the blogname of the post being reblogged, breaking the `reblog_key`-finding code. This PR is a one-digit change to account for this.

The change to reblog URLs seems to be universal - I can observe it on both my main Tumblr account and my alt, which respectively do and do not have access to the beta post editor.