### PR TITLE
One-Click Postage: Don't use outdated API endpoint

### DIFF
--- a/Extensions/one_click_postage.css
+++ b/Extensions/one_click_postage.css
@@ -40,40 +40,6 @@
 	color: rgb(80,80,80);
 }
 
-#xkit-1cp-social-twitter,
-#xkit-1cp-social-facebook {
-	background: rgba(245,245,245,1);
-	color: #7a7f8e;
-	border-bottom: 0;
-	font-size: 12px;
-	float: left;
-	width: 99px;
-	text-align: center;
-	height: 30px;
-	cursor: pointer;
-}
-
-#xkit-1cp-social {
-	margin-top: 1px;
-}
-
-#xkit-1cp-social-twitter:hover,
-#xkit-1cp-social-facebook:hover {
-	background-color: rgba(234,239,246,1);
-	color: #7a7f8e;
-}
-
-#xkit-1cp-social-twitter.selected,
-#xkit-1cp-social-facebook.selected {
-	background-color: #c5cdd8;
-	box-shadow: inset 1px 0px 0px rgba(255,255,255,0.12), inset 0px 1px 3px rgba(0,0,0,0.12);
-}
-
-#xkit-1cp-social-twitter {
-	border-left: 0;	width: 100px;
-	margin-left: 1px;
-}
-
 .xkit-one-click-reblog-working:after,
 .xkit-one-click-reblog-working {
 	background-image: url(data:image/gif;base64,R0lGODlhEgASAOYAAIjJ9Wmq14e42KXZ+rbo/Kz8/Lz+/KT0/OTu9pTk/ITT/OT0/Izc/Hq02XzM/Hi45pzs/LT9/HTE/JbH6Mz+/HapysT+/IjD6jyMxGeky9T+/Eyc1DSEvGy89ESNu9zq9Ie+5ix8tHWt2FSl3GS17LzZ7CR1rNzz/JTN9cTb7Fyt5ESVzLfc99Ts/Mvj9Oz2/KTs/JTc/IzT/KTk/KTL6K3j/Jzc/Lzy/JfB3Jzj/Kzz/FydxMT0/Kzs/FSUvLTx/EyVxHzD9Fyj1JTV/Mz0/MTs/FSbzGScxOz+/OT+/Nz+/ESSxCx6rDSCtFyq3FSi1Oz6/PT6/EyazPz6/DyKvGSy5OT6/NTq9Mze7Gy67DR+tDyGvGy27Mzi7NTm9GSu41SWxHTC9PT2/HS+9FyezJzW/FSe1HzG/Nzu/FyWxNzm9MTW5EyRvOzy9ESOxDR6rD+GtGyy5HzB6szu/KzT77TQ5OTy9J3Q88nm/FSaxNTy/Fym3NTi7PT+/Pz+/P///yH/C05FVFNDQVBFMi4wAwEAAAAh+QQJCQB/ACwAAAAAEgASAAAHtYB/gn9+KRVwJoOKix87IUwmiYuLWFRNISEmTJOKH0tbHFsCH1Ocgn4BGBh5H6aKLksYKwiug34gK0A0tX69qBsbL7x+fX0jI061gn1IfU4jVcp/zEkPKl9RvElJSHdVJHi1fUpKSC0kWQB+pn7kSn1+AGESA+uLfkkUFErrCw7/NhbYm0bBggUNfQadUMCQwYwbNwxEMGCAApJFL2wwSJAAwoECBSJQSDjJz4kbMDyKRDLwTyAAIfkECQkAfwAsAAAAABIAEgAAB7OAf4J/fikNbE0hHhUug45/HxkYHFohTCYmBo+CLlIYkxyJTBybfwhmK0tLOB9TUwgam34NGxsBCKWPLiMjT7i5jhNOI3TAjw8qKi/GjlwkDcyOWR1h0X7XAGESUcZ+fX1+AxISc919SH1oDg4xfrl+SPHXNgoMBO6P8ElJSO5QDAwS9LCC708fJQiVFFyQIAGEAxEsUJhIQYOSPo+g/HhYIIIBAxI1YJRlhUIEjxaU9HMUCAAh+QQJCQB/ACwAAAAAEgASAAAHtoB/gn9+XQJGVBxsFSl+g48IIisYGBwcISEmPmqPf14jGytLGFRbTUwmJl+PC06gZhMffn5qOFtLj34grgELnX9tfY8tKipfvr+/dx0kLMnJAB0dL8+/EhJn1b8O3NqdMg4KwtWOgjUKMnras7MnDAwz5b9+fX3sNQkJN/KD9Ej1jqBAgHDAABJ5fpIkQXJwkJUDBwpEsKChogYlCvn96WNAogEDFChcTKJRkB8kFCxYEJnE3qNAACH5BAkJAH8ALAAAAAARABIAAAe1gH+Cf34uIEJLbmANKX6DgwsPGxsrSxyXWjsfj1dfT0+UlVscIUxaKYILXCpOTjQffn4IOFQmJm9qfgAkVQ8Ij4JtPiZVfS0dyG3Agy8GggMSYSzL1DIOElDUywoOMtrbMgzfwDYMMX3jgwQMCSfpgkkJEDqO1LGCfj8HBxb1j7H3/kDRUaCABST+/PRB0idgkggRDBigoCSJxSQM/f3pY8GABQsUNCip2HCZHyRKNIRUknFQIAAh+QQJCQB/ACwAAAAAEgASAAAHuIB/gn9+VxNxTxtCAlh+g48LFyoqiVIrGBgZH49/aGMkVSojiZdUHFRYgwtnHR1cdAtTfnY0QBxNTZt+ZRISAAucfy87ISFpficOyi/BgmIeJiZrBAoKRc2DddEVOQwKUdiCUTkUfwkJOeHBEAkH6pw9EAeO74I8BwdJ9YJJBQUG9N75sRAhgoaA6voYMGBBQ5+AfhAOQmLBAgUKSpIgQdLnYbM+GihoUJKR40OJgvz0SZJR48lHgQAAIfkECQkAfwAsAAAAABIAEgAAB7KAf4J/fi0DciQqcTh4foOPL0MSHVmJI08bIh+PfycKDhJhHSRfmBsrUl2DUAwKnywLU34vdE9LGEubfjUMDEMvnH8vARhUGX5WCcrAwX9iUk0cKTwQCUTNg3VNIRU6Bwd92IJTHCEeBQcF4oM+TEwFBRHrgmAmTBYRBo7rERJgGgYMJJk3CIkBCxT2zfOjgQKFJArX9dFAEWJEbBOVKEmCpI+fi5z8JOHY0ePCPiU/NgsEACH5BAkJAH8ALAAAAAASABIAAAe4gH+Cf34nNTISY0F3V36Dj1AzCgoSEh0kVU4PCI9/VjkMDAoOiSQqTiN7XYNIMAkJDAQvfn4vLF8bG2acfjcQEDBQnX8vDVIrAX5JBQcHYsOCYkJLGFgUBQUa0IMlGBgCBhERfduCU24cUgbr5YNkTRwW8u2CO01NFBYUjuV+WyEelFCggKSdFxMhKvTRoEEJP2gzTJhY40eJkiRIHg7TkIzQxSR9aNEjhBFJyJGE+qjU2I6WyHKBAAAh+QQJCQB/ACwAAAAAEgASAAAHtoB/gn9+CwQxCg4OAy1+g49QBAkMCokSHVkXC49/SQcQk5QOlyRVVVeDfQWfEEUvfn4vLFlOtQiEFgUFP32cfy9yI08NfkgRx0i+glEBGxsuGgYGSsqDJRtLAhQWBr3Vf1NAS2TbFN+DGRgYFBQa54IZHBhKGhqO334eHGlJSkre1fiECCGij5IkSO758rNjYIpiCPsofITDhIk0joohkThREJIQbz4M8tNHYjUKKTjB6viOpbJAACH5BAkJAH8ALAAAAAASABIAAAe4gH+Cf35WPDAxDDE1aH6Dj30GBxAJDAwKDhIoC49/SBEFk5QMDpkdYy2DkaAFFFB+flB4QR1cXJx+FAa7fZ1/UQAqKiB+fRYWBr2+vw8jIy5KFBZJy4MuziAaGhSO1YRPGwHaSt6DIitSSkrU5X8BKytJ8t3VflIYO31JSPTLXhxURPhBgqRPv0d+MnDgkKKYwYOC/AgIoWWHI1gQ/yw4YiJEkw+DMhIKYUJLinaDJPgAiVKQwUeBAAAh+QQJCQB/ACwAAAAAEgASAAAHrIB/gn9+SBQRBzAwNyd+g499hxEFBxAJCQwDL49/fRYWBpM6MJgMCgong5EUoEpIfn5RcwwOtQuEShoUFH2cf1FlEmEAfn25Go6+vw5ZWS1ISq7Kg3gkJHdJ2cnTfiROD0jh048PTk7hveOCDyMjfe/byn5CGwGwsOotK1Ig+Op+IpYscaFOkB8cGDDYK+glQxMOSz6oa+CBSYgmVLAUXMHE4g6JBaXAqZAiXiAAIfkECQkAfwAsAAAAABIAEgAAB7GAf4J/fn1KFgYRBhZWfoOPfkoUFogRBQcHP1CPf4YaFBQGiZcQOQkLg35JShoaSX1+hRowCQwxm35ISauOnH0wDAo2sUi6vZydMQAOJ319SH3Ijy0ODgOFsNKpZx0AscfafwAdEuHIFyRc5pBcKg/rgx9OKhPwhA0bIy7wfhMbGw3ACcom6IOIJSueIJA2Ak6GDGA4YMAgZR8yDSZMMGHSpAmGDB+0XakAhyObBljABQIAIfkECQkAfwAsAAAAABIAEgAAB62Af4J/fn1JGhQWFhpIfoOPfklKiIkGEQUGfY+ESZKTlZcFB1aDfkhInUh9foVKEQcQM0iEfX2njpt9PxAJPayFq5uDfbwMJ7+4woJ6MgoEysp+Cgoy0MplDg7WwkMSEtuQQR0A4INoJFl35YQXJCRem1PCfjQjTiDJfyQ+WMkfDRvsIXikwIQJJh4yiCCzZEVAeI/U+GASIgQHDhiWLBExcF4KEWw4UDEioEu+QAAh+QQJCQB/ACwBAAAAEQASAAAHtoB/gn5+SEoaiEpIfoKNf4VJSYcUFBYGFH2Ofn1ISJJKlAYGERFIg5uci4R9SaMFBaaPfX2Mjn99BgcHP7WEto1+OhAQC7/GJwkJN8a/fgkMOcy/MzIK0rY2CtbXgwpnMtyCCxISA4IaUcx+AB0dLX8KJhlTzXQkJAB+H0wmJmBYtf58AOFEBZdif1JoYRKiCRARDTJseDLiyxVHH3aE4MABA4YVGzY8QKgpRQMwGJYIAeEi4J9AACH5BAkJAH8ALAAAAAASABIAAAe1gH+Cf35+fUhJSUpJfX6Dj4V9h4lKGhQafY+DkYhJGpYUFkiagoWmfkihBgaZpKR+FAYRFo6umn4GBQWjtppJBQcWvbcHBzrDmj8QEMiPPQkJf0owYsN+MQw5FSYmdcMLCgoEa9xsUbZ+ZQ4KJ35pISEV57cDEmdljh8cIRxkXbV/EKDo0OHMgkFY4HCggoFMAxBxnFQhMeaKpg8ZMGBYIWXDExUqLhx81UWAEClPAky4AvBPIAAh+QQJCQB/ACwAAAAAEgASAAAHs4B/goN/fn59iH1+hIyChn1ISElJi42Eh5JJSkp9loOGh5saGp2el0oUFBqVpo4aFhZIrYRIBgYaYB0FrJZ+BhEWTCZas38WEQXCcMUGBQUeIVpirX46BwUVIU11rVYQEDwpHBx5UZ5+NQkJVn4ZHBgNU41+BAwMNYsfSxgrAV6sC2woUMAAyqAuUlZs2BDgwgQ5YSQ4ULCAEYIAG56MUEEiS4cwNl706oIjDkc5A1rIGxQIACH5BAkJAH8ALAAAAAASABIAAAexgH+Cg4R+hn6EiYmGfX2Iiop+jUhIfZCLfkhJm4h+ARSXf5lKSkl+ayYmCqF+pBp9Fak4oX99FBRKHiFMCLR+txRNIVS0ghoWFhxNHsV/FAYGYBxUYr4GEQYCGBgltEgFERRY2wFRl343BwWmASsrII+FPBAQN4gnZhtPD1fxCzUJEhyAMsjLkxFOVARBUQaFAgUMcixIhOCBiipVOkiQ8HAGwUhXUAQZI0FGjRPx/gQCACH5BAkJAH8ALAAAAAASABIAAAe2gH+Cg4SDfoWIhX6LhSlJiX9+fX2Hgh9vHH2Ii31ISId+aSYmAYmSnp8pTCZaH5B+SElKfRUhITiQgn1KSklAHE0IuZFKGkpUHG7DgkoUFBhUQMt/Gs5kGEtRw34WFhQCKyslw0gGBhouQBtfU68WERGfDRsjIJWEfhQFBRaHCE4jVFxAcw/KDwgHCiAZdOWLChIdHAwYEINBAggwFhRacAGiBAcOFFjsAcVUiwEAQsYgsODen0AAIfkECQkAfwAsAAAAABIAEgAAB7CAf4J/fn6Dh4iDHz4OiY5/KVomTI+EiltMk0SOhYZ+RyEhbB+cfaZ+KRxNW6SlfUh+AhwcOJWESElIRhgYdrZ+ScErS1K2gklKSlIrZsZ/yBoBG2ZRvxoUSiBPTym2SBTYLiMjD9WcFBYWsA8qVShTiX4aBgYUhgtcVVkAJ4aCSBYKRDDQZ1CLDh0kOJBRg8AMCAcEIkG0AIVCBwoYJIBoYGI8NDViMIgx44YVf4ICAQA7) !important;
@@ -89,7 +55,6 @@
 	padding: 10px;
 	resize: none;
 	border: 0;
-	box-shadow: 0px 1px 0px white;
 	margin: 0; display: block;
 	vertical-align: middle;
 	background: white;
@@ -134,33 +99,6 @@
 
 #x1cpostage_clear_tags {
 	border-top: 1px solid #abafbc;
-}
-
-#x1cpostage_replace {
-	width: 200px;
-	padding: 5px 10px;
-	padding-left: 22px;
-	resize: none;
-	background: rgba(255,255,255,0.86);
-	font-size: 12px;
-	color: #7a7f8e;
-	border-top: 0;
-	margin: 0;
-	margin-top: 2px;
-	position: relative;
-	cursor: pointer;
-}
-
-#x1cpostage_replace.selected div {
-	background: #4c990d;
-}
-
-#x1cpostage_replace div {
-	position: absolute;
-	top: 8px; left: 8px;
-	width: 10px; height: 10px;
-	border: 1px solid #abafbc;
-	border-radius: 10px;
 }
 
 #x1cpostage_reblog,
