### PR TITLE
Insert XKit button before crabs, etc

### DIFF
--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -81,6 +81,7 @@ XKit.extensions.xkit_preferences = new Object({
 			const menuContainer = XKit.css_map.keyToCss("menuContainer");
 			const drawerContent = XKit.css_map.keyToCss("drawerContent");
 			const navigationLinks = XKit.css_map.keyToCss("navigationLinks");
+			const startChildWrapper = XKit.css_map.keyToCss("startChildWrapper");
 			const hamburger = XKit.css_map.keyToCss("hamburger");
 
 			const check_and_reinsert = () => {
@@ -96,7 +97,13 @@ XKit.extensions.xkit_preferences = new Object({
 				}
 
 				if (nav && !nav.closest(drawerContent)) {
-					nav.append(button);
+					const primaryNavItems = [...nav.children].filter(
+						el => el.querySelector(startChildWrapper) || (el.matches('ul') && el.previousElementSibling.querySelector(startChildWrapper))
+					);
+
+					primaryNavItems.length
+						? primaryNavItems[primaryNavItems.length - 1].after(button)
+						: nav.append(button);
 					return;
 				}
 


### PR DESCRIPTION
There are about a million ways to do this, as I'm sure you have seen from my various PRs.

In the vertical nav layout, this adjusts the XKit button to be inserted in between the primary set of navigation items (that it looks like) and anything else in the left navigation element. If the selector it relies on is removed, it will fall back to inserting the button at the very end of the nav element. 

This is still potentially prone to inconsistency:

> oh fun effect: if I put the xkit button right after the settings menu (where it would go if tumblr moved the tumblrmart button elsewhere and a user had no optional buttons), then resize around the 1162px breakpoint, some of the menus get destroyed and reattached and the xkit button winds up above account
>
> so to make it totally consistent, either one has to rely on at least the tumblrmart button still existing and being the same in all non-mobile breakpoints, or one has to properly style the button to not look weird inline and then put it before account where it used to be

But hopefully(?) this does something semi-reasonable in most possible breakage scenarios.