### PR TITLE
mv3 userScript world proof of concept

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,7 +6,6 @@
     es2022: true
     browser: true
     jquery: true
-    webextensions: true
   extends: eslint:recommended
   rules:
     dot-notation: [error, allowPattern: "^[A-Z]"]
@@ -72,3 +71,5 @@
     GM_openInTab: writable
     GM_listValues: writable
     GM_xmlhttpRequest: writable
+
+    bridge_call: writable

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -21,10 +21,11 @@ XKit.extensions.xkit_patches = new Object({
 		if (XKit.browser().firefox === true && XKit.storage.get("xkit_patches", "w_edition_warned") !== "true") {
 			let version = XKit.tools.parse_version(XKit.version);
 			if (version.major === 7 && version.minor >= 8) {
-				fetch(browser.extension.getURL("manifest.json")) // eslint-disable-line no-undef
+				fetch(browser.runtime.getURL("manifest.json")) // eslint-disable-line no-undef
 					.then(response => response.json())
 					.then(responseData => {
-						if (responseData.applications.gecko.id === "@new-xkit-w") {
+						if (responseData.applications && responseData.applications.gecko.id === "@new-xkit-w" ||
+							responseData.browser_specific_settings && responseData.browser_specific_settings.gecko.id === "@new-xkit-w") {
 							XKit.window.show(
 								"W Edition warning",
 								"XKit Patches has determined that you are using <br><b>New XKit (W Edition)</b>, an unofficial upload of New XKit.<br><br>" +

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -21,8 +21,7 @@ XKit.extensions.xkit_patches = new Object({
 		if (XKit.browser().firefox === true && XKit.storage.get("xkit_patches", "w_edition_warned") !== "true") {
 			let version = XKit.tools.parse_version(XKit.version);
 			if (version.major === 7 && version.minor >= 8) {
-				fetch(browser.runtime.getURL("manifest.json")) // eslint-disable-line no-undef
-					.then(response => response.json())
+				bridge_call("browser.runtime.getManifest")
 					.then(responseData => {
 						if (responseData.applications && responseData.applications.gecko.id === "@new-xkit-w" ||
 							responseData.browser_specific_settings && responseData.browser_specific_settings.gecko.id === "@new-xkit-w") {

--- a/background.js
+++ b/background.js
@@ -1,0 +1,90 @@
+/* globals browser, chrome */
+
+if (typeof browser === "undefined") {
+	// eslint-disable-next-line no-global-assign
+	browser = chrome;
+}
+
+function isUserScriptsAvailable() {
+	try {
+		return Boolean(browser.userScripts);
+	} catch {
+		return false;
+	}
+}
+
+if (isUserScriptsAvailable()) {
+	browser.userScripts.configureWorld({
+		csp: "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+		messaging: true,
+	});
+
+	browser.runtime.onInstalled.addListener(async () => {
+		const existingScripts = await browser.userScripts.getScripts({
+			ids: ["new-xkit"],
+		});
+		browser.userScripts[existingScripts.length > 0 ? "update" : "register"]([
+			{
+				id: "new-xkit",
+				// allFrames: true,
+				runAt: "document_start",
+				excludeMatches: [
+					"*://*.tumblr.com/*/audio_player_iframe/*",
+					"*://*.tumblr.com/*/photoset_iframe/*",
+					"*://assets.tumblr.com/*",
+					"*://*.media.tumblr.com/*",
+					"*://www.tumblr.com/upload/image*",
+					"*://www.tumblr.com/video/*",
+				],
+				matches: ["*://*.tumblr.com/*"],
+				js: [
+					"bridge.js",
+					"vendor/lodash.min.js",
+					"vendor/jquery.js",
+					"vendor/tiptip.js",
+					"vendor/moment.js",
+					"vendor/nano.js",
+					"xkit.js",
+				].map(file => ({file})),
+				world: "USER_SCRIPT",
+			},
+		]);
+	});
+
+	// must use synchronous callback form due to https://issues.chromium.org/issues/40753031
+	browser.runtime.onUserScriptMessage.addListener((request, sender, sendResponse) => {
+		console.log("onUserScriptMessage", {request, sender, sendResponse});
+
+		if (request.func) {
+			(async () => {
+				const {func, args = []} = request;
+
+				switch (func) {
+					case "browser.runtime.getManifest":
+						sendResponse(await browser.runtime.getManifest(...args));
+						break;
+					case "browser.storage.local.get":
+						sendResponse(await browser.storage.local.get(...args));
+						break;
+					case "browser.storage.local.getBytesInUse":
+						sendResponse(await browser.storage.local.getBytesInUse(...args));
+						break;
+					case "browser.storage.local.remove":
+						sendResponse(await browser.storage.local.remove(...args));
+						break;
+					case "browser.storage.local.clear":
+						sendResponse(await browser.storage.local.clear(...args));
+						break;
+					case "browser.storage.local.set":
+						sendResponse(await browser.storage.local.set(...args));
+						break;
+					case "browser.runtime.getURL":
+						sendResponse(await browser.runtime.getURL(...args));
+						break;
+				}
+			})();
+		}
+
+		return true;
+	});
+}

--- a/background.js
+++ b/background.js
@@ -13,6 +13,12 @@ function isUserScriptsAvailable() {
 	}
 }
 
+browser.runtime.onInstalled.addListener(() => {
+	if (!isUserScriptsAvailable()) {
+		browser.runtime.openOptionsPage();
+	}
+});
+
 if (isUserScriptsAvailable()) {
 	browser.userScripts.configureWorld({
 		csp: "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
@@ -67,7 +73,7 @@ if (isUserScriptsAvailable()) {
 						sendResponse(await browser.storage.local.get(...args));
 						break;
 					case "browser.storage.local.getBytesInUse":
-						sendResponse(await browser.storage.local.getBytesInUse(...args));
+						sendResponse(await browser.storage.local.getBytesInUse?.(...args));
 						break;
 					case "browser.storage.local.remove":
 						sendResponse(await browser.storage.local.remove(...args));

--- a/bridge.js
+++ b/bridge.js
@@ -51,7 +51,7 @@ function getBridgeError() { // eslint-disable-line no-redeclare
 
 function getVersion() {
 	var xhr = new XMLHttpRequest();
-	xhr.open('GET', browser.extension.getURL('manifest.json'), false);
+	xhr.open('GET', browser.runtime.getURL('manifest.json'), false);
 	xhr.send(null);
 	var manifest = JSON.parse(xhr.responseText);
 	return manifest.version;

--- a/manifest.json
+++ b/manifest.json
@@ -11,29 +11,30 @@
       "*://www.tumblr.com/upload/image*",
       "*://www.tumblr.com/video/*"
     ],
-    "js": [
-      "bridge.js",
-      "vendor/jquery.js",
-      "vendor/tiptip.js",
-      "vendor/moment.js",
-      "vendor/nano.js",
-      "xkit.js"
-    ],
     "matches": [ "*://*.tumblr.com/*" ]
   } ],
+  "background": {
+    "scripts": [ "background.js" ],
+    "service_worker": "background.js",
+    "persistent": false
+  },
   "description": "A fork of XKit, the extension framework for Tumblr.",
   "homepage_url": "https://github.com/new-xkit/XKit",
   "icons": {
     "128": "icon.png"
   },
-  "manifest_version": 2,
-  "minimum_chrome_version": "103.0",
+  "manifest_version": 3,
+  "minimum_chrome_version": "120.0",
   "name": "New XKit",
   "author": "New XKit Team",
-  "permissions": ["storage", "unlimitedStorage", "*://*.tumblr.com/*", "https://new-xkit.github.io/XKit/*", "https://cloud.new-xkit.com/*" ],
+  "permissions": ["storage", "unlimitedStorage", "userScripts" ],
+  "host_permissions": [ "*://*.tumblr.com/*", "https://new-xkit.github.io/XKit/*", "https://cloud.new-xkit.com/*" ],
   "version": "7.10.0",
-  "web_accessible_resources": [ "*.js", "*.json", "*.css", "*.txt" ],
-  "applications": {
+  "web_accessible_resources": [{
+    "resources": [ "*.js", "*.json", "*.css", "*.txt" ],
+    "matches": [ "*://www.tumblr.com/*" ]
+  }],
+  "browser_specific_settings": {
     "gecko": {
       "id": "@new-xkit",
       "strict_min_version": "115.0",

--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,9 @@
     "service_worker": "background.js",
     "persistent": false
   },
+  "options_ui": {
+    "page": "options_ui/options.html"
+  },
   "description": "A fork of XKit, the extension framework for Tumblr.",
   "homepage_url": "https://github.com/new-xkit/XKit",
   "icons": {
@@ -28,6 +31,7 @@
   "name": "New XKit",
   "author": "New XKit Team",
   "permissions": ["storage", "unlimitedStorage", "userScripts" ],
+  "optional_permissions": ["userScripts"],
   "host_permissions": [ "*://*.tumblr.com/*", "https://new-xkit.github.io/XKit/*", "https://cloud.new-xkit.com/*" ],
   "version": "7.10.0",
   "web_accessible_resources": [{
@@ -37,7 +41,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "@new-xkit",
-      "strict_min_version": "115.0",
+      "strict_min_version": "136.0b1",
       "update_url": "https://new-xkit.github.io/XKit/Extensions/dist/page/FirefoxUpdate.json"
     }
   }

--- a/options_ui/options.html
+++ b/options_ui/options.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>New XKit Options</title>
+  </head>
+  <body>
+    <p id="permissions-request" hidden>
+      &#x26A0;&#xFE0F; New XKit needs the user script permission.
+      <button id="grant-user-script-permission">Request user script permission</button>
+    </p>
+    <p>
+      Configure New XKit from a Tumblr page!
+    </p>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/options_ui/options.js
+++ b/options_ui/options.js
@@ -1,0 +1,20 @@
+/* globals browser, chrome */
+if (typeof browser === "undefined") {
+	// eslint-disable-next-line no-global-assign
+	browser = chrome;
+}
+
+const permissionsRequestElement = document.getElementById('permissions-request');
+const permissionsButton = document.getElementById('grant-user-script-permission');
+const updatePermissionsVisibility = hasPermission => {
+	permissionsRequestElement.hidden = hasPermission;
+};
+permissionsButton.addEventListener('click', () => {
+	browser.permissions
+		.request({ permissions: ['userScripts'] })
+		.then(updatePermissionsVisibility);
+});
+browser.permissions
+	.contains({ permissions: ['userScripts'] })
+	.then(updatePermissionsVisibility);
+

--- a/xkit.js
+++ b/xkit.js
@@ -6,7 +6,7 @@ var xkit_global_start = Date.now();  // log start timestamp
 	if (typeof XKit !== "undefined") { return; }
 
 	XKit = {
-		version: framework_version,
+		version: undefined,
 		api_key: "kZSI0VnPBJom8cpIeTFw4huEh9gGbq4KfWKY7z5QECutAAki6D",
 		page: {
 			standard:
@@ -23,7 +23,8 @@ var xkit_global_start = Date.now();  // log start timestamp
 			xkit:
 				document.location.href.indexOf('://www.tumblr.com/xkit_') !== -1
 		},
-		init: function() {
+		init: function(version) {
+			XKit.version = version;
 			if (!XKit.page.xkit) {
 				XKit.init_flags();
 			}
@@ -4397,7 +4398,7 @@ async function xkit_init_special() {
 	document.title = "XKit";
 
 	XKit.notifications.init();
-	XKit.notifications.add("<b>Welcome to XKit " + framework_version + "</b><br/>&copy; 2011-2013 STUDIOXENIX");
+	XKit.notifications.add("<b>Welcome to XKit " + XKit.version + "</b><br/>&copy; 2011-2013 STUDIOXENIX");
 
 	if (document.location.href.indexOf("/xkit_reset") !== -1) {
 		XKit.special.reset();
@@ -4418,7 +4419,7 @@ async function xkit_init_special() {
 	if (document.location.href.indexOf("/xkit_editor") !== -1) {
 		if (typeof(browser) !== 'undefined') {
 			try {
-				await import(browser.runtime.getURL("/editor.js"));
+				await import(await bridge_call("browser.runtime.getURL", ["/editor.js"]));
 				XKit.extensions.xkit_editor.run();
 			} catch (e) {
 				XKit.window.show("Can't launch XKit Editor", "<p>" + e.message + "</p>", "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");
@@ -4596,7 +4597,7 @@ function install_extension(mdata, callback) {
 
 function xkit_install() {
 
-	XKit.window.show("Welcome to New XKit " + framework_version + "!", "<b>Please wait while I initialize the setup. This might take a while.<br/>Please do not navigate away from this page.</b>", "info");
+	XKit.window.show("Welcome to New XKit " + XKit.version + "!", "<b>Please wait while I initialize the setup. This might take a while.<br/>Please do not navigate away from this page.</b>", "info");
 	console.log("Trying to retrieve XKit Installer.");
 
 	XKit.install("xkit_installer", function(mdata) {
@@ -4672,7 +4673,7 @@ function show_error_update(message) {
  * Functions used in place of gulp build server
  */
 
-const loadFile = path => fetch(browser.runtime.getURL(path)).then(response => response.text());
+const loadFile = async path => fetch(await bridge_call("browser.runtime.getURL", [path])).then(response => response.text());
 
 const extensionDataCache = {};
 


### PR DESCRIPTION
I kind of doubt the extension stores would count this as kosher, but.

This is an incomplete but working proof of concept for running the entirety of New XKit in Chrome's MV3 "userScript" world, which is kind of like ISOLATED except you're allowed to run strings (not currently used) and set CSP. Firefox will get this feature ~~eventually~~ in version 136, which will release in March 2025.

This version uses `script-src 'self' 'unsafe-inline' 'unsafe-eval'` as the CSP value, which is of course not particularly secure; in this form what the PR does is effectively whitelisting the privileged extension APIs our insecurely-executed-out-of-storage code can access. We basically only need `storage.local`.

There's no technical reason one can't remove `'unsafe-inline'` (using XKit Rewritten's MV3 injection method; I have this implemented in test builds already) or even potentially `'unsafe-eval'` (by grabbing the enabled script bodies from storage in the background script and injecting them as part of the `browser.userScripts.update` call; this sounds rather annoying to refactor). Doing both of those would be fairly interesting.

But doing the rest of this work and bugfixing the large number of ways to break things using mismatched stored script versions would be ~~waiting on a Firefox implementation and~~ gambling on the extension stores considering this a valid use of the new userScript API, just in order to preserve the XKit Editor functionality in an extension that's, to a first-order approximation, broken. Simply following the MV3 guidelines and removing the editor is a simpler way to let this codebase live on.