### PR TITLE
Match redpop font weight

### DIFF
--- a/Extensions/xkit_preferences.css
+++ b/Extensions/xkit_preferences.css
@@ -1486,6 +1486,7 @@
 
 	.xkit--react nav #xkit_button > button > p {
 		color: rgba(var(--white-on-dark));
+		font-weight: 500;
 		margin: 0;
 	}
 }


### PR DESCRIPTION
Low-hanging fruit: this adjusts the XKit button text font to have the same weight as its siblings'.

I could also go put in the different min height and flex gap for `pointer: fine`, or whatever, but that seemed like a lot of work.