### PR TITLE
Fix `lint` package script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "web-ext run --no-reload",
     "test": "eslint .",
-    "lint": "web-ext lint",
+    "lint": "web-ext lint --ignore-files Extensions/*.icon.js",
     "build": "web-ext build",
     "sign": "web-ext sign"
   },


### PR DESCRIPTION
`.icon.js` files used to be ignored by `web-ext lint`, because we didn't include them in the extension package. Now that we do, they need to be ignored only in the lint command (that, of course, or we could make them not have .js file extensions for some weird reason, obviously).