### PR TITLE
fix React key finding

### DIFF
--- a/Extensions/notificationblock.js
+++ b/Extensions/notificationblock.js
@@ -1,5 +1,5 @@
 //* TITLE NotificationBlock **//
-//* VERSION 1.4.1 **//
+//* VERSION 1.4.2 **//
 //* DESCRIPTION Blocks notifications from a post **//
 //* DEVELOPER new-xkit **//
 //* DETAILS One post got way too popular and now just annoying you? Click on the notification block icon on that post to hide the notifications from that post. If you have Go-To-Dash installed, you can click on a notification, then click View button on top-right corner to quickly go back to the post on your dashboard.  **//
@@ -142,7 +142,7 @@ XKit.extensions.notificationblock = new Object({
 			);
 
 			elements.forEach(element => {
-				let fiber = element[keyStartsWith(element, '__reactInternalInstance')];
+				let fiber = element[keyStartsWith(element, '__reactFiber')];
 				const notificationProp = () => fiber.memoizedProps && fiber.memoizedProps.notification;
 
 				while (fiber && !notificationProp()) {

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.15 **//
+//* VERSION 7.4.16 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -889,7 +889,7 @@ XKit.extensions.xkit_patches = new Object({
 						const keyStartsWith = (obj, prefix) =>
 							Object.keys(obj).find(key => key.startsWith(prefix));
 						const element = document.querySelector(`[data-id="${post_id}"]`);
-						let fiber = element[keyStartsWith(element, '__reactInternalInstance')];
+						let fiber = element[keyStartsWith(element, '__reactFiber')];
 
 						while (fiber.memoizedProps.timelineObject === undefined) {
 							fiber = fiber.return;


### PR DESCRIPTION
Tumblr has upgraded to React 17 (AprilSylph/XKit-Rewritten#410), changing `__reactInternalInstance` to `__reactFiber`, breaking most features which work on Redpop.