### PR TITLE
Anti-Capitalism: block cruelSummer takeover

### DIFF
--- a/Extensions/anti_capitalism.js
+++ b/Extensions/anti_capitalism.js
@@ -1,5 +1,5 @@
 //* TITLE Anti-Capitalism **//
-//* VERSION 1.6.5 **//
+//* VERSION 1.6.6 **//
 //* DESCRIPTION Removes sponsored posts, vendor buttons, and other nonsense that wants your money. **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//

--- a/Extensions/anti_capitalism.js
+++ b/Extensions/anti_capitalism.js
@@ -98,12 +98,6 @@ XKit.extensions.anti_capitalism = new Object({
 						display: none !important;
 					}
 				`, "anti_capitalism");
-
-				XKit.tools.add_css(`
-					${XKit.css_map.keyToCss('timelineOptionsItemWrapper')}:not(${XKit.css_map.keyToCss('active')}):has(> a[href="/dashboard/freeform_campaign"]) {
-						display: none !important;
-					}
-				`, "anti_capitalism");
 			}
 
 			return;

--- a/Extensions/anti_capitalism.js
+++ b/Extensions/anti_capitalism.js
@@ -98,6 +98,12 @@ XKit.extensions.anti_capitalism = new Object({
 						display: none !important;
 					}
 				`, "anti_capitalism");
+
+				XKit.tools.add_css(`
+					${XKit.css_map.keyToCss('timelineOptionsItemWrapper')}:not(${XKit.css_map.keyToCss('active')}):has(> a[href="/dashboard/freeform_campaign"]) {
+						display: none !important;
+					}
+				`, "anti_capitalism");
 			}
 
 			return;

--- a/Extensions/anti_capitalism.js
+++ b/Extensions/anti_capitalism.js
@@ -25,6 +25,11 @@ XKit.extensions.anti_capitalism = new Object({
 			default: true,
 			value: true
 		},
+		"takeover_ad": {
+			text: "Hide some elements from takeover ads",
+			default: true,
+			value: true
+		},
 		"sep1": {
 			text: "Legacy Options",
 			type: "separator",
@@ -85,6 +90,14 @@ XKit.extensions.anti_capitalism = new Object({
 			if (this.preferences.sidebar_ad.value) {
 				const selector = XKit.css_map.keyToCss("mrecContainer");
 				XKit.interface.hide(selector, "anti_capitalism");
+			}
+
+			if (this.preferences.takeover_ad.value) {
+				XKit.tools.add_css(`
+					${XKit.css_map.keyToCss('cruelSummer')} {
+						display: none !important;
+					}
+				`, "anti_capitalism");
 			}
 
 			return;


### PR DESCRIPTION
This hides the bottom elements from the "cruel summer" takeover ad, including the start menu and "reminder: turn your computer off before midnight on 12/31/99" animated sticker GIF.

~~In Chromium-based browsers, it also hides the "1999" dashboard tab added by this takeover. I used a `:has()` selector to do this; it is possible via adding our own class so that it will also work in Firefox, but this is difficult to implement without bugs because changing tabs updates the classlists on the tab item wrappers.~~

