### PR TITLE
AccessKit: Don't activate on blog themes

### DIFF
--- a/Extensions/accesskit.js
+++ b/Extensions/accesskit.js
@@ -1,5 +1,5 @@
 //* TITLE AccessKit **//
-//* VERSION 2.0.2 **//
+//* VERSION 2.0.3 **//
 //* DESCRIPTION Accessibility tools for Tumblr **//
 //* DETAILS Provides accessibility tools for XKit and your dashboard, such as increased font sizes, more contrast on icons and more. **//
 //* DEVELOPER new-xkit **//
@@ -133,6 +133,10 @@ XKit.extensions.accesskit = new Object({
 
 	run: function() {
 		this.running = true;
+
+		if (!XKit.interface.is_tumblr_page()) {
+			return;
+		}
 
 		XKit.tools.init_css('accesskit');
 


### PR DESCRIPTION
fixes an issue where `<span>` elements on blog themes could be affected by the `no_npf_colors` option