### PR TITLE
Fix React settings pages disabling XKit

### DIFF
--- a/Extensions/xkit_main.js
+++ b/Extensions/xkit_main.js
@@ -15,7 +15,7 @@
 			const react = Boolean($("link[href*='/pop/']").length);
 			const excludedPage = location.href.includes("://www.tumblr.com/login") || location.href.includes("://www.tumblr.com/settings");
 
-			if (excludedPage && react === false) {
+			if (excludedPage && !react) {
 				console.log("Refusing to run XKit, login or settings page!");
 				return;
 			}

--- a/Extensions/xkit_main.js
+++ b/Extensions/xkit_main.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Main **//
-//* VERSION 2.1.1 **//
+//* VERSION 2.1.2 **//
 //* DESCRIPTION Boots XKit up **//
 //* DEVELOPER New-XKit **//
 (function() {
@@ -12,7 +12,10 @@
 
 		run: function() {
 
-			if (location.href.includes("://www.tumblr.com/login") || location.href.includes("://www.tumblr.com/settings")) {
+			const react = Boolean($("link[href*='/pop/']").length);
+			const excludedPage = location.href.includes("://www.tumblr.com/login") || location.href.includes("://www.tumblr.com/settings");
+
+			if (excludedPage && react === false) {
 				console.log("Refusing to run XKit, login or settings page!");
 				return;
 			}
@@ -27,7 +30,7 @@
 			}
 
 			if (XKit.page.react === undefined) {
-				XKit.page.react = Boolean($("link[href*='/pop/']").length);
+				XKit.page.react = react;
 				if (XKit.page.react) {
 					$("body").addClass('xkit--react');
 					const waitUntilReactLoaded = setInterval(() => {

--- a/Extensions/xkit_main.js
+++ b/Extensions/xkit_main.js
@@ -10,12 +10,12 @@
 		enabled_extensions: ["xkit_main"],
 		disabled_extensions: [],
 
-		run: function() {
+		run: async function() {
 
-			const react = Boolean($("link[href*='/pop/']").length);
+			XKit.page.react = Boolean($("link[href*='/pop/']").length);
+
 			const excludedPage = location.href.includes("://www.tumblr.com/login") || location.href.includes("://www.tumblr.com/settings");
-
-			if (excludedPage && !react) {
+			if (excludedPage && !XKit.page.react) {
 				console.log("Refusing to run XKit, login or settings page!");
 				return;
 			}
@@ -29,17 +29,14 @@
 				return;
 			}
 
-			if (XKit.page.react === undefined) {
-				XKit.page.react = react;
-				if (XKit.page.react) {
-					$("body").addClass('xkit--react');
-					const waitUntilReactLoaded = setInterval(() => {
-						if ($('[data-rh]').length === 0) {
-							clearInterval(waitUntilReactLoaded);
-							this.run();
-						}
-					}, 100);
-					return;
+			if (XKit.page.react) {
+				$("body").addClass('xkit--react');
+
+				const isReactLoaded = () => $('[data-rh]').length === 0;
+				const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+				while (!isReactLoaded()) {
+					await sleep(100);
 				}
 			}
 


### PR DESCRIPTION
This disables the XKit page exclusion check if the current page uses React.

On React pages, the initial page URL does not make sense as a distinguishing factor that determines if XKit should run. Soft navigation within the group of Redpop pages cannot start or stop XKit scripts from running, so excluding XKit from a subset of those pages has no beneficial effect and causes the extension to unexpectedly appear broken.