### PR TITLE
Outbox: Add export buttons

### DIFF
--- a/Extensions/outbox.css
+++ b/Extensions/outbox.css
@@ -51,4 +51,5 @@
 	overflow-y: hidden;
 	font-size: 12px;
 	min-height: 300px;
+	user-select: text;
 }

--- a/Extensions/outbox.css
+++ b/Extensions/outbox.css
@@ -50,5 +50,5 @@
 	overflow-x: auto;
 	overflow-y: hidden;
 	font-size: 12px;
-	min-height: 250px;
+	min-height: 300px;
 }

--- a/Extensions/outbox.css
+++ b/Extensions/outbox.css
@@ -24,3 +24,31 @@
 	padding: 3px 8px;
 
 }
+
+#xkit-outbox-info {
+	padding: 15px;
+	font-size: 12px;
+	color: rgb(80,80,80);
+}
+
+#xkit-outbox-toolbar {
+	background: rgb(245,245,245);
+	padding: 3px 15px;
+	border-bottom: 1px solid rgb(190,190,190);
+}
+
+#xkit-outbox-cpanel-none-message {
+	padding: 15px;
+	color: rgb(150,150,150);
+	font-size: 14px;
+	line-height: 22px;
+	text-align: center;
+}
+
+#xkit-outbox-cpanel-pre {
+	padding: 18px 0 0 18px;
+	overflow-x: auto;
+	overflow-y: hidden;
+	font-size: 12px;
+	min-height: 250px;
+}

--- a/Extensions/outbox.css
+++ b/Extensions/outbox.css
@@ -43,4 +43,5 @@
 	overflow-y: hidden;
 	font-size: 12px;
 	user-select: text;
+	font-family: monospace;
 }

--- a/Extensions/outbox.css
+++ b/Extensions/outbox.css
@@ -37,19 +37,10 @@
 	border-bottom: 1px solid rgb(190,190,190);
 }
 
-#xkit-outbox-cpanel-none-message {
-	padding: 15px;
-	color: rgb(150,150,150);
-	font-size: 14px;
-	line-height: 22px;
-	text-align: center;
-}
-
 #xkit-outbox-cpanel-pre {
 	padding: 18px 0 0 18px;
 	overflow-x: auto;
 	overflow-y: hidden;
 	font-size: 12px;
-	min-height: 300px;
 	user-select: text;
 }

--- a/Extensions/outbox.js
+++ b/Extensions/outbox.js
@@ -102,10 +102,6 @@ XKit.extensions.outbox = new Object({
 			}
 		}
 
-		const preview_section = data ?
-			`<pre id="xkit-outbox-cpanel-pre"></pre>` :
-			`<div id="xkit-outbox-cpanel-none-message">You have no outbox data!</div>`;
-
 		const toolbar_html = `
 			<div id="xkit-outbox-custom-panel">
 				<div id="xkit-outbox-toolbar">
@@ -113,13 +109,14 @@ XKit.extensions.outbox = new Object({
 					<div id="outbox-download-json-button" class="xkit-button">Download json file</div>
 				</div>
 				<div id="preview-section">
-					${preview_section}
+					<pre id="xkit-outbox-cpanel-pre"></pre>
 				</div>
 			</div>`;
 		$(m_div).append(toolbar_html);
 
 		if (data) {
-			$("#xkit-outbox-cpanel-pre").text(data_text);
+			$("#xkit-outbox-cpanel-pre").text(data_text)
+				.css('min-height', '300px');
 
 			$("#outbox-download-json-button").mouseover(function() {
 				$("#xkit-outbox-cpanel-pre").text(data_JSON);
@@ -134,6 +131,8 @@ XKit.extensions.outbox = new Object({
 			$("#outbox-download-text-button").click(function() {
 				save_data(data_text, 'txt');
 			});
+		} else {
+			$("#xkit-outbox-cpanel-pre").text('You have no outbox data!');
 		}
 
 		$("#xkit-extensions-panel-right").nanoScroller();

--- a/Extensions/outbox.js
+++ b/Extensions/outbox.js
@@ -156,9 +156,7 @@ XKit.extensions.outbox = new Object({
 			tempLink.href = blobUrl;
 			tempLink.download = `XKit Outbox Data @ ${dateString}.${type}`;
 
-			document.documentElement.appendChild(tempLink);
 			tempLink.click();
-			tempLink.parentNode.removeChild(tempLink);
 			URL.revokeObjectURL(blobUrl);
 		};
 	},

--- a/Extensions/outbox.js
+++ b/Extensions/outbox.js
@@ -39,7 +39,7 @@ XKit.extensions.outbox = new Object({
 
 		$(m_div).append(`
 			<div id="xkit-outbox-info">
-				This extension no longer functions, but you can view and export your saved data here:
+				This extension no longer functions and has been replaced by a standalone extension, <a href="https://github.com/AprilSylph/Outbox-for-Tumblr#readme" target="_blank">Outbox for Tumblr</a>! You can view and export your saved data here:
 			</div>
 			`);
 

--- a/Extensions/outbox.js
+++ b/Extensions/outbox.js
@@ -39,7 +39,7 @@ XKit.extensions.outbox = new Object({
 
 		$(m_div).append(`
 			<div id="xkit-outbox-info">
-				This extension no longer functions and has been replaced by a standalone extension, <a href="https://github.com/AprilSylph/Outbox-for-Tumblr#readme" target="_blank">Outbox for Tumblr</a>! You can view and export your saved data here:
+				This feature no longer works and has been replaced by <a href="https://github.com/AprilSylph/Outbox-for-Tumblr#readme" target="_blank">Outbox for Tumblr</a>.<br><br>For personal archiving, you can view and export your historical XKit Outbox data here:
 			</div>
 			`);
 

--- a/Extensions/outbox.js
+++ b/Extensions/outbox.js
@@ -1,5 +1,5 @@
 //* TITLE Outbox **//
-//* VERSION 0.11.3 **//
+//* VERSION 0.11.4 **//
 //* DESCRIPTION Saves your sent replies and asks. **//
 //* DETAILS This extension stores and lets you view the last 50 asks you've answered privately. Please keep in mind that this is a highly experimental extension, so if you hit a bug, please send the XKit blog an ask with the problem you've found. **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/outbox.js
+++ b/Extensions/outbox.js
@@ -1,5 +1,5 @@
 //* TITLE Outbox **//
-//* VERSION 0.11.4 **//
+//* VERSION 0.11.3 **//
 //* DESCRIPTION Saves your sent replies and asks. **//
 //* DETAILS This extension stores and lets you view the last 50 asks you've answered privately. Please keep in mind that this is a highly experimental extension, so if you hit a bug, please send the XKit blog an ask with the problem you've found. **//
 //* DEVELOPER STUDIOXENIX **//


### PR DESCRIPTION
This adds export buttons to Outbox so people can get their data in plain text or JSON formats.

File export code based on [XKit Rewritten's backup function](https://github.com/AprilSylph/XKit-Rewritten/blob/f0a66086d640ac6910f5f7b268a20cf37cfec2b6/src/browser_action/render_backup.js#L29)!

"I hope Marcus isn't getting too cute with the UI for no good reason like always" - April, I can only assume

- [x] JSON button
- [x] plain text button
- [x] make code good