### PR TITLE
XKit Preferences: Update wide vertical nav breakpoint

### DIFF
--- a/Extensions/xkit_preferences.css
+++ b/Extensions/xkit_preferences.css
@@ -1467,7 +1467,7 @@
 	opacity: .65;
 }
 
-@media (min-width: 1150px) {
+@media (min-width: 1162px) {
 	.xkit--react nav #xkit_button {
 		justify-content: flex-start;
 	}


### PR DESCRIPTION
To correspond with a change to the vertical nav layout CSS, this adjusts the breakpoint at which the XKit button adapts its position to match the widest display mode of the left nav rail.