### PR TITLE
Quick Tags: Prevent breaking non-legacy posts (modernized)

### DIFF
--- a/Extensions/quick_tags.js
+++ b/Extensions/quick_tags.js
@@ -121,8 +121,8 @@ XKit.extensions.quick_tags = new Object({
 			XKit.interface.fetch(m_post, async function(data) {
 				const { id: post_id, tags: current_tags = '' } = data.data.post;
 
-				const current_tags_array = current_tags.split(',').map(tag => tag.trim());
-				const add_tags_array = tags.split(',').map(tag => tag.trim());
+				const current_tags_array = current_tags.split(',').map(tag => tag.trim()).filter(Boolean);
+				const add_tags_array = tags.split(',').map(tag => tag.trim()).filter(Boolean);
 
 				if (XKit.extensions.quick_tags.preferences.append_not_replace.value === false) {
 					await XKit.interface.mass_edit([post_id], { mode: 'remove', tags: current_tags_array });

--- a/Extensions/quick_tags.js
+++ b/Extensions/quick_tags.js
@@ -118,7 +118,7 @@ XKit.extensions.quick_tags = new Object({
 			const { response } = await XKit.interface.react.api_fetch(`/v2/blog/${uuid}/posts/${post_id}`);
 
 			const current_tags_array = response.tags.map(tag => tag.trim()).filter(Boolean);
-			const add_tags_array = tags.split(',').map(tag => tag.trim()).filter(Boolean);
+			const add_tags_array = tags.split(',').map(tag => tag.replaceAll('#', '').trim()).filter(Boolean);
 
 			if (XKit.extensions.quick_tags.preferences.append_not_replace.value === false) {
 				await XKit.interface.mass_edit([post_id], { mode: 'remove', tags: current_tags_array });

--- a/Extensions/quick_tags.js
+++ b/Extensions/quick_tags.js
@@ -111,42 +111,33 @@ XKit.extensions.quick_tags = new Object({
 			return;
 		}
 
-		// Find the post object.
-		var m_post = await XKit.interface.react.find_post($(button).attr('data-post-id'));
+		try {
+			const post_id = $(button).attr('data-post-id');
 
-		var m_button = $(button);
+			const { blog: { uuid } } = await XKit.interface.react.post_props(post_id);
+			const { response } = await XKit.interface.react.api_fetch(`/v2/blog/${uuid}/posts/${post_id}`);
 
-		// Fetch info about it!
-		if (!m_post.error) {
-			XKit.interface.fetch(m_post, async function(data) {
-				try {
-					const { id: post_id, tags: current_tags = '' } = data.data.post;
+			const current_tags_array = response.tags.map(tag => tag.trim()).filter(Boolean);
+			const add_tags_array = tags.split(',').map(tag => tag.trim()).filter(Boolean);
 
-					const current_tags_array = current_tags.split(',').map(tag => tag.trim()).filter(Boolean);
-					const add_tags_array = tags.split(',').map(tag => tag.trim()).filter(Boolean);
+			if (XKit.extensions.quick_tags.preferences.append_not_replace.value === false) {
+				await XKit.interface.mass_edit([post_id], { mode: 'remove', tags: current_tags_array });
+				current_tags_array.splice(0);
+			}
 
-					if (XKit.extensions.quick_tags.preferences.append_not_replace.value === false) {
-						await XKit.interface.mass_edit([post_id], { mode: 'remove', tags: current_tags_array });
-						current_tags_array.splice(0);
-					}
+			await XKit.interface.mass_edit([post_id], { mode: 'add', tags: add_tags_array });
+			current_tags_array.push(...add_tags_array);
 
-					await XKit.interface.mass_edit([post_id], { mode: 'add', tags: add_tags_array });
-					current_tags_array.push(...add_tags_array);
-
-					await XKit.interface.react.update_view.tags(m_post, current_tags_array.join(','));
-				} catch (error) {
-					if (error.json) {
-						const response = await error.json();
-						XKit.window.show("Unable to edit post", `Server responded with status ${response.meta.status}: ${response.meta.msg}.<br /><pre>${JSON.stringify(response, null, 2)}</pre>`, "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
-					} else {
-						XKit.window.show("Unable to edit post", `<pre>${error}</pre>`, "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
-					}
-				} finally {
-					XKit.interface.switch_control_button($(m_button), false);
-				}
-			}, false);
-		} else {
-			XKit.window.show("Unable to edit post", "Something went wrong, my apologies.<br/>Please try again later or file a bug report with the error code:<br/>QT02", "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
+			await XKit.interface.react.update_view.tags({ id: post_id }, current_tags_array.join(','));
+		} catch (error) {
+			if (error.json) {
+				const response = await error.json();
+				XKit.window.show("Unable to edit post", `Server responded with status ${response.meta.status}: ${response.meta.msg}.<br /><pre>${JSON.stringify(response, null, 2)}</pre>`, "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
+			} else {
+				XKit.window.show("Unable to edit post", `<pre>${error}</pre>`, "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
+			}
+		} finally {
+			XKit.interface.switch_control_button($(button), false);
 		}
 
 		XKit.extensions.quick_tags.user_on_box = false;

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.19 **//
+//* VERSION 7.4.20 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -1096,7 +1096,7 @@ XKit.extensions.xkit_patches = new Object({
 								tags_array[i] = tags_array[i].substring(1);
 							}
 
-							m_inner = m_inner + `<a class="${post_tag}" href=\"/tagged/" ${formatted} \">#${tags_array[i]}</a>`;
+							m_inner = m_inner + `<a class="${post_tag}" href="/tagged/${formatted}">#${tags_array[i]}</a>`;
 						}
 
 						var tags_class = XKit.css_map.keyToCss("tags");

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1172,6 +1172,19 @@ XKit.extensions.xkit_patches = new Object({
 				destroy_collapsed: function(id) {
 					$(`.${id}-collapsed`).removeClass(`${id}-collapsed`);
 					$(`.${id}-collapsed-note`).remove();
+				},
+
+				api_fetch: async function(resource, init) {
+					return XKit.tools.async_add_function(
+						async ({ resource, init = {}, headerVersion }) => { // eslint-disable-line no-shadow
+							// add XKit header to all API requests
+							if (!init.headers) init.headers = {};
+							init.headers['X-XKit-Version'] = headerVersion;
+
+							return window.tumblr.apiFetch(resource, init);
+						},
+					{ resource, init, headerVersion: XKit.version }
+					);
 				}
 			};
 

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -460,11 +460,12 @@ XKit.extensions.xkit_patches = new Object({
 
 			/**
 			 * Edit up to 100 posts at a time via Mass Post Editor
-			 * @param {Object[]} post_ids - array of post IDs to edit
-			 * @param {Object[]} config - settings object
-			 * @param {String} config.mode - "add", "remove", or "delete"
-			 * @param {Object[]} [config.tags] - array of tags to add or remove
-			 * @return {Promise}
+			 *
+			 * @param {string[]} post_ids - array of post IDs to edit
+			 * @param {object} config - settings object
+			 * @param {string} config.mode - "add", "remove", or "delete"
+			 * @param {string[]} [config.tags] - array of tags to add or remove
+			 * @returns {Promise<object>}
 			 */
 			XKit.interface.mass_edit = function(post_ids, config) {
 			    const path = {

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1088,15 +1088,11 @@ XKit.extensions.xkit_patches = new Object({
 						var post_tag = XKit.css_map.keyToClasses("tag").join(" ");
 
 						for (var i = 0; i < tags_array.length; i++) {
-							var formatted = encodeURIComponent(tags_array[i]);
+							const tag = tags_array[i].trim();
 
-							if (tags_array[i] === "" || tags_array[i] === " ") { continue; }
-
-							if (tags_array[i].substring(0, 1) === " ") {
-								tags_array[i] = tags_array[i].substring(1);
+							if (tag) {
+								m_inner += `<a class="${post_tag}" href="/tagged/${encodeURIComponent(tag)}">#${tag}</a>`;
 							}
-
-							m_inner = m_inner + `<a class="${post_tag}" href="/tagged/${formatted}">#${tags_array[i]}</a>`;
 						}
 
 						var tags_class = XKit.css_map.keyToCss("tags");


### PR DESCRIPTION
Do you want to review an apiFetch helper? If not, close this and review #2106.

---

This implements an apiFetch helper in `XKit.interface.react` and uses it to replace the legacy SVC API endpoint used in Quick Tags with the less-old mass editor endpoint. This prevents posts from being converted to the legacy format and breaking things like polls and preventing XKit Rewritten's Trim Reblogs from working on the edited thread.

The mass editor endpoint seems to work on both legacy and new post formats without side effects, so it's well-suited to maintaining this version of XKit with maximum compatibility.

Don't ask how long I have now spent reading `xkit_patches`, at this point.

Resolves #2105.