### PR TITLE
Fix tap area and hover behavior to match native items

### DIFF
--- a/Extensions/xkit_preferences.css
+++ b/Extensions/xkit_preferences.css
@@ -1477,7 +1477,7 @@
 }
 
 .xkit--react nav #xkit_button button:hover {
-	background-color: rgba(var(--white-on-dark),.07);
+	background-color: rgba(var(--white-on-dark), .07);
 }
 
 @media (min-width: 1162px) {

--- a/Extensions/xkit_preferences.css
+++ b/Extensions/xkit_preferences.css
@@ -1467,6 +1467,19 @@
 	opacity: .65;
 }
 
+.xkit--react nav #xkit_button {
+	margin: 0
+}
+
+.xkit--react nav #xkit_button button {
+	padding: 8px 16px;
+	width: 100%
+}
+
+.xkit--react nav #xkit_button button:hover {
+	background-color: rgba(var(--white-on-dark),.07);
+}
+
 @media (min-width: 1162px) {
 	.xkit--react nav #xkit_button {
 		justify-content: flex-start;

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 7.6.24 **//
+//* VERSION 7.7.0 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER new-xkit **//
 


### PR DESCRIPTION
Before:
![before mouse](https://github.com/new-xkit/XKit/assets/233815/60761f86-a95d-4a0e-bf06-d598c45ea2f3)

After:
![after mouse](https://github.com/new-xkit/XKit/assets/233815/16cb7f9d-a91f-492d-b683-ee3b10f4790b)

this makes it much nicer to use. I'm also including a preferences version bump in this one.