### PR TITLE
Update and re-fire W Edition warning

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -38,9 +38,11 @@ XKit.extensions.xkit_patches = new Object({
 										"Also, since the two versions conflict, you should uninstall W Edition before re-installing from GitHub."
 									) : (
 										"XKit Patches has determined that you are using <br><b>New XKit (W Edition)</b>, an unofficial upload of New XKit.<br><br>" +
-										'Due to how XKit\'s extension gallery works, this upload violates <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/AMO/Policy/Reviews#Development_Practices" target="_blank">Mozilla\'s policy on remote code execution</a> ' +
+										"Extension updates may be delayed or the extension update functionality may be broken.<br><br>" +
+										'Additionally, due to how XKit\'s extension gallery works, this upload violates <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/AMO/Policy/Reviews#Development_Practices" target="_blank">Mozilla\'s policy on remote code execution</a> ' +
 										"for listed add-ons, and is in danger of being banned at any time; potentially deleting your local XKit data.<br><br>" +
-										"We recommend installing the official distribution of New XKit from GitHub to avoid this possibility.<br><br>" +
+										"We recommend installing the official distribution of New XKit from GitHub to avoid this possibility and " +
+										"to continue to receive bug fixes and improvements.<br><br>" +
 										"Be sure to upload or export your configuration using XCloud before uninstalling W Edition. " +
 										"Also, since the two versions conflict, you should uninstall W Edition before re-installing from GitHub."
 									),

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -18,7 +18,8 @@ XKit.extensions.xkit_patches = new Object({
 			});
 		}
 
-		if (XKit.browser().firefox === true && XKit.storage.get("xkit_patches", "w_edition_warned") !== "true") {
+		const w_edition_storage_key = "w_edition_warned";
+		if (XKit.browser().firefox === true && XKit.storage.get("xkit_patches", w_edition_storage_key) !== "true") {
 			let version = XKit.tools.parse_version(XKit.version);
 			if (version.major === 7 && version.minor >= 8) {
 				fetch(browser.extension.getURL("manifest.json")) // eslint-disable-line no-undef
@@ -43,15 +44,15 @@ XKit.extensions.xkit_patches = new Object({
 
 							$("#dismiss-warning").click(() => {
 								XKit.window.close();
-								XKit.storage.set("xkit_patches", "w_edition_warned", "true");
+								XKit.storage.set("xkit_patches", w_edition_storage_key, "true");
 							});
 						} else {
-							XKit.storage.set("xkit_patches", "w_edition_warned", "true");
+							XKit.storage.set("xkit_patches", w_edition_storage_key, "true");
 						}
 					})
 					.catch(console.error);
 			} else {
-				XKit.storage.set("xkit_patches", "w_edition_warned", "true");
+				XKit.storage.set("xkit_patches", w_edition_storage_key, "true");
 			}
 		}
 

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -28,12 +28,22 @@ XKit.extensions.xkit_patches = new Object({
 						if (responseData.applications.gecko.id === "@new-xkit-w") {
 							XKit.window.show(
 								"W Edition warning",
-								"XKit Patches has determined that you are using <br><b>New XKit (W Edition)</b>, an unofficial upload of New XKit.<br><br>" +
-								'Due to how XKit\'s extension gallery works, this upload violates <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/AMO/Policy/Reviews#Development_Practices" target="_blank">Mozilla\'s policy on remote code execution</a> ' +
-								"for listed add-ons, and is in danger of being banned at any time; potentially deleting your local XKit data.<br><br>" +
-								"We recommend installing the official distribution of New XKit from GitHub to avoid this possibility.<br><br>" +
-								"Be sure to upload or export your configuration using XCloud before uninstalling W Edition. " +
-								"Also, since the two versions conflict, you should uninstall W Edition before re-installing from GitHub.",
+								version.minor >= 10
+									? (
+										"XKit Patches has determined that you are using <br><b>New XKit (W Edition)</b>, an unofficial upload of New XKit.<br><br>" +
+										"Extension updates may be delayed or the extension update functionality may be broken, and you may lose access to your local " +
+										"XKit data if the upload is ever removed.<br><br>" +
+										"We recommend installing the official distribution of New XKit from GitHub to continue to receive bug fixes and improvements.<br><br>" +
+										"Be sure to upload or export your configuration using XCloud before uninstalling W Edition. " +
+										"Also, since the two versions conflict, you should uninstall W Edition before re-installing from GitHub."
+									) : (
+										"XKit Patches has determined that you are using <br><b>New XKit (W Edition)</b>, an unofficial upload of New XKit.<br><br>" +
+										'Due to how XKit\'s extension gallery works, this upload violates <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/AMO/Policy/Reviews#Development_Practices" target="_blank">Mozilla\'s policy on remote code execution</a> ' +
+										"for listed add-ons, and is in danger of being banned at any time; potentially deleting your local XKit data.<br><br>" +
+										"We recommend installing the official distribution of New XKit from GitHub to avoid this possibility.<br><br>" +
+										"Be sure to upload or export your configuration using XCloud before uninstalling W Edition. " +
+										"Also, since the two versions conflict, you should uninstall W Edition before re-installing from GitHub."
+									),
 
 								"warning",
 

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -18,7 +18,7 @@ XKit.extensions.xkit_patches = new Object({
 			});
 		}
 
-		const w_edition_storage_key = "w_edition_warned";
+		const w_edition_storage_key = "w_edition_warned_1";
 		if (XKit.browser().firefox === true && XKit.storage.get("xkit_patches", w_edition_storage_key) !== "true") {
 			let version = XKit.tools.parse_version(XKit.version);
 			if (version.major === 7 && version.minor >= 8) {

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.23 **//
+//* VERSION 7.4.24 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 


### PR DESCRIPTION
I can think of two possibilities about what the "W Edition" upload of New XKit will do if we release 7.10.0:

**a)** Nothing. This will mean that users with the "W Edition" installed will never receive future extension updates. We should update the warning message to include this information, keeping the warning about it being in violation of store policies, and change the storage key so that users who have dismissed it a long time ago will see it again. We should merge this only once 7.10.0 is out (as it would be inaccurate otherwise; currently "W Edition" **does** receive extension updates).

**b)** Update itself when New XKit releases, possibly quickly but possibly on any amount of delay. This will mean that users with the "W Edition" installed may or may not receive future extension updates in a timely fashion. We should update the warning message to include this information and change the storage key so that users who have dismissed it a long time ago will see it again. We should ideally merge this before 7.10 is released, to make sure it makes it in to a hypothetical W edition 7.10.

This PR splits the warning message copy into variants for pre- and post-7.10.0 and updates them accordingly, and bumps the storage key. As per those points, it makes sense to merge this into 7.10.0 right before it's released (to minimize merge conflicts) and then to wait on merging it in to 7.9.2 until that release passes review (if it does, obviously) and is published.