### PR TITLE
XKit Preferences: Cancel first-install tour on any successful click

### DIFF
--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Preferences **//
-//* VERSION 7.7.1 **//
+//* VERSION 7.7.2 **//
 //* DESCRIPTION Lets you customize XKit **//
 //* DEVELOPER new-xkit **//
 
@@ -680,13 +680,15 @@ XKit.extensions.xkit_preferences = new Object({
 		$("#xkit-control-panel-shadow").fadeIn('slow');
 		$("#xkit-control-panel-shadow").click(XKit.extensions.xkit_preferences.close);
 
+		if (XKit.storage.get("xkit_preferences", "shown_welcome_bubble") !== "true") {
+			XKit.storage.set("xkit_preferences", "shown_welcome_bubble", "true");
+		}
+
 		if (XKit.extensions.xkit_preferences.bubble_tour_mode === true) {
 
 			XKit.extensions.xkit_preferences.bubble_tour_mode = false;
 			$("#xkit-welcoming-bubble").remove();
 			$("#xkit-welcoming-bubble-shadow").remove();
-
-			XKit.storage.set("xkit_preferences", "shown_welcome_bubble", "true");
 
 			XKit.window.show("Welcome to the control panel!",
 				"<b>This is the My XKit panel.</b><br/>This is where you customize your XKit.<br/>" +


### PR DESCRIPTION
I've got a user report in DMs in which the "Welcome to XKit! Let's get started." interface appears and makes the Tumblr UI inaccessible. I have no explanation for exactly how this could occur, and troubleshooting hasn't uncovered it. The user has been opening Tumblr to a non-dashboard page to get around the tour interface.

This PR moves the "end tour" logic so that it applies on any successful XKit preferences button click, instead of only when the button is clicked from the tour interface. Presumably if a user has found the button, they no longer need a tour. 

This should be copied into the 7.9.2 branch as well (note: copy the whole xkit_preferences.js and xkit_preferences.css files rather than cherry picking).