### PR TITLE
7.10.0 xkit patches version bump

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.21 **//
+//* VERSION 7.4.23 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 


### PR DESCRIPTION
Bumps the xkit_patches version on the main branch so it's higher than the value used in 4c909e9673b2d9264e5506bc755d8607da12efd6.

(Yes, I am acutely aware at this point that modifying the deploy process without making a document outlining every step for doing so, getting approval for this entire document from another team member, and requesting branch protection override permissions to fix what I inevitably broke while doing so myself was a bad idea; you don't have to tell me :D)