### PR TITLE
Fix for OCP AlreadyReblogged icon color change

### DIFF
--- a/Extensions/one_click_postage.css
+++ b/Extensions/one_click_postage.css
@@ -396,8 +396,8 @@
 	display: none;
 }
 
-.xkit--react .reblogged svg[fill="rgba(var(--black), 0.65)"] {
-	fill: rgb(var(--green));
+.xkit--react .reblogged svg {
+	--icon-color-primary: rgb(var(--green)) !important;
 }
 
 /* in-frame styles */


### PR DESCRIPTION
Re issue #2098: https://github.com/new-xkit/XKit/issues/2098

A tumblr update changed the selector and property for the reblog icon; this fixes the css so that AlreadyReblogged turns green as expected.  Couldn't get the selector [style="--icon-color-primary:rgba(var(--black), 0.65)"] to work properly for some reason, but at least this works.