### PR TITLE
Linter: Fix moment global

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -52,6 +52,7 @@
   globals:
     BigInt: readonly
     _: readonly
+    moment: readonly
     XKit: writable
     XBridge: writable
     centerIt: writable

--- a/Extensions/auto_tagger.js
+++ b/Extensions/auto_tagger.js
@@ -227,9 +227,6 @@ XKit.extensions.auto_tagger = new Object({
 	},
 
 	return_date_tag: function() {
-		// defined in moment.js
-		/* globals moment */
-
 		var nowdate = new Date();
 		var nowdatem = moment(nowdate);
 		var m_date = nowdatem.format("Do[,]MMMM[,]YYYY[,]MMMM Do YYYY");

--- a/Extensions/bookmarker.js
+++ b/Extensions/bookmarker.js
@@ -234,9 +234,6 @@ XKit.extensions.bookmarker = new Object({
 	},
 
 	create_bookmark_div: function(current_bookmark) {
-		// defined in moment.js
-		/* globals moment */
-
 		var nowdate = new Date();
 		var nowdatem = moment(nowdate);
 

--- a/Extensions/outbox.js
+++ b/Extensions/outbox.js
@@ -542,8 +542,6 @@ XKit.extensions.outbox = new Object({
 		var m_date = "";
 
 		if (obj.time !== "" && typeof obj.time !== "undefined") {
-			// defined in moment.js
-			/* globals moment */
 			var moment_val = moment(obj.time);
 			m_day = moment_val.format('ddd');
 			m_date = moment_val.format('MM/DD/YY hh:mm a');

--- a/Extensions/profiler.js
+++ b/Extensions/profiler.js
@@ -359,8 +359,6 @@ XKit.extensions.profiler = new Object({
 
 				var data = JSON.parse(response.responseText).response;
 				var dtx = new Date(data.blog.updated * 1000);
-				// defined in moment.js
-				/* globals moment */
 				var dt = moment(dtx);
 
 				$("#xkit-profiler-last-update").removeClass("loading-up").html(dt.from(new Date()));

--- a/Extensions/timestamps.js
+++ b/Extensions/timestamps.js
@@ -7,9 +7,6 @@
 //* BETA false **//
 //* SLOW true **//
 
-// depends on moment.js
-/* globals moment */
-
 XKit.extensions.timestamps = new Object({
 
 	running: false,


### PR DESCRIPTION
This adds moment to the global variables in the eslint config file so it doesn't have to be manually referenced in a globals comment.

As in a few other PRs, this doesn't version bump anything since it's a whitespace-only change.