### PR TITLE
Fix settings page exclusion disabling XKit on settings toggle

### DIFF
--- a/Extensions/xkit_main.js
+++ b/Extensions/xkit_main.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Main **//
-//* VERSION 2.1.1 **//
+//* VERSION 2.1.2 **//
 //* DESCRIPTION Boots XKit up **//
 //* DEVELOPER New-XKit **//
 (function() {
@@ -12,8 +12,21 @@
 
 		run: function() {
 
-			if (location.href.includes("://www.tumblr.com/login") || location.href.includes("://www.tumblr.com/settings")) {
-				console.log("Refusing to run XKit, login or settings page!");
+			const exclusions = [
+				/:\/\/www.tumblr.com\/$/,
+				new RegExp('tumblr.com/login'),
+				new RegExp('tumblr.com/register'),
+				new RegExp('tumblr.com/account'),
+				new RegExp('tumblr.com/auth'),
+				new RegExp('tumblr.com/policy'),
+				new RegExp('tumblr.com/privacy'),
+				new RegExp('help.tumblr.com'),
+				new RegExp('shop.tumblr.com'),
+				new RegExp('advertise.tumblr.com'),
+			];
+
+			if (exclusions.some(exclusion => exclusion.test(location.href))) {
+				console.log("Refusing to run XKit! Login, settings, or other excluded page!");
 				return;
 			}
 


### PR DESCRIPTION
Look, man, I don't know.

This removes the settings page from the list of pages that XKit attempts to exclude itself from running on, and adds some others where it actually might make sense.

This exclusion behavior only happens on initial page load or when you change a setting that Tumblr's React code refreshes the page to apply. Soft navigation within the group of Redpop pages doesn't trigger this test (and it's effectively impossible to have a soft refresh stop XKit scripts that are currently running, anyway, unless you force a hard refresh yourself), so the only effect of trying to exclude the settings page is buggy behavior where XKit suddenly vanishes, and users don't realize that a hard refresh on a non-settings page will bring it back.

No idea what the exclusion list should actually be, realistically. Should XKit run on https://www.tumblr.com/jobs? ¯\\\_(ツ)\_/¯ 