### PR TITLE
Clean up whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,6 @@ trim_trailing_whitespace = true
 
 [*.{js,css}]
 indent_style = tab
-indent_size = 4
 
 [{.*,package.json,.travis.yml}]
 indent_style = space

--- a/Extensions/better_reblogs.js
+++ b/Extensions/better_reblogs.js
@@ -185,10 +185,10 @@ XKit.extensions.better_reblogs = new Object({
 			var $el = $(this);
 			$el.blur();
 			XKit.window.show("Warning", "Changing the reblog style requires refreshing the page. " +
-                "<br>Are you sure you wish to continue?",
-                "warning",
-                '<div id="xkit-confirm-refresh" class="xkit-button default">Refresh</div>' +
-                '<div id="xkit-close-message" class="xkit-button">Cancel</div>');
+				"<br>Are you sure you wish to continue?",
+				"warning",
+				'<div id="xkit-confirm-refresh" class="xkit-button default">Refresh</div>' +
+				'<div id="xkit-close-message" class="xkit-button">Cancel</div>');
 			$("#xkit-confirm-refresh").click(function() {
 				window.location.reload();
 			});
@@ -209,18 +209,18 @@ XKit.extensions.better_reblogs = new Object({
 
 		if (this.preferences.margin.value) {
 			XKit.tools.add_css(list_sel + ".reblog-list-item .reblog-content {margin-left:35px;} " +
-                list_sel + ".reblog-list-item .reblog-title {margin-left:35px;}", "better_reblogs");
+				list_sel + ".reblog-list-item .reblog-title {margin-left:35px;}", "better_reblogs");
 		}
 
 		if (this.preferences.remove_icon.value) {
 			XKit.tools.add_css(".reblog-header .sub-icon-reblog:before {display: none!important;} " +
-                ".reblog-header .sub-icon-reblog:after {display:none!important;}", "better_reblogs");
+				".reblog-header .sub-icon-reblog:after {display:none!important;}", "better_reblogs");
 
 		}
 
 		if (this.preferences.add_border.value) {
 			XKit.tools.add_css(list_sel + ".reblog-list-item .reblog-content {border-left: 2px solid #E7E7E7; padding-left: 10px;} " +
-                ".post.post_full " + list_sel + ".reblog-list-item .tmblr-full > img {padding: 0 20px}", "better_reblogs");
+				".post.post_full " + list_sel + ".reblog-list-item .tmblr-full > img {padding: 0 20px}", "better_reblogs");
 
 			if (!(this.preferences.margin.value || this.preferences.remove_user_names.value)) {
 				XKit.tools.add_css(".reblog-list-item .reblog-content {margin-left: 3px;}", "better_reblogs");
@@ -239,32 +239,32 @@ XKit.extensions.better_reblogs = new Object({
 
 		if (this.preferences.remove_user_names.value) {
 			XKit.tools.add_css(".reblog-tumblelog-name {display:none;} .reblog-list-item .reblog-header {margin-bottom: 0;} " +
-                list_sel + ".reblog-content {margin-left:35px;} .reblog-title {margin-left:35px; margin-top:-10px;}", "better_reblogs");
+				list_sel + ".reblog-content {margin-left:35px;} .reblog-title {margin-left:35px; margin-top:-10px;}", "better_reblogs");
 		}
 
 		if (this.preferences.remove_avatars.value) {
 			XKit.tools.add_css(".reblog-avatar {display:none !important;} .reblog-header {padding-left: 0px !important;}",
-                "better_reblogs");
+				"better_reblogs");
 		}
 
 		if (this.preferences.alternating_reblogs.value) {
 			XKit.tools.add_css(
-                ".reblog-list-item:nth-child(odd){background-color: rgb(245,245,245); padding-bottom: 15px;}" +
-                ".reblog-list-item:nth-child(even){background-color: rgb(250,250,250);}" +
-                ".original-reblog-content {background-color: #fff !important; padding-bottom: 15px;}" +
-                ".contributed-content {background-color: #F0F5FA !important;" +
-                    "padding-bottom:15px !important; border-top: 1px solid #D9E2EA;}",
-                "better_reblogs");
+				".reblog-list-item:nth-child(odd){background-color: rgb(245,245,245); padding-bottom: 15px;}" +
+				".reblog-list-item:nth-child(even){background-color: rgb(250,250,250);}" +
+				".original-reblog-content {background-color: #fff !important; padding-bottom: 15px;}" +
+				".contributed-content {background-color: #F0F5FA !important;" +
+					"padding-bottom:15px !important; border-top: 1px solid #D9E2EA;}",
+				"better_reblogs");
 		}
 
 		if (this.preferences.slim_new_reblog.value) {
 			XKit.tools.add_css(".reblog-list-item {padding: 10px 20px 5px !important; min-height: 41px;}",
-                "better_reblogs");
+				"better_reblogs");
 		}
 
 		if (this.preferences.reorder_reblog_title.value) {
 			XKit.tools.add_css(".reblog-list-item .reblog-title {margin-left:0!important;}",
-                "better_reblogs");
+				"better_reblogs");
 		}
 
 		XKit.extensions.better_reblogs.do_flat();
