### PR TITLE
Fix control button basic functionality with upcoming footer tweaks

### DIFF
--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -997,9 +997,19 @@ XKit.extensions.xkit_patches = new Object({
 					var controlIconClass = control.attr("class");
 					var buttonClass = get_used_class_from_map("button");
 
+					XKit.tools.add_css(
+						`.xkit-footer-control-icon {
+							display: flex;
+							align-items: center;
+
+							padding: 8px;
+						}`,
+						'xkit_react_control_button'
+					);
+
 					var new_control = `
-						<div class="${controlIconClass || ''} {{className}} xkit-interface-control-button" title="{{text}}" {{additional}}>
-							<button class="${buttonClass || ''}" aria-label="" tabindex="0">
+						<div class="${controlIconClass || 'xkit-footer-control-icon'} {{className}} xkit-interface-control-button" title="{{text}}" {{additional}}>
+							<button class="${buttonClass || 'xkit-footer-control-button'}" aria-label="" tabindex="0">
 								<div class="xkit-interface-icon" {{data}}></div>
 							</button>
 						</div>

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 7.4.23 **//
+//* VERSION 7.4.24 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER new-xkit **//
 
@@ -943,13 +943,21 @@ XKit.extensions.xkit_patches = new Object({
 					if (without_tag !== undefined) {
 						selector += `:not(.${without_tag})`;
 					}
+					let posts = [...document.querySelectorAll(selector)];
 
 					if (can_edit) {
-						const edit_label = await XKit.interface.translate("Edit");
-						return $(selector).filter((index, post) => $(post).find(`[aria-label='${edit_label}']`).length !== 0);
+						const postsWithProps = await Promise.all(
+							posts.map(async post => ({
+								post,
+								props: await XKit.interface.react.post_props(post.dataset.id),
+							}))
+						);
+						posts = postsWithProps
+							.filter(({ props }) => props.canEdit)
+							.map(({ post }) => post);
 					}
 
-					return $(selector);
+					return $(posts);
 				},
 
 				/**
@@ -990,8 +998,8 @@ XKit.extensions.xkit_patches = new Object({
 					var buttonClass = get_used_class_from_map("button");
 
 					var new_control = `
-						<div class="${controlIconClass} {{className}} xkit-interface-control-button" title="{{text}}" {{additional}}>
-							<button class="${buttonClass}" aria-label="" tabindex="0">
+						<div class="${controlIconClass || ''} {{className}} xkit-interface-control-button" title="{{text}}" {{additional}}>
+							<button class="${buttonClass || ''}" aria-label="" tabindex="0">
 								<div class="xkit-interface-icon" {{data}}></div>
 							</button>
 						</div>

--- a/xkit.js
+++ b/xkit.js
@@ -4004,13 +4004,21 @@ var xkit_global_start = Date.now();  // log start timestamp
 			if (without_tag !== undefined) {
 				selector += `:not(.${without_tag})`;
 			}
+			let posts = [...document.querySelectorAll(selector)];
 
 			if (can_edit) {
-				const edit_label = await XKit.interface.translate("Edit");
-				return $(selector).filter((index, post) => $(post).find(`[aria-label='${edit_label}']`).length !== 0);
+				const postsWithProps = await Promise.all(
+					posts.map(async post => ({
+						post,
+						props: await XKit.interface.react.post_props(post.dataset.id),
+					}))
+				);
+				posts = postsWithProps
+					.filter(({ props }) => props.canEdit)
+					.map(({ post }) => post);
 			}
 
-			return $(selector);
+			return $(posts);
 		},
 
 		/**
@@ -4051,8 +4059,8 @@ var xkit_global_start = Date.now();  // log start timestamp
 			var buttonClass = get_used_class_from_map("button");
 
 			var new_control = `
-				<div class="${controlIconClass} {{className}} xkit-interface-control-button" title="{{text}}" {{additional}}>
-					<button class="${buttonClass}" aria-label="" tabindex="0">
+				<div class="${controlIconClass || ''} {{className}} xkit-interface-control-button" title="{{text}}" {{additional}}>
+					<button class="${buttonClass || ''}" aria-label="" tabindex="0">
 						<div class="xkit-interface-icon" {{data}}></div>
 					</button>
 				</div>

--- a/xkit.js
+++ b/xkit.js
@@ -4058,9 +4058,19 @@ var xkit_global_start = Date.now();  // log start timestamp
 			var controlIconClass = control.attr("class");
 			var buttonClass = get_used_class_from_map("button");
 
+			XKit.tools.add_css(
+				`.xkit-footer-control-icon {
+					display: flex;
+					align-items: center;
+
+					padding: 8px;
+				}`,
+				'xkit_react_control_button'
+			);
+
 			var new_control = `
-				<div class="${controlIconClass || ''} {{className}} xkit-interface-control-button" title="{{text}}" {{additional}}>
-					<button class="${buttonClass || ''}" aria-label="" tabindex="0">
+				<div class="${controlIconClass || 'xkit-footer-control-icon'} {{className}} xkit-interface-control-button" title="{{text}}" {{additional}}>
+					<button class="${buttonClass || 'xkit-footer-control-button'}" aria-label="" tabindex="0">
 						<div class="xkit-interface-icon" {{data}}></div>
 					</button>
 				</div>


### PR DESCRIPTION
Upcoming tweaks to the post footer may result in our "find the edit button" code to determine whether a post is editable breaking, and may not have any CSS class on some footer button elements that we currently try to copy classes from.

This preserves the basic functionality of adding our own control buttons correctly if these tweaks occur (though it does not fix any layout breakage; we could of course do so in the future).

Specifically, this detects whether a post is editable in react mode using our react `post_props` utility, and makes sure we don't add the css class "undefined" when we don't detect a css class to copy.

These are xkit.js changes, which for this currently undeployed 7.10 branch are all that is needed. Deploying this to the live 7.9.2 branch, if I recall correctly, is an xkit patches change, so we will need to PR a change targeting that branch which copy-pastes xkit patches 7.4.24 from this. I think. Probably.

The maintenence state of this codebase is _fine_.