### PR TITLE
Blacklist: Implement blacklist to native filtering export (and fix)

### DIFF
--- a/Extensions/blacklist.css
+++ b/Extensions/blacklist.css
@@ -260,3 +260,45 @@
 	background: rgba(var(--black), 0.25);
 	border-color: rgba(var(--black), 0.8);
 }
+
+#xkit-blacklist-native-custom-panel {
+    padding: 1em;
+    font-size: 14px;
+    line-height: 1.5;
+    color: rgb(80,80,80);
+}
+
+#blacklist-native-container {
+	max-height: calc(100vh - 200px);
+	overflow-y: auto;
+	padding: 0.5em;
+}
+#blacklist-native-container > * {
+	margin-bottom: 0.75em;
+}
+
+#blacklist-native-export-table {
+	width: 100%;
+	outline: 1px solid gray;
+}
+#blacklist-native-export-table th, #blacklist-native-export-table td {
+	text-align: center;
+	vertical-align: middle;
+	padding: 0.4em;
+	line-height: normal;
+}
+#blacklist-native-export-table input[type="text"] {
+	margin: 0;
+}
+#blacklist-native-export-table thead {
+	background-color: lightgray;
+}
+#blacklist-native-export-table tbody tr:not(:last-child) {
+	border-bottom: 1px solid lightgray;
+}
+#blacklist-native-word-header {
+	max-width: 30%;
+}
+#blacklist-native-tag-header, #blacklist-native-content-header {
+	width: 15%;
+}

--- a/Extensions/blacklist.css
+++ b/Extensions/blacklist.css
@@ -261,44 +261,44 @@
 	border-color: rgba(var(--black), 0.8);
 }
 
-#xkit-blacklist-native-custom-panel {
+#xkit-bne-custom-panel {
     padding: 1em;
     font-size: 14px;
     line-height: 1.5;
     color: rgb(80,80,80);
 }
 
-#blacklist-native-container {
+#xkit-bne-container {
 	max-height: calc(100vh - 200px);
 	overflow-y: auto;
 	padding: 0.5em;
 }
-#blacklist-native-container > * {
+#xkit-bne-container > * {
 	margin-bottom: 0.75em;
 }
 
-#blacklist-native-export-table {
+#xkit-bne-export-table {
 	width: 100%;
 	outline: 1px solid gray;
 }
-#blacklist-native-export-table th, #blacklist-native-export-table td {
+#xkit-bne-export-table th, #xkit-bne-export-table td {
 	text-align: center;
 	vertical-align: middle;
 	padding: 0.4em;
 	line-height: normal;
 }
-#blacklist-native-export-table input[type="text"] {
+#xkit-bne-export-table input[type="text"] {
 	margin: 0;
 }
-#blacklist-native-export-table thead {
+#xkit-bne-export-table thead {
 	background-color: lightgray;
 }
-#blacklist-native-export-table tbody tr:not(:last-child) {
+#xkit-bne-export-table tbody tr:not(:last-child) {
 	border-bottom: 1px solid lightgray;
 }
-#blacklist-native-word-header {
+#xkit-bne-word-header {
 	max-width: 30%;
 }
-#blacklist-native-tag-header, #blacklist-native-content-header {
+#xkit-bne-tag-header, #xkit-bne-content-header {
 	width: 15%;
 }

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1,5 +1,5 @@
 //* TITLE Blacklist **//
