### PR TITLE
No-editor, no-eval branch

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -3,7 +3,7 @@
   parserOptions:
     ecmaVersion: 2022
   env:
-    es6: true
+    es2022: true
     browser: true
     jquery: true
     webextensions: true
@@ -50,7 +50,6 @@
       parserOptions:
         sourceType: module
   globals:
-    BigInt: readonly
     _: readonly
     XKit: writable
     XBridge: writable

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,7 +1,7 @@
 ---
   root: true
   parserOptions:
-    ecmaVersion: 2018
+    ecmaVersion: 2022
   env:
     es6: true
     browser: true

--- a/Extensions/audio_plus.js
+++ b/Extensions/audio_plus.js
@@ -230,7 +230,10 @@ XKit.extensions.audio_plus = {
 	},
 
 	create_pop_out_controls: function() {
-		const controls_markup = `
+
+		var psuedo_post = document.createElement("div");
+		psuedo_post.classList.add("xkit-audio-plus-pseudo-post");
+		psuedo_post.innerHTML = `
 			<div class="xkit-audio-plus-controls audio-player">
 				<div class="progress"></div>
 				<div class="play-pause">
@@ -245,10 +248,6 @@ XKit.extensions.audio_plus = {
 				<div id="xkit-audio-plus-controls-undock"></div>
 			</div>
 		`;
-
-		var psuedo_post = document.createElement("div");
-		psuedo_post.classList.add("xkit-audio-plus-pseudo-post");
-		psuedo_post.innerHTML = controls_markup;
 		document.body.appendChild(psuedo_post);
 
 		this.pop_out_controls = psuedo_post;
@@ -384,11 +383,11 @@ XKit.extensions.audio_plus = {
 		this.icon_observer.observe(pause_icon, config);
 
 		if (player.querySelector(".track-name").innerHTML != "") {
-			this.pop_out_controls_track_name.innerHTML = player.querySelector(".track-name").innerHTML;
+			this.pop_out_controls_track_name.replaceChildren(player.querySelector(".track-name").cloneNode(true));
 		} else {
 			this.pop_out_controls_track_name.innerHTML = "Listen";
 		}
-		this.pop_out_controls_track_artist.innerHTML = player.querySelector(".track-artist").innerHTML;
+		this.pop_out_controls_track_artist.replaceChildren(player.querySelector(".track-artist").cloneNode(true));
 
 		this.current_player = player;
 		this.pop_out_controls.classList.add("showing");

--- a/Extensions/old_stats.js
+++ b/Extensions/old_stats.js
@@ -179,7 +179,7 @@ XKit.extensions.old_stats = new Object({
 				$(".no_push.selected_blog, .no_push.old_stats_blog").last().css("margin", "0 0 18px");
 
 				$(".old_stats_blog").click(function() {
-					$(".no_push.selected_blog .open_blog.with_subtitle")[0].outerHTML = this.firstChild.outerHTML.replace("span", "a");
+					// $(".no_push.selected_blog .open_blog.with_subtitle")[0].outerHTML = this.firstChild.outerHTML.replace("span", "a");
 					loading = true;
 					$("#old_stats_switcher").click();
 					XKit.extensions.old_stats.fetchStats($(this).find(".currently_selected_blog").html());

--- a/Extensions/servant.js
+++ b/Extensions/servant.js
@@ -718,7 +718,7 @@ XKit.extensions.servant = new Object({
 
 		run_js: {
 
-			text: "Run Javascript Code",
+			text: "Run Javascript Code (disabled)",
 			compatibility: "",
 			type: "textarea",
 			placeholder: "ie: 'if (mary.has_lamb == true) {\n\treturn true;\n }'",
@@ -731,7 +731,10 @@ XKit.extensions.servant = new Object({
 				var m_return = false;
 
 				try {
+					/*
 					m_return = new Function(parameter + "\n//# sourceURL=xkit/servant/servant" + (new Date()).getTime() + ".js")();
+					*/
+					throw new Error('"Run Javascript Code" cause is disabled.');
 				} catch (e) {
 					m_return = false;
 					console.error("Unable to run Servant! ---> " + e.message);
@@ -1115,7 +1118,7 @@ XKit.extensions.servant = new Object({
 
 		run_js: {
 
-			text: "Run Javascript Code",
+			text: "Run Javascript Code (disabled)",
 			compatibility: "",
 			type: "textarea",
 			placeholder: "ie: 'alert(&quot;%1 happened!&quot;);'",
@@ -1142,7 +1145,9 @@ XKit.extensions.servant = new Object({
 					var post = m_post[0];
 				}
 
+				/*
 				new Function(parameter_fixed + "\n//# sourceURL=xkit/servant/servant" + (new Date()).getTime() + ".js")();
+				*/
 
 			}
 

--- a/Extensions/xkit_installer.js
+++ b/Extensions/xkit_installer.js
@@ -103,7 +103,7 @@ XKit.extensions.xkit_installer = new Object({
 		console.log("Will be installing " + to_install);
 		$("#xkit-install-process").html("Installing package " + to_install + "...");
 
-		XKit.install(to_install, function(mdata) {
+		XKit.install(to_install, async function(mdata) {
 			// defined in xkit.js
 			/* globals show_error_installation */
 
@@ -125,9 +125,9 @@ XKit.extensions.xkit_installer = new Object({
 			}
 
 			try {
-				// Try evaling the script.
+				// Try importing the script.
 				// If it's working, then move to the next one.
-				new Function(mdata.script + "\n//# sourceURL=xkit/" + mdata.id + ".js")();
+				await mdata.import();
 				XKit.extensions.xkit_installer.installed++;
 				XKit.extensions.xkit_installer.next();
 			} catch (e) {

--- a/Extensions/xkit_main.js
+++ b/Extensions/xkit_main.js
@@ -60,7 +60,7 @@
 				}
 
 				try {
-					new Function(extension.script + "\n//# sourceURL=xkit/" + extension.id + ".js")();
+					await extension.import();
 
 					if (typeof XKit.extensions[extension.id].preferences !== "undefined") {
 						this.load_extension_preferences(extension.id);

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -21,10 +21,11 @@ XKit.extensions.xkit_patches = new Object({
 		if (XKit.browser().firefox === true && XKit.storage.get("xkit_patches", "w_edition_warned") !== "true") {
 			let version = XKit.tools.parse_version(XKit.version);
 			if (version.major === 7 && version.minor >= 8) {
-				fetch(browser.extension.getURL("manifest.json")) // eslint-disable-line no-undef
+				fetch(browser.runtime.getURL("manifest.json")) // eslint-disable-line no-undef
 					.then(response => response.json())
 					.then(responseData => {
-						if (responseData.applications.gecko.id === "@new-xkit-w") {
+						if (responseData.applications && responseData.applications.gecko.id === "@new-xkit-w" ||
+							responseData.browser_specific_settings && responseData.browser_specific_settings.gecko.id === "@new-xkit-w") {
 							XKit.window.show(
 								"W Edition warning",
 								"XKit Patches has determined that you are using <br><b>New XKit (W Edition)</b>, an unofficial upload of New XKit.<br><br>" +

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -996,7 +996,7 @@ XKit.extensions.xkit_preferences = new Object({
 
 				$(this).parent().addClass("overlayed");
 
-				XKit.install($(this).attr('data-extension-id'), function(extension_data) {
+				XKit.install($(this).attr('data-extension-id'), async function(extension_data) {
 					// defined in xkit.js
 					/* globals show_error_installation */
 
@@ -1023,7 +1023,7 @@ XKit.extensions.xkit_preferences = new Object({
 					$("#xkit-gallery-extension-" + extension_data.id).find(".overlay").html("Installed!");
 
 					try {
-						new Function(extension_data.script + "\n//# sourceURL=xkit/" + m_extension_id + ".js")();
+						await extension_data.import();
 						XKit.extensions.xkit_main.load_extension_preferences(m_extension_id);
 						if (XKit.installed.enabled(m_extension_id)) {
 							XKit.extensions[m_extension_id].run();

--- a/Extensions/xkit_preferences.js
+++ b/Extensions/xkit_preferences.js
@@ -1321,8 +1321,6 @@ XKit.extensions.xkit_preferences = new Object({
 
 		m_html = m_html + '</div><div class="buttons">';
 
-		m_html = m_html + '<div class="xkit-button" id="xkit-extension-update">Update</div>';
-
 		if (!this_is_internal) {
 			m_html = m_html + '<div class="xkit-button" id="xkit-extension-uninstall">Uninstall</div>';
 			m_html = m_html + '<div class="xkit-button" id="xkit-extension-reset">Reset Settings</div>';
@@ -1412,46 +1410,6 @@ XKit.extensions.xkit_preferences = new Object({
 			XKit.window.show("This feature might slow down your computer",
 				"Turning this feature on might slow down your computer, especially if you have a slow internet connection or an older computer.",
 				"warning", '<div id="xkit-close-message" class="xkit-button default">OK</div>');
-
-		});
-
-		$("#xkit-extension-update").click(function() {
-
-			var $this = $(this);
-
-			if ($this.hasClass("disabled") === true) { return; }
-
-			$("#xkit-extensions-panel-right-inner").html('<div id="xkit-extension-panel-no-settings">Updating...</div>');
-
-			if (typeof XKit.extensions.xkit_updates === "undefined" || typeof XKit.extensions.xkit_updates.update === "undefined") {
-				XKit.window.show("Can't update",
-					'It looks like "XKit Updates" extension is missing or not working properly. It is highly recommended that you reset XKit.', "error",
-					'<div id="xkit-close-message" class="xkit-button default">OK</div>' +
-					'<a href="http://www.tumblr.com/xkit_reset" class="xkit-button">Reset XKit</a>');
-				XKit.extensions.xkit_preferences.open_extension_control_panel(XKit.extensions.xkit_preferences.current_open_extension_panel);
-				return;
-			}
-
-			$(this).addClass("disabled");
-
-			XKit.extensions.xkit_updates.update(XKit.extensions.xkit_preferences.current_open_extension_panel, function(mdata) {
-
-				if (mdata.errors === false) {
-					XKit.window.show("Done!", "<b>Done updating extension.</b><br/>" +
-						"Please refresh the page for changes to take effect.", "info",
-						'<div id="xkit-close-message" class="xkit-button default">OK</div>');
-					XKit.extensions.xkit_preferences.open_extension_control_panel(XKit.extensions.xkit_preferences.current_open_extension_panel);
-					return;
-				}
-
-				XKit.window.show("Can't update",
-					"Update manager returned the following message:<p>" + mdata.error + "</p>" +
-					"Please try again later or if the problem continues, contact New XKit Support.", "error",
-					'<div id="xkit-close-message" class="xkit-button default">OK</div>' +
-					'<a href="http://new-xkit-support.tumblr.com/support" class="xkit-button">Support Chat Room</a>');
-				XKit.extensions.xkit_preferences.open_extension_control_panel(XKit.extensions.xkit_preferences.current_open_extension_panel);
-
-			});
 
 		});
 
@@ -1991,7 +1949,6 @@ XKit.extensions.xkit_preferences = new Object({
 				'<div class="nano long" id="xkit-extensions-panel-left">' +
 					'<div class="content" id="xkit-extensions-panel-left-inner">' +
 						'<div class="xkit-extension text-only separator">Configuration</div>' +
-						'<div data-pname="update-all" class="xkit-extension text-only">Update All</div>' +
 						'<div data-pname="reset" class="xkit-extension text-only">Reset XKit</div>' +
 						'<div data-pname="config" class="xkit-extension text-only">Export Configuration</div>' +
 						'<div data-pname="storage" class="xkit-extension text-only">Storage</div>' +
@@ -2028,9 +1985,6 @@ XKit.extensions.xkit_preferences = new Object({
 			}
 			if ($this.attr('data-pname') === "updates") {
 				XKit.extensions.xkit_preferences.show_others_panel_updates();
-			}
-			if ($this.attr('data-pname') === "update-all") {
-				XKit.extensions.xkit_preferences.show_others_panel_update_all();
 			}
 			if ($this.attr('data-pname') === "news") {
 				XKit.extensions.xkit_preferences.show_others_panel_news();
@@ -2319,33 +2273,6 @@ XKit.extensions.xkit_preferences = new Object({
 		$("#xkit-panel-show-flags").click(function() {
 
 			XKit.extensions.xkit_preferences.flags();
-
-		});
-
-	},
-
-	show_others_panel_update_all: function() {
-
-		var m_html =
-				'<div class="xkit-others-panel">' +
-				'<div class="title">Update All</div>' +
-				'<div class="description">' +
-					"If you would like to force XKit to update itself now, or for some reason, you can not receive updates, click the button below to trigger Automatic Updates now. XKit will check for the new versions of extensions and update them if necessary." +
-				"</div>" +
-				'<div class="bottom-part">' +
-					'<div id="xkit-panel-force-update-xkit" class="xkit-button block">Update all my extensions</div>' +
-				"</div>" +
-				"</div>";
-
-		$("#xkit-extensions-panel-right-inner").html(m_html);
-		$("#xkit-extensions-panel-right").nanoScroller();
-
-		$("#xkit-panel-force-update-xkit").click(function() {
-
-			XKit.window.show("Forcing Automatic Updates",
-				"Please wait while I review the changes and update myself..<br/>Please do not navigate away from this page." +
-				'<div id="xkit-forced-auto-updates-message">Initializing...</div>', "info");
-			XKit.extensions.xkit_updates.get_list(true);
 
 		});
 

--- a/Extensions/xkit_updates.js
+++ b/Extensions/xkit_updates.js
@@ -1,11 +1,16 @@
 //* TITLE XKit Updates **//
 //* VERSION 2.1.3 **//
-//* DESCRIPTION Provides automatic updating of extensions **//
+//* DESCRIPTION Deprecated (installed for compatibility) **//
 //* DEVELOPER new-xkit **//
 XKit.extensions.xkit_updates = new Object({
 
 	running: false,
 
+	run: function() {
+		this.running = true;
+	},
+
+	/*
 	default_interval: 18000000,
 	min_interval: 3600000,
 	max_interval: 86400000,
@@ -259,6 +264,7 @@ XKit.extensions.xkit_updates = new Object({
 		}
 		return false;
 	},
+	*/
 
 	destroy: function() {
 		this.running = false;

--- a/bridge.js
+++ b/bridge.js
@@ -51,7 +51,7 @@ function getBridgeError() { // eslint-disable-line no-redeclare
 
 function getVersion() {
 	var xhr = new XMLHttpRequest();
-	xhr.open('GET', browser.extension.getURL('manifest.json'), false);
+	xhr.open('GET', browser.runtime.getURL('manifest.json'), false);
 	xhr.send(null);
 	var manifest = JSON.parse(xhr.responseText);
 	return manifest.version;

--- a/editor.js
+++ b/editor.js
@@ -17,6 +17,19 @@
 			XKit.extensions.xkit_editor.filename = "";
 			document.title = "XKit Extension Editor";
 			extension_editor_run();
+
+			XKit.window.show(
+				"Script editing is disabled",
+				`
+					Due to increased extension security requirements, this version of New XKit does not allow script editing from inside the browser.
+					You can still use the XKit Editor to see the source code of your scripts.
+					<br /><br />
+					If you're a developer, loading XKit as an unpacked/temporary extension provides an even better development experience than before!
+					See <a href="https://github.com/new-xkit/XKit/tree/master/docs" target="_blank">the documentation on GitHub</a> for instructions.
+				`,
+				"info",
+				`<div id="xkit-close-message" class="xkit-button default">OK</div>`
+			);
 		}
 
 	});

--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,7 @@
   "permissions": ["storage", "unlimitedStorage", "*://*.tumblr.com/*", "https://new-xkit.github.io/XKit/*", "https://cloud.new-xkit.com/*" ],
   "version": "7.10.0",
   "web_accessible_resources": [ "*.js", "*.json", "*.css" ],
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "@new-xkit",
       "strict_min_version": "115.0",

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,7 @@
     "128": "icon.png"
   },
   "manifest_version": 2,
-  "minimum_chrome_version": "44.0",
+  "minimum_chrome_version": "103.0",
   "name": "New XKit",
   "author": "New XKit Team",
   "permissions": ["storage", "unlimitedStorage", "*://*.tumblr.com/*", "https://new-xkit.github.io/XKit/*", "https://cloud.new-xkit.com/*" ],
@@ -36,6 +36,7 @@
   "applications": {
     "gecko": {
       "id": "@new-xkit",
+      "strict_min_version": "115.0",
       "update_url": "https://new-xkit.github.io/XKit/Extensions/dist/page/FirefoxUpdate.json"
     }
   }

--- a/xkit.js
+++ b/xkit.js
@@ -4391,7 +4391,7 @@ function show_message(title, msg, icon, buttons) {
 	});
 }
 
-function xkit_init_special() {
+async function xkit_init_special() {
 
 	$("body").html("");
 	document.title = "XKit";
@@ -4417,11 +4417,8 @@ function xkit_init_special() {
 
 	if (document.location.href.indexOf("/xkit_editor") !== -1) {
 		if (typeof(browser) !== 'undefined') {
-			var xhr = new XMLHttpRequest();
-			xhr.open('GET', browser.extension.getURL('editor.js'), false);
-			xhr.send(null);
 			try {
-				new Function(xhr.responseText + "\n//# sourceURL=xkit/editor.js")();
+				await import(browser.runtime.getURL("/editor.js"));
 				XKit.extensions.xkit_editor.run();
 			} catch (e) {
 				XKit.window.show("Can't launch XKit Editor", "<p>" + e.message + "</p>", "error", "<div id=\"xkit-close-message\" class=\"xkit-button default\">OK</div>");

--- a/xkit.js
+++ b/xkit.js
@@ -23,10 +23,12 @@ var xkit_global_start = Date.now();  // log start timestamp
 			xkit:
 				document.location.href.indexOf('://www.tumblr.com/xkit_') !== -1
 		},
-		init: function() {
+		init: async function() {
 			if (!XKit.page.xkit) {
 				XKit.init_flags();
 			}
+			await XKit.installed.init();
+
 			$(document).ready(XKit.init_extension);
 		},
 		init_extension: function() {
@@ -47,7 +49,7 @@ var xkit_global_start = Date.now();  // log start timestamp
 			}
 
 		},
-		init_normal: function() {
+		init_normal: async function() {
 
 			try {
 
@@ -100,10 +102,10 @@ var xkit_global_start = Date.now();  // log start timestamp
 
 				// It exists! Great.
 				var xkit_main = XKit.installed.get("xkit_main");
-				if (!xkit_main.errors && xkit_main.script) {
+				if (!xkit_main.errors) {
 					console.log("Trying to run xkit_main.");
 					try {
-						new Function(xkit_main.script + "\n//# sourceURL=xkit/xkit_main.js")();
+						await xkit_main.import();
 						XKit.extensions.xkit_main.run();
 					} catch (e) {
 						show_error_reset("Can't run xkit_main: " + e.message);
@@ -115,12 +117,6 @@ var xkit_global_start = Date.now();  // log start timestamp
 						xkit_install();
 						return;
 					}
-					if (xkit_main.error == "parse_error") {
-						// Corrupt storage? Recomment reset.
-						console.error("xkit_main is corrupt!");
-						show_error_reset("Package xkit_main is corrupted!");
-						return;
-					}
 				}
 
 			} catch (e) {
@@ -128,7 +124,7 @@ var xkit_global_start = Date.now();  // log start timestamp
 				show_error_update("xkit_init(): " + e.message);
 			}
 		},
-		init_frame: function() {
+		init_frame: async function() {
 
 			// Load frame extensions.
 			// First lets check if it actually exists.
@@ -139,10 +135,10 @@ var xkit_global_start = Date.now();  // log start timestamp
 
 			// It exists! Great.
 			var xkit_main = XKit.installed.get("xkit_main");
-			if (!xkit_main.errors && xkit_main.script) {
+			if (!xkit_main.errors) {
 				console.log("Trying to run xkit_main.");
 				try {
-					new Function(xkit_main.script + "\n//# sourceURL=xkit/xkit_main.js")();
+					await xkit_main.import();
 					XKit.frame_mode = true;
 					XKit.extensions.xkit_main.run();
 				} catch (e) {
@@ -210,9 +206,6 @@ var xkit_global_start = Date.now();  // log start timestamp
 					}
 				});
 			},
-			extension: function(extension_id, callback) {
-				getExtensionData(extension_id).then(callback);
-			},
 			page: function(page, callback) {
 				if (page === 'gallery.php') {
 					getGalleryData().then(callback);
@@ -234,13 +227,30 @@ var xkit_global_start = Date.now();  // log start timestamp
 		},
 		install: function(extension_id, callback) {
 			// Installs the extension.
-			XKit.download.extension(extension_id, function(mdata) {
+			getExtensionData(extension_id).then((data) => {
 				console.log("download.extension of '" + extension_id + "' was successful. Calling callback.");
-				install_extension(mdata, callback);
+				XKit.installed.add(extension_id, data);
+				callback(data);
 			});
 		},
 		installed: {
-			add: function(extension_id) {
+			data: {},
+
+			/**
+			 * Must be awaited before running XKit.installed.get();
+			 * this allows the latter to be synchronous for historical reasons.
+			 * @returns {Promise}
+			 */
+			init: () => Promise.all(
+				XKit.installed.list().map(extension_id =>
+					getExtensionData(extension_id).then(data => {
+						XKit.installed.data[extension_id] = data;
+					})
+				)
+			),
+			add: function(extension_id, data) {
+				XKit.installed.data[extension_id] = data;
+
 				// Add extension to the installed list.
 				if (XKit.installed.check(extension_id) === true) {
 					// Already added, stop.
@@ -323,30 +333,10 @@ var xkit_global_start = Date.now();  // log start timestamp
 				setTimeout(check, 0);
 			},
 			get: function(extension_id) {
-				// Returns the object.
-				var app_data = XKit.tools.get_setting("extension_" + extension_id, "");
-				if (app_data === "") {
-					return {
-						errors: true,
-						error: "not_installed"
-					};
-				}
-				try {
-					var m_object = JSON.parse(app_data);
-					m_object.errors = false;
-					return m_object;
-				} catch (e) {
-					return {
-						errors: true,
-						error: "parse_error"
-					};
-				}
-			},
-			update: function(extension_id, new_object) {
-				XKit.tools.set_setting("extension_" + extension_id, JSON.stringify(new_object));
-				if (XKit.installed.check(extension_id) === false) {
-					XKit.installed.add(extension_id);
-				}
+				return XKit.installed.data[extension_id] || {
+					errors: true,
+					error: "not_installed"
+				};
 			},
 			enable: function(extension_id) {
 				XKit.tools.set_setting("extension__" + extension_id + "__enabled", "true");
@@ -4431,138 +4421,12 @@ function xkit_check_storage() {
 
 }
 
-function install_extension(mdata, callback) {
-
-	try {
-
-		if (mdata.errors || !mdata.script) {
-			// Server returned an error or empty script.
-			console.warn("install_extension failed: Empty script or errors.");
-			return callback(mdata);
-		}
-
-		var m_object = {
-			script: mdata.script,
-			id: mdata.id
-		};
-
-		if (typeof mdata.icon !== "undefined") {
-			m_object.icon = mdata.icon;
-		} else {
-			m_object.icon = "";
-		}
-
-		if (typeof mdata.css !== "undefined") {
-			m_object.css = mdata.css;
-		} else {
-			m_object.css = "";
-		}
-
-		if (typeof mdata.title !== "undefined") {
-			m_object.title = mdata.title;
-		} else {
-			m_object.title = mdata.id;
-		}
-
-		if (typeof mdata.description !== "undefined") {
-			m_object.description = mdata.description;
-		} else {
-			m_object.description = "";
-		}
-
-		if (typeof mdata.developer !== "undefined") {
-			m_object.developer = mdata.developer;
-		} else {
-			m_object.developer = "";
-		}
-
-		if (typeof mdata.version !== "undefined") {
-			m_object.version = mdata.version;
-		} else {
-			m_object.version = "";
-		}
-
-		if (typeof mdata.frame !== "undefined") {
-			if (mdata.frame === "true" || mdata.frame === " true") {
-				m_object.frame = true;
-			} else {
-				m_object.frame = false;
-			}
-		} else {
-			m_object.frame = false;
-		}
-
-		if (typeof mdata.beta !== "undefined") {
-			if (mdata.beta === "true" || mdata.beta === " true") {
-				m_object.beta = true;
-			} else {
-				m_object.beta = false;
-			}
-		} else {
-			m_object.beta = false;
-		}
-
-		if (typeof mdata.slow !== "undefined") {
-			if (mdata.slow === "true" || mdata.slow === " true") {
-				m_object.slow = true;
-			} else {
-				m_object.slow = false;
-			}
-		} else {
-			m_object.slow = false;
-		}
-
-		if (typeof mdata.details !== "undefined") {
-			m_object.details = mdata.details;
-		} else {
-			m_object.details = "";
-		}
-
-		var m_result = XKit.tools.set_setting("extension_" + mdata.id, JSON.stringify(m_object));
-		if (m_result.errors === false) {
-			// Saved data without any errors!
-			XKit.installed.add(mdata.id);
-			var ext_id = mdata.id;
-			Object.defineProperty(m_object, 'script', {
-				enumerable: true,
-				get: function() {
-					return XKit.installed.script(ext_id);
-				}
-			});
-			Object.defineProperty(m_object, 'icon', {
-				enumerable: true,
-				get: function() {
-					return XKit.installed.icon(ext_id);
-				}
-			});
-			Object.defineProperty(m_object, 'css', {
-				enumerable: true,
-				get: function() {
-					return XKit.installed.css(ext_id);
-				}
-			});
-			callback(m_object);
-		} else {
-			// Something awful has happened.
-			m_result.storage_error = true;
-			return m_result;
-		}
-
-	} catch (e) {
-
-		show_error_script("install_extension failed: " + e.message);
-		console.error("install_extension failed: " + e.message);
-
-	}
-
-}
-
 function xkit_install() {
 
 	XKit.window.show("Welcome to New XKit " + framework_version + "!", "<b>Please wait while I initialize the setup. This might take a while.<br/>Please do not navigate away from this page.</b>", "info");
 	console.log("Trying to retrieve XKit Installer.");
 
-	XKit.install("xkit_installer", function(mdata) {
+	XKit.install("xkit_installer", async function(mdata) {
 		if (mdata.errors) {
 			if (mdata.storage_error === true) {
 				show_error_installation("[Code: 401] Storage error: " + mdata.error);
@@ -4577,7 +4441,7 @@ function xkit_install() {
 		}
 
 		try {
-			new Function(mdata.script + "\n//# sourceURL=xkit/xkit_installer.js")();
+			await mdata.import();
 			XKit.extensions.xkit_installer.run();
 		} catch (e) {
 			show_error_installation("[Code: 102] " + e.message);
@@ -4659,11 +4523,11 @@ async function getExtensionData(id) {
  * {boolean} [slow]      - Value of the optional SLOW field in `script`
  */
 const extensionAttributes = [
-	{name: "title", default: null, required: true},
-	{name: "description", default: null, required: true},
-	{name: "developer", default: null, required: true},
-	{name: "version", default: null, required: true},
-	{name: "details", default: null, required: false},
+	{name: "title", default: '', required: true},
+	{name: "description", default: '', required: true},
+	{name: "developer", default: '', required: true},
+	{name: "version", default: '', required: true},
+	{name: "details", default: '', required: false},
 	{name: "frame", default: "false", required: false},
 	{name: "beta", default: "false", required: false},
 	{name: "slow", default: "false", required: false},
@@ -4676,9 +4540,12 @@ async function loadExtensionData(id) {
 	const extension = {
 		id,
 		script: contents,
+		import: () => import(browser.runtime.getURL(`/Extensions/${id}.js`)),
 		file: "found",
 		server: "up",
 		errors: false,
+		icon: '',
+		css: '',
 	};
 
 	if (index[id].icon) {
@@ -4694,12 +4561,13 @@ async function loadExtensionData(id) {
 
 	extensionAttributes.forEach(({name: key, default: defaultValue}) => {
 		const match = contents.match(new RegExp("/\\*\\s*" + key.toUpperCase() + "\\s*(.+?)\\s*\\*\\*?/"));
-		if (match) {
-			extension[key] = match[1];
-		} else if (defaultValue) {
-			extension[key] = defaultValue;
-		}
+		extension[key] = match ? match[1] : defaultValue;
 	});
+
+	extension.title = extension.title || id;
+	extension.frame = extension.frame && extension.frame.includes("true") ? true : false;
+	extension.beta = extension.beta && extension.beta.includes("true") ? true : false;
+	extension.slow = extension.slow && extension.slow.includes("true") ? true : false;
 
 	return extension;
 }

--- a/xkit.js
+++ b/xkit.js
@@ -98,12 +98,6 @@ var xkit_global_start = Date.now();  // log start timestamp
 					return;
 				}
 
-				// Before we run main--if patches is a broken version,
-				// we need to force an update.
-				if (XKit.installed.version('xkit_patches') === '7.2.8') {
-					XKit.special.force_update();
-				}
-
 				// It exists! Great.
 				var xkit_main = XKit.installed.get("xkit_main");
 				if (!xkit_main.errors && xkit_main.script) {
@@ -220,10 +214,6 @@ var xkit_global_start = Date.now();  // log start timestamp
 				getExtensionData(extension_id).then(callback);
 			},
 			page: function(page, callback) {
-				if (page === 'list.php') {
-					getListData().then(callback);
-					return;
-				}
 				if (page === 'gallery.php') {
 					getGalleryData().then(callback);
 					return;
@@ -3207,33 +3197,6 @@ var xkit_global_start = Date.now();  // log start timestamp
 		},
 		special: {
 
-			force_update: function() {
-				XKit.install("xkit_updates", data => {
-					if (data.errors) {
-						if (data.storage_error === true) {
-							show_error_installation("[Code: 401] Storage error: " + data.error);
-						} else {
-							if (data.server_down === true) {
-								show_error_installation("[Code: 101] Can't reach New XKit servers");
-							} else {
-								show_error_installation("[Code: 100] Server returned error/empty script");
-							}
-						}
-						return;
-					}
-
-					try {
-						new Function(data.script + "\n//# sourceURL=xkit/xkit_updates.js")();
-						XKit.window.show("Forcing Extension Updates",
-							"Please do not navigate away from this page. Your extensions are being updated for compatibility with the latest XKit version." +
-							'<div id="xkit-forced-auto-updates-message">Initializing...</div>', "info");
-						XKit.extensions.xkit_updates.get_list(true);
-					} catch (e) {
-						show_error_installation("[Code: 102] " + e.message);
-					}
-				});
-			},
-
 			reset: function() {
 
 				XKit.window.show("Reset XKit", "Really delete all the data stored in XKit?<br/>Your settings will be lost. You can not undo this action.", "question", "<div id=\"reset-xkit-yes\" class=\"xkit-button default\">Yes, reset XKit</div><div id=\"reset-xkit-no\" class=\"xkit-button\">Cancel</div>");
@@ -4657,10 +4620,8 @@ function show_error_reset(message) {
 		"error",
 
 		'<div id="xkit-close-message" class="xkit-button">OK</div>' +
-		'<div id="xkit-force-update" class="xkit-button default">Update Extensions</div>' +
 		'<a href="https://new-xkit-support.tumblr.com" class="xkit-button">New XKit Support</a>'
 	);
-	$("#xkit-force-update").click(XKit.special.force_update);
 }
 
 function show_error_update(message) {
@@ -4760,16 +4721,6 @@ async function getGalleryData() {
 			icon,
 			details,
 		})),
-	};
-}
-
-async function getListData() {
-	const index = JSON.parse(await loadFile("/Extensions/_index.json"));
-	const extensionData = await Promise.all(Object.keys(index).map(getExtensionData));
-
-	return {
-		server: "up",
-		extensions: extensionData.map(({id, version}) => ({name: id, version})),
 	};
 }
 


### PR DESCRIPTION
The XKit Editor, which lets users customize the code of their scripts from a special page in the browser, is built on the fact that New XKit stores its executable extension code in storage and runs it using `eval`. This is how user script extensions work, and as I understand it is tied to the history of this extension as a collection of user scripts and/or as a user script manager specifically for Tumblr. 

This is kind of neat, and doesn't seem to break any Firefox addon policies per my line-by-line reading... and, I mean, violentmonkey is on the store, right? On the other hand, I have to assume that if we had metrics they would report that the editor functionality is basically completely unused by our userbase. The core functionality of the extension would still inarguably exist without the editor, and maybe a reviewer would argue that that's not a valid use of eval. And review aside, I think there are valid arguments to be made on both sides of whether the editor version or the no-editor version of the codebase is better. (It does kind of involve deciding on the purpose of this codebase going forward, which is another discussion.)

Anyway, I've never been interested in having that decision hinge entirely upon whether one version of the codebase exists and functions or not; I had the technical side solved ages ago. Thus, here is a fully functional branch with the XKit editor's save functionality disabled, with no eval use or storage of extension code and which thus has no version-number-based internal update functionality because the latest versions of scripts are always run directly out of the package (internal update notifications are gone, though we could put them back). This includes cleaning up all remaining `web-ext lint` warnings by factoring or killing some code in outdated scripts.

Discuss!

Technical notes:
- This includes the commits of #2176.
- XKit's internals expect script metadata to be accessible synchronously, but dynamic import (like extension storage access) is asynchronous. XKit Bridge makes storage contents synchronously accessible by keeping them in a global variable and delaying initialization while populating it to solve this; I had to create `XKit.installed.data` and `XKit.installed.init()` to serve a similar purpose.
- `install_extension()` in xkit.js was left as-is in my 7.10.0 migration to keep the API surface of what used to be "the JSON downloaded from XKit servers/Github Pages" stable, but there's no point to doing that anymore and it's awful. It's implemented as tweaks to the defaults in `loadExtensionData()` here.

The rest of the diff should be comprehensible from the above points.
