### PR TITLE
XKit Preferences: Improve button click handler reliability

### DIFF
--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -116,12 +116,12 @@ XKit.extensions.xkit_preferences = new Object({
 		};
 
 		let button_ready = Promise.resolve();
+		const button = $(m_html).get(0);
 		if (XKit.page.react) {
-			const button = $(m_html).get(0);
 			button.setAttribute('tabindex', 0);
 			button_ready = react_add_button(button);
 		} else {
-			$("#account_button").before(m_html);
+			$("#account_button").before(button);
 			$("#account_button > button").attr("tabindex", "8");
 		}
 
@@ -130,7 +130,7 @@ XKit.extensions.xkit_preferences = new Object({
 				this.show_welcome_bubble();
 			}
 
-			$("#xkit_button").click(XKit.extensions.xkit_preferences.open);
+			$(button).click(XKit.extensions.xkit_preferences.open);
 
 			const unread_mail_count = XKit.extensions.xkit_preferences.news.unread_count();
 			if (unread_mail_count > 0) {


### PR DESCRIPTION
This fixes a small issue where, if XKit is loaded on a page which matches none of the criteria for button insertion, the XKit button will not do anything when clicked even after a later page mutation causes the button to be properly inserted. This is due to `$("#xkit_button").click()` unnecessarily relying on the button being attached to the DOM at the moment it runs.

This issue likely only happens when the dashboard is modified aggressively via e.g. userscripts or when Staff has made a change that the button insertion code has not yet been updated for.