### PR TITLE
Fix async_form_key failure causing kitty error

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.14 **//
+//* VERSION 7.4.15 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -1182,7 +1182,7 @@ XKit.extensions.xkit_patches = new Object({
 			};
 
 			XKit.interface.async_form_key = async function() {
-				const request = await fetch('https://www.tumblr.com/settings/dashboard');
+				const request = await fetch('https://www.tumblr.com/about');
 				const meta_tag = (await request.text()).match(
 					/tumblr-form-key[^>]*content=("([^"]+)"|'([^']+)')/
 				);


### PR DESCRIPTION
I think it should be this simple.

This changes the legacy URL used to populate the form key from the settings page (which Staff has migrated to React) to the about page. This is the same URL used by XKit Rewritten to get the form key in `mega_editor.js`.

Seems to work in a fresh install in Firefox 95.0b12.

Resolves #2079.