### PR TITLE
Update browser requirements to es2022

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -3,7 +3,7 @@
   parserOptions:
     ecmaVersion: 2022
   env:
-    es6: true
+    es2022: true
     browser: true
     jquery: true
     webextensions: true
@@ -50,7 +50,6 @@
       parserOptions:
         sourceType: module
   globals:
-    BigInt: readonly
     _: readonly
     XKit: writable
     XBridge: writable

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,7 +1,7 @@
 ---
   root: true
   parserOptions:
-    ecmaVersion: 2018
+    ecmaVersion: 2022
   env:
     es6: true
     browser: true

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,7 @@
     "128": "icon.png"
   },
   "manifest_version": 2,
-  "minimum_chrome_version": "44.0",
+  "minimum_chrome_version": "103.0",
   "name": "New XKit",
   "author": "New XKit Team",
   "permissions": ["storage", "unlimitedStorage", "*://*.tumblr.com/*", "https://new-xkit.github.io/XKit/*", "https://cloud.new-xkit.com/*" ],
@@ -36,6 +36,7 @@
   "applications": {
     "gecko": {
       "id": "@new-xkit",
+      "strict_min_version": "115.0",
       "update_url": "https://new-xkit.github.io/XKit/Extensions/dist/page/FirefoxUpdate.json"
     }
   }

--- a/xkit.js
+++ b/xkit.js
@@ -4391,7 +4391,7 @@ function show_message(title, msg, icon, buttons) {
 	});
 }
 
-function xkit_init_special() {
+async function xkit_init_special() {
 
 	$("body").html("");
 	document.title = "XKit";
@@ -4417,11 +4417,8 @@ function xkit_init_special() {
 
 	if (document.location.href.indexOf("/xkit_editor") !== -1) {
 		if (typeof(browser) !== 'undefined') {
-			var xhr = new XMLHttpRequest();
-			xhr.open('GET', browser.extension.getURL('editor.js'), false);
-			xhr.send(null);
 			try {
-				new Function(xhr.responseText + "\n//# sourceURL=xkit/editor.js")();
+				await import(browser.runtime.getURL("/editor.js"));
 				XKit.extensions.xkit_editor.run();
 			} catch (e) {
 				XKit.window.show("Can't launch XKit Editor", "<p>" + e.message + "</p>", "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");


### PR DESCRIPTION
This updates the minimum supported browser versions to Firefox 115/Chrome 103, which enables the use of modern es2022 javascript constructs while keeping the maximum operating system support.

Firefox 115 ESR and Chrome 103 will both run on Windows 7 and MacOS 10.12. Chrome 103 will also run on MacOS 10.11; it's not worth dropping the Firefox version low enough to support both browsers on this OS (no `import()` support, which is the whole point of making this change).

This should not exclude XKit use on any relevant Firefox fork; being based on at least the oldest supported ESR should be a baseline requirement for use, and per my testing all reasonable Firefox forks are now on 128 ESR anyway (as of <https://blog.ablaze.one/4464/2024-08-01/>)

This enables the use of, for example:
- `.?`
- `''.replaceAll()`
- `??=`
- `:not(a, b)` selectors
- top-level `await`
- `import()`
- `[].at()`
- `[].findLast()`

This then makes use of dynamic import to replace an otherwise-unnecessary eval in xkit.js. Dynamic import change tested and working in Firefox 89/Chrome 88 (they're the versions I had lying around).

Edit: Also tested in Edge 109 and Firefox 115 on Windows 7.