### PR TITLE
Old Blue: Fix accent colors not applying

### DIFF
--- a/Extensions/old_blue.js
+++ b/Extensions/old_blue.js
@@ -1,5 +1,5 @@
 //* TITLE Old Blue **//
-//* VERSION 2.1.3 **//
+//* VERSION 2.1.4 **//
 //* DESCRIPTION No more dark blue background! **//
 //* DETAILS Reverts the colour scheme and font to that of 2018 Tumblr. Overrides any Tumblr-provided color palettes. **//
 //* DEVELOPER New-XKit **//
@@ -48,6 +48,7 @@ XKit.extensions.old_blue = new Object({
 						--pink: 116, 128, 137;
 
 						--accent: 82, 158, 204;
+						--deprecated-accent: 82, 158, 204;
 						--secondary-accent: 229, 231, 234;
 						--follow: 243, 248, 251;
 


### PR DESCRIPTION
Fixes accent colors not being affected by Old Blue due to a Tumblr code change that I didn't really look into.

I left in the `--accent` override because I wouldn't be surprised if some Tumblr code still used it (erroneously or otherwise) and what's the harm, right. Also, I ain't testing that.