### PR TITLE
OCP: Fix popup losing focus in the blog view

### DIFF
--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -587,6 +587,9 @@ XKit.extensions.one_click_postage = new Object({
 
 		$("body").append(m_html);
 
+		// prevents Tumblr's trapFocusInsideGlass function from stealing focus in blog/view
+		$("#x1cpostage_box").attr('data-skip-glass-focus-trap', true);
+
 		$(document).on("mouseover", "#x1cpostage_queue", function() {
 			$("#x1cpostage_box").removeClass("xkit_x1cpostage_queue_press");
 			$("#x1cpostage_box").addClass("xkit_x1cpostage_queue_hover");


### PR DESCRIPTION
This fixes a bug where the one-click postage popup was not usable in the blog view: none of its text boxes can be focused and it vanishes if you attempt to select a blog.

This is because, unlike XKit Rewritten's version, the popup is always at the end of the DOM tree (for... some reason) rather than being within the post element, which causes some Tumblr code to (correctly, imo) conclude that it's a background element and should not be focused.

Rather than trying to modify and test any of this 9 year old codebase, I just found a flag in Tumblr's code that disables this functionality. Thanks, redpop devs. (I guess this is not super robust, but... whatever.)

For future reference/just for fun, this is the relevant obfuscated Tumblr code:
```js
o()(this, "trapFocusInsideGlass", (e=>{
  const {glassContainerRef: t} = this.props.glassContext;
  if ((null == t ? void 0 : t.lastElementChild) === this.glassEl) {
    var n;
    if (!(null !== (n = this.glassEl) && void 0 !== n && n.contains(e.target))) {
      let t = !1;
      e.target instanceof HTMLElement && (t = !!e.target.closest("[data-skip-glass-focus-trap]")),
      t || this.closeButtonEl.current.focus()
    }
  }
}))

document.addEventListener("focus", this.trapFocusInsideGlass, !0)
```

Pro tip: if you want to find what code is fired around a certain event, freeze the browser for 20ms whenever that event happens and look at a Chromium performance trace. Works every time, about half the time.

```js
const timer = performance.now();
while (performance.now() - timer < 20) {}
```