### PR TITLE
XKit Preferences: Fix welcome bubble blocking screen

### DIFF
--- a/Extensions/xkit_preferences.css
+++ b/Extensions/xkit_preferences.css
@@ -169,6 +169,8 @@
 	height: 100%;
 	background: var(--xkit-53-shadow);
 	z-index: 4;
+
+	pointer-events: none;
 }
 
 #xkit-extension-panel-slow-extension {

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 7.6.22 **//
+//* VERSION 7.6.23 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER new-xkit **//
 


### PR DESCRIPTION
This ensures that a new or reinstalling user does not get stuck on the welcome bubble screen if it covers the XKit button because of its z-index.

This thing is fairly broken right now anyway—it doesn't even open on tumblr.com because `XKit.interface.where` is busted, but.

Resolves #2113