### PR TITLE
Fix duplicate control button race condition

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.16 **//
+//* VERSION 7.4.17 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -938,14 +938,12 @@ XKit.extensions.xkit_patches = new Object({
 						selector += `:not(.${without_tag})`;
 					}
 
-					var $posts = $(selector);
-
 					if (can_edit) {
 						const edit_label = await XKit.interface.translate("Edit");
-						$posts = $posts.filter((index, post) => $(post).find(`[aria-label='${edit_label}']`).length !== 0);
+						return $(selector).filter((index, post) => $(post).find(`[aria-label='${edit_label}']`).length !== 0);
 					}
 
-					return $posts;
+					return $(selector);
 				},
 
 				/**


### PR DESCRIPTION
As [reported on discord](https://discord.com/channels/104051306309644288/317335902810537985/965372101739560980),  post control buttons can be inserted multiple times.

This is caused by a race condition in `XKit.interface.react.get_posts` when called with `can_edit` (i.e. notificationblock and quick tags, though quick tags has a manual fix for this). Because there is an `await` statement between querying for posts that exclude the excluded class and the function returning, and because the excluded class will only be added once the function does return, calling `XKit.interface.react.get_posts` twice in the same microtask will result in both invocations selecting the same posts before the excluded class is added.

This runs the query selector at the end of `XKit.interface.react.get_posts`, ensuring that the selection, function return, and subsequent processing of returned content are synchronous. (XKit Rewritten automatically added exclude classes during its `get_posts` equivalent to avoid this potential race condition before it removed this functionality completely.)