### PR TITLE
Fix gh-pages workflow (master branch)

### DIFF
--- a/.github/workflows/gh-pages-update.yml
+++ b/.github/workflows/gh-pages-update.yml
@@ -6,6 +6,10 @@ on:
       - 'master'
     paths:
       - 'Extensions/dist/'
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -25,4 +29,14 @@ jobs:
         run: npm ci
 
       - name: Update gh-pages
-        run: npx gh-pages --add --dist . --src "Extensions/dist/"
+        run: >
+          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+
+          npx gh-pages
+          -u "github-actions-bot <support+actions@github.com>"
+          --add
+          --dist .
+          --src "Extensions/dist/"
+          --message 'Update Extensions/dist/'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-pages-update.yml
+++ b/.github/workflows/gh-pages-update.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'master'
     paths:
-      - 'Extensions/dist/'
+      - 'Extensions/dist/*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - 'Extensions/*'
       - 'Themes/*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -14,26 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@v4
         with:
           node-version: 14
-
-      - name: Configure git
-        run: |
-          git config --global user.name "github-actions"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Fetch and reset gh-pages
-        run: |
-          git remote set-branches --add origin gh-pages
-          git fetch
-          git checkout -f -t -b gh-pages origin/gh-pages
-          git reset --hard 7.9.2
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
@@ -47,10 +38,15 @@ jobs:
       - name: Build distribution
         run: gulp build
 
-      - name: Commit changes
-        run: |
-          git add --force Extensions/
-          git commit -m 'Rebuild Distribution'
+      - name: Push changes to gh-pages
+        run: >
+          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
 
-      - name: Force-push to gh-pages
-        run: git push -f
+          npx gh-pages
+          -u "github-actions-bot <support+actions@github.com>"
+          --add
+          --dist .
+          --src "{Extensions/dist/*.json,Extensions/dist/page/gallery.json,Extensions/dist/page/list.json,Extensions/dist/page/themes.json}"
+          --message 'Rebuild Distribution'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `gh-pages` action requires some configuration to be run in github actions that I apparently didn't put in (I think I mixed up the official github pages actions, this action, and `peaceiris/actions-gh-pages`. Also, I misconfigured the target path.

This makes the required fix and syncs the 7.9.2 action from #2169.

Tested here: https://github.com/marcustyphoon/XKit/actions/runs/12109595098/workflow