### PR TITLE
Hotfix: Translation utility breaking button insertion

### DIFF
--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 7.6.19 **//
+//* VERSION 7.6.20 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER new-xkit **//
 
@@ -77,25 +77,43 @@ XKit.extensions.xkit_preferences = new Object({
 		}
 
 		const react_add_button = async (button) => {
-			const account_label = await XKit.interface.translate("Account");
-			const menu_label = await XKit.interface.translate("Menu");
+			// const account_label = await XKit.interface.translate("Account");
+			// const menu_label = await XKit.interface.translate("Menu");
+
+			await XKit.css_map.getCssMap();
+			const menuContainerSelector = XKit.css_map.keyToCss("menuContainer");
+			const hamburgerSelector = XKit.css_map.keyToCss("hamburger");
 
 			const check_and_reinsert = () => {
 				if (button.isConnected) return;
 				const header = document.querySelector('header');
 				if (header === null) return;
 
-				const desktopAccountButton = header.querySelector(`[aria-label="${account_label}"]`);
-				if (desktopAccountButton) {
-					desktopAccountButton.closest('div').before(button);
+				// const desktopAccountButton = header.querySelector(`[aria-label="${account_label}"]`);
+				// if (desktopAccountButton) {
+				// 	desktopAccountButton.closest('div').before(button);
+				// 	return;
+				// }
+
+				const menuContainers = header.querySelectorAll(menuContainerSelector);
+				if (menuContainers.length) {
+					const lastMenuContainer = menuContainers[menuContainers.length - 1];
+					lastMenuContainer.before(button);
 					return;
 				}
 
-				const mobileMenuButton = header.querySelector(`[aria-label="${menu_label}"]`);
-				if (mobileMenuButton) {
-					mobileMenuButton.parentNode.append(button);
+				// const mobileMenuButton = header.querySelector(`[aria-label="${menu_label}"]`);
+				// if (mobileMenuButton) {
+				// 	mobileMenuButton.parentNode.append(button);
+				// 	return;
+				// }
+
+				const hamburger = header.querySelector(hamburgerSelector);
+				if (hamburger) {
+					hamburger.parentNode.parentNode.append(button);
 					return;
 				}
+
 			};
 
 			check_and_reinsert();

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -95,7 +95,7 @@ XKit.extensions.xkit_preferences = new Object({
 
 				const mobileHamburgerMenu = header.querySelector(hamburger);
 				if (mobileHamburgerMenu) {
-					mobileHamburgerMenu.parentNode.parentNode.append(button);
+					mobileHamburgerMenu.closest(XKit.css_map.keyToCss("left")).append(button);
 					return;
 				}
 

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -77,40 +77,25 @@ XKit.extensions.xkit_preferences = new Object({
 		}
 
 		const react_add_button = async (button) => {
-			// const account_label = await XKit.interface.translate("Account");
-			// const menu_label = await XKit.interface.translate("Menu");
-
 			await XKit.css_map.getCssMap();
-			const menuContainerSelector = XKit.css_map.keyToCss("menuContainer");
-			const hamburgerSelector = XKit.css_map.keyToCss("hamburger");
+			const menuContainer = XKit.css_map.keyToCss("menuContainer");
+			const hamburger = XKit.css_map.keyToCss("hamburger");
 
 			const check_and_reinsert = () => {
 				if (button.isConnected) return;
 				const header = document.querySelector('header');
 				if (header === null) return;
 
-				// const desktopAccountButton = header.querySelector(`[aria-label="${account_label}"]`);
-				// if (desktopAccountButton) {
-				// 	desktopAccountButton.closest('div').before(button);
-				// 	return;
-				// }
-
-				const menuContainers = header.querySelectorAll(menuContainerSelector);
-				if (menuContainers.length) {
-					const lastMenuContainer = menuContainers[menuContainers.length - 1];
-					lastMenuContainer.before(button);
+				const desktopMenuItems = header.querySelectorAll(menuContainer);
+				if (desktopMenuItems.length) {
+					const desktopAccountMenu = desktopMenuItems[desktopMenuItems.length - 1];
+					desktopAccountMenu.before(button);
 					return;
 				}
 
-				// const mobileMenuButton = header.querySelector(`[aria-label="${menu_label}"]`);
-				// if (mobileMenuButton) {
-				// 	mobileMenuButton.parentNode.append(button);
-				// 	return;
-				// }
-
-				const hamburger = header.querySelector(hamburgerSelector);
-				if (hamburger) {
-					hamburger.parentNode.parentNode.append(button);
+				const mobileHamburgerMenu = header.querySelector(hamburger);
+				if (mobileHamburgerMenu) {
+					mobileHamburgerMenu.parentNode.parentNode.append(button);
 					return;
 				}
 


### PR DESCRIPTION
At the moment, `window.tumblr.languageData` appears to be down, always returning an empty translation object no matter what language you're in. This breaks a few things if you select a non-English language, of course, but the most notable one is the XKit button and the corresponding part of the XKit welcome sequence.

This replaces the `XKit.interface.translate`-based logic in the button insertion code with CSS map-based code, assuming that the last `menuContainer` in the header is the account button and finding the mobile menu button by searching for a `hamburger`. This should be enough to not break the extension completely for those who use other languages.