### PR TITLE
Implement cloned native nav styling

### DIFF
--- a/Extensions/xkit_preferences.css
+++ b/Extensions/xkit_preferences.css
@@ -1471,35 +1471,47 @@
 	margin: 0
 }
 
-.xkit--react nav #xkit_button button {
-	padding: 8px 16px;
-	width: 100%
+.xkit--react nav #xkit_button > button {
+	font-size: unset;
+}
+.xkit--react nav #xkit_button > button > svg {
+	order: -1;
+}
+.xkit--react nav #xkit_button > button > p {
+	flex: 1;
+	margin: 0;
+
+	font-weight: 500;
+	color: rgba(var(--white-on-dark));
 }
 
-.xkit--react nav #xkit_button button:hover {
-	background-color: rgba(var(--white-on-dark), .07);
+@media (min-width: 990px) {
+	.xkit--react nav #xkit_button > button > p {
+		display: none;
+	}
+}
+@media (min-width: 1018px) {
+	.xkit--react nav #xkit_button > button > p {
+		display: unset;
+	}
 }
 
 @media (min-width: 1162px) {
-	.xkit--react nav #xkit_button {
-		justify-content: flex-start;
-	}
-
-	.xkit--react nav #xkit_button > button {
-		display: flex;
-		align-items: center;
-		gap: 14px;
-
-		font-size: 1rem;
-	}
-
-	.xkit--react nav #xkit_button > button > svg {
-		order: -1;
-	}
-
 	.xkit--react nav #xkit_button > button > p {
-		color: rgba(var(--white-on-dark));
-		margin: 0;
+		text-align: left;
+	}
+}
+
+.xkit--react nav #xkit_button > button > svg {
+	margin: -1px;
+
+	width: 23px;
+	height: 23px;
+}
+@media (pointer: fine) {
+	.xkit--react nav #xkit_button > button > svg {
+		width: 18px;
+		height: 18px;
 	}
 }
 

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -83,8 +83,16 @@ XKit.extensions.xkit_preferences = new Object({
 			const navigationLinks = XKit.css_map.keyToCss("navigationLinks");
 			const hamburger = XKit.css_map.keyToCss("hamburger");
 
+			const redpopNavItemClasses = XKit.css_map.keyToClasses("navItem");
+			const redpopNavLinkClasses = XKit.css_map.keyToClasses("navLink");
+
 			const check_and_reinsert = () => {
 				if (button.isConnected) return;
+				const innerButton = button.querySelector('button');
+
+				button.classList.remove(...redpopNavItemClasses);
+				innerButton.classList.remove(...redpopNavLinkClasses);
+
 				const header = document.querySelector('header');
 				const nav = document.querySelector(navigationLinks);
 
@@ -96,6 +104,9 @@ XKit.extensions.xkit_preferences = new Object({
 				}
 
 				if (nav && !nav.closest(drawerContent)) {
+					button.classList.add(...redpopNavItemClasses);
+					innerButton.classList.add(...redpopNavLinkClasses);
+
 					nav.append(button);
 					return;
 				}

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -86,6 +86,8 @@ XKit.extensions.xkit_preferences = new Object({
 			const redpopNavItemClasses = XKit.css_map.keyToClasses("navItem");
 			const redpopNavLinkClasses = XKit.css_map.keyToClasses("navLink");
 
+			const accountString = await XKit.interface.translate("Account");
+
 			const check_and_reinsert = () => {
 				if (button.isConnected) return;
 				const innerButton = button.querySelector('button');
@@ -107,7 +109,9 @@ XKit.extensions.xkit_preferences = new Object({
 					button.classList.add(...redpopNavItemClasses);
 					innerButton.classList.add(...redpopNavLinkClasses);
 
-					nav.append(button);
+					const accountNavItem = [...nav.children].find(el => el.querySelector(`[aria-label="${accountString}"]`));
+
+					accountNavItem ? accountNavItem.before(button) : nav.append(button);
 					return;
 				}
 


### PR DESCRIPTION
Complicated, fragile. Probably too complicated and too fragile.

But as a proof of concept and to determine exactly how complicated and how fragile it actually is, this essentially fully clones the redpop nav styling for the XKit button, in all three non-mobile breakpoints, with or without touch.