### PR TITLE
XKit Preferences: Vertical nav layout menu button fix

### DIFF
--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -80,15 +80,13 @@ XKit.extensions.xkit_preferences = new Object({
 			await XKit.css_map.getCssMap();
 			const menuContainer = XKit.css_map.keyToCss("menuContainer");
 			const drawerContent = XKit.css_map.keyToCss("drawerContent");
-			const navigationLinks = XKit.css_map.keyToCss("navigationLinks");
 			const navItem = XKit.css_map.keyToCss("navItem");
-			const subNav = XKit.css_map.keyToCss("subNav");
 			const hamburger = XKit.css_map.keyToCss("hamburger");
 
 			const check_and_reinsert = () => {
 				if (button.isConnected) return;
 				const header = document.querySelector('header');
-				const nav = document.querySelector(navigationLinks);
+				const nav = document.querySelector('nav');
 
 				const desktopMenuItems = header ? [...header.querySelectorAll(menuContainer)] : [];
 				if (desktopMenuItems.length) {
@@ -97,11 +95,7 @@ XKit.extensions.xkit_preferences = new Object({
 					return;
 				}
 
-				const desktopPrimaryNavItems =
-					nav && !nav.closest(drawerContent)
-						? [...nav.children].filter((el) => el.matches(navItem) || el.matches(subNav))
-						: [];
-
+				const desktopPrimaryNavItems = nav && !nav.closest(drawerContent) ? [...nav.querySelectorAll(navItem)] : [];
 				if (desktopPrimaryNavItems.length) {
 					const lastNavItem = desktopPrimaryNavItems[desktopPrimaryNavItems.length - 1];
 					lastNavItem.after(button);

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -80,13 +80,15 @@ XKit.extensions.xkit_preferences = new Object({
 			await XKit.css_map.getCssMap();
 			const menuContainer = XKit.css_map.keyToCss("menuContainer");
 			const drawerContent = XKit.css_map.keyToCss("drawerContent");
+			const navigationLinks = XKit.css_map.keyToCss("navigationLinks");
 			const navItem = XKit.css_map.keyToCss("navItem");
+			const subNav = XKit.css_map.keyToCss("subNav");
 			const hamburger = XKit.css_map.keyToCss("hamburger");
 
 			const check_and_reinsert = () => {
 				if (button.isConnected) return;
 				const header = document.querySelector('header');
-				const nav = document.querySelector('nav');
+				const nav = document.querySelector('navigationLinks');
 
 				const desktopMenuItems = header ? [...header.querySelectorAll(menuContainer)] : [];
 				if (desktopMenuItems.length) {
@@ -95,7 +97,11 @@ XKit.extensions.xkit_preferences = new Object({
 					return;
 				}
 
-				const desktopPrimaryNavItems = nav && !nav.closest(drawerContent) ? [...nav.querySelectorAll(navItem)] : [];
+				const desktopPrimaryNavItems =
+					nav && !nav.closest(drawerContent)
+						? [...nav.children].filter((el) => el.matches(navItem) || el.matches(subNav))
+						: [];
+
 				if (desktopPrimaryNavItems.length) {
 					const lastNavItem = desktopPrimaryNavItems[desktopPrimaryNavItems.length - 1];
 					lastNavItem.after(button);

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -80,13 +80,13 @@ XKit.extensions.xkit_preferences = new Object({
 			await XKit.css_map.getCssMap();
 			const menuContainer = XKit.css_map.keyToCss("menuContainer");
 			const drawerContent = XKit.css_map.keyToCss("drawerContent");
-			const navItem = XKit.css_map.keyToCss("navItem");
+			const navigationLinks = XKit.css_map.keyToCss("navigationLinks");
 			const hamburger = XKit.css_map.keyToCss("hamburger");
 
 			const check_and_reinsert = () => {
 				if (button.isConnected) return;
 				const header = document.querySelector('header');
-				const nav = document.querySelector('nav');
+				const nav = document.querySelector(navigationLinks);
 
 				const desktopMenuItems = header ? [...header.querySelectorAll(menuContainer)] : [];
 				if (desktopMenuItems.length) {
@@ -95,10 +95,8 @@ XKit.extensions.xkit_preferences = new Object({
 					return;
 				}
 
-				const desktopPrimaryNavItems = nav && !nav.closest(drawerContent) ? [...nav.querySelectorAll(navItem)] : [];
-				if (desktopPrimaryNavItems.length) {
-					const lastNavItem = desktopPrimaryNavItems[desktopPrimaryNavItems.length - 1];
-					lastNavItem.after(button);
+				if (nav && !nav.closest(drawerContent)) {
+					nav.append(button);
 					return;
 				}
 

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -88,7 +88,7 @@ XKit.extensions.xkit_preferences = new Object({
 			const check_and_reinsert = () => {
 				if (button.isConnected) return;
 				const header = document.querySelector('header');
-				const nav = document.querySelector('navigationLinks');
+				const nav = document.querySelector(navigationLinks);
 
 				const desktopMenuItems = header ? [...header.querySelectorAll(menuContainer)] : [];
 				if (desktopMenuItems.length) {


### PR DESCRIPTION
The logic I implemented in #2109 is fragile: in the vertical nav layout, it appends the XKit menu button after the last `navItem` element, which is currently the "get a domain" button. If this is removed, however, the last `navItem` element will be nested inside the account drawer, which is obviously bad.

This implements* the same logic as `${keyToCss('drawerContent')} ${keyToCss('navigationLinks')} > ${keyToCss('navItem', 'subNav')}` from https://github.com/AprilSylph/XKit-Rewritten/pull/1107: it finds the element which contains the top level of navigation and inserts the XKit control button after the last of its children which is either a navigation item or the menu that one opens.

This should ensure that the XKit control button is a) at the top level, not nested somewhere wild, and b) after other nav items but before things like the frogs, bells, crabs, whatever.

_*manually, since :is() requires chromium 88 and I have no idea what our browser support list is supposed to be_