-//* VERSION 3.1.9 **//
+//* VERSION 3.2.0 **//
 //* DESCRIPTION Clean your dash **//
 //* DETAILS This extension allows you to block posts based on the words you specify. If a post has the text you've written in the post itself or it's tags, it will be replaced by a warning, or won't be shown on your dashboard, depending on your settings. **//
 //* DEVELOPER new-xkit **//

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1319,11 +1319,6 @@ XKit.extensions.blacklist = new Object({
 				createRow([name, textInput, tagCheckbox, contentCheckbox])
 			);
 
-			const tableBodyId = 'xkit-bne-export-table-body';
-			const doExportId = 'xkit-bne-export-do-export';
-			const selectAllId = 'xkit-bne-export-select-all';
-			const selectNoneId = 'xkit-bne-export-select-none';
-
 			XKit.window.show(
 				'Tumblr Native Filtering Export',
 				`
@@ -1359,8 +1354,8 @@ XKit.extensions.blacklist = new Object({
 							Nothing will be removed from blacklist or from the native filtering lists.
 						</div>
 						<div>
-							<div id="${selectAllId}" class="xkit-button">Select All</div>
-							<div id="${selectNoneId}" class="xkit-button">Select None</div>
+							<div id="xkit-bne-export-select-all" class="xkit-button">Select All</div>
+							<div id="xkit-bne-export-select-none" class="xkit-button">Select None</div>
 						</div>
 						<table id="xkit-bne-export-table">
 							<thead>
@@ -1369,22 +1364,22 @@ XKit.extensions.blacklist = new Object({
 								<th id="xkit-bne-tag-header">Filter as Tag</th>
 								<th id="xkit-bne-content-header">Filter as Content</th>
 							</thead>
-							<tbody id=${tableBodyId}></tbody>
+							<tbody id="xkit-bne-export-table-body"></tbody>
 						</table>
 					</div>
 				`,
 				'info',
 				`
-					<div id="${doExportId}" class="xkit-button default">Export Words</div>
+					<div id="xkit-bne-export-do-export" class="xkit-button default">Export Words</div>
 					<div id="xkit-close-message" class="xkit-button">Close</div>
 				`,
 				true
 			);
 
-			$(document.getElementById(tableBodyId)).append(rows);
-			$(`#${selectAllId}`).on('click', selectAll);
-			$(`#${selectNoneId}`).on('click', selectNone);
-			$(`#${doExportId}`).on('click', doExport);
+			$(document.getElementById('xkit-bne-export-table-body')).append(rows);
+			$('#xkit-bne-export-select-all').on('click', selectAll);
+			$('#xkit-bne-export-select-none').on('click', selectNone);
+			$('#xkit-bne-export-do-export').on('click', doExport);
 
 			centerIt($("#xkit-window"));
 		};

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1319,17 +1319,15 @@ XKit.extensions.blacklist = new Object({
 				createRow([name, textInput, tagCheckbox, contentCheckbox])
 			);
 
-			const containerId = 'blacklist-native-container';
-			const tableId = 'blacklist-native-export-table';
-			const tableBodyId = 'blacklist-native-export-table-body';
-			const doExportId = 'blacklist-native-export-do-export';
-			const selectAllId = 'blacklist-native-export-select-all';
-			const selectNoneId = 'blacklist-native-export-select-none';
+			const tableBodyId = 'xkit-bne-export-table-body';
+			const doExportId = 'xkit-bne-export-do-export';
+			const selectAllId = 'xkit-bne-export-select-all';
+			const selectNoneId = 'xkit-bne-export-select-none';
 
 			XKit.window.show(
 				'Tumblr Native Filtering Export',
 				`
-					<div id=${containerId}>
+					<div id="xkit-bne-container">
 						<div>
 							Tumblr's native filtering has two categories of words: filtered tags and
 							filtered post content.
@@ -1364,12 +1362,12 @@ XKit.extensions.blacklist = new Object({
 							<div id="${selectAllId}" class="xkit-button">Select All</div>
 							<div id="${selectNoneId}" class="xkit-button">Select None</div>
 						</div>
-						<table id="${tableId}">
+						<table id="xkit-bne-export-table">
 							<thead>
-								<th id="blacklist-native-word-header">Blacklist Entry</th>
-								<th id="blacklist-native-edit-word-header">Word(s)/Phrase(s) to Export</th>
-								<th id="blacklist-native-tag-header">Filter as Tag</th>
-								<th id="blacklist-native-content-header">Filter as Content</th>
+								<th id="xkit-bne-word-header">Blacklist Entry</th>
+								<th id="xkit-bne-edit-word-header">Word(s)/Phrase(s) to Export</th>
+								<th id="xkit-bne-tag-header">Filter as Tag</th>
+								<th id="xkit-bne-content-header">Filter as Content</th>
 							</thead>
 							<tbody id=${tableBodyId}></tbody>
 						</table>
@@ -1391,8 +1389,8 @@ XKit.extensions.blacklist = new Object({
 			centerIt($("#xkit-window"));
 		};
 
-		const nativePanelId = 'xkit-blacklist-native-custom-panel';
-		const nativeButtonId = 'xkit-blacklist-native-button';
+		const nativePanelId = 'xkit-bne-custom-panel';
+		const nativeButtonId = 'xkit-bne-button';
 
 		$(`#${nativePanelId}`).remove();
 

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -627,11 +627,6 @@ XKit.extensions.blacklist = new Object({
 					}).get().join(" ");
 				}
 
-				// format natively filtered posts with matching content only in "don't display" mode
-				if (XKit.extensions.blacklist.preferences.dont_display.value) {
-					m_content += " " + $(this).find(XKit.css_map.descendantSelector('filteredScreen', 'linkOut')).text();
-				}
-
 				m_content = m_content + " " + m_title;
 
 				if (XKit.extensions.blacklist.preferences.check_authors.value) {

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1381,7 +1381,7 @@ XKit.extensions.blacklist = new Object({
 							filtered post content.
 						</div>
 						<div>
-							At the time this message was last updated:
+							As of 2022:
 						</div>
 						<ul>
 							<li>

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1183,37 +1183,25 @@ XKit.extensions.blacklist = new Object({
 
 	nativeExportCpanel: function(m_div) {
 
-		const apiFetch = async (resource, init) => {
-			return XKit.tools.async_add_function(
-				async ({ resource, init = {} }) => { // eslint-disable-line no-shadow
-					// add XKit header to all API requests
-					if (!init.headers) init.headers = {};
-					init.headers['X-XKit'] = '1';
+		$('#xkit-bne-custom-panel').remove();
+		$(m_div).prepend(`
+			<div id="xkit-bne-custom-panel">
+				<p>
+					Tumblr now has built-in tag and content filtering that works both in web browsers and on
+					mobile. You can apply a slimmer layout to natively filtered posts or hide them completely
+					using the options in Tweaks in
+					<a href="https://github.com/AprilSylph/XKit-Rewritten#readme" target="_blank">
+					XKit Rewritten</a>!
+				</p>
+				<p>
+					Export your blacklisted words using this interactive form:
+				</p>
+				<button class="xkit-button" id="xkit-bne-button">Export to Native Filtering</button>
+			</div>
+		`);
+		$('#xkit-bne-button').on('click', () => showNativeExport().catch(showNativeExportError));
 
-					return window.tumblr.apiFetch(resource, init);
-				},
-			{ resource, init }
-			);
-		};
-
-		const showNativeExportError = e => {
-			console.error(e);
-			XKit.window.show(
-				'Tumblr Native Filtering Export Error',
-				`<pre>${e.toString()}</pre>`,
-				'error',
-				'<div class="xkit-button default" id="xkit-close-message">OK</div>',
-				true,
-			);
-		};
-
-		const getTextInputWords = (textInput) =>
-			textInput.value
-				.split(',')
-				.map((word) => word.trim().replace(/^#/, ''))
-				.filter(Boolean);
-
-		const showNativeExport = async () => {
+		async function showNativeExport() {
 			const currentFilteredTags = await apiFetch('/v2/user/filtered_tags')
 				.then(({ response: { filteredTags } }) => filteredTags);
 			const currentFilteredContent = await apiFetch('/v2/user/filtered_content')
@@ -1382,27 +1370,38 @@ XKit.extensions.blacklist = new Object({
 			$('#xkit-bne-export-do-export').on('click', doExport);
 
 			centerIt($("#xkit-window"));
-		};
+		}
 
-		$('#xkit-bne-custom-panel').remove();
+		function showNativeExportError(e) {
+			console.error(e);
+			XKit.window.show(
+				'Tumblr Native Filtering Export Error',
+				`<pre>${e.toString()}</pre>`,
+				'error',
+				'<div class="xkit-button default" id="xkit-close-message">OK</div>',
+				true,
+			);
+		}
 
-		$(m_div).prepend(`
-			<div id="xkit-bne-custom-panel">
-				<p>
-					Tumblr now has built-in tag and content filtering that works both in web browsers and on
-					mobile. You can apply a slimmer layout to natively filtered posts or hide them completely
-					using the options in Tweaks in
-					<a href="https://github.com/AprilSylph/XKit-Rewritten#readme" target="_blank">
-					XKit Rewritten</a>!
-				</p>
-				<p>
-					Export your blacklisted words using this interactive form:
-				</p>
-				<button class="xkit-button" id="xkit-bne-button">Export to Native Filtering</button>
-			</div>
-		`);
+		function getTextInputWords(textInput) {
+			return textInput.value
+				.split(',')
+				.map((word) => word.trim().replace(/^#/, ''))
+				.filter(Boolean);
+		}
 
-		$('#xkit-bne-button').on('click', () => showNativeExport().catch(showNativeExportError));
+		async function apiFetch(resource, init) {
+			return XKit.tools.async_add_function(
+				async ({ resource, init = {} }) => { // eslint-disable-line no-shadow
+					// add XKit header to all API requests
+					if (!init.headers) init.headers = {};
+					init.headers['X-XKit'] = '1';
+
+					return window.tumblr.apiFetch(resource, init);
+				},
+			{ resource, init }
+			);
+		}
 	}
 
 });

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1328,7 +1328,7 @@ XKit.extensions.blacklist = new Object({
 								Filtering a word or phrase as post content will hide any post with the
 								specified word or phrase anywhere in the post text or in any usernames,
 								including in the middle of a word (filtering "ash" will hide posts with
-								"dashboard" or "fashion", or with a comment by a user named
+								"dashboard" or "fashion", or with a reblog comment by a user named
 								"ash-ketchum"). It will not search the post tags.
 							</li>
 						</ul>

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1267,7 +1267,7 @@ XKit.extensions.blacklist = new Object({
 					updateAlreadyFiltered();
 					textInput.addEventListener('input', updateAlreadyFiltered);
 
-					return { name, textInput, tagCheckbox, contentCheckbox, updateAlreadyFiltered };
+					return { name, textInput, tagCheckbox, contentCheckbox };
 				});
 
 			if (!blacklistItemData.length) {
@@ -1281,17 +1281,15 @@ XKit.extensions.blacklist = new Object({
 			}
 
 			const selectAll = () =>
-				blacklistItemData.forEach(({ tagCheckbox, contentCheckbox, updateAlreadyFiltered }) => {
+				blacklistItemData.forEach(({ tagCheckbox, contentCheckbox }) => {
 					tagCheckbox.checked = true;
 					contentCheckbox.checked = true;
-					updateAlreadyFiltered();
 				});
 
 			const selectNone = () =>
-				blacklistItemData.forEach(({ tagCheckbox, contentCheckbox, updateAlreadyFiltered }) => {
-					tagCheckbox.checked = false;
-					contentCheckbox.checked = false;
-					updateAlreadyFiltered();
+				blacklistItemData.forEach(({ tagCheckbox, contentCheckbox }) => {
+					if (!tagCheckbox.disabled) tagCheckbox.checked = false;
+					if (!contentCheckbox.disabled) contentCheckbox.checked = false;
 				});
 
 			const doExport = () => {

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1386,15 +1386,16 @@ XKit.extensions.blacklist = new Object({
 						</div>
 						<ul>
 							<li>
-								Filtering a word or phrase as a tag will hide any post with that exact
-								tag (no wildcards) and reblog chains whose original root posts contain
-								that exact tag.
+								Filtering a word or phrase as a tag will hide any posts with that exact
+								tag (no wildcards) and any reblog chains where the original root post contains
+								that tag.
 							</li>
 							<li>
 								Filtering a word or phrase as post content will hide any post with the
 								specified word or phrase anywhere in the post text or in any usernames,
 								including in the middle of a word (filtering "ash" will hide posts with
-								"dashboard" or "fashion"). It will not search the post tags.
+								"dashboard" or "fashion", or with a comment by a user named
+								"ash-ketchum"). It will not search the post tags.
 							</li>
 						</ul>
 						<div>

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1392,14 +1392,14 @@ XKit.extensions.blacklist = new Object({
 
 		async function apiFetch(resource, init) {
 			return XKit.tools.async_add_function(
-				async ({ resource, init = {} }) => { // eslint-disable-line no-shadow
+				async ({ resource, init = {}, headerVersion }) => { // eslint-disable-line no-shadow
 					// add XKit header to all API requests
 					if (!init.headers) init.headers = {};
-					init.headers['X-XKit'] = '1';
+					init.headers['X-XKit-Version'] = headerVersion;
 
 					return window.tumblr.apiFetch(resource, init);
 				},
-			{ resource, init }
+			{ resource, init, headerVersion: XKit.version }
 			);
 		}
 	}

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1190,34 +1190,6 @@ XKit.extensions.blacklist = new Object({
 					if (!init.headers) init.headers = {};
 					init.headers['X-XKit'] = '1';
 
-					// convert all keys in the body to snake_case
-					if (init.body !== undefined) {
-						const objects = [init.body];
-
-						while (objects.length !== 0) {
-							const currentObjects = objects.splice(0);
-
-							currentObjects.forEach(obj => {
-								Object.keys(obj).forEach(key => {
-									const snakeCaseKey = key
-										.replace(/^[A-Z]/, match => match.toLowerCase())
-										.replace(/[A-Z]/g, match => `_${match.toLowerCase()}`);
-
-									if (snakeCaseKey !== key) {
-										obj[snakeCaseKey] = obj[key];
-										delete obj[key];
-									}
-								});
-							});
-
-							objects.push(
-								...currentObjects
-								.flatMap(Object.values)
-								.filter(value => value instanceof Object)
-							);
-						}
-					}
-
 					return window.tumblr.apiFetch(resource, init);
 				},
 			{ resource, init }

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1384,13 +1384,10 @@ XKit.extensions.blacklist = new Object({
 			centerIt($("#xkit-window"));
 		};
 
-		const nativePanelId = 'xkit-bne-custom-panel';
-		const nativeButtonId = 'xkit-bne-button';
-
-		$(`#${nativePanelId}`).remove();
+		$('#xkit-bne-custom-panel').remove();
 
 		$(m_div).prepend(`
-			<div id="${nativePanelId}">
+			<div id="xkit-bne-custom-panel">
 				<p>
 					Tumblr now has built-in tag and content filtering that works both in web browsers and on
 					mobile. You can apply a slimmer layout to natively filtered posts or hide them completely
@@ -1401,11 +1398,11 @@ XKit.extensions.blacklist = new Object({
 				<p>
 					Export your blacklisted words using this interactive form:
 				</p>
-				<button class="xkit-button" id="${nativeButtonId}">Export to Native Filtering</button>
+				<button class="xkit-button" id="xkit-bne-button">Export to Native Filtering</button>
 			</div>
 		`);
 
-		$(`#${nativeButtonId}`).on('click', () => showNativeExport().catch(showNativeExportError));
+		$('#xkit-bne-button').on('click', () => showNativeExport().catch(showNativeExportError));
 	}
 
 });

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1183,28 +1183,6 @@ XKit.extensions.blacklist = new Object({
 
 	nativeExportCpanel: function(m_div) {
 
-		/**
-		 * Create elements with simple syntax
-		 *
-		 * @param {string} tagName - Type of element to create
-		 * @param {object} [attributes] - Property-value pairs to set as HTML/XML attributes (e.g. { href: '/' })
-		 * @param {object} [events] - Property-value pairs to set as event listeners (e.g. { click: () => {} })
-		 * @param {(Node|string)[]} [children] - Zero or more valid children
-		 * @returns {Element} Element created to specification
-		 */
-		const dom = (tagName, attributes = {}, events = {}, children = []) => {
-			const element = attributes && attributes.xmlns
-				? document.createElementNS(attributes.xmlns, tagName)
-				: document.createElement(tagName);
-
-			attributes && Object.entries(attributes).forEach(([name, value]) => element.setAttribute(name, value));
-			events && Object.entries(events).forEach(([type, listener]) => element.addEventListener(type, listener));
-			children && element.replaceChildren(...children);
-
-			element.normalize();
-			return element;
-		};
-
 		const apiFetch = async (resource, init) => {
 			return XKit.tools.async_add_function(
 				async ({ resource, init = {} }) => { // eslint-disable-line no-shadow
@@ -1270,10 +1248,10 @@ XKit.extensions.blacklist = new Object({
 					const isTag = name.startsWith('#');
 					const initialValue = name.replace('#', '').replace('*', '');
 
-					const textInput = dom('input', { type: 'text', value: initialValue });
+					const textInput = $(`<input type="text" value="${initialValue}">`).get(0);
 
-					const tagCheckbox = dom('input', { type: 'checkbox'});
-					const contentCheckbox = dom('input', { type: 'checkbox'});
+					const tagCheckbox = $(`<input type="checkbox">`).get(0);
+					const contentCheckbox = $(`<input type="checkbox">`).get(0);
 					tagCheckbox.checked = isTag;
 					contentCheckbox.checked = !isTag;
 
@@ -1359,7 +1337,7 @@ XKit.extensions.blacklist = new Object({
 			};
 
 			const createRow = (data) =>
-				dom('tr', null, null, data.map((contents) => dom('td', null, null, [contents])));
+				$('<tr>').append(data.map((contents) => $('<td>').append(contents)));
 
 			const rows = blacklistItemData.map(({ name, textInput, tagCheckbox, contentCheckbox }) =>
 				createRow([name, textInput, tagCheckbox, contentCheckbox])
@@ -1429,7 +1407,7 @@ XKit.extensions.blacklist = new Object({
 				true
 			);
 
-			document.getElementById(tableBodyId).append(...rows);
+			$(document.getElementById(tableBodyId)).append(rows);
 			$(`#${selectAllId}`).on('click', selectAll);
 			$(`#${selectNoneId}`).on('click', selectNone);
 			$(`#${doExportId}`).on('click', doExport);

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1222,8 +1222,8 @@ XKit.extensions.blacklist = new Object({
 							currentObjects.forEach(obj => {
 								Object.keys(obj).forEach(key => {
 									const snakeCaseKey = key
-									.replace(/^[A-Z]/, match => match.toLowerCase())
-									.replace(/[A-Z]/g, match => `_${match.toLowerCase()}`);
+										.replace(/^[A-Z]/, match => match.toLowerCase())
+										.replace(/[A-Z]/g, match => `_${match.toLowerCase()}`);
 
 									if (snakeCaseKey !== key) {
 										obj[snakeCaseKey] = obj[key];
@@ -1355,7 +1355,6 @@ XKit.extensions.blacklist = new Object({
 						'info',
 						'<div id="xkit-close-message" class="xkit-button">Close</div>',
 					)).catch(showNativeExportError);
-
 				}
 			};
 

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -1364,7 +1364,7 @@ XKit.extensions.blacklist = new Object({
 				true
 			);
 
-			$(document.getElementById('xkit-bne-export-table-body')).append(rows);
+			$('#xkit-bne-export-table-body').append(rows);
 			$('#xkit-bne-export-select-all').on('click', selectAll);
 			$('#xkit-bne-export-select-none').on('click', selectNone);
 			$('#xkit-bne-export-do-export').on('click', doExport);

--- a/Extensions/blacklist.js
+++ b/Extensions/blacklist.js
@@ -988,21 +988,20 @@ XKit.extensions.blacklist = new Object({
 
 	destroy: function() {
 		this.running = false;
-		clearTimeout(XKit.extensions.blacklist.check_interval);
 		XKit.post_listener.remove("blacklist");
-		setTimeout(function() {
-			$(".xblacklist-done").each(function() {
-				$(this).removeClass("xblacklist_blacklisted_post");
-				$(this).find(".xblacklist_excuse_container").remove();
-				const postContentSel = XKit.css_map.keyToCss('post') || '.post_content';
-				$(this).find(postContentSel).html($(this).find(".xblacklist_old_content").html());
-				$(this).find(".xkit-shorten-posts-embiggen").css("display", "block");
-				XKit.extensions.blacklist.unhide_post($(this));
-			});
-			$(".xblacklist-done").removeClass("xblacklist-done");
-			$(".xblacklist_hidden_post").removeClass("xblacklist_hidden_post");
-			$(".xblacklist_blacklisted_post").removeClass("xblacklist_blacklisted_post");
-		}, 500);
+
+		$(".xblacklist-done").each(function() {
+			$(this).removeClass("xblacklist_blacklisted_post");
+			$(this).find(".xblacklist_excuse_container").remove();
+			const postContentSel = XKit.css_map.keyToCss('post') || '.post_content';
+			$(this).find(postContentSel).html($(this).find(".xblacklist_old_content").html());
+			$(this).find(".xkit-shorten-posts-embiggen").css("display", "block");
+			XKit.extensions.blacklist.unhide_post($(this));
+		});
+		$(".xblacklist-done").removeClass("xblacklist-done");
+		$(".xblacklist_hidden_post").removeClass("xblacklist_hidden_post");
+		$(".xblacklist_blacklisted_post").removeClass("xblacklist_blacklisted_post");
+
 		XKit.tools.remove_css("blacklist");
 	},
 


### PR DESCRIPTION
This implements an interactive UI for exporting the user's blacklisted words into Tumblr's native tag filtering and post content filtering lists. The user is given the opportunity to customize their terms, hopefully helping them account for the functional differences between the Tumblr filtering and Blacklist's filtering, like the lack of asterisk wildcards.

<img width="707" src="https://user-images.githubusercontent.com/8336245/203697828-f82b193c-f36b-4d0d-8175-7aa55799bea7.png">

~~I ported the `dom` and `apiFetch` helper functions from XKit Rewritten for ease of development. (Of course they don't belong inline like this, given the premise that this is an actively developed project and all.)~~

Also, this fixes that destroy() had a random 0.5 second delay, which would make it run after it restarted whenever you changed a setting, which would unhide every correctly hidden post on the screen, which... is... interesting.
