### PR TITLE
Fix XKit button behavior in Redpop

### DIFF
--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 7.6.19 **//
+//* VERSION 7.6.18 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER new-xkit **//
 
@@ -18,8 +18,6 @@ XKit.extensions.xkit_preferences = new Object({
 	},
 
 	hide_xcloud_if_not_installed: false,
-
-	xkit_button_observer: null,
 
 	run: function() {
 
@@ -76,33 +74,11 @@ XKit.extensions.xkit_preferences = new Object({
 			XKit.tools.add_css(mobile_control_panel, 'mobile_xkit_menu');
 		}
 
-		const watch_button = async ($button) => {
-			const account_label = await XKit.interface.translate("Account");
-			const button = $button.get(0);
-
-			this.xkit_button_observer = new MutationObserver(mutations => {
-				if (button.isConnected) return;
-
-				const addedAccountButton = [...mutations]
-					.flatMap(({ addedNodes }) => [...addedNodes])
-					.filter(addedNode => addedNode instanceof Element)
-					.map(element => element.querySelector(`[aria-label="${account_label}"]`))
-					.find(Boolean);
-
-				if (addedAccountButton) {
-					addedAccountButton.closest('div').before(button);
-				}
-			});
-			this.xkit_button_observer.observe(document.getElementById('root'), { childList: true, subtree: true });
-		};
-
 		let button_ready = Promise.resolve();
 		if (XKit.page.react) {
 			button_ready = XKit.interface.translate("Account").then(account_label => {
-				const $button = $(m_html);
-				$button.insertBefore(`header div div:has([aria-label="${account_label}"])`);
-				$button.attr('tabindex', '0');
-				watch_button($button);
+				$(`header div div:has([aria-label="${account_label}"])`).before(m_html);
+				$(".xkit--react #xkit_button").attr('tabindex', '0');
 			});
 		} else {
 			$("#account_button").before(m_html);
@@ -2467,9 +2443,6 @@ XKit.extensions.xkit_preferences = new Object({
 	},
 
 	destroy: function() {
-		if (this.xkit_button_observer) {
-			this.xkit_button_observer.disconnect();
-		}
 		$("#xkit_button").remove();
 		XKit.tools.remove_css('mobile_xkit_menu');
 		this.running = false;

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -85,15 +85,13 @@ XKit.extensions.xkit_preferences = new Object({
 				const header = document.querySelector('#base-container > div > div > header');
 				if (header === null) return;
 
-				// desktop
-				const accountButton = header.querySelector(`[aria-label="${account_label}"]`);
+				const desktopAccountButton = header.querySelector(`[aria-label="${account_label}"]`);
 				if (accountButton) {
 					accountButton.closest('div').before(button);
 					return;
 				}
 
-				// mobile
-				const menuButton = header.querySelector(`[aria-label="${menu_label}"]`);
+				const mobileMenuButton = header.querySelector(`[aria-label="${menu_label}"]`);
 				if (menuButton) {
 					menuButton.parentNode.append(button);
 					return;

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 7.6.18 **//
+//* VERSION 7.6.19 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER new-xkit **//
 
@@ -18,6 +18,8 @@ XKit.extensions.xkit_preferences = new Object({
 	},
 
 	hide_xcloud_if_not_installed: false,
+
+	xkit_button_observer: null,
 
 	run: function() {
 
@@ -74,11 +76,33 @@ XKit.extensions.xkit_preferences = new Object({
 			XKit.tools.add_css(mobile_control_panel, 'mobile_xkit_menu');
 		}
 
+		const watch_button = async ($button) => {
+			const account_label = await XKit.interface.translate("Account");
+			const button = $button.get(0);
+
+			this.xkit_button_observer = new MutationObserver(mutations => {
+				if (button.isConnected) return;
+
+				const addedAccountButton = [...mutations]
+					.flatMap(({ addedNodes }) => [...addedNodes])
+					.filter(addedNode => addedNode instanceof Element)
+					.map(element => element.querySelector(`[aria-label="${account_label}"]`))
+					.find(Boolean);
+
+				if (addedAccountButton) {
+					addedAccountButton.closest('div').before(button);
+				}
+			});
+			this.xkit_button_observer.observe(document.getElementById('root'), { childList: true, subtree: true });
+		};
+
 		let button_ready = Promise.resolve();
 		if (XKit.page.react) {
 			button_ready = XKit.interface.translate("Account").then(account_label => {
-				$(`header div div:has([aria-label="${account_label}"])`).before(m_html);
-				$(".xkit--react #xkit_button").attr('tabindex', '0');
+				const $button = $(m_html);
+				$button.insertBefore(`header div div:has([aria-label="${account_label}"])`);
+				$button.attr('tabindex', '0');
+				watch_button($button);
 			});
 		} else {
 			$("#account_button").before(m_html);
@@ -2443,6 +2467,9 @@ XKit.extensions.xkit_preferences = new Object({
 	},
 
 	destroy: function() {
+		if (this.xkit_button_observer) {
+			this.xkit_button_observer.disconnect();
+		}
 		$("#xkit_button").remove();
 		XKit.tools.remove_css('mobile_xkit_menu');
 		this.running = false;

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -80,26 +80,26 @@ XKit.extensions.xkit_preferences = new Object({
 			const account_label = await XKit.interface.translate("Account");
 			const menu_label = await XKit.interface.translate("Menu");
 
-			const insert = () => {
+			const check_and_reinsert = () => {
 				if (button.isConnected) return;
-				const header = document.querySelector('#base-container > div > div > header');
+				const header = document.querySelector('header');
 				if (header === null) return;
 
 				const desktopAccountButton = header.querySelector(`[aria-label="${account_label}"]`);
-				if (accountButton) {
-					accountButton.closest('div').before(button);
+				if (desktopAccountButton) {
+					desktopAccountButton.closest('div').before(button);
 					return;
 				}
 
 				const mobileMenuButton = header.querySelector(`[aria-label="${menu_label}"]`);
-				if (menuButton) {
-					menuButton.parentNode.append(button);
+				if (mobileMenuButton) {
+					mobileMenuButton.parentNode.append(button);
 					return;
 				}
 			};
 
-			insert();
-			this.xkit_button_observer = new MutationObserver(insert);
+			check_and_reinsert();
+			this.xkit_button_observer = new MutationObserver(check_and_reinsert);
 			this.xkit_button_observer.observe(document.getElementById('root'), { childList: true, subtree: true });
 		};
 

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 7.6.18 **//
+//* VERSION 7.6.19 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER new-xkit **//
 
@@ -18,6 +18,8 @@ XKit.extensions.xkit_preferences = new Object({
 	},
 
 	hide_xcloud_if_not_installed: false,
+
+	xkit_button_observer: null,
 
 	run: function() {
 
@@ -74,20 +76,15 @@ XKit.extensions.xkit_preferences = new Object({
 			XKit.tools.add_css(mobile_control_panel, 'mobile_xkit_menu');
 		}
 
-		let button_ready = Promise.resolve();
-		if (XKit.page.react) {
-			button_ready = XKit.interface.translate("Account").then(account_label => {
-				$(`header div div:has([aria-label="${account_label}"])`).before(m_html);
-				$(".xkit--react #xkit_button").attr('tabindex', '0');
-			});
-		} else {
-			$("#account_button").before(m_html);
-			$("#account_button > button").attr("tabindex", "8");
-		}
+		const account_label = XKit.interface.translate("Account");
 
-		button_ready.then(() => {
-			if (XKit.storage.get("xkit_preferences", "shown_welcome_bubble") !== "true" && XKit.interface.where().dashboard) {
-				this.show_welcome_bubble();
+		const insert_button = async () => {
+			if (XKit.page.react) {
+				$(`header div div:has([aria-label="${await account_label}"])`).before(m_html);
+				$(".xkit--react #xkit_button").attr('tabindex', '0');
+			} else {
+				$("#account_button").before(m_html);
+				$("#account_button > button").attr("tabindex", "8");
 			}
 
 			$("#xkit_button").click(XKit.extensions.xkit_preferences.open);
@@ -96,6 +93,28 @@ XKit.extensions.xkit_preferences = new Object({
 			if (unread_mail_count > 0) {
 				$(".xkit_notice_container > .tab_notice_value").html(unread_mail_count);
 				$(".xkit_notice_container").addClass("tab-notice--active");
+			}
+		};
+
+		if (XKit.page.react) {
+			this.xkit_button_observer = new MutationObserver(async mutations => {
+				const account_label_selector = `[aria-label="${await account_label}"]`;
+
+				const addedAccountButton = [...mutations]
+					.flatMap(({ addedNodes }) => [...addedNodes])
+					.filter(addedNode => addedNode instanceof Element)
+					.some(element => element.querySelector(account_label_selector));
+
+				if (addedAccountButton && document.querySelector('#xkit_button') === null) {
+					insert_button();
+				}
+			});
+			this.xkit_button_observer.observe(document.getElementById('root'), { childList: true, subtree: true });
+		}
+
+		insert_button().then(() => {
+			if (XKit.storage.get("xkit_preferences", "shown_welcome_bubble") !== "true" && XKit.interface.where().dashboard) {
+				this.show_welcome_bubble();
 			}
 		});
 
@@ -2444,6 +2463,9 @@ XKit.extensions.xkit_preferences = new Object({
 
 	destroy: function() {
 		$("#xkit_button").remove();
+		if (this.xkit_button_observer) {
+			this.xkit_button_observer.disconnect();
+		}
 		XKit.tools.remove_css('mobile_xkit_menu');
 		this.running = false;
 	}


### PR DESCRIPTION
This uses a mutation observer to re-add the XKit button to the page whenever Tumblr's React code adds the account button that it's supposed to be next to. Mostly copy-pasted from XKit Rewritten.