### PR TITLE
Go-To-Dash: remove obsolete sidebar option, change button icon

### DIFF
--- a/Extensions/go_to_dash.css
+++ b/Extensions/go_to_dash.css
@@ -1,4 +1,13 @@
-#xkit_gotodash::before{
-    font-family: tumblr-icons, None;
-    content: "\EA20";
+#xkit_gotodash::before {
+	content: "\EA18";
+	font-family: tumblr-icons, Blank;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-smoothing: antialiased;
+	text-rendering: optimizeLegibility;
+	font-style: normal;
+	font-variant: normal;
+	font-weight: 400;
+	text-decoration: none;
+	text-transform: none;
 }

--- a/Extensions/go_to_dash.js
+++ b/Extensions/go_to_dash.js
@@ -2,7 +2,7 @@
 //* VERSION 1.3.5 **//
 //* DESCRIPTION View a post from a blog on your dashboard or sidebar. **//
 //* DEVELOPER STUDIOXENIX **//
-//* DETAILS This extension adds a 'view' button on peoples blogs that allows you to go back to that post on your dashboard. This feature only works on the blogs you follow. If the post was made before you followed them, you might not see them on your dashboard when you click the view button. **//
+//* DETAILS This extension adds a 'view' button on blogs that allows you to go back to that post on your dashboard. This feature only works on the blogs you follow, and may fail if the post dates to before you followed them. **//
 //* FRAME true **//
 //* BETA false **//
 

--- a/Extensions/go_to_dash.js
+++ b/Extensions/go_to_dash.js
@@ -1,22 +1,14 @@
 //* TITLE Go-To-Dash **//
-//* VERSION 1.3.4 **//
+//* VERSION 1.3.5 **//
 //* DESCRIPTION View a post from a blog on your dashboard or sidebar. **//
 //* DEVELOPER STUDIOXENIX **//
-//* DETAILS This extension adds a 'view' button on people's blogs that allows you to go back to that post on your dashboard or sidebar. Viewing on dashboard only works on the blogs you follow, and may fail if the post dates to before you followed them. **//
+//* DETAILS This extension adds a 'view' button on peoples blogs that allows you to go back to that post on your dashboard. This feature only works on the blogs you follow. If the post was made before you followed them, you might not see them on your dashboard when you click the view button. **//
 //* FRAME true **//
 //* BETA false **//
 
 XKit.extensions.go_to_dash = new Object({
 
 	running: false,
-
-	preferences: {
-		"use_sidebar": {
-			text: "View using sidebar instead of dashboard",
-			default: false,
-			value: false
-		}
-	},
 
 	run: function() {
 		"use strict";
@@ -26,9 +18,8 @@ XKit.extensions.go_to_dash = new Object({
 			return;
 		}
 
-		var use_sidebar = XKit.extensions.go_to_dash.preferences.use_sidebar.value;
-		// Not following the user and not using sidebar - won't work here
-		if (!use_sidebar && XKit.iframe.unfollow_button().hasClass("hidden")) {
+		// Not following the user
+		if (XKit.iframe.unfollow_button().hasClass("hidden")) {
 			return;
 		}
 
@@ -44,16 +35,8 @@ XKit.extensions.go_to_dash = new Object({
 
 		var html_pieces = ['<a href="https://www.tumblr.com/', '" class="tx-icon-button" target="_top" ' +
 			'id="xkit_gotodash" title="View on dashboard"><span class="button-label">View</span></a>'];
-		if (use_sidebar) {
-			var blog = XKit.iframe.get_tumblelog();
-			go_back_html = html_pieces.join('blog/view/' + blog + '/' + post_id);
-		} else {
-			var next_post_id = BigInt(post_id) + BigInt(1);
-			go_back_html = html_pieces.join('dashboard?max_post_id=' + next_post_id);
-		}
-		// Remove the text from the dashboard button because otherwise the iframe
-		// overflows
-		XKit.iframe.hide_button(XKit.iframe.dashboard_button());
+		var next_post_id = BigInt(post_id) + BigInt(1);
+		go_back_html = html_pieces.join('dashboard?max_post_id=' + next_post_id);
 
 		var is_following = XKit.iframe.unfollow_button().length;
 		var place = is_following ? XKit.iframe.dashboard_button() : XKit.iframe.delete_button();

--- a/Extensions/xkit_installer.js
+++ b/Extensions/xkit_installer.js
@@ -15,8 +15,7 @@ XKit.extensions.xkit_installer = new Object({
 		'one_click_postage',
 		'one_click_reply',
 		'tweaks',
-		'xcloud',
-		'go_to_dash'
+		'xcloud'
 	],
 
 	run: function() {


### PR DESCRIPTION
Yesterday, Tumblr introduced a native "Open in Dashboard" button to blog iframes, using the same eye icon which Go-To-Dash has been using, which takes you to the peepr for that entire blog (outside of post pages) or the specific post (from post pages).

This PR removes the open in sidebar option in Go-To-Dash, changes the button icon to a rewind symbol, and removes Go-To-Dash from XKit Installer's list of extensions to install upon setup.

![image](https://user-images.githubusercontent.com/28949509/109971166-d6563780-7ced-11eb-9e02-274b2ee6250e.png)
