### PR TITLE
Eslint 8 fix

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -3114,7 +3114,7 @@ XKit.extensions.xkit_patches = new Object({
 					$("#xkit_notification_" + m_notification_id).slideDown('slow');
 				}, 100);
 				$("#xkit_notification_" + m_notification_id).click(function() {
-					if (typeof callback !== undefined) {
+					if (typeof callback !== "undefined") {
 						try {
 							callback();
 						} catch (e) {


### PR DESCRIPTION
And this is why one enables the "only allow merging up-to-date branches" option :P 

Fixes a lint error that should have been in #2157 but was pasted in after its diff.