### PR TITLE
Fix icon file loading

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,7 @@
   "author": "New XKit Team",
   "permissions": ["storage", "unlimitedStorage", "*://*.tumblr.com/*", "https://new-xkit.github.io/XKit/*", "https://cloud.new-xkit.com/*" ],
   "version": "7.10.0",
-  "web_accessible_resources": [ "*.js", "*.json", "*.css" ],
+  "web_accessible_resources": [ "*.js", "*.json", "*.css", "*.txt" ],
   "applications": {
     "gecko": {
       "id": "@new-xkit",


### PR DESCRIPTION
I somehow missed making this change in #2190, ~~even though I remember testing that PR? I don't know, man.~~ because... apparently Firefox just... ignores the web_accessible_resources list? Um, what? Sure, I guess.

This fixes the icons in the extension gallery not loading as of the linked PR in Chromium.