### PR TITLE
Remove commented CSS

### DIFF
--- a/Extensions/xkit_preferences.css
+++ b/Extensions/xkit_preferences.css
@@ -1542,7 +1542,6 @@
 .xkit--react #xkit-gallery-extension-tagviewer,
 .xkit--react #xkit-gallery-extension-video_downloader,
 .xkit--react #xkit-gallery-extension-read_more_now,
-/* .xkit--react #xkit-gallery-extension-retags, (retags is mostly broken but works on blog pages) */
 .xkit--react #xkit-gallery-extension-transparent_img_hover,
 .xkit--react #xkit-gallery-extension-notifications_plus,
 .xkit--react #xkit-gallery-extension-xinbox,


### PR DESCRIPTION
Y'all really don't like comments, huh!

As per discussion after the merge, this removes the commented CSS from https://github.com/new-xkit/XKit/pull/2088.