### PR TITLE
XKit Preferences: Remove broken Old Sidebar script

### DIFF
--- a/Extensions/xkit_preferences.css
+++ b/Extensions/xkit_preferences.css
@@ -1569,7 +1569,6 @@
 .xkit--react #xkit-gallery-extension-mirrorposts,
 .xkit--react #xkit-gallery-extension-mute,
 .xkit--react #xkit-gallery-extension-mutualchecker,
-.xkit--react #xkit-gallery-extension-estufars_sidebar_fix,
 .xkit--react #xkit-gallery-extension-old_stats,
 .xkit--react #xkit-gallery-extension-one_click_reply,
 .xkit--react #xkit-gallery-extension-outbox,
@@ -1596,5 +1595,9 @@
 .xkit--react #xkit-gallery-extension-stats,
 .xkit--react #xkit-gallery-extension-show_more,
 .xkit--react #xkit-gallery-extension-xwidgets {
+	display: none !important;
+}
+
+#xkit-gallery-extension-estufars_sidebar_fix {
 	display: none !important;
 }

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 7.6.23 **//
+//* VERSION 7.6.24 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER new-xkit **//
 
@@ -212,6 +212,16 @@ XKit.extensions.xkit_preferences = new Object({
 	spring_cleaning_m_list_html: "",
 
 	spring_cleaning: function() {
+
+		const silent_clean_list = [
+			"estufars_sidebar_fix",
+		];
+
+		for (const extension of silent_clean_list) {
+			if (XKit.installed.check(extension)) {
+				XKit.installed.remove(extension);
+			}
+		}
 
 		var clean_list = [
 			"separator",


### PR DESCRIPTION
Old Sidebar, of course, doesn't work, but more to the point it still does run this, which is bad:
```js
var account = document.getElementById("account_button");
account.click();
```

This removes it (without a notification, to avoid user confusion due to an update to New XKit containing the phrase "sidebar" coming during a period of discussion about a related-but-different sidebar).