### PR TITLE
Implement silent update functionality

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.19 **//
+//* VERSION 7.4.20 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -1326,6 +1326,7 @@ XKit.extensions.xkit_patches = new Object({
 					version.major = parseInt(versionSplit[0]);
 					version.minor = parseInt(versionSplit[1]);
 					version.patch = parseInt(versionSplit[2]);
+					version.silent_patch = versionSplit[3] ? parseInt(versionSplit[3]) : 0;
 				}
 				return version;
 			};


### PR DESCRIPTION
In theory, this implements a fourth version number field that, when incremented, causes an extension to be updated without notifying the user (unless they are in force update mode).

Incrementing this field on an extension should do nothing if the user has not yet installed this PR. Once the user installs this PR, the increment should be detected as a silent update.

To be very clear: I have not tested this code at all. I literally have not, as of writing this message, even installed it. If someone could figure out how to test it, that would be great.

I would love to have this functionality to be able to put harder lockouts on all of the currently-does-nothing-on-React scripts without spamming the user with what looks like updates. But reading through this code base's internals is actual torture.