@@ -274,14 +274,14 @@ XKit.extensions.better_reblogs = new Object({
 
 	run_nested: function() {
 		XKit.tools.add_css('.posts .reblog-list {display: none!important} ' +
-                '.posts .reblog-title {display: none!important} ' +
-                '.posts .reblog-list-item.contributed-content ' +
-                    '{display: none!important;} ' +
-                '.posts .post_full.post .post_content_inner .post_media ' +
-                '~ .xkit-better-reblogs-old {margin-top: 13px;} ' +
-                '.xkit-better-reblogs-old p.reblog-user {margin-bottom: 10px} ' +
-                '.xkit-better-reblogs-old blockquote.reblog-quote {margin-top: 10px}',
-            'better_reblogs');
+				'.posts .reblog-title {display: none!important} ' +
+				'.posts .reblog-list-item.contributed-content ' +
+					'{display: none!important;} ' +
+				'.posts .post_full.post .post_content_inner .post_media ' +
+				'~ .xkit-better-reblogs-old {margin-top: 13px;} ' +
+				'.xkit-better-reblogs-old p.reblog-user {margin-bottom: 10px} ' +
+				'.xkit-better-reblogs-old blockquote.reblog-quote {margin-top: 10px}',
+			'better_reblogs');
 		XKit.extensions.better_reblogs.do_nested();
 		XKit.post_listener.add("better_reblogs", XKit.extensions.better_reblogs.do_nested);
 		if (this.preferences.color_quotes.value) {
@@ -295,7 +295,7 @@ XKit.extensions.better_reblogs = new Object({
 	run_cq: function() {
 		if (this.preferences.increase_padding.value === true) {
 			XKit.tools.add_css("#posts .post_content blockquote " +
-                "{ padding-top: 8px; padding-bottom: 8px; }", "colorquotes_padding");
+				"{ padding-top: 8px; padding-bottom: 8px; }", "colorquotes_padding");
 		}
 
 		if ($("#posts").length > 0) {
@@ -380,9 +380,9 @@ XKit.extensions.better_reblogs = new Object({
 			all_quotes.forEach(function(data, index, all) {
 				var reblog_content = data.reblog_content;
 				all_quotes_text =
-                    '<p class="reblog-user">' + "<a class='tumblr_blog' href='" + data.reblog_url + "'>" +
-                        data.reblog_author + "</a>:</p>" +
-                    '<blockquote class="reblog-quote">' + all_quotes_text + reblog_content + "</blockquote>";
+					'<p class="reblog-user">' + "<a class='tumblr_blog' href='" + data.reblog_url + "'>" +
+						data.reblog_author + "</a>:</p>" +
+					'<blockquote class="reblog-quote">' + all_quotes_text + reblog_content + "</blockquote>";
 			});
 
 			$this.find(".xkit-better-reblogs-old").append(all_quotes_text);
@@ -396,7 +396,7 @@ XKit.extensions.better_reblogs = new Object({
 		var posts = XKit.interface.get_posts("xkit-color-quoted");
 
 		var colors = XKit.extensions.better_reblogs
-            .colors[XKit.extensions.better_reblogs.preferences.cq_theme.value];
+			.colors[XKit.extensions.better_reblogs.preferences.cq_theme.value];
 
 		$(posts).each(function() {
 

--- a/Extensions/limit_people.js
+++ b/Extensions/limit_people.js
@@ -87,9 +87,9 @@ XKit.extensions.limit_people = new Object({
 		var total = $(posts).length;
 
 		$(posts).each(function(index) {
-			
+
 			if ($(this).parents('.peepr-drawer').length > 0) { return; }
-			
+
 			var m_post = XKit.interface.post($(this));
 			$(this).addClass("xkit-limit-people-checked");
 

--- a/Extensions/mass_deleter.js
+++ b/Extensions/mass_deleter.js
@@ -398,7 +398,7 @@ XKit.extensions.mass_deleter = new Object({
 					//We didn't get the next page, so we're assuming this one was the last.
 					XKit.extensions.mass_deleter.unlike_current_array();
 					stop_action = true;
-				
+
 				}
 				if (stop_action) { return; }
 

--- a/Extensions/mirrorposts.js
+++ b/Extensions/mirrorposts.js
@@ -36,11 +36,11 @@ XKit.extensions.mirrorposts = new Object({
 		XKit.post_listener.remove("archivebutton_addButton");
 		XKit.tools.remove_css("mirrorposts");
 		$(".archivebutton-button").remove();
-		
+
 		$(".archivebutton_applied .share_social_button").unbind();
 		$(".archivebutton_applied").removeClass("archivebutton_applied");
-		
-		
+
+
 		this.running = false;
 
 	},
@@ -70,7 +70,7 @@ XKit.extensions.mirrorposts = new Object({
 					window.open(archiveurl, '_blank');
 				});
 				$(".post_controls_inner", this).prepend(button);
-				
+
 			} else {
 				$(".share_social_button", this).click(function() {
 					var menuitem = $('<li class="popover_menu_item"><a class="popover_menu_item_anchor">Archive this post</a></li>');

--- a/Extensions/pokes.js
+++ b/Extensions/pokes.js
@@ -136,11 +136,11 @@ XKit.extensions.pokes = {
 
 			if (XKit.extensions.pokes.preferences.allow_fullwidth.value) {
 				poke_html = `<div class="poke ${poke_class}${shiny_class}" data-pokeid="${db_nr}" data-pokesortid="${poke_sortid}" data-pokename="${poke_name}" data-pokegender="${poke_gender}" style="left:${xpos}px; margin-top:${ypos}px;">` +
-					`<img src="${poke_sprite}" alt="${poke_name}"/>` + 
+					`<img src="${poke_sprite}" alt="${poke_name}"/>` +
 				'</div>';
 			} else {
 				poke_html = `<div class="poke fixed ${poke_class}${shiny_class}" data-pokeid="${db_nr}" data-pokesortid="${poke_sortid}" data-pokename="${poke_name}" data-pokegender="${poke_gender}" style="margin-top:${ypos}px;">` +
-					`<img src="${poke_sprite}" alt="${poke_name}"/>` + 
+					`<img src="${poke_sprite}" alt="${poke_name}"/>` +
 				'</div>';
 			}
 
@@ -252,14 +252,14 @@ XKit.extensions.pokes = {
 			'<div class="xkit-pokes-lightbox" style="opacity: 0">' +
 			'<div class="xkit-pokes-pc">' +
 					'<div class="xkit-pokes-pc-sorter">' +
-              '<input type="radio" name="xkit-pokes-sort" class="xkit-pokes-sorter" id="chronological" title="Order of capture" checked="checked"></input>' +
-              '<label for="chronological"></label>' +
-              '<input type="radio" name="xkit-pokes-sort" class="xkit-pokes-sorter" id="alphabetical" title="Name"></input>' +
-              '<label for="alphabetical"></label>' +
-              '<input type="radio" name="xkit-pokes-sort" class="xkit-pokes-sorter" id="pokeid" title="Pokédex # ordering"></input>' +
-              '<label for="pokeid"></label>' +
-              '<input type="checkbox" class="xkit-pokes-sorter" id="reverse-toggle"></input>' +
-              '<label for="reverse-toggle"></label>' +
+				'<input type="radio" name="xkit-pokes-sort" class="xkit-pokes-sorter" id="chronological" title="Order of capture" checked="checked"></input>' +
+				'<label for="chronological"></label>' +
+				'<input type="radio" name="xkit-pokes-sort" class="xkit-pokes-sorter" id="alphabetical" title="Name"></input>' +
+				'<label for="alphabetical"></label>' +
+				'<input type="radio" name="xkit-pokes-sort" class="xkit-pokes-sorter" id="pokeid" title="Pokédex # ordering"></input>' +
+				'<label for="pokeid"></label>' +
+				'<input type="checkbox" class="xkit-pokes-sorter" id="reverse-toggle"></input>' +
+				'<label for="reverse-toggle"></label>' +
 					'</div>' +
 				'<div class="xkit-pokes-pc-info">' +
 					'<div class="gender"></div>' +

--- a/Extensions/video_downloader.js
+++ b/Extensions/video_downloader.js
@@ -23,7 +23,7 @@ XKit.extensions.video_downloader = new Object({
 		XKit.post_listener.remove("video_downloader");
 		this.running = false;
 	},
-	
+
 	makeButton: function(url) {
 		var el = document.createElement("a");
 		var filename = url.split("/").pop();
@@ -34,7 +34,7 @@ XKit.extensions.video_downloader = new Object({
 		el.innerText = "Download this video";
 		return el;
 	},
-	
+
 	addButtons: function() {
 		setTimeout(function() {
 			var vids = document.querySelectorAll(".crt-video:not(.xvd-processed)");


### PR DESCRIPTION
This fixes a few space-indented code sections that weren't converted by eslint and removes some trailing whitespace, and removes the enforced tab width in the editorconfig, which doesn't do anything besides overriding the user's IDE tab width preference.

I don't think this needs version bumps and deployment, really?