### PR TITLE
Remove "New XKit" branding from codebase

### DIFF
--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.4.22 **//
+//* VERSION 4.4.23 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -1476,7 +1476,7 @@ XKit.extensions.one_click_postage = new Object({
 			"error",
 
 			'<div class="xkit-button default" id="xkit-close-message">OK</div>' +
-			'<a href="https://new-xkit-extension.tumblr.com/" target="_blank" class="xkit-button">Visit the New XKit Blog</a>' +
+			'<a href="https://new-xkit-extension.tumblr.com/" target="_blank" class="xkit-button">Visit the XKit 7 Blog</a>' +
 			'<a href="https://new-xkit-extension.tumblr.com/discord-support" target="_blank" class="xkit-button">Live support</a>'
 		);
 	}

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.14 **//
+//* VERSION 7.4.15 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -25,16 +25,16 @@ XKit.extensions.xkit_patches = new Object({
 						if (responseData.applications.gecko.id === "@new-xkit-w") {
 							XKit.window.show(
 								"W Edition warning",
-								"XKit Patches has determined that you are using <br><b>New XKit (W Edition)</b>, an unofficial upload of New XKit.<br><br>" +
+								"XKit Patches has determined that you are using <br><b>New XKit (W Edition)</b>, an unofficial upload of XKit 7.<br><br>" +
 								'Due to how XKit\'s extension gallery works, this upload violates <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/AMO/Policy/Reviews#Development_Practices" target="_blank">Mozilla\'s policy on remote code execution</a> ' +
 								"for listed add-ons, and is in danger of being banned at any time; potentially deleting your local XKit data.<br><br>" +
-								"We recommend installing the official distribution of New XKit from GitHub to avoid this possibility.<br><br>" +
+								"We recommend installing the official distribution of XKit 7 from GitHub to avoid this possibility.<br><br>" +
 								"Be sure to upload or export your configuration using XCloud before uninstalling W Edition. " +
 								"Also, since the two versions conflict, you should uninstall W Edition before re-installing from GitHub.",
 
 								"warning",
 
-								'<a href="https://github.com/new-xkit/XKit/releases/latest" target="_blank" class="xkit-button default">New XKit installation page &rarr;</a>' +
+								'<a href="https://github.com/new-xkit/XKit/releases/latest" target="_blank" class="xkit-button default">XKit 7 installation page &rarr;</a>' +
 								'<div id="xkit-close-message" class="xkit-button">Close</div>' +
 								`<div id="dismiss-warning" class="xkit-button float-right">Don't show this again</div>`
 							);

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 7.6.18 **//
+//* VERSION 7.6.19 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER new-xkit **//
 
@@ -146,10 +146,10 @@ XKit.extensions.xkit_preferences = new Object({
 						json: false,
 						onerror: function(response) {
 							XKit.window.show("Well, this is embarrassing.",
-								"Tumblr would not allow me to follow the New XKit blog for you.<br><br>" +
+								"Tumblr would not allow me to follow the XKit 7 blog for you.<br><br>" +
 								"You can follow it manually via the link below instead.",
 								"error",
-								'<a class="xkit-button default" href="https://new-xkit-extension.tumblr.com" target="_blank">New XKit Blog</a>' +
+								'<a class="xkit-button default" href="https://new-xkit-extension.tumblr.com" target="_blank">XKit 7 Blog</a>' +
 								'<div class="xkit-button" id="xkit-close-message">OK</div>'
 							);
 						},
@@ -213,7 +213,7 @@ XKit.extensions.xkit_preferences = new Object({
 
 		if (removed_list.length > 0) {
 
-			XKit.notifications.add("New XKit removed <b>" + removed_list.length + "</b> obsolete extension(s). Click here for more information.",
+			XKit.notifications.add("XKit 7 removed <b>" + removed_list.length + "</b> obsolete extension(s). Click here for more information.",
 				"warning", true, function() {
 					XKit.window.show(
 						"Spring Cleaning",
@@ -1396,7 +1396,7 @@ XKit.extensions.xkit_preferences = new Object({
 
 				XKit.window.show("Can't update",
 					"Update manager returned the following message:<p>" + mdata.error + "</p>" +
-					"Please try again later or if the problem continues, contact New XKit Support.", "error",
+					"Please try again later or if the problem continues, contact XKit 7 Support.", "error",
 					'<div id="xkit-close-message" class="xkit-button default">OK</div>' +
 					'<a href="http://new-xkit-support.tumblr.com/support" class="xkit-button">Support Chat Room</a>');
 				XKit.extensions.xkit_preferences.open_extension_control_panel(XKit.extensions.xkit_preferences.current_open_extension_panel);
@@ -2418,7 +2418,7 @@ XKit.extensions.xkit_preferences = new Object({
 					'without whom we all would have been lost to the outer darkness some time ago.</div>' +
 				'</div>' +
 				'<div id="xkit-about-window-links">' +
-					'<a href="https://new-xkit-extension.tumblr.com" target="_blank">New XKit Tumblr</a>' +
+					'<a href="https://new-xkit-extension.tumblr.com" target="_blank">XKit 7 Tumblr</a>' +
 					'<a href="#" id="xkit-open-credits">Credits</a>' +
 					'<a href="https://new-xkit-support.tumblr.com/support" target="_blank">Support</a>' +
 					'<a href="https://github.com/new-xkit/XKit/wiki" target="_blank">Documentation</a>' +

--- a/Extensions/xkit_updates.js
+++ b/Extensions/xkit_updates.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Updates **//
-//* VERSION 2.1.2 **//
+//* VERSION 2.1.3 **//
 //* DESCRIPTION Provides automatic updating of extensions **//
 //* DEVELOPER new-xkit **//
 XKit.extensions.xkit_updates = new Object({
@@ -128,14 +128,14 @@ XKit.extensions.xkit_updates = new Object({
 
 	show_update_failure: function() {
 
-		XKit.notifications.add("<b>Could not update New XKit:</b><br/>" +
-			"I could not reach the New XKit servers to update myself. " +
-			"You might be running an old and buggy version of New XKit. Click here for details.",
+		XKit.notifications.add("<b>Could not update extensions:</b><br/>" +
+			"I could not reach the XKit 7 servers to update myself. " +
+			"You might be running an old and buggy versions of extensions. Click here for details.",
 			"error", true, function() {
 
 				XKit.window.show("Auto-Update failed.",
 
-					"New XKit automatically updates itself from time to time in the background " +
+					"XKit 7 automatically updates its extensions in the background " +
 					"to bring you the latest features and bug fixes. Unfortunately, it was " +
 					"unable to contact the servers and download the latest updates. This " +
 					"might be a temporary server error or a problem with your connection." +
@@ -147,8 +147,8 @@ XKit.extensions.xkit_updates = new Object({
 					"error",
 
 					'<div class="xkit-button default" id="xkit-updates-troubleshooting">Troubleshooting &rarr;</div>' +
-					'<a href="https://new-xkit-extension.tumblr.com" class="xkit-button">New XKit Blog</a>' +
-					'<a href="https://new-xkit-support.tumblr.com" class="xkit-button">New XKit Support</a>' +
+					'<a href="https://new-xkit-extension.tumblr.com" class="xkit-button">XKit 7 Blog</a>' +
+					'<a href="https://new-xkit-support.tumblr.com" class="xkit-button">XKit 7 Support</a>' +
 					'<div class="xkit-button" id="xkit-close-message">OK</div>'
 				);
 
@@ -161,7 +161,7 @@ XKit.extensions.xkit_updates = new Object({
 						Use the <b>Connect</b> button to open a test page from our servers in a new tab,
 						then follow the appropriate advice:<br><br>
 
-						<b>If you can connect</b>, something local is impeding New XKit's connection to <code>new-xkit.github.io</code> -
+						<b>If you can connect</b>, something local is impeding XKit 7's connection to <code>new-xkit.github.io</code> -
 						this is usually another browser add-on blocking it. Be sure to whitelist the domain in any script blockers.<br><br>
 
 						<b>If you can't connect</b>, either GitHub is having issues or there's a problem with your network.
@@ -173,7 +173,7 @@ XKit.extensions.xkit_updates = new Object({
 
 						'<a href="https://new-xkit.github.io/XKit/Test" class="xkit-button default" target="_blank">Connect</a>' +
 						'<a href="https://www.githubstatus.com" class="xkit-button" target="_blank">GitHub Status</a>' +
-						'<a href="https://new-xkit-extension.tumblr.com" class="xkit-button" target="_blank">New XKit Blog</a>' +
+						'<a href="https://new-xkit-extension.tumblr.com" class="xkit-button" target="_blank">XKit 7 Blog</a>' +
 						'<div id="xkit-close-message" class="xkit-button">Close</div>'
 					);
 

--- a/bridge.js
+++ b/bridge.js
@@ -83,7 +83,7 @@ function init_bridge() {
 
 			if (last_error !== "") {
 
-				XKit.window.show("Corrupt storage", "XKit noticed that your browser's storage area allocated for XKit is corrupt and will now reset itself and clear the storage area so it can save it data and function properly.<br/><br/><b>Your browser returned the following error message:</b><br/>\"" + last_error + "\"<br/><br/>If you keep seeing this message, it means your browser's profile file is corrupt, please try uninstalling and reinstalling New XKit", "error",  "<div class=\"xkit-button default\" id=\"xkit-bridge-reset-and-continue\">OK</div>");
+				XKit.window.show("Corrupt storage", "XKit noticed that your browser's storage area allocated for XKit is corrupt and will now reset itself and clear the storage area so it can save it data and function properly.<br/><br/><b>Your browser returned the following error message:</b><br/>\"" + last_error + "\"<br/><br/>If you keep seeing this message, it means your browser's profile file is corrupt, please try uninstalling and reinstalling XKit 7", "error",  "<div class=\"xkit-button default\" id=\"xkit-bridge-reset-and-continue\">OK</div>");
 				$("#xkit-bridge-reset-and-continue").click(function() {
 					GM_flushStorage(function() {
 						init_bridge();
@@ -120,7 +120,7 @@ function init_bridge() {
 		});
 
 	} catch (e) {
-		XKit.window.show("Corrupt storage", "XKit noticed that your browser's storage area allocated for XKit is corrupt and will now reset itself and clear the storage area so it can save it data and function properly.<br/><br/><b>Your browser returned the following error message:</b><br/>\"" + last_error + "\"<br/><br/>If you keep seeing this message, it means your browser's profile file is corrupt, please try uninstalling and reinstalling New XKit", "error",  "<div class=\"xkit-button default\" id=\"xkit-bridge-reset-and-continue\">OK</div>");
+		XKit.window.show("Corrupt storage", "XKit noticed that your browser's storage area allocated for XKit is corrupt and will now reset itself and clear the storage area so it can save it data and function properly.<br/><br/><b>Your browser returned the following error message:</b><br/>\"" + last_error + "\"<br/><br/>If you keep seeing this message, it means your browser's profile file is corrupt, please try uninstalling and reinstalling XKit 7", "error",  "<div class=\"xkit-button default\" id=\"xkit-bridge-reset-and-continue\">OK</div>");
 
 		$("#xkit-bridge-reset-and-continue").click(function() {
 			GM_flushStorage(function() {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# New XKit Documentation
+# XKit 7 Documentation
 
 ## Get started
 
@@ -22,8 +22,8 @@
 
 ## Important Links
 
-* [New XKit Extension](https://new-xkit-extension.tumblr.com/) - Main blog
-* [New XKit Support](https://new-xkit-support.tumblr.com/) - Get support
-* [New XKit Live Support](https://new-xkit-support.tumblr.com/support) - Get live support for issues with New XKit
-* [New XKit Discussion](https://new-xkit-discussion.tumblr.com/) - Ask questions, suggest ideas, interact with the team
-* [New XKit Developer Chat](https://new-xkit-extension.tumblr.com/discord) - Want to help out with New XKit development?  Get involved here!
+* [XKit 7 Extension](https://new-xkit-extension.tumblr.com/) - Main blog
+* [XKit 7 Support](https://new-xkit-support.tumblr.com/) - Get support
+* [XKit 7 Live Support](https://new-xkit-support.tumblr.com/support) - Get live support for issues with XKit 7
+* [XKit 7 Discussion](https://new-xkit-discussion.tumblr.com/) - Ask questions, suggest ideas, interact with the team
+* [XKit 7 Developer Chat](https://new-xkit-extension.tumblr.com/discord) - Want to help out with XKit 7 development?  Get involved here!

--- a/docs/contributing/Fixing-a-Bug.md
+++ b/docs/contributing/Fixing-a-Bug.md
@@ -6,7 +6,7 @@ An extension broke and it's time to fix it. Here's how!
 2. Click on "Open Extension" and select the extension you want to change
 3. Click "Save Extension" after making changes
 4. Refresh any open Tumblr page to see if your changes worked
-5. Once your changes are complete, open up your fork of New XKit and find the extension's file in the Extensions directory.
+5. Once your changes are complete, open up your fork of XKit 7 and find the extension's file in the Extensions directory.
 6. Edit this file using GitHub's editor, duplicating whatever changes you made in XKit's editor.
 7. Commit the changes and submit a pull request. Our documentation on pull requests is [here](./Pull-Requests.md). For more general information, check out
 [GitHub's documentation](https://help.github.com/articles/using-pull-requests/).

--- a/manifest.json
+++ b/manifest.json
@@ -29,7 +29,7 @@
   },
   "manifest_version": 2,
   "minimum_chrome_version": "44.0",
-  "name": "New XKit",
+  "name": "XKit 7",
   "author": "New XKit Team",
   "permissions": ["storage", "unlimitedStorage", "*://*.tumblr.com/*", "https://new-xkit.github.io/XKit/*", "https://cloud.new-xkit.com/*" ],
   "version": "7.9.2",

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
     ],
     "matches": [ "*://*.tumblr.com/*" ]
   } ],
-  "description": "A fork of XKit, the extension framework for Tumblr.",
+  "description": "The extension framework for Tumblr",
   "homepage_url": "https://github.com/new-xkit/XKit",
   "icons": {
     "128": "icon.png"

--- a/xkit.js
+++ b/xkit.js
@@ -55,7 +55,7 @@ var xkit_global_start = Date.now();  // log start timestamp
 				var bridge_status = getBridgeError();
 				if (bridge_status.errors === true) {
 					// Bridge encountered an error!
-					XKit.window.show("XKit couldn't start.", "<b>Generated Error message:</b><br/><p>XKit Bridge Error<br/>" + bridge_status.error.message + "</p>Please reload the page to try again or get in contact with New XKit Support.", "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div><a href=\"https://new-xkit-support.tumblr.com\" class=\"xkit-button\">Support</a>");
+					XKit.window.show("XKit couldn't start.", "<b>Generated Error message:</b><br/><p>XKit Bridge Error<br/>" + bridge_status.error.message + "</p>Please reload the page to try again or get in contact with XKit 7 Support.", "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div><a href=\"https://new-xkit-support.tumblr.com\" class=\"xkit-button\">Support</a>");
 					return;
 				}
 
@@ -954,9 +954,9 @@ var xkit_global_start = Date.now();  // log start timestamp
 				}
 
 				if (m_obj.fatal === false) {
-					XKit.window.show("Potential Extension Conflicts Found", "<b>New XKit found the following potential conflicts:</b>" + m_obj.html + "It is highly recommended that you disable or remove the extensions/options listed below. You can click Ignore and Continue, which will prevent XKit from showing this window again, but no support will be provided to you if something goes wrong.", "warning", "<div class=\"xkit-button default\" id=\"xkit-disable-conflict-warning\">Ignore and Continue</div>");
+					XKit.window.show("Potential Extension Conflicts Found", "<b>XKit 7 found the following potential conflicts:</b>" + m_obj.html + "It is highly recommended that you disable or remove the extensions/options listed below. You can click Ignore and Continue, which will prevent XKit from showing this window again, but no support will be provided to you if something goes wrong.", "warning", "<div class=\"xkit-button default\" id=\"xkit-disable-conflict-warning\">Ignore and Continue</div>");
 				} else {
-					XKit.window.show("Fatal Extension Conflicts Found", "<b>New XKit found the following conflicts:</b>" + m_obj.html + "XKit can not continue loading before you disable other versions of XKit. Please check your browser's documentation on how to disable/remove extensions and remove other versions of XKit.", "warning");
+					XKit.window.show("Fatal Extension Conflicts Found", "<b>XKit 7 found the following conflicts:</b>" + m_obj.html + "XKit can not continue loading before you disable other versions of XKit. Please check your browser's documentation on how to disable/remove extensions and remove other versions of XKit.", "warning");
 				}
 
 				$("#xkit-disable-conflict-warning").click(function() {
@@ -3214,7 +3214,7 @@ var xkit_global_start = Date.now();  // log start timestamp
 							show_error_installation("[Code: 401] Storage error: " + data.error);
 						} else {
 							if (data.server_down === true) {
-								show_error_installation("[Code: 101] Can't reach New XKit servers");
+								show_error_installation("[Code: 101] Can't reach XKit servers");
 							} else {
 								show_error_installation("[Code: 100] Server returned error/empty script");
 							}
@@ -3537,7 +3537,7 @@ function install_extension(mdata, callback) {
 
 function xkit_install() {
 
-	XKit.window.show("Welcome to New XKit " + framework_version + "!", "<b>Please wait while I initialize the setup. This might take a while.<br/>Please do not navigate away from this page.</b>", "info");
+	XKit.window.show("Welcome to XKit " + framework_version + "!", "<b>Please wait while I initialize the setup. This might take a while.<br/>Please do not navigate away from this page.</b>", "info");
 	console.log("Trying to retrieve XKit Installer.");
 
 	XKit.install("xkit_installer", function(mdata) {
@@ -3546,7 +3546,7 @@ function xkit_install() {
 				show_error_installation("[Code: 401] Storage error: " + mdata.error);
 			} else {
 				if (mdata.server_down === true) {
-					show_error_installation("[Code: 101] Can't reach New XKit servers");
+					show_error_installation("[Code: 101] Can't reach XKit servers");
 				} else {
 					show_error_installation("[Code: 100] Server returned error/empty script");
 				}
@@ -3568,7 +3568,7 @@ function xkit_install() {
 
 function show_error_installation(message) {
 	// Shortcut to call when there is an installation error.
-	XKit.window.show("Can not install New XKit",
+	XKit.window.show("Can not install XKit 7",
 
 		"<b>Generated Error message:</b><br/>" +
 		"<p>" + message + "</p>" +
@@ -3589,7 +3589,7 @@ function show_error_installation(message) {
 			Use the <b>Connect</b> button to open a test page from our servers in a new tab,
 			then follow the appropriate advice:<br><br>
 
-			<b>If you can connect</b>, something local is impeding New XKit's connection to <code>new-xkit.github.io</code> -
+			<b>If you can connect</b>, something local is impeding XKit 7's connection to <code>new-xkit.github.io</code> -
 			this is usually another browser add-on blocking it. Be sure to whitelist the domain in any script blockers.<br><br>
 
 			<b>If you can't connect</b>, either GitHub is having issues or there's a problem with your network.
@@ -3601,7 +3601,7 @@ function show_error_installation(message) {
 
 			'<a href="https://new-xkit.github.io/XKit/Test" class="xkit-button default" target="_blank">Connect</a>' +
 			'<a href="https://www.githubstatus.com" class="xkit-button" target="_blank">GitHub Status</a>' +
-			'<a href="https://new-xkit-extension.tumblr.com" class="xkit-button" target="_blank">New XKit Blog</a>' +
+			'<a href="https://new-xkit-extension.tumblr.com" class="xkit-button" target="_blank">XKit 7 Blog</a>' +
 			'<div id="xkit-close-message" class="xkit-button">Close</div>'
 		);
 
@@ -3617,7 +3617,7 @@ function show_error_installation(message) {
 
 function show_error_script(message) {
 	// Shortcut to call when there is a javascript error.
-	XKit.window.show("XKit ran into a scripting error.", "<b>Generated Error message:</b><br/><p>" + message + "</p>Write down the error message above and contact New XKit Support to see how you can fix this or reload the page to try again.", "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div><a href=\"https://new-xkit-support.tumblr.com\" class=\"xkit-button\">New XKit Support</a>");
+	XKit.window.show("XKit ran into a scripting error.", "<b>Generated Error message:</b><br/><p>" + message + "</p>Write down the error message above and contact XKit 7 Support to see how you can fix this or reload the page to try again.", "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div><a href=\"https://new-xkit-support.tumblr.com\" class=\"xkit-button\">XKit 7 Support</a>");
 }
 
 function show_error_reset(message) {
@@ -3628,18 +3628,18 @@ function show_error_reset(message) {
 		"<b>Generated Error message:</b><br/><p>" + message + "</p>" +
 		"It is recommended that you update XKit.<br><br>" +
 		"If you've seen this message more than once, try restarting your browser. " +
-		"If you continue to see this message after completing the update process and restarting your browser, please contact us at New XKit Support.",
+		"If you continue to see this message after completing the update process and restarting your browser, please contact us at XKit 7 Support.",
 
 		"error",
 
 		'<div id="xkit-close-message" class="xkit-button">OK</div>' +
 		'<div id="xkit-force-update" class="xkit-button default">Update Extensions</div>' +
-		'<a href="https://new-xkit-support.tumblr.com" class="xkit-button">New XKit Support</a>'
+		'<a href="https://new-xkit-support.tumblr.com" class="xkit-button">XKit 7 Support</a>'
 	);
 	$("#xkit-force-update").click(XKit.special.force_update);
 }
 
 function show_error_update(message) {
 	// Shortcut to call when there is a javascript error.
-	XKit.window.show("XKit ran into an error.", "<b>Generated Error message:</b><br/><p>" + message + "</p>You might need to update XKit manually. Please visit the New XKit Blog. Alternatively, you can write down the error message above and contact New XKit Support to see how you can fix this or reload the page to try again.", "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div><a href=\"https://new-xkit-extension.tumblr.com\" class=\"xkit-button\">New XKit Blog</a><a href=\"https://new-xkit-support.tumblr.com\" class=\"xkit-button\">New XKit Support</a>");
+	XKit.window.show("XKit ran into an error.", "<b>Generated Error message:</b><br/><p>" + message + "</p>You might need to update XKit manually. Please visit the XKit 7 Blog. Alternatively, you can write down the error message above and contact XKit 7 Support to see how you can fix this or reload the page to try again.", "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div><a href=\"https://new-xkit-extension.tumblr.com\" class=\"xkit-button\">XKit 7 Blog</a><a href=\"https://new-xkit-support.tumblr.com\" class=\"xkit-button\">XKit 7 Support</a>");
 }


### PR DESCRIPTION
removes the phrase "New XKit" from the usable codebase, replacing it with "XKit 7". Our fork no longer needs to be distinguished from StudioXenix-published XKit (since it's now relatively ancient history), but does need to be distinguished from XKit 8/Rewritten (which the "New" part makes difficult/confusing).

- does not modify references to the "New XKit team"
- does not modify reference to "New XKit (W Edition)"
- does not remove the phrase in broken extensions
  - Enhanced Queue
  - Tag Replacer
  - Post Limit Checker
  - XStats

blocked by #2068 since `manifest.json` is modified without a version bump