### PR TITLE
Anti-Capitalism Port working ad selection from XKit Rewritten

### DIFF
--- a/Extensions/anti_capitalism.js
+++ b/Extensions/anti_capitalism.js
@@ -1,5 +1,5 @@
 //* TITLE Anti-Capitalism **//
-//* VERSION 1.6.4 **//
+//* VERSION 1.6.5 **//
 //* DESCRIPTION Removes sponsored posts, vendor buttons, and other nonsense that wants your money. **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -63,24 +63,21 @@ XKit.extensions.anti_capitalism = new Object({
 			await XKit.css_map.getCssMap();
 
 			if (this.preferences.sponsored_posts.value) {
-				const listTimelineObject = XKit.css_map.keyToClasses("listTimelineObject");
-				const masonryTimelineObject = XKit.css_map.keyToClasses("masonryTimelineObject");
-
-				// pattern created:
-				// listTimelineObject:not([data-id]):not(masonryTimelineObject)
-				const no_id_selector = XKit.tools.cartesian_product([listTimelineObject, masonryTimelineObject])
-					.map(i => `.${i[0]}:not([data-id]):not(.${i[1]})`)
+				const adSelector = ["adTimelineObject", "instreamAd", "nativeIponWebAd", "takeoverBanner"]
+					.map(key => XKit.css_map.keyToCss(key))
+					.filter(Boolean)
 					.join(", ");
-				XKit.interface.hide(no_id_selector, "anti_capitalism");
+				XKit.tools.add_css(`${adSelector} { display: none !important; }`, "anti_capitalism");
 
-				var selectorArray = XKit.css_map.keyToClasses("sponsoredContainer");
-				selectorArray.push(XKit.css_map.keyToClasses("headerSponsored"));
-				selectorArray.push(XKit.css_map.keyToClasses("sponsoredIndicator"));
+				const videoCTASelector = ["videoCTA", "videoImageCTA"]
+					.map(key => XKit.css_map.keyToClasses(key))
+					.filter(Boolean)
+					.map(classes => classes.map(cls => `.${cls}:not(.anti-capitalism-done)`).join(", "))
+					.join(", ");
+				this.videoCTASelector = videoCTASelector;
+				this.listTimelineObjectInnerSelector = XKit.css_map.keyToCss("listTimelineObjectInner");
 
-				this.has_indicator_selector = selectorArray
-					.map(cls => `.${cls}:not(.anti-capitalism-done)`)
-					.join(', ');
-				XKit.interface.hide(".anti-capitalism-hidden", "anti_capitalism");
+				XKit.tools.add_css(`.anti-capitalism-hidden { display: none !important; }`, "anti_capitalism");
 				XKit.post_listener.add("anti_capitalism", this.process_posts);
 				this.process_posts();
 			}
@@ -134,10 +131,10 @@ XKit.extensions.anti_capitalism = new Object({
 	},
 
 	process_posts: async function() {
-		const {has_indicator_selector} = XKit.extensions.anti_capitalism;
-		const $containers = $(has_indicator_selector).addClass("anti-capitalism-done");
+		const {videoCTASelector, listTimelineObjectInnerSelector} = XKit.extensions.anti_capitalism;
+		const $containers = $(videoCTASelector).addClass("anti-capitalism-done");
 		for (let container of $containers.get()) {
-			$(container).closest('[data-id]').addClass('anti-capitalism-hidden');
+			$(container).closest(listTimelineObjectInnerSelector).addClass('anti-capitalism-hidden');
 		}
 	},
 


### PR DESCRIPTION
Instead of blindly hiding literally anything from the timeline that is not a post, this ports the selectors from XKit Rewritten's version of Anti-Capitalism. Hopefully this helps fix the "XKit hides important UI elements and makes Staff's a/b tests turn horrible" thing.

Also, fixes ```.map(cls => `.${cls}:not(.anti-capitalism-done)`)``` being called on a nested array, which was relying on type coercion and the inner arrays only having one item.

This will, be a functionality change, as the "you're caught up" indicator is now no longer hidden as an ad. This makes logical sense, as it... isn't an ad. So.

I didn't use `Array.prototype.flat`/`Array.prototype.flatMap` because I think it was introduced after the current minimum browser versions for this extension and it caused me physical pain.