### PR TITLE
WebExt workflow: activate via manual dispatch

### DIFF
--- a/.github/workflows/web-ext.yml
+++ b/.github/workflows/web-ext.yml
@@ -1,11 +1,6 @@
 name: Web-Ext Tasks
 
-on:
-  push:
-    branches:
-      - master
-    paths:
-      - 'manifest.json'
+on: workflow_dispatch
 
 jobs:
   lint:


### PR DESCRIPTION
changes the webextension signing workflow to be triggered manually via the Actions tab rather than by any modification to `manifest.json`, allowing us to modify said file without the added commitment to an imminent release