### PR TITLE
Editable Reblogs: Fix crash on post (hopefully)

### DIFF
--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -1,5 +1,5 @@
 //* TITLE Editable Reblogs **//
-//* VERSION 3.3.13 **//
+//* VERSION 3.3.14 **//
 //* DESCRIPTION Restores ability to edit previous reblogs of a post **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -203,9 +203,9 @@ XKit.extensions.editable_reblogs = new Object({
 	},
 
 	wrap_html_links: function(html_text) {
-		var nodes = $(html_text);
+		var nodes = $($.parseHTML(html_text));
 		nodes.find('a').wrap('<span></span>');
-		var nodes_text = $('<div>').append($(nodes).clone()).html();
+		var nodes_text = $('<div>').append(nodes.clone()).html();
 		return nodes_text;
 	},
 
@@ -477,7 +477,7 @@ XKit.extensions.editable_reblogs = new Object({
 
 		var text = XKit.interface.post_window.get_content_html();
 
-		var nodes = $('<div>').append($(text));
+		var nodes = $('<div>').append(text);
 		nodes.find('.tmblr-truncated').replaceWith('[[MORE]]');
 		XKit.extensions.editable_reblogs.format_video_media(nodes);
 

--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -203,7 +203,7 @@ XKit.extensions.editable_reblogs = new Object({
 	},
 
 	wrap_html_links: function(html_text) {
-		var nodes = $($.parseHTML(html_text));
+		var nodes = $($.parseHTML('hello' + html_text));
 		nodes.find('a').wrap('<span></span>');
 		var nodes_text = $('<div>').append(nodes.clone()).html();
 		return nodes_text;
@@ -477,7 +477,7 @@ XKit.extensions.editable_reblogs = new Object({
 
 		var text = XKit.interface.post_window.get_content_html();
 
-		var nodes = $('<div>').append(text);
+		var nodes = $('<div>').append('hello' + text);
 		nodes.find('.tmblr-truncated').replaceWith('[[MORE]]');
 		XKit.extensions.editable_reblogs.format_video_media(nodes);
 

--- a/Extensions/editable_reblogs.js
+++ b/Extensions/editable_reblogs.js
@@ -203,7 +203,7 @@ XKit.extensions.editable_reblogs = new Object({
 	},
 
 	wrap_html_links: function(html_text) {
-		var nodes = $($.parseHTML('hello' + html_text));
+		var nodes = $($.parseHTML(html_text));
 		nodes.find('a').wrap('<span></span>');
 		var nodes_text = $('<div>').append(nodes.clone()).html();
 		return nodes_text;
@@ -477,7 +477,7 @@ XKit.extensions.editable_reblogs = new Object({
 
 		var text = XKit.interface.post_window.get_content_html();
 
-		var nodes = $('<div>').append('hello' + text);
+		var nodes = $('<div>').append(text);
 		nodes.find('.tmblr-truncated').replaceWith('[[MORE]]');
 		XKit.extensions.editable_reblogs.format_video_media(nodes);
 


### PR DESCRIPTION
This potentially fixes the inconsistent crash in Editable Reblogs discussed in Discord here: https://discord.com/channels/104051306309644288/327155782934200320/959176488186425354

I was completely incapable of reproducing the problem exactly in the way that the user reported it, and `XKit.tools.github_issue` is broken in Firefox. The `error.stack` property only includes the actual error *message* in Chromium, so the Github reports only include a stack trace if the user is using Firefox.

However, I received a screenshot of the error via direct message, and it identifies that `XKit.interface.post_window.get_content_html` is returning a string that begins with a text node, i.e. 

```html
text
<blockquote>/* ... */</blockquote>
<p>/* ... */</p>
```

This is wrong in the sense that the DOM structure isn't supposed to be like that, but it's valid as the innerHTML of a div.

I investigated many possible ways this could happen and did not manage to find a way to reproduce it (I'll spare you the details for now - might be Tumblr, might be us). Anyway, the reason this is a crash is because JQuery's `$()` function is overloaded to accept both HTML text and CSS selectors, and if the "html" does not begin with a tag, it thinks it's a selector. 

Because the reason for the payload not beginning with a tag appears to be that the content of the first "paragraph" is a direct child of the `.editor.editor-richtext` div, rather than e.g. a missing wrapper tag, I fixed this by passing through the unmodified `get_content_html` contents. This seems to work fine, with some text artificially added to the beginning of the "html" string.

This also fixes the same crash if you use Editable Reblogs with the post form in HTML mode and begin your post with some plain text. Thus, even if `get_content_html`'s return value always started with `<`, this would still be more correct behavior.
