### PR TITLE
Unhide Retags from extension drawer.

### DIFF
--- a/Extensions/retags.css
+++ b/Extensions/retags.css
@@ -107,3 +107,9 @@ div.retags a:after {
     font-size: 0;
     line-height: 0;
 }
+
+#xkit-retags-info {
+	padding: 15px;
+	font-size: 12px;
+	color: rgb(80,80,80);
+}

--- a/Extensions/retags.js
+++ b/Extensions/retags.js
@@ -1,6 +1,6 @@
 //* TITLE       Retags **//
 //* DEVELOPER   new-xkit **//
-//* VERSION     1.2.8 **//
+//* VERSION     1.2.9 **//
 //* DESCRIPTION Adds tags to reblog notes **//
 //* FRAME       false **//
 //* SLOW        false **//
@@ -11,6 +11,22 @@ XKit.extensions.retags = {
 	api_key: XKit.api_key,
 	selectors: '.type_2,.type_8,.type_6,.reblog:not(.ui_avatar_link, .retags_has_processed),.is_reblog:not(.rollup),.is_reblog_naked,.notification_reblog,.is_reply,.is_answer,.is_user_mention,.notification_user_mention',
 	blog_name: "",
+
+	preferences: {
+		"note": {
+			text: "Note",
+			type: "separator"
+		},
+	},
+
+	cpanel: function(m_div) {
+
+		$(m_div).append(`
+			<div id="xkit-retags-info">
+				This feature no longer works and has been replaced by Tumblr's native reblogs view, but it still functions on many blog pages.
+			</div>
+			`);
+	},
 
 	run: function() {
 		this.running = true;

--- a/Extensions/xkit_preferences.css
+++ b/Extensions/xkit_preferences.css
@@ -1507,6 +1507,7 @@
 .xkit--react .xkit-extension[data-extension-id="post_limit_checker"],
 .xkit--react .xkit-extension[data-extension-id="profiler"],
 .xkit--react .xkit-extension[data-extension-id="better_reblogs"],
+.xkit--react .xkit-extension[data-extension-id="retags"],
 .xkit--react .xkit-extension[data-extension-id="satsukimous"],
 .xkit--react .xkit-extension[data-extension-id="scroll_to_bottom"],
 .xkit--react .xkit-extension[data-extension-id="search_likes"],
@@ -1532,7 +1533,6 @@
 .xkit--react .xkit-extension[data-extension-id="tagviewer"],
 .xkit--react .xkit-extension[data-extension-id="video_downloader"],
 .xkit--react .xkit-extension[data-extension-id="read_more_now"],
-.xkit--react .xkit-extension[data-extension-id="retags"],
 .xkit--react .xkit-extension[data-extension-id="transparent_img_hover"],
 .xkit--react .xkit-extension[data-extension-id="notifications_plus"] {
 	background-color: rgba(255, 73, 47, .2) !important;
@@ -1542,7 +1542,7 @@
 .xkit--react #xkit-gallery-extension-tagviewer,
 .xkit--react #xkit-gallery-extension-video_downloader,
 .xkit--react #xkit-gallery-extension-read_more_now,
-.xkit--react #xkit-gallery-extension-retags,
+/* .xkit--react #xkit-gallery-extension-retags, (retags is mostly broken but works on blog pages) */
 .xkit--react #xkit-gallery-extension-transparent_img_hover,
 .xkit--react #xkit-gallery-extension-notifications_plus,
 .xkit--react #xkit-gallery-extension-xinbox,

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 7.6.20 **//
+//* VERSION 7.6.21 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER new-xkit **//
 


### PR DESCRIPTION
As reported by Mindset on Discord, Retags is still somewhat useful on blog pages, so this unhides it from the extension drawer (keeping its broken coloration in the installed list) and adds a note to its settings panel. 