### PR TITLE
Add 7.9.2 deployment workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,56 @@
+name: Rebuild Distribution (7.9.2)
+
+on:
+  push:
+    branches:
+      - '7.9.2'
+    paths:
+      - 'Extensions/*'
+      - 'Themes/*'
+
+jobs:
+  build:
+    name: Autobuild extensions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: 14
+
+      - name: Configure git
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch and reset gh-pages
+        run: |
+          git remote set-branches --add origin gh-pages
+          git fetch
+          git checkout -f -t -b gh-pages origin/gh-pages
+          git reset --hard 7.9.2
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Install gulp-cli
+        run: npm install gulp-cli
+
+      - name: Build distribution
+        run: gulp build
+
+      - name: Commit changes
+        run: |
+          git add --force Extensions/
+          git commit -m 'Rebuild Distribution'
+
+      - name: Force-push to gh-pages
+        run: git push -f


### PR DESCRIPTION
In order to deploy code changes to the 7.9.2 version, which gets its extension updates from github.io, we need a branch of this repository which contains that version of the deployment code and for its github action to exist on the main branch. (Note that it technically can be anything; the version of the action on the target branch is executed. The main branch just has to include an action file with the same name.)

This is required in order to deploy versions past 7.9.2, due to an interesting bug: XKit Patches will run every patch it has if the XKit version is one it does not have an entry for. These patches will override the 7.10.0 changes.

https://github.com/new-xkit/XKit/blob/d3bc76af11f2602faa668edc4c6410e2954b40c8/Extensions/xkit_patches.js#L13-L17