### PR TITLE
Release action: fix XPI download step

### DIFF
--- a/.github/workflows/release-after-signing.yml
+++ b/.github/workflows/release-after-signing.yml
@@ -22,6 +22,9 @@ jobs:
 
       - name: Firefox — Download Latest Signed XPI
         run: node dev/download_signed_xpi.mjs
+        env:
+          WEB_EXT_API_KEY: ${{ secrets.WEB_EXT_API_KEY }}
+          WEB_EXT_API_SECRET: ${{ secrets.WEB_EXT_API_SECRET }}
 
       - name: Get Release Version
         uses: actions/github-script@v7


### PR DESCRIPTION
Adds some lines I must have forgotten to migrate to the generate-release-if-Mozilla-timed-out action.