### PR TITLE
Fix duplicate control buttons

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.17 **//
+//* VERSION 7.4.18 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -1057,7 +1057,7 @@ XKit.extensions.xkit_patches = new Object({
 					// we know that XKit.css_map.getCssMap() has been called because we have a template from create_control_button
 					// so we skip that call with this XKit.css_map.keyToCss() call.
 					var controlsSelector = XKit.css_map.keyToCss("controls");
-					var controls = $(obj).find(controlsSelector);
+					var controls = $(obj).find(controlsSelector).last();
 
 					if (controls.length > 0) {
 						controls.prepend(m_html);


### PR DESCRIPTION
This is the simplest possible fix for the [problem reported in Discord](https://discord.com/channels/104051306309644288/317335902810537985/968349318182498387) in which a preview version of the post footer has multiple copies of the control buttons, presumably due to the Tumble code using the `controls` CSS key for multiple elements in the UI: it only actions on the last `controls` element in the post.

This is untested on the new footer preview, but seems harmless and logical. Naturally we'll need some more CSS tweaks for things to look perfect.