### PR TITLE
v7.9.2: Fix XKit Patches on any future versions

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -11,9 +11,9 @@ XKit.extensions.xkit_patches = new Object({
 		this.running = true;
 
 		this.run_order.filter(x => {
-			return this.run_order.indexOf(x) >= this.run_order.indexOf(XKit.version);
+			return this.run_order.indexOf(x) >= this.run_order.includes(XKit.version) ? this.run_order.indexOf(XKit.version) : Infinity;
 		}).forEach(x => {
-			this.patches[x]();
+			this.patches[x] && this.patches[x]();
 		});
 
 		if (XKit.browser().firefox === true && XKit.storage.get("xkit_patches", "w_edition_warned") !== "true") {

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.21 **//
+//* VERSION 7.4.20 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -179,10 +179,10 @@ XKit.extensions.xkit_patches = new Object({
 		}, 1000);
 	},
 
-	run_order: ["7.8.1", "7.8.2", "7.9.0", "7.9.1", "7.9.2", "7.10.0"],
+	run_order: ["7.8.1", "7.8.2", "7.9.0", "7.9.1", "7.9.2"],
 
 	patches: {
-		"7.10.0": function() {
+		"7.9.2": function() {
 
 			/**
 			 * Given a list of different collections in `items`, return all

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.20 **//
+//* VERSION 7.4.23 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -10,11 +10,13 @@ XKit.extensions.xkit_patches = new Object({
 	run: function() {
 		this.running = true;
 
-		this.run_order.filter(x => {
-			return this.run_order.indexOf(x) >= this.run_order.includes(XKit.version) ? this.run_order.indexOf(XKit.version) : Infinity;
-		}).forEach(x => {
-			this.patches[x] && this.patches[x]();
-		});
+		if (this.run_order.includes(XKit.version)) {
+			this.run_order.filter(x => {
+				return this.run_order.indexOf(x) >= this.run_order.indexOf(XKit.version);
+			}).forEach(x => {
+				this.patches[x] && this.patches[x]();
+			});
+		}
 
 		if (XKit.browser().firefox === true && XKit.storage.get("xkit_patches", "w_edition_warned") !== "true") {
 			let version = XKit.tools.parse_version(XKit.version);

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -470,29 +470,29 @@ XKit.extensions.xkit_patches = new Object({
 			 * @returns {Promise<object>}
 			 */
 			XKit.interface.mass_edit = function(post_ids, config) {
-			    const path = {
-			        "add": "add_tags_to_posts",
-			        "remove": "remove_tags_from_posts",
-			        "delete": "delete_posts"
-			    }[config.mode];
+				const path = {
+					"add": "add_tags_to_posts",
+					"remove": "remove_tags_from_posts",
+					"delete": "delete_posts"
+				}[config.mode];
 
-			    let payload = {
-			        "post_ids": post_ids.join(","),
-			        "form_key": XKit.interface.form_key()
-			    };
+				let payload = {
+					"post_ids": post_ids.join(","),
+					"form_key": XKit.interface.form_key()
+				};
 
-			    if (config.mode !== "delete") {
-			        payload.tags = config.tags.join(",");
-			    }
+				if (config.mode !== "delete") {
+					payload.tags = config.tags.join(",");
+				}
 
-			    return XKit.tools.Nx_XHR({
-			        method: "POST",
-			        url: `https://www.tumblr.com/${path}`,
-			        headers: {
-			            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
-			        },
-			        data: $.param(payload)
-			    });
+				return XKit.tools.Nx_XHR({
+					method: "POST",
+					url: `https://www.tumblr.com/${path}`,
+					headers: {
+						"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
+					},
+					data: $.param(payload)
+				});
 			};
 
 			// Override "Search Page Brick Post Fix" from xkit.css

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.22 **//
+//* VERSION 7.4.21 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -1275,8 +1275,6 @@ XKit.extensions.xkit_patches = new Object({
 				XKit.tools.add_css(`${selector} {height: 0; margin: 0; overflow: hidden;}`, extension);
 			};
 		},
-
-		"7.9.2": function() {},
 
 		"7.9.1": function() {},
 


### PR DESCRIPTION
As in #2165, this improves the XKit Patches `run_order` logic a bit, such that versions not contained in the `run_order` array simply have no patches applied and it thus does not need to be updated for future releases. It also fixes the crash if one adds an entry to `run_order` without adding a corresponding (potentially empty) entry to `patches` that I triggered earlier, and pulls a whitespace change from the main branch.