### PR TITLE
Update legacy url for async_form_key

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.18 **//
+//* VERSION 7.4.19 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1180,7 +1180,7 @@ XKit.extensions.xkit_patches = new Object({
 			};
 
 			XKit.interface.async_form_key = async function() {
-				const request = await fetch('https://www.tumblr.com/about');
+				const request = await fetch('https://www.tumblr.com/developers');
 				const meta_tag = (await request.text()).match(
 					/tumblr-form-key[^>]*content=("([^"]+)"|'([^']+)')/
 				);


### PR DESCRIPTION
As the about page has been transitioned from legacy to react, it can no longer be used to fetch the legacy form key. This uses https://www.tumblr.com/developers instead.