### PR TITLE
Prevent message overflow

### DIFF
--- a/xkit.css
+++ b/xkit.css
@@ -368,6 +368,8 @@
 	-moz-user-select: none;
 	-webkit-user-select: none;
 	user-select: none;
+	max-height: 80vh;
+  overflow-y: scroll;
 }
 
 .xkit-window-msg a {

--- a/xkit.css
+++ b/xkit.css
@@ -369,7 +369,7 @@
 	-webkit-user-select: none;
 	user-select: none;
 	max-height: 80vh;
-  overflow-y: scroll;
+	overflow-y: scroll;
 }
 
 .xkit-window-msg a {


### PR DESCRIPTION
It's currently possible to wind up in a situation where an XKit message is so tall that it can't be dismissed, which I discovered while switching branches in development (effectively simulating a downgrade from a hypothetical MV3 version, if you're curious). This adds some CSS to make the message scroll if it's too tall.

(Scroll bars not shown in the screenshot, as I'm on a Mac with a trackpad where by default they're only shown when scrolling, but I can confirm they do appear/scrolling does work).

| before | after |
| - | - |
| <img src="https://github.com/user-attachments/assets/ff302f32-868f-411f-8276-540297602a5a"> | <img src="https://github.com/user-attachments/assets/f56ce6db-33c6-40e0-b7a3-4bdeff1abcfe"> |