@@ -253,14 +191,6 @@
 #x1cpostage_reblog i::before,
 #x1cpostage_queue i::before,
 #x1cpostage_draft i::before,
-#xkit-1cp-social-facebook::before,
-#xkit-1cp-social-twitter::before {
-	font-family: tumblr-icons, Blank;
-	font-size: 2em;
-	margin-left: 2px;
-	vertical-align: middle;
-	position: relative;
-}
 
 #x1cpostage_reblog i::before,
 #x1cpostage_queue i::before,
@@ -304,21 +234,6 @@
 .xkit--react #x1cpostage_queue i::before,
 .xkit--react #x1cpostage_draft i::before {
 	display: none;
-}
-
-
-#xkit-1cp-social-twitter::before {
-	content: "\EAA5";
-	bottom: 1px;
-}
-#xkit-1cp-social-facebook::before {
-	content: "\EA40";
-	background: #7a7f8e;
-	font-size: 1.2em;
-	color: rgba(245,245,245,1);
-	border-radius: 2px;
-	padding: 5px 0 0 5px;
-	top: 8px; left: 2px;
 }
 
 #x1cpostage_tags {

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1287,8 +1287,14 @@ XKit.extensions.one_click_postage = new Object({
 
 		const requestPath = `/v2/blog/${blog_id}/posts`;
 
+		const content = caption
+			.split('\n')
+			.map((text) => text.trim())
+			.filter(Boolean)
+			.map((text) => ({ formatting: [], type: 'text', text }));
+
 		const requestBody = {
-			content: caption ? [{ formatting: [], type: 'text', text: caption }] : [],
+			content,
 			tags,
 			parent_post_id: post_id,
 			parent_tumblelog_uuid,

--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1,5 +1,5 @@
 //* TITLE One-Click Postage **//
-//* VERSION 4.4.23 **//
+//* VERSION 4.5.0 **//
 //* DESCRIPTION Lets you easily reblog, draft and queue posts **//
 //* DEVELOPER new-xkit **//
 //* FRAME false **//
@@ -91,11 +91,6 @@ XKit.extensions.one_click_postage = new Object({
 			default: false,
 			value: false
 		},
-		"show_caption_remover": {
-			text: "Show the Remove Caption button",
-			default: true,
-			value: true
-		},
 		"show_caption": {
 			text: "Show the Caption box",
 			default: true,
@@ -116,11 +111,6 @@ XKit.extensions.one_click_postage = new Object({
 			default: false,
 			value: false
 		},
-		"show_social": {
-			text: "Show Post To Facebook and Twitter buttons",
-			default: false,
-			value: false
-		},
 		"allow_resize": {
 			text: "Allow resizing of the caption box vertically",
 			experimental: true,
@@ -138,11 +128,6 @@ XKit.extensions.one_click_postage = new Object({
 		},
 		"dont_show_notifications": {
 			text: "Turn off the notifications displayed when successfully reblogged/queued/drafted",
-			default: false,
-			value: false
-		},
-		"use_toasts": {
-			text: "Use tumblr-style notifications instead of XKit ones",
 			default: false,
 			value: false
 		},
@@ -540,12 +525,6 @@ XKit.extensions.one_click_postage = new Object({
 
 	init: async function(m_blogs) {
 
-		var m_remove_button = "<div id=\"x1cpostage_remove_caption\">remove caption</div>";
-
-		if (!this.preferences.show_caption_remover.value) {
-			m_remove_button = "";
-		}
-
 		var m_remove_box_style = "";
 		if (!this.preferences.show_caption.value) {
 			m_remove_box_style = " style=\"display: none;\" ";
@@ -564,22 +543,18 @@ XKit.extensions.one_click_postage = new Object({
 						'<input id="x1cpostage_tags" placeholder="tags (comma separated)" autocomplete="off"/>' +
 						m_clear_tags_button +
 						"<textarea id=\"x1cpostage_caption\" " + m_remove_box_style + " placeholder=\"caption\"></textarea>" +
-						"<div id=\"x1cpostage_replace\" " + m_remove_box_style + "><div>&nbsp;</div>replace caption, not append</div>" +
-						m_remove_button +
 						"<div id=\"x1cpostage_reblog\"><i>&nbsp;</i></div>" +
 						"<div id=\"x1cpostage_queue\"><i>&nbsp;</i></div>" +
 						"<div id=\"x1cpostage_draft\"><i>&nbsp;</i></div>" +
 					"</div>";
 
-			XKit.tools.add_css("#x1cpostage_draft { border-radius: 0px 0px 3px 0px; } #x1cpostage_reblog { border-radius: 0px 0px 0px 3px; } #x1cpostage_tags { border-radius: 3px 3px 0px 0px; border-bottom: 0; } #x1cpostage_replace { border-bottom: 0; } #x1cpostage_remove_caption { border-top: 1px solid #abafbc; border-bottom: 0; }", "x1cpostage_reverse_ui");
+			XKit.tools.add_css("#x1cpostage_draft { border-radius: 0px 0px 3px 0px; } #x1cpostage_reblog { border-radius: 0px 0px 0px 3px; } #x1cpostage_tags { border-radius: 3px 3px 0px 0px; border-bottom: 0; }", "x1cpostage_reverse_ui");
 		} else {
 			m_html = "<div id=\"x1cpostage_box\" class=\"xkit-no-nipple xkit-1xcpostage-non-reversed\">" +
 						"<div id=\"x1cpostage_reblog\"><i>&nbsp;</i></div>" +
 						"<div id=\"x1cpostage_queue\"><i>&nbsp;</i></div>" +
 						"<div id=\"x1cpostage_draft\"><i>&nbsp;</i></div>" +
 						"<textarea id=\"x1cpostage_caption\" " + m_remove_box_style + " placeholder=\"caption\"></textarea>" +
-						"<div id=\"x1cpostage_replace\" " + m_remove_box_style + "><div>&nbsp;</div>replace caption, not append</div>" +
-						m_remove_button +
 						'<input id="x1cpostage_tags" placeholder="tags (comma separated)" autocomplete="off"/>' +
 						m_clear_tags_button +
 					"</div>";
@@ -628,31 +603,6 @@ XKit.extensions.one_click_postage = new Object({
 				$("#x1cpostage_blog").val(this.preferences.default_blog.value);
 			}
 		}
-
-		if (this.preferences.show_social.value) {
-			var socials_html = "<div id=\"xkit-1cp-social\">" +
-					"<div data-site=\"facebook\" id=\"xkit-1cp-social-facebook\">&nbsp;</div>" +
-					"<div data-site=\"twitter\" id=\"xkit-1cp-social-twitter\">&nbsp;</div>" +
-					"</div>";
-			if (this.preferences.show_reverse_ui.value) {
-				$("#x1cpostage_reblog").before(socials_html);
-			} else {
-				$("#x1cpostage_draft").after(socials_html);
-			}
-		}
-
-		var share_fb = XKit.storage.get("one_click_postage", "share_on_facebook", "false");
-		var share_twitter = XKit.storage.get("one_click_postage", "share_on_twitter", "false");
-
-		if (share_fb === "true") { $("#xkit-1cp-social-facebook").addClass("selected"); }
-		if (share_twitter === "true") { $("#xkit-1cp-social-twitter").addClass("selected"); }
-
-		$("#xkit-1cp-social-facebook, #xkit-1cp-social-twitter").click(function() {
-			$(this).toggleClass("selected");
-			var m_value = "false";
-			if ($(this).hasClass("selected") === true) { m_value = "true"; }
-			XKit.storage.set("one_click_postage", "share_on_" + $(this).attr('data-site'), m_value);
-		});
 
 		var reblog_buttons = [
 			'.reblog_button',
@@ -712,38 +662,8 @@ XKit.extensions.one_click_postage = new Object({
 			event.stopImmediatePropagation();
 		});
 
-		$("#x1cpostage_remove_caption").click(function() {
-			if (XKit.extensions.one_click_postage.preferences.show_reverse_ui.value) {
-				$("#x1cpostage_remove_caption").css('display', 'none');
-				$("#x1cpostage_caption").css('display', 'none');
-				$("#x1cpostage_replace").css('display', 'none');
-
-				// Determine where we are going to show the box.
-				var obj = XKit.extensions.one_click_postage.last_icon_object;
-				var offset = $(obj).offset();
-
-				// Box position
-				var box_left = offset.left - ($("#x1cpostage_box").width() / 2) + 13;
-				var box_top = (offset.top - $("#x1cpostage_box").height()) - 12;
-
-				$("#x1cpostage_box").css("top", box_top + "px");
-				$("#x1cpostage_box").css("left", box_left + "px");
-			} else {
-				$("#x1cpostage_remove_caption").slideUp('fast');
-				$("#x1cpostage_caption").slideUp('fast');
-				$("#x1cpostage_replace").slideUp('fast');
-			}
-
-			$("#x1cpostage_caption").addClass("x1cpostage_remove_caption_on");
-			$("#x1cpostage_tags").css("border-top", "1px solid #abafbc");
-		});
-
 		$("#x1cpostage_clear_tags").click(function() {
 			$("#x1cpostage_tags").val("");
-		});
-
-		$("#x1cpostage_replace").click(function() {
-			$(this).toggleClass("selected");
 		});
 
 		$("#x1cpostage_reblog").click(function() {
@@ -998,14 +918,10 @@ XKit.extensions.one_click_postage = new Object({
 		// Re-show the caption stuff.
 		if (XKit.extensions.one_click_postage.preferences.show_caption.value) {
 			$("#x1cpostage_caption").css("display", "block");
-			$("#x1cpostage_replace").css("display", "block");
 		} else {
 			$("#x1cpostage_caption").css("display", "none");
-			$("#x1cpostage_replace").css("display", "none");
 		}
 
-		$("#x1cpostage_remove_caption").css("display", "block");
-		$("#x1cpostage_caption").removeClass("x1cpostage_remove_caption_on");
 		$("#x1cpostage_tags").css("border-top", "0px");
 		$("#x1cpostage_caption").css("height", XKit.extensions.one_click_postage.caption_height + "px");
 
@@ -1225,6 +1141,11 @@ XKit.extensions.one_click_postage = new Object({
 			}
 		}
 
+		if (XKit.page.react) {
+			this.react_process(state, blog_id, post_id, caption, tags, m_button, quick_queue_mode);
+			return;
+		}
+
 		m_object.form_key = form_key;
 		m_object.channel_id = blog_id;
 
@@ -1260,14 +1181,6 @@ XKit.extensions.one_click_postage = new Object({
 			m_object["post[tags]"] = "";
 		}
 
-		if ($("#xkit-1cp-social-twitter").hasClass("selected") === true) {
-			m_object.send_to_twitter = "on";
-		}
-
-		if ($("#xkit-1cp-social-facebook").hasClass("selected") === true) {
-			m_object.send_to_fbog = "on";
-		}
-
 		if (typeof data.post.two === "undefined") {
 			data.post.two = "";
 		}
@@ -1282,30 +1195,14 @@ XKit.extensions.one_click_postage = new Object({
 			current_caption = data.post.three;
 		}
 
-		if ($("#x1cpostage_caption").hasClass("x1cpostage_remove_caption_on") === true) {
-			// User wishes to remove caption.
-			m_object.remove_reblog_tree = true;
-			m_object["post[two]"] = "";
-			m_object["post[three]"] = "";
-		} else {
-			if (caption !== "" && typeof caption !== "undefined") {
-				if ($("#x1cpostage_replace").hasClass("selected") === false) {
-					if (!XKit.extensions.one_click_postage.preferences.enable_popup_html.value) {
-						m_object[variable_to_use] = current_caption + "<p>" + caption.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') + "</p>";
-					} else {
-						m_object[variable_to_use] = current_caption + "<p>" + caption + "</p>";
-					}
-				} else {
-					m_object.remove_reblog_tree = true;
-					if (!XKit.extensions.one_click_postage.preferences.enable_popup_html.value) {
-						m_object[variable_to_use] = caption.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-					} else {
-						m_object[variable_to_use] = caption;
-					}
-				}
+		if (caption !== "" && typeof caption !== "undefined") {
+			if (!XKit.extensions.one_click_postage.preferences.enable_popup_html.value) {
+				m_object[variable_to_use] = current_caption + "<p>" + caption.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') + "</p>";
 			} else {
-				m_object[variable_to_use] = current_caption;
+				m_object[variable_to_use] = current_caption + "<p>" + caption + "</p>";
 			}
+		} else {
+			m_object[variable_to_use] = current_caption;
 		}
 
 		if (m_object[variable_to_use]) {
@@ -1363,17 +1260,7 @@ XKit.extensions.one_click_postage = new Object({
 							}
 						}
 						if (!this.preferences.dont_show_notifications.value) {
-							if (this.preferences.use_toasts.value && !XKit.page.react) {
-								XKit.toast.add(
-									responseData.created_post,
-									responseData.verbiage,
-									responseData.post_tumblelog.name_or_id,
-									responseData.post.id,
-									responseData.post_context_page
-								);
-							} else {
-								XKit.notifications.add(responseData.message, "ok");
-							}
+							XKit.notifications.add(responseData.message, "ok");
 						}
 					}
 				})
@@ -1387,6 +1274,51 @@ XKit.extensions.one_click_postage = new Object({
 					this.show_error(error, state);
 				});
 		});
+	},
+
+	react_process: async function(state, blog_id, post_id, caption, tags, m_button, quick_queue_mode) {
+		const state_string = {
+			0: 'published',
+			1: 'draft',
+			2: 'queue'
+		}[state];
+
+		const { blog: { uuid: parent_tumblelog_uuid }, reblogKey, rebloggedRootId } = await XKit.interface.react.post_props(post_id);
+
+		const requestPath = `/v2/blog/${blog_id}/posts`;
+
+		const requestBody = {
+			content: caption ? [{ formatting: [], type: 'text', text: caption }] : [],
+			tags,
+			parent_post_id: post_id,
+			parent_tumblelog_uuid,
+			reblog_key: reblogKey,
+			state: state_string
+		};
+
+		try {
+			const { meta, response } = await XKit.interface.react.api_fetch(requestPath, { method: 'POST', body: requestBody });
+			if (meta.status === 201) {
+				if (this.preferences.enable_alreadyreblogged.value) {
+					this.add_to_alreadyreblogged(rebloggedRootId);
+				}
+				if (this.preferences.enable_alreadyreblogged.value || this.preferences.dim_posts_after_reblog.value) {
+					if (quick_queue_mode !== true) {
+						this.make_button_reblogged(m_button);
+					} else {
+						XKit.interface.switch_control_button($(m_button), false);
+						XKit.interface.completed_control_button($(m_button), true);
+					}
+				}
+				if (!this.preferences.dont_show_notifications.value) {
+					XKit.notifications.add(response.displayText, "ok");
+				}
+			}
+		} catch (error) {
+			this.show_error(error, state);
+		} finally {
+			$(m_button).removeClass("xkit-one-click-reblog-working");
+		}
 	},
 
 	add_to_alreadyreblogged: function(post_id) {

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.19 **//
+//* VERSION 7.4.20 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -1176,6 +1176,19 @@ XKit.extensions.xkit_patches = new Object({
 				destroy_collapsed: function(id) {
 					$(`.${id}-collapsed`).removeClass(`${id}-collapsed`);
 					$(`.${id}-collapsed-note`).remove();
+				},
+
+				api_fetch: async function(resource, init) {
+					return XKit.tools.async_add_function(
+						async ({ resource, init = {}, headerVersion }) => { // eslint-disable-line no-shadow
+							// add XKit header to all API requests
+							if (!init.headers) init.headers = {};
+							init.headers['X-XKit-Version'] = headerVersion;
+
+							return window.tumblr.apiFetch(resource, init);
+						},
+					{ resource, init, headerVersion: XKit.version }
+					);
 				}
 			};
 


### PR DESCRIPTION
One-Click Postage is relatively similar to Quick Reblog in XKit Rewritten, so doing this instead of just breaking it doesn't preserve much functionality (sure, autotagger, multiline captions, yeah, yeah, whatever). I don't see this as as important like I do #2106.

---

This migrates One-Click Postage to use the modernized backend code that XKit Rewritten's Quick Reblog does instead of the legacy and presumably-someday-removed SVC endpoint when possible (i.e. on React pages).

It removes the share to Twitter/share to Facebook and caption replace options as well as an old option to use a different notification style. Off the top of my head, social media sharing is gone, caption replacing is not a thing post-NPF, and the other notification style didn't work on most pages anyway.