### PR TITLE
 Old Blue: Prevent erroneous accent color overrides

### DIFF
--- a/Extensions/old_blue.js
+++ b/Extensions/old_blue.js
@@ -1,5 +1,5 @@
 //* TITLE Old Blue **//
-//* VERSION 2.1.4 **//
+//* VERSION 2.1.5 **//
 //* DESCRIPTION No more dark blue background! **//
 //* DETAILS Reverts the colour scheme and font to that of 2018 Tumblr. Overrides any Tumblr-provided color palettes. **//
 //* DEVELOPER New-XKit **//
@@ -47,7 +47,6 @@ XKit.extensions.old_blue = new Object({
 						--purple: 167, 125, 194;
 						--pink: 116, 128, 137;
 
-						--accent: 82, 158, 204;
 						--deprecated-accent: 82, 158, 204;
 						--secondary-accent: 229, 231, 234;
 						--follow: 243, 248, 251;


### PR DESCRIPTION
<img width="414" src="https://github.com/AprilSylph/Palettes-for-Tumblr/assets/8336245/cfd9868b-eef4-41c2-baed-57aabe78ac39">

As per my comment here: https://github.com/AprilSylph/Palettes-for-Tumblr/pull/185#issuecomment-2134525907

It appears that Tumblr's code will expect `--accent` to be a color rather than a numerical triplet, and also that it may or may not make sense to override it in this extension (we'll have to see what it's actually used for). In either case, setting it to a numerical triplet is probably bad news. This therefore removes its